### PR TITLE
Address release-blocking review findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  FLATPAK_CARGO_GENERATOR_COMMIT: 737c0085912f9f7dabf9341d4608e2a77a51a73a
+  FLATPAK_CARGO_GENERATOR_SHA256: b373c8ab1a05378ec5d8ed0645c7b127bcec7d2f7a1798694fbc627d570d856c
 
 jobs:
   # ── Security audit ─────────────────────────────────────────────────────────
@@ -317,14 +319,24 @@ jobs:
       options: --privileged
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install Python dependencies
-        run: pip3 install tomlkit aiohttp --break-system-packages || pip3 install tomlkit aiohttp
+        run: |
+          pip3 install --requirement build-aux/flatpak/generator-requirements.txt \
+            --break-system-packages \
+            || pip3 install --requirement build-aux/flatpak/generator-requirements.txt
 
       - name: Download flatpak-cargo-generator
         run: |
           mkdir -p build-aux/flatpak
-          curl -o build-aux/flatpak/flatpak-cargo-generator.py https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/master/cargo/flatpak-cargo-generator.py
+          curl --fail --show-error --silent --location \
+            --proto '=https' --tlsv1.2 \
+            --output build-aux/flatpak/flatpak-cargo-generator.py \
+            "https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/${FLATPAK_CARGO_GENERATOR_COMMIT}/cargo/flatpak-cargo-generator.py"
+          echo "${FLATPAK_CARGO_GENERATOR_SHA256}  build-aux/flatpak/flatpak-cargo-generator.py" \
+            | sha256sum --check --strict
 
       - name: Generate cargo-sources.json
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,22 +6,85 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to build (e.g. v0.1.0). Leave empty for HEAD."
-        required: false
+        description: "Existing release tag to build (for example, v0.5.0)"
+        required: true
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  FLATPAK_CARGO_GENERATOR_COMMIT: 737c0085912f9f7dabf9341d4608e2a77a51a73a
+  FLATPAK_CARGO_GENERATOR_SHA256: b373c8ab1a05378ec5d8ed0645c7b127bcec7d2f7a1798694fbc627d570d856c
 
 jobs:
+  # Resolve the event tag once, validate it against the tagged source, and
+  # expose an immutable commit SHA to every build job.
+  prepare:
+    name: Resolve release source
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      build_ref: ${{ steps.source.outputs.build_ref }}
+      tag: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.source.outputs.version }}
+    steps:
+      - name: Validate requested tag
+        id: release
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          DISPATCH_TAG: ${{ inputs.tag }}
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
+            TAG="${RELEASE_TAG}"
+          elif [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            TAG="${DISPATCH_TAG}"
+          else
+            echo "Unsupported release event: ${GITHUB_EVENT_NAME}" >&2
+            exit 1
+          fi
+
+          SEMVER_TAG='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?(\+[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$'
+          if [[ ! "${TAG}" =~ ${SEMVER_TAG} ]]; then
+            echo "Release tag must be a v-prefixed semantic version; got '${TAG}'" >&2
+            exit 1
+          fi
+          echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
+
+      - uses: actions/checkout@v6
+        with:
+          ref: refs/tags/${{ steps.release.outputs.tag }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Resolve immutable source and version
+        id: source
+        env:
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          BUILD_REF="$(git rev-parse HEAD)"
+          VERSION="$(awk -F'"' '/^\[package\]/{in_package=1; next} in_package && /^version = /{print $2; exit}' Cargo.toml)"
+          if [[ -z "${VERSION}" ]]; then
+            echo "Could not read package version from Cargo.toml" >&2
+            exit 1
+          fi
+          if [[ "${TAG}" != "v${VERSION}" ]]; then
+            echo "Tag ${TAG} does not match Cargo.toml version ${VERSION}" >&2
+            exit 1
+          fi
+          echo "build_ref=${BUILD_REF}" >> "${GITHUB_OUTPUT}"
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+
   # ── Linux Flatpak (x86_64 + aarch64) ─────────────────────────────────────
   flatpak:
     name: Flatpak (${{ matrix.arch }})
+    needs: prepare
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:
@@ -31,13 +94,16 @@ jobs:
             runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.build_ref }}
+          persist-credentials: false
 
       # Install Flatpak natively on the runner instead of using an x86_64 container.
       - name: Install Flatpak & Dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y flatpak flatpak-builder elfutils python3-pip
-          
+
           # Fix Polkit permission errors for headless bare-metal Flatpak
           sudo mkdir -p /etc/polkit-1/rules.d
           sudo tee /etc/polkit-1/rules.d/99-flatpak.rules << 'EOF'
@@ -47,18 +113,25 @@ jobs:
               }
           });
           EOF
-          
+
           # Add the Flathub repository
           sudo flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
 
       - name: Install Python dependencies
-        run: pip3 install tomlkit aiohttp --break-system-packages || pip3 install tomlkit aiohttp
+        run: |
+          pip3 install --requirement build-aux/flatpak/generator-requirements.txt \
+            --break-system-packages \
+            || pip3 install --requirement build-aux/flatpak/generator-requirements.txt
 
       - name: Download flatpak-cargo-generator
         run: |
           mkdir -p build-aux/flatpak
-          curl -o build-aux/flatpak/flatpak-cargo-generator.py \
-            https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/master/cargo/flatpak-cargo-generator.py
+          curl --fail --show-error --silent --location \
+            --proto '=https' --tlsv1.2 \
+            --output build-aux/flatpak/flatpak-cargo-generator.py \
+            "https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/${FLATPAK_CARGO_GENERATOR_COMMIT}/cargo/flatpak-cargo-generator.py"
+          echo "${FLATPAK_CARGO_GENERATOR_SHA256}  build-aux/flatpak/flatpak-cargo-generator.py" \
+            | sha256sum --check --strict
 
       - name: Generate cargo-sources.json
         run: |
@@ -72,12 +145,6 @@ jobs:
           cache-key: flatpak-${{ matrix.arch }}-${{ hashFiles('**/Cargo.lock') }}
           arch: ${{ matrix.arch }}
 
-      - name: Upload Flatpak to release
-        if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v3
-        with:
-          files: tributary-linux-${{ matrix.arch }}.flatpak
-
       - name: Upload Flatpak as workflow artifact
         uses: actions/upload-artifact@v7
         with:
@@ -87,7 +154,10 @@ jobs:
   # ── macOS (.dmg) ──────────────────────────────────────────────────────────
   macos:
     name: macOS (${{ matrix.arch }})
+    needs: prepare
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:
@@ -96,6 +166,9 @@ jobs:
             rust_target: aarch64-apple-darwin
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.build_ref }}
+          persist-credentials: false
 
       - name: Install system dependencies (Homebrew)
         run: |
@@ -126,12 +199,6 @@ jobs:
       - name: Rename DMG for release
         run: mv dist/Tributary.dmg dist/tributary-macos-${{ matrix.arch }}.dmg
 
-      - name: Upload DMG to release
-        if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v3
-        with:
-          files: dist/tributary-macos-${{ matrix.arch }}.dmg
-
       - name: Upload DMG as workflow artifact
         uses: actions/upload-artifact@v7
         with:
@@ -141,7 +208,10 @@ jobs:
   # ── Windows (.zip + Inno Setup .exe) ──────────────────────────────────────
   windows:
     name: Windows (${{ matrix.arch }})
+    needs: prepare
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
     # Cap the job so a hung MSYS2 mirror fails fast and re-runs instead of
     # stalling to the 6-hour ceiling.
     timeout-minutes: 45
@@ -167,6 +237,9 @@ jobs:
         shell: msys2 {0}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.build_ref }}
+          persist-credentials: false
 
       - name: Set up MSYS2 (${{ matrix.msystem }})
         uses: msys2/setup-msys2@v2.32.0
@@ -252,14 +325,6 @@ jobs:
         run: |
           Move-Item dist/tributary-setup.exe dist/tributary-windows-${{ matrix.arch }}-setup.exe
 
-      - name: Upload Windows artifacts to release
-        if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v3
-        with:
-          files: |
-            dist/tributary-windows-${{ matrix.arch }}.zip
-            dist/tributary-windows-${{ matrix.arch }}-setup.exe
-
       - name: Upload Windows artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -271,7 +336,10 @@ jobs:
   # ── Linux Native Installers (deb, rpm, arch pkg) ─────────────────────────
   linux-deb:
     name: Debian Package (${{ matrix.arch }})
+    needs: prepare
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
     container:
       image: debian:sid
     strategy:
@@ -293,6 +361,9 @@ jobs:
             libdbus-1-dev
 
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.build_ref }}
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -314,12 +385,6 @@ jobs:
       - name: Build .deb package
         run: cargo deb -o target/debian/tributary-${{ matrix.deb_arch }}.deb
 
-      - name: Upload .deb to release
-        if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v3
-        with:
-          files: target/debian/tributary-${{ matrix.deb_arch }}.deb
-
       - name: Upload .deb as workflow artifact
         uses: actions/upload-artifact@v7
         with:
@@ -328,7 +393,10 @@ jobs:
 
   linux-rpm:
     name: RPM Package (${{ matrix.arch }})
+    needs: prepare
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
     container:
       image: fedora:41
     strategy:
@@ -349,6 +417,9 @@ jobs:
             pkgconf-pkg-config git curl
 
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.build_ref }}
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -378,12 +449,6 @@ jobs:
           RPM_FILE=$(ls target/generate-rpm/*.rpm | head -1)
           mv "$RPM_FILE" "target/generate-rpm/tributary-${{ matrix.rpm_arch }}.rpm"
 
-      - name: Upload .rpm to release
-        if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v3
-        with:
-          files: target/generate-rpm/tributary-${{ matrix.rpm_arch }}.rpm
-
       - name: Upload .rpm as workflow artifact
         uses: actions/upload-artifact@v7
         with:
@@ -392,7 +457,10 @@ jobs:
 
   linux-arch:
     name: Arch Linux Package (x86_64)
+    needs: prepare
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     container:
       image: archlinux:base-devel
     steps:
@@ -402,6 +470,9 @@ jobs:
             gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav dbus rust
 
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.build_ref }}
+          persist-credentials: false
 
       - name: Cache Cargo registry
         uses: actions/cache@v5
@@ -424,8 +495,8 @@ jobs:
           # Copy PKGBUILD and build
           cd /home/builder/tributary
           cp build-aux/arch/PKGBUILD .
-          # Set the version from the release tag
-          VERSION="${GITHUB_REF_NAME#v}"
+          # Set the version from the validated, checked-out release source.
+          VERSION="${{ needs.prepare.outputs.version }}"
           sed -i "s/^pkgver=.*/pkgver=${VERSION}/" PKGBUILD
 
           su builder -c "BUILDDIR=/tmp/makepkg makepkg -sf --noconfirm --skipchecksums"
@@ -435,12 +506,6 @@ jobs:
           PKG_FILE=$(ls /home/builder/tributary/*.pkg.tar.zst | head -1)
           mkdir -p dist
           cp "$PKG_FILE" dist/tributary-x86_64.pkg.tar.zst
-
-      - name: Upload Arch package to release
-        if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v3
-        with:
-          files: dist/tributary-x86_64.pkg.tar.zst
 
       - name: Upload Arch package as workflow artifact
         uses: actions/upload-artifact@v7
@@ -453,7 +518,8 @@ jobs:
     name: SHA256 Checksums
     runs-on: ubuntu-24.04
     needs: [flatpak, macos, windows, linux-deb, linux-rpm, linux-arch]
-    if: always()
+    permissions:
+      contents: read
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v8
@@ -466,19 +532,44 @@ jobs:
           find . -type f \( -name '*.zip' -o -name '*.dmg' -o -name '*.flatpak' \
             -o -name '*.deb' -o -name '*.rpm' -o -name '*.pkg.tar.zst' \
             -o -name '*-setup.exe' \) \
-            -exec sha256sum {} + | sed 's|  \./|  |' | sort -k2 > ../SHA256SUMS.txt
+            -exec sha256sum {} + | sed 's|  .*/|  |' | sort -k2 > ../SHA256SUMS.txt
           cat ../SHA256SUMS.txt
 
-      - name: Upload SHA256SUMS to release
-        if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v3
-        with:
-          files: SHA256SUMS.txt
-
-      - name: Upload SHA256SUMS as artifact (workflow_dispatch)
-        if: github.event_name == 'workflow_dispatch'
+      - name: Upload SHA256SUMS as artifact
         uses: actions/upload-artifact@v7
         with:
           name: SHA256SUMS
           path: SHA256SUMS.txt
-          if-no-files-found: warn
+          if-no-files-found: error
+
+  # The only job with a repository write token. It checks out no project or
+  # build code and uses immutable action revisions only to transfer completed
+  # artifacts to the already-created GitHub release.
+  publish:
+    name: Publish release assets
+    if: github.event_name == 'release'
+    needs: [prepare, checksums]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Download verified build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          path: release-assets
+          merge-multiple: true
+
+      - name: Publish assets to the validated release tag
+        uses: softprops/action-gh-release@7c4723f7a335432393329f8f1c564994ce50185d # v3
+        with:
+          tag_name: ${{ needs.prepare.outputs.tag }}
+          fail_on_unmatched_files: true
+          files: |
+            release-assets/*.flatpak
+            release-assets/*.dmg
+            release-assets/*.zip
+            release-assets/*-setup.exe
+            release-assets/*.deb
+            release-assets/*.rpm
+            release-assets/*.pkg.tar.zst
+            release-assets/SHA256SUMS.txt

--- a/CODE_REVIEW_2026-07-10.md
+++ b/CODE_REVIEW_2026-07-10.md
@@ -1,0 +1,403 @@
+# Tributary — Holistic Code Review
+
+- **Date:** 2026-07-10
+- **Version reviewed:** 0.5.0
+- **Commit:** `598b332d31c6206aea620aa951b78335e4d659ed`
+**Scope:** Full Rust source tree, database migrations, network backends, audio outputs,
+GTK state management, packaging, CI/release workflows, and user-facing metadata.
+
+## Executive summary
+
+The codebase is thoughtfully organized and statically clean, but the reviewed commit is
+not ready for release. No critical memory-safety defect was found. The highest risks are:
+
+- data corruption or library metadata loss during migration and filesystem scanning;
+- DAAP and playback lifecycle bugs that invalidate sessions or select the wrong track;
+- credential exposure through redirects, logs, and broad authenticated stream URLs;
+- destructive callbacks retained by recycled GTK sidebar rows; and
+- release-pipeline integrity and reproducibility problems.
+
+The project has strong lint discipline, useful pure-logic tests, structured backend errors,
+bounded Subsonic concurrency, parser depth limits, fuzzing, and generally clear module
+documentation. Its largest quality gap is integration coverage around migrations,
+filesystem failures, HTTP behavior, GTK widget recycling, and real output state machines.
+
+## Verification performed
+
+- `cargo fmt --all -- --check` — passed.
+- `cargo test --all-targets` — 152 tests passed.
+- `cargo test --release` — 152 tests passed.
+- `cargo clippy --all-targets -- -D warnings` — passed.
+- `cargo clippy --release -- -D warnings` — passed.
+- `appstreamcli validate --no-net` — passed.
+- `desktop-file-validate` — warned that the `Audio`/`Music` categories require
+  `AudioVideo`.
+- `cargo audit` — failed with two current vulnerabilities and three warnings.
+- The playlist migration failure was independently reproduced against SQLite.
+- The worktree remained clean throughout the review.
+
+The review was source- and test-based. It did not include interactive testing against real
+GTK desktops, media servers, Chromecast/AirPlay/MPD receivers, USB devices, or each target
+operating system.
+
+## High-priority findings
+
+### H1. Playlist migration can corrupt ordering and block database startup
+
+[`m20250104_000004_unique_entry_position.rs`](src/db/migration/m20250104_000004_unique_entry_position.rs#L22)
+updates `position` while its correlated subquery reads rows already modified by that same
+statement. SQLite therefore produces results that depend on row-update order.
+
+A reproduction with entries inserted as `c:30`, `b:20`, `a:10` changed every position to
+`2`; creation of the unique index then failed. SeaORM does not implicitly wrap SQLite
+migrations in a transaction, so the invalid update persists even though the migration is
+not recorded as applied. Subsequent starts can mutate the positions again and eventually
+produce a different order.
+
+**Impact:** an upgrade can make the local library unavailable and permanently reorder
+playlist entries.
+
+**Recommendation:** materialize the desired ranking in a temporary table or CTE that is
+independent of the target update, then apply the rank update and unique-index creation in
+an explicit transaction. Add an upgrade test containing duplicates and row insertion order
+that differs from playlist order.
+
+### H2. Partially unreadable library roots can lose persisted metadata
+
+The initial scan silently discards every `WalkDir` error in
+[`engine.rs`](src/local/engine.rs#L121), then treats a root as available when at least one
+audio file was found under it at [`engine.rs`](src/local/engine.rs#L144).
+
+This fails in both directions:
+
+- If one subtree becomes unreadable but another file is readable, the root is considered
+  authoritative and rows from the unreadable subtree are deleted as stale at
+  [`engine.rs`](src/local/engine.rs#L218). This destroys stable IDs, dates, play counts,
+  and playlist linkage.
+- If a healthy directory is intentionally emptied while Tributary is closed, it is treated
+  as unavailable, so its stale rows survive indefinitely.
+
+**Recommendation:** record traversal completion and errors per configured root. Never
+perform stale deletion for a root whose traversal was incomplete. Treat a successfully
+scanned empty directory as authoritative, and use persisted mount/device identity or an
+explicit unavailable-volume state for removable/network roots.
+
+### H3. DAAP sessions are logged out immediately after loading tracks
+
+DAAP success paths copy `backend.all_tracks()` and then drop the backend in
+[`window.rs`](src/ui/window.rs#L496) and
+[`source_connect.rs`](src/ui/source_connect.rs#L716). `DaapBackend::drop` immediately
+spawns a logout request in [`daap/backend.rs`](src/daap/backend.rs#L428).
+
+The copied stream and artwork URLs contain the same session ID. A successful library sync
+therefore races an immediate logout, and playback fails once the server invalidates the
+session. The explicit sidebar logout URL is never populated either.
+
+**Recommendation:** retain a session-owning backend object in a per-source registry. Resolve
+stream URLs at playback time and perform logout only on explicit disconnect or controlled
+application shutdown. Avoid network side effects in `Drop`.
+
+### H4. Playback identity is coupled to a mutable view index
+
+[`playback.rs`](src/ui/playback.rs#L47) stores `current_pos` as an index into the visible
+`SortListModel`. Sorting does not remap that index. Source changes clear it while current
+audio continues, and Next/EOS with no index starts at row zero.
+
+As a result, sorting, filtering, or changing sources during playback can make Next,
+Previous, repeat-one, or automatic advance load an unrelated track. Output switching adds
+another inconsistent transition: [`output_switch.rs`](src/ui/output_switch.rs#L42) stops
+the current output before checking whether the selected target actually changed, constructs
+an empty output, and leaves `current_pos` populated.
+
+**Recommendation:** introduce a `PlaybackSession` containing a stable source/track ID and
+queue snapshot independent of the browser model. Make reselecting the current output a
+no-op, and explicitly transfer or clear the session when changing output targets.
+
+### H5. Recycled sidebar rows retain destructive click handlers
+
+Every list-item bind calls `connect_clicked` in
+[`sidebar.rs`](src/ui/sidebar.rs#L235), while unbind only hides the action button at
+[`sidebar.rs`](src/ui/sidebar.rs#L398). GTK list items are recycled, and this code also
+forces remove/reinsert rebinds.
+
+A button rebound from server A to server B can retain both handlers. Clicking B may also
+delete or disconnect A. Header bindings can similarly accumulate duplicate actions.
+
+**Recommendation:** connect once during setup and resolve the item currently bound to the
+list item, or retain and disconnect each `SignalHandlerId` during unbind.
+
+### H6. Playlist track references do not have the declared database foreign key
+
+The playlist migration creates `track_id` at
+[`m20250102_000002_create_playlists.rs`](src/db/migration/m20250102_000002_create_playlists.rs#L80)
+but defines only the playlist foreign key. The SeaORM entity declares `ON DELETE SET NULL`,
+but entity metadata does not alter the SQLite schema.
+
+Deleting and rediscovering a track therefore leaves a non-null dangling ID. Meanwhile,
+[`reconcile_all`](src/local/playlist_manager.rs#L333) only examines rows whose ID is null,
+so the playlist item remains invisible and can never be repaired. Watcher renames currently
+delete and reinsert tracks, making this reachable during ordinary file organization.
+
+**Recommendation:** rebuild the table in a migration with
+`track_id REFERENCES tracks(id) ON DELETE SET NULL`, first nulling existing dangling IDs.
+Handle paired filesystem renames as path updates that preserve track identity.
+
+### H7. Redirect handling can expose bearer credentials
+
+Subsonic and DAAP put credentials in URL queries and use default reqwest redirect behavior.
+The album-art worker likewise follows redirects for every backend's credential-bearing URL
+at [`album_art.rs`](src/ui/album_art.rs#L38). Reqwest enables automatic `Referer`; on an
+allowed cross-origin redirect, that header can contain the full previous URL query.
+
+Plex and Jellyfin attempt to constrain redirects, but compare only `host_str` at
+[`plex/client.rs`](src/plex/client.rs#L332) and
+[`jellyfin/client.rs`](src/jellyfin/client.rs#L379). They therefore permit a port change or
+HTTPS-to-HTTP downgrade while retaining custom token headers.
+
+**Recommendation:** disable automatic `Referer` for credential-bearing clients and allow
+redirects only within the exact origin: scheme, hostname, and effective port. Never allow a
+TLS downgrade. Rebuild authenticated requests only after validating the target.
+
+### H8. Release Flatpak job executes mutable upstream code with write credentials
+
+[`release.yml`](.github/workflows/release.yml#L13) grants `contents: write` to the entire
+workflow. Checkout persists credentials by default, after which the Flatpak job downloads
+and executes a Python script from the mutable `flatpak-builder-tools/master` branch at
+[`release.yml`](.github/workflows/release.yml#L57).
+
+An upstream compromise can poison release artifacts and potentially recover a repository
+write token from the checkout configuration. Unpinned pip packages compound the exposure.
+
+**Recommendation:** vendor the generator or pin it to an immutable commit and verify its
+checksum. Set `persist-credentials: false`, give build jobs `contents: read`, and isolate
+release publication into a minimal job with write permission.
+
+### H9. Manual release tag input is ignored
+
+The workflow declares a `tag` input at
+[`release.yml`](.github/workflows/release.yml#L6), but no checkout references it. Manual
+"build tag X" runs therefore build the dispatch branch or HEAD. The Arch job derives its
+version from `GITHUB_REF_NAME`, which can produce `pkgver=main`.
+
+**Recommendation:** compute one validated build ref from the release event or manual input,
+pass it to every checkout, and derive package versions from the checked-out source/tag.
+
+## Medium-priority findings
+
+### M1. Response body limits are bypassable with chunked transfers
+
+The Subsonic, Jellyfin, Plex, and DAAP guards inspect only `Content-Length`, for example in
+[`subsonic/client.rs`](src/subsonic/client.rs#L321), then call `json()`, `text()`, or
+`bytes()` and buffer the entire response. A chunked peer can send indefinitely while
+remaining inside the idle read timeout. Radio, authentication, and album-art responses have
+even less coverage.
+
+Consume response streams with a running byte count, abort when the limit is exceeded, and
+apply a separate overall request deadline.
+
+### M2. Scan/watcher handoff and directory events allow permanent drift
+
+The watcher is installed only after the complete initial scan at
+[`engine.rs`](src/local/engine.rs#L77), creating a gap where changes are missed. Event
+classification at [`engine.rs`](src/local/engine.rs#L351) filters every path by audio
+extension, so directory rename/removal events do nothing. A file rename is handled as
+delete-plus-insert, resetting identity and metadata.
+
+Install and buffer the watcher before enumeration, replay buffered events after the scan,
+rescan affected subtrees for directory events, and perform a safe full reconciliation after
+watcher overflow/errors.
+
+### M3. AirPlay `shairport-sync` fallback cannot transmit to the receiver
+
+[`airplay_output.rs`](src/audio/airplay_output.rs#L283) explicitly discards the selected
+host and port, starts `shairport-sync -o pipe -- /dev/stdin`, then writes PCM into its stdin.
+Shairport Sync is an AirPlay receiver; its pipe backend outputs received audio rather than
+accepting audio to transmit.
+
+Remove the fallback or replace it with a real RAOP sender. Move process lookup, spawn, and
+pipeline teardown off the GTK main thread.
+
+### M4. MPD output never reports successful playback state
+
+[`mpd_output.rs`](src/audio/mpd_output.rs#L245) emits `Buffering`, but successful commands
+never emit `Playing`, position, or track completion. The UI spinner can remain indefinitely,
+OS playback state is wrong, and automatic advance cannot work.
+
+Use one serialized MPD worker or persistent connection that emits authoritative status,
+position, and completion events. Avoid logging the full `add "<authenticated URL>"` command.
+
+### M5. Chromecast cancellation occurs after stale external side effects
+
+[`chromecast_output.rs`](src/audio/chromecast_output.rs#L205) assigns a generation before
+spawning, but the worker does not check it while connecting, launching the receiver, or
+loading media. A superseded worker can load an old track and emit `Playing` before its first
+generation check. Detached stop/play/seek operations are also unordered.
+
+Serialize commands in one worker and check the generation before every external side effect
+and event. Ensure each error transitions to `Stopped`; the current local-file resolve error
+can be followed by a contradictory `Buffering` event.
+
+### M6. Late async source results overwrite newer navigation
+
+Playlist and radio completions render unconditionally in
+[`source_connect.rs`](src/ui/source_connect.rs#L118) and `radio.rs`. If the user selects a
+different source while a request is running, the late result replaces the current view.
+
+Capture a source key/generation with each operation, cache late results, and render only when
+that source remains active. The USB branch already demonstrates this guard pattern.
+
+### M7. Broad backend credentials are materialized and sent to Cast receivers
+
+Jellyfin and Plex place reusable user/account bearer tokens in stream URLs. The generic
+`Track` model retains those URLs, and Chromecast passes the raw value to any selected LAN
+receiver as `content_id`.
+
+Prefer an app-owned, opaque, short-lived proxy URL or server-provided least-privilege stream
+ticket. Keep credentials out of the generic track model.
+
+### M8. DAAP session credentials remain visible in logs and errors
+
+[`daap/client.rs`](src/daap/client.rs#L179) logs the raw session ID at info level. Several
+reqwest errors retain the request URL containing `session-id`, despite debug URL redaction.
+
+Omit or irreversibly fingerprint the session ID and call `without_url()` before formatting
+or retaining request errors.
+
+### M9. Smart-playlist date, limit, and live-update semantics are inconsistent
+
+[`smart_rules.rs`](src/local/smart_rules.rs#L472) compares RFC3339 timestamps to date-only
+strings lexically, so `is 2026-07-10` fails for a track on that date while `is after` may
+incorrectly pass. Compound sorting is applied before limit selection, but the limit path
+sorts again at [`smart_rules.rs`](src/local/smart_rules.rs#L531), discarding the requested
+final order. `live_updating` is persisted but never changes evaluation behavior.
+
+Parse dates into chrono values with explicit date/instant semantics, select/truncate before
+applying the requested final sort, validate relative-date bounds, and implement or remove the
+live-update option.
+
+### M10. Playlist import/export and tag writes are not fully failure-safe
+
+XSPF export truncates the destination before incremental writes, so an I/O failure destroys
+an existing export. Import tries ambiguous metadata before an exact file path and ignores
+unmatched tracks and insertion errors, allowing a silent partial playlist.
+
+Tag writing uses a predictable sibling temp path, silently accepts invalid numeric edits,
+does not apply the declared album-artist field, and can leave the temp behind on rename
+failure.
+
+Use exclusive random sibling temp files and atomic replacement, make import transactional,
+prefer exact paths before fingerprint matching, preserve unmatched entries for later
+reconciliation, validate every edit up front, and surface matched/unmatched/error counts.
+
+### M11. Removable-media traversal and Flatpak permissions conflict with the feature set
+
+USB browsing uses `WalkDir::follow_links(true)` at
+[`source_connect.rs`](src/ui/source_connect.rs#L267). A removable device can contain a
+symlink into the user's home, causing Tributary to traverse host files outside the selected
+volume.
+
+The Flatpak grants write access only to XDG Music and does not expose `/media/$USER` or
+`/run/media/$USER`, so advertised USB browsing does not work there and tag editing outside
+XDG Music is normally read-only.
+
+Disable link following, verify canonical paths remain on the selected mount, use platform
+mount APIs, and define narrow Flatpak/portal permissions for removable and custom folders.
+
+### M12. Packaging and desktop integration metadata are inconsistent
+
+- [`build-linux.sh`](scripts/build-linux.sh#L139) invokes a Flatpak generator absent from
+  the repository and writes `cargo-sources.json` somewhere the manifest does not read.
+- The standalone RPM spec still declares `Version: v0.1.0` and constructs `vv0.1.0` in
+  `Source0`.
+- [`Cargo.toml`](Cargo.toml#L13) enables GTK 4.16 and libadwaita 1.6 APIs, while native
+  package metadata permits GTK 4.14 and libadwaita 1.5.
+- [`io.github.tributary.Tributary.desktop`](data/io.github.tributary.Tributary.desktop#L6)
+  declares audio MIME types but `Exec=tributary` has no `%F`/`%U`, so Linux file managers
+  cannot pass selected files.
+- The README advertises Rust 1.80+, while `Cargo.toml` requires 1.85 and CI tests only the
+  latest stable toolchain.
+- AppStream release metadata stops at 0.4.1 while the crate is 0.5.0.
+
+Synchronize package metadata from one version source, raise runtime minima, fix the desktop
+field codes/categories, vendor the Flatpak source generator, and add an MSRV CI job.
+
+## Architectural assessment
+
+The documented `MediaBackend` boundary is mostly declarative rather than operational. The
+UI constructs concrete backends, copies `Vec<Track>` values containing authenticated URLs,
+and discards backend ownership. `LocalBackend` is not constructed by the application, and
+several of its trait methods return `Unsupported` or create ephemeral IDs.
+
+A source/session registry holding `Arc<dyn MediaBackend>` plus opaque source and track IDs
+would address several findings together:
+
+1. preserve DAAP and future session lifetimes;
+2. resolve fresh stream URLs only when playback begins;
+3. keep bearer credentials out of generic track models and receiver devices;
+4. give playback stable identity independent of UI sorting/filtering; and
+5. centralize refresh, cancellation, disconnect, and error-state behavior.
+
+This should be treated as an intentional architectural milestone rather than folded into an
+isolated bug fix.
+
+## Dependency audit status
+
+As of 2026-07-10, `cargo audit` reports:
+
+- `crossbeam-epoch 0.9.18` — RUSTSEC-2026-0204; upgrade to `>= 0.9.20`.
+- `quinn-proto 0.11.14` — RUSTSEC-2026-0185; upgrade to `>= 0.11.15`.
+- warnings for unmaintained `paste` and `proc-macro-error2`, plus the
+  `anyhow 1.0.102` `downcast_mut` unsoundness advisory.
+
+`quinn-proto` is present through reqwest's optional HTTP/3 dependency graph and is not active
+in the normal build, but the lockfile audit job still fails. The current code does not call
+the affected `anyhow::Error::downcast_mut` path. The lockfile should nevertheless be updated
+before release, and the warnings should be tracked to their upstream dependency owners.
+
+## Strengths
+
+- Strict debug and release Clippy checks are clean.
+- The pure logic suite is fast and covers smart rules, DMAP primitives, URL redaction,
+  range parsing, MPD escaping, and several conversion edge cases.
+- Network clients generally use structured errors, URL validation, and connection/read
+  timeouts.
+- Subsonic metadata fetching uses bounded concurrency.
+- DMAP parsing has a recursion-depth guard and a weekly fuzz target.
+- MPD argument escaping defends the newline-delimited protocol boundary.
+- Cast file serving uses opaque random IDs rather than path-derived routes and handles byte
+  range edge cases.
+- Runtime playlist reordering is transactional and avoids transient unique-position
+  collisions; the defect is specifically in the upgrade migration.
+- GTK objects are generally kept on the main thread, with background work bridged through
+  channels.
+
+## Test gaps to close
+
+The following deserve integration or failure-injection coverage:
+
+- upgrading a database containing reordered or duplicate playlist positions;
+- foreign-key deletion and playlist reconciliation;
+- empty, unavailable, and partially unreadable library roots;
+- watcher startup handoff, directory events, rename identity, and overflow recovery;
+- redirects, `Referer`, chunked body caps, timeouts, and pagination using mock servers;
+- DAAP session ownership and explicit disconnect;
+- GTK list-item recycling and stale async result suppression;
+- fake MPD state/position/EOS behavior and output switching;
+- delayed/superseded Chromecast sessions;
+- XSPF round trips, partial I/O failures, and duplicate fingerprints;
+- tag-write validation and failure cleanup;
+- USB symlink escape and platform mount enumeration; and
+- packaging/release dry runs, desktop validation, and the declared minimum Rust/toolkit
+  versions.
+
+## Recommended implementation order
+
+1. Fix and regression-test the playlist migration before producing another build.
+2. Make scan reconciliation non-destructive under incomplete traversal.
+3. Retain backend/session ownership and remove DAAP logout from `Drop`.
+4. Introduce stable playback-session identity and repair sidebar signal lifetimes.
+5. Harden authenticated redirect and bounded-response handling.
+6. Lock down and make the release workflow reproducible; clear the audit failure.
+7. Repair watcher identity, playlist foreign keys, and output state machines.
+8. Address packaging, smart-playlist, import/export, tag-writing, and removable-media gaps.
+9. Complete the source/session registry architectural milestone and add integration harnesses.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"
@@ -714,9 +714,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -3047,9 +3047,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -4786,6 +4786,7 @@ dependencies = [
  "reqwest",
  "rust-i18n",
  "rust_cast",
+ "rustix 1.1.4",
  "rustls",
  "sea-orm",
  "sea-orm-migration",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["io"] }
 
 # Error handling
-anyhow = "1"
+anyhow = "1.0.103"
 thiserror = "2"
 
 # Logging / Tracing
@@ -105,6 +105,10 @@ souvlaki = "0.8"
 # Windows-only: GDK4 Win32 backend (HWND extraction for souvlaki SMTC)
 [target.'cfg(target_os = "windows")'.dependencies]
 gdk4-win32 = "0.11"
+
+# Stable filesystem IDs for removable/network library-root safety.
+[target.'cfg(unix)'.dependencies]
+rustix = { version = "1", features = ["fs"] }
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 winresource = "0.1"

--- a/build-aux/flatpak/generator-requirements.txt
+++ b/build-aux/flatpak/generator-requirements.txt
@@ -1,0 +1,5 @@
+# Runtime dependencies for the pinned flatpak-cargo-generator revision used
+# by CI and release builds. Keep these exact so generator execution does not
+# change without a reviewed repository update.
+aiohttp==3.14.1
+tomlkit==0.15.0

--- a/docs/task.md
+++ b/docs/task.md
@@ -1,0 +1,395 @@
+# Tributary remediation tracker
+
+Source review: [`CODE_REVIEW_2026-07-10.md`](../CODE_REVIEW_2026-07-10.md)
+
+Reviewed commit: `598b332d31c6206aea620aa951b78335e4d659ed`
+Created: 2026-07-10
+
+## How to use this file
+
+- Keep tasks unchecked until their acceptance criteria and listed verification are complete.
+- Add the implementing commit or PR beside a completed task.
+- If scope changes, update the review document or record the decision under **Decisions**.
+- Run the global validation gate after every milestone.
+- Do not combine the architecture milestone with unrelated bug fixes.
+
+Status summary:
+
+- [ ] P0 release blockers complete
+- [ ] P1 correctness and security complete
+- [ ] P2 resilience and packaging complete
+- [ ] P3 architecture and integration coverage complete
+
+## P0 — Release blockers
+
+### P0.1 Fix playlist-position migration
+
+- [x] Replace the self-referential rank update with a materialized snapshot.
+- [x] Wrap rank normalization and unique-index creation in an explicit transaction.
+- [x] Preserve existing playlist order when row insertion order differs.
+- [x] Add migration fixtures for gaps, duplicates, reordered rows, multiple playlists, and
+  an empty table.
+- [x] Verify a failed migration cannot leave partially updated positions.
+- [x] Record implementation: current worktree (commit pending); 10 focused migration tests.
+
+Acceptance criteria: upgrading a v0.5.0-style database always yields a unique contiguous
+`0..N` position sequence per playlist without changing the intended order.
+
+### P0.2 Make initial reconciliation non-destructive
+
+- [x] Collect traversal errors and completion state per configured root.
+- [x] Skip stale deletion for any root whose traversal was incomplete.
+- [x] Correctly reconcile a healthy root containing zero audio files.
+- [x] Define and persist availability/mount identity for removable or network roots.
+- [x] Add tests for missing, empty, permission-denied, partially unreadable, and overlapping
+  roots.
+- [ ] Add an explicit trust/re-enrollment flow for roots inherited from a pre-identity database;
+  content similarity is not accepted as proof of physical volume identity.
+- [ ] Pin reconciliation and watcher mutations to a root handle or equivalent mount generation
+  on every supported platform; Linux has mount-instance guards, while portable Unix ABA
+  resistance remains incomplete.
+- [ ] Record implementation: safety core is in the current worktree with 32 focused tests;
+  explicit legacy trust and portable root pinning remain open.
+
+Acceptance criteria: Tributary never deletes persisted track metadata based on an incomplete
+view of a library root, while intentional offline deletion is eventually reflected.
+
+### P0.3 Preserve DAAP session lifetime
+
+- [x] Retain the connected backend/session for as long as the source is connected.
+- [x] Remove logout network activity from `DaapBackend::drop`.
+- [x] Populate and/or replace the explicit disconnect path with owned backend shutdown.
+- [x] Resolve stream/artwork URLs from the live session at playback time.
+- [x] Add a mock DAAP lifecycle test covering connect, sync, play, and disconnect.
+- [x] Record implementation: current worktree (commit pending); 7 focused lifecycle and
+  replacement-race tests.
+
+Acceptance criteria: a DAAP session remains valid after library synchronization and is
+logged out exactly once on explicit disconnect or controlled shutdown.
+
+### P0.4 Introduce stable playback-session identity
+
+- [x] Replace the raw visible-row `current_pos` identity with stable source and track IDs.
+- [x] Store a playback queue snapshot independent of sorting/filtering/navigation.
+- [x] Define Next, Previous, shuffle, repeat-one, and repeat-all semantics after view changes.
+- [x] Make reselecting the current output a no-op.
+- [x] Explicitly transfer or clear playback when the output target changes.
+- [x] Add tests for sort, filter, source change, output change, EOS, and external-file playback.
+- [x] Record implementation: current worktree (commit pending); 25 focused UI/output tests.
+
+Acceptance criteria: view mutations never change the identity of the playing track or the
+meaning of queue navigation.
+
+### P0.5 Fix recycled sidebar action handlers
+
+- [x] Connect the action button once or disconnect handlers on every unbind.
+- [x] Ensure each click resolves only the currently bound `SourceObject`.
+- [x] Cover delete, DAAP eject, playlist creation, and forced remove/reinsert rebinds.
+- [x] Add a GTK test or focused harness that repeatedly recycles the same list item.
+- [x] Record implementation: current worktree (commit pending); focused recycling harness.
+
+Acceptance criteria: one click emits exactly one action for the currently displayed row.
+
+### P0.6 Lock down release build inputs and credentials
+
+- [x] Vendor or immutably pin the Flatpak Cargo generator and verify its checksum.
+- [x] Pin Python build dependencies or run them from a reviewed lock/environment.
+- [x] Set `persist-credentials: false` on build-job checkouts.
+- [x] Move `contents: write` to a minimal publication job.
+- [x] Give all build jobs `contents: read`.
+- [x] Record implementation: current worktree (commit pending); YAML, checksum, and contract
+  checks passed locally.
+
+Acceptance criteria: release build jobs execute only repository or immutable verified code
+and cannot access a repository write credential.
+
+### P0.7 Honor the manual release tag
+
+- [x] Compute a single validated build ref for release and manual-dispatch events.
+- [x] Pass the ref to every checkout in the release workflow.
+- [x] Derive every package version from the checked-out source/tag.
+- [x] Reject a missing or malformed requested tag.
+- [ ] Add a dry-run/manual workflow test demonstrating that tag X builds tag X.
+- [ ] Record implementation: workflow contract implemented in the current worktree; live
+  manual-dispatch verification pending after push.
+
+Acceptance criteria: all artifacts in a run are built from the same requested immutable ref
+and carry the same version.
+
+### P0.8 Clear the dependency audit failure
+
+- [x] Update `crossbeam-epoch` to `>= 0.9.20` through its dependency chain.
+- [x] Update the locked `quinn-proto` to `>= 0.11.15` or remove the unused optional graph.
+- [x] Review the `anyhow`, `paste`, and `proc-macro-error2` warnings and document upstream
+  disposition.
+- [x] Run `cargo audit` successfully.
+- [x] Record implementation: current worktree (commit pending); `cargo audit` passes with two
+  documented informational warnings.
+
+Audit disposition recorded 2026-07-10:
+
+| Advisory | Dependency path | Disposition | Revisit by |
+|---|---|---|---|
+| [`RUSTSEC-2026-0190`](https://rustsec.org/advisories/RUSTSEC-2026-0190) (`anyhow`) | direct and transitive | Fixed by locking and requiring `anyhow >= 1.0.103`. | Closed |
+| [`RUSTSEC-2024-0436`](https://rustsec.org/advisories/RUSTSEC-2024-0436) (`paste`) | `lofty 0.24.0 -> paste 1.0.15` | Informational/unmaintained, with no patched `paste` release. Track Lofty migration to a maintained replacement; no direct Tributary use. | 2026-10-10 or next release, whichever comes first |
+| [`RUSTSEC-2026-0173`](https://rustsec.org/advisories/RUSTSEC-2026-0173) (`proc-macro-error2`) | `sea-orm 1.1.20 -> sea-bae 0.2.1` | Informational/unmaintained compile-time macro dependency. Track SeaORM's removal or evaluate the SeaORM 2 migration. | 2026-10-10 or next release, whichever comes first |
+
+Acceptance criteria: the CI security-audit job passes with every remaining ignored advisory
+explicitly justified and time-bounded.
+
+## P1 — Correctness and security
+
+### P1.1 Add the real playlist-entry track foreign key
+
+- [ ] Rebuild `playlist_entries` with `track_id -> tracks(id) ON DELETE SET NULL`.
+- [ ] Null existing dangling IDs before enabling the constraint.
+- [ ] Reconcile newly orphaned entries after scans and watcher insertions.
+- [ ] Test delete, rename, re-add, and full rebuild behavior.
+- [ ] Record implementation: _pending_
+
+### P1.2 Preserve identity across filesystem renames
+
+- [ ] Treat paired file renames as transactional path updates.
+- [ ] Preserve UUID, `date_added`, play count, and playlist linkage.
+- [ ] Handle directory rename/removal by rescanning the affected subtree.
+- [ ] Define fallback behavior when rename pairing is unavailable.
+- [ ] Record implementation: _pending_
+
+### P1.3 Close the scan/watcher handoff gap
+
+- [ ] Install the watcher before initial enumeration.
+- [ ] Buffer and replay events generated during the scan.
+- [ ] Reconcile after watcher errors or overflow.
+- [ ] Use bounded/coalescing event delivery where appropriate.
+- [ ] Add race-oriented tests.
+- [ ] Record implementation: _pending_
+
+### P1.4 Enforce exact-origin authenticated redirects
+
+- [ ] Disable automatic `Referer` for every credential-bearing client.
+- [ ] Compare scheme, hostname, and effective port.
+- [ ] Forbid HTTPS-to-HTTP downgrade.
+- [ ] Apply the policy to API, stream, artwork, and DAAP clients.
+- [ ] Strip credential-bearing URLs from every retained/formatted error.
+- [ ] Stop logging raw DAAP session IDs and authenticated MPD commands.
+- [ ] Add redirect matrix tests using mock servers.
+- [ ] Record implementation: _pending_
+
+### P1.5 Enforce response limits while streaming
+
+- [ ] Replace `Content-Length`-only checks with counted streaming reads.
+- [ ] Apply caps to API JSON, DAAP, authentication, radio, and album-art responses.
+- [ ] Add overall deadlines in addition to idle timeouts.
+- [ ] Test missing, false, and oversized `Content-Length`, plus endless chunked bodies.
+- [ ] Record implementation: _pending_
+
+### P1.6 Stop exposing broad bearer tokens to receivers
+
+- [ ] Define an opaque short-lived media proxy/ticket design.
+- [ ] Keep backend credentials outside generic `Track` values.
+- [ ] Proxy or mint least-privilege URLs for Chromecast and MPD.
+- [ ] Expire/revoke proxy registrations when playback/session ends.
+- [ ] Threat-model spoofed and compromised LAN receivers.
+- [ ] Record implementation: _pending_
+
+### P1.7 Serialize Chromecast lifecycle and commands
+
+- [ ] Use one ordered worker/session for load, play, pause, seek, volume, and stop.
+- [ ] Check cancellation before each external side effect and emitted event.
+- [ ] Prevent stale loads from launching or replacing newer media.
+- [ ] Ensure every failure terminates in a coherent state, never Error then Buffering.
+- [ ] Add delayed-device and supersession tests.
+- [ ] Record implementation: _pending_
+
+### P1.8 Implement authoritative MPD state
+
+- [ ] Serialize MPD commands through one worker or persistent connection.
+- [ ] Emit Playing, Paused, Stopped, position, duration, and completion events.
+- [ ] Clear buffering timers on success and error.
+- [ ] Redact authenticated URLs from command logs.
+- [ ] Add fake-server tests including slow and reordered commands.
+- [ ] Record implementation: _pending_
+
+### P1.9 Prevent stale async source rendering
+
+- [ ] Attach a source key/generation to playlist, radio, and remote loads.
+- [ ] Cache completed results even when no longer active.
+- [ ] Render only if the requested source remains selected.
+- [ ] Reuse the active-key guard pattern already present in USB loading.
+- [ ] Add navigation-race tests.
+- [ ] Record implementation: _pending_
+
+## P2 — Resilience, data semantics, and packaging
+
+### P2.1 Correct smart-playlist semantics
+
+- [ ] Parse dates/timestamps instead of comparing strings.
+- [ ] Define date-only versus instant behavior and timezone rules.
+- [ ] Validate relative-date amounts and use checked arithmetic.
+- [ ] Select/truncate by limit criteria before applying final compound sort.
+- [ ] Implement snapshot behavior for `live_updating = false` or remove the option.
+- [ ] Add combined rule/limit/sort/date tests.
+- [ ] Record implementation: _pending_
+
+### P2.2 Make playlist import/export transactional and deterministic
+
+- [ ] Export through a sibling temporary file and atomic replacement.
+- [ ] Prefer an exact existing file path before metadata matching.
+- [ ] Enforce the documented duration tolerance and deterministic tie-breaking.
+- [ ] Return database errors rather than treating them as no-match.
+- [ ] Import playlist and entries in one transaction.
+- [ ] Preserve unmatched entries for later reconciliation.
+- [ ] Surface matched, unmatched, and failed counts.
+- [ ] Record implementation: _pending_
+
+### P2.3 Harden tag writes
+
+- [ ] Validate all numeric edits before copying or modifying a file.
+- [ ] Apply or remove the declared album-artist edit.
+- [ ] Use an exclusively created random sibling temp path.
+- [ ] Guarantee cleanup on every failure path.
+- [ ] Preserve permissions and define durability/fsync behavior accurately.
+- [ ] Add concurrent-write and injected-failure tests.
+- [ ] Record implementation: _pending_
+
+### P2.4 Make removable-media browsing safe and asynchronous
+
+- [ ] Disable symlink following during device scans.
+- [ ] Verify canonical descendants remain on the selected mount/device.
+- [ ] Move mount discovery and traversal off the GTK thread.
+- [ ] Use platform mount/volume APIs rather than directory heuristics.
+- [ ] Add malicious symlink, stale mount, and duplicate-device tests.
+- [ ] Record implementation: _pending_
+
+### P2.5 Repair Flatpak behavior and local build path
+
+- [ ] Put the pinned generator where local and CI builds both use it.
+- [ ] Generate `build-aux/flatpak/cargo-sources.json` consistently.
+- [ ] Define narrow USB/removable-media permissions or a portal workflow.
+- [ ] Define writable custom-library behavior for tag editing.
+- [ ] Run a local Flatpak build and smoke-test USB/custom-library behavior.
+- [ ] Record implementation: _pending_
+
+### P2.6 Synchronize packaging metadata
+
+- [ ] Fix RPM `Version`, `Source0`, and `%autosetup` naming.
+- [ ] Raise GTK runtime minimum to 4.16.
+- [ ] Raise libadwaita runtime minimum to 1.6.
+- [ ] Add `%U` or `%F` to the desktop `Exec` line.
+- [ ] Add the required `AudioVideo` desktop category.
+- [ ] Add the 0.5.0 AppStream release entry.
+- [ ] Update README Rust requirement from 1.80 to 1.85.
+- [ ] Add CI on the declared Rust 1.85 MSRV.
+- [ ] Record implementation: _pending_
+
+### P2.7 Fix platform cache paths
+
+- [ ] Store GStreamer registries in a per-user cache directory.
+- [ ] Avoid writes inside `/Applications` and Program Files.
+- [ ] Generate or patch the macOS pixbuf loader cache for the installed absolute bundle path.
+- [ ] Verify macOS signature integrity after first launch.
+- [ ] Record implementation: _pending_
+
+## P3 — Architecture and integration coverage
+
+### P3.1 Introduce a source/session registry
+
+- [ ] Define stable source IDs and backend-native track IDs.
+- [ ] Store `Arc<dyn MediaBackend>` or a deliberate session abstraction per source.
+- [ ] Remove long-lived authenticated URLs from the generic `Track` model.
+- [ ] Resolve playable URLs/tickets at playback time.
+- [ ] Centralize source refresh, cancellation, disconnect, and failure state.
+- [ ] Decide how local, radio, and external-file sources fit the same lifecycle.
+- [ ] Record architecture decision: _pending_
+- [ ] Record implementation: _pending_
+
+### P3.2 Make the backend abstraction real and stable
+
+- [ ] Construct and use `LocalBackend` through the same integration boundary.
+- [ ] Replace ephemeral album/artist UUIDs with stable identities.
+- [ ] Group local albums by a disambiguating key, not title alone.
+- [ ] Implement or remove unsupported trait methods.
+- [ ] Align README architecture claims with actual code.
+- [ ] Record implementation: _pending_
+
+### P3.3 Add network integration harnesses
+
+- [ ] Mock Subsonic, Jellyfin, Plex, DAAP, Radio-Browser, and geolocation services.
+- [ ] Cover auth, redirect, timeout, body cap, pagination, partial failure, and reverse-proxy
+  prefix behavior.
+- [ ] Cover DAAP malformed nested containers and session expiration.
+- [ ] Record implementation: _pending_
+
+### P3.4 Add UI/output integration harnesses
+
+- [ ] Cover GTK list-item recycling and stale callback prevention.
+- [ ] Cover playback-session behavior across sorting/filtering/navigation.
+- [ ] Cover output transfer and reselect semantics.
+- [ ] Cover fake MPD and delayed Chromecast state machines.
+- [ ] Cover stale album-art and source-result generations.
+- [ ] Add keyboard context-menu and slider accessibility checks.
+- [ ] Record implementation: _pending_
+
+### P3.5 Make coverage reporting representative
+
+- [ ] Stop excluding all UI, remote backends, migrations, desktop integration, and `main.rs`
+  from the only coverage report.
+- [ ] Split pure unit and integration coverage if platform constraints require it.
+- [ ] Establish a documented baseline and ratchet policy.
+- [ ] Record implementation: _pending_
+
+## Global validation gate
+
+Run before marking any milestone complete:
+
+- [x] `cargo fmt --all -- --check`
+- [x] `cargo clippy --all-targets -- -D warnings`
+- [x] `cargo clippy --release -- -D warnings`
+- [x] `cargo test --all-targets`
+- [x] `cargo test --release`
+- [x] `cargo audit`
+- [ ] `desktop-file-validate data/io.github.tributary.Tributary.desktop`
+- [x] `appstreamcli validate --no-net data/io.github.tributary.Tributary.metainfo.xml`
+- [x] Targeted migration upgrade tests
+- [x] Targeted mock-network tests
+- [x] Targeted GTK/output lifecycle tests
+- [ ] Packaging dry runs for affected targets
+- [x] Confirm `git diff --check` is clean
+
+`desktop-file-validate` still reports the pre-existing missing `AudioVideo` category tracked
+by P2.6. Packaging dry runs and the live manual release-workflow run remain outstanding.
+
+## Decisions
+
+Record scope or design decisions here so deferred work is explicit.
+
+- 2026-07-10 — Implemented P0.1, P0.3-P0.6, and P0.8 in the current worktree. P0.7's
+  workflow contract is implemented, but its live manual-dispatch acceptance test requires a
+  pushed ref and remains open.
+- 2026-07-10 — P0.2 now fails closed for incomplete traversal, unavailable/replaced roots,
+  nested mounts, mount-table failures, and ambiguous legacy databases. Legacy roots with
+  existing metadata are intentionally not made deletion-authoritative from content heuristics;
+  explicit trust UX and portable root-handle pinning keep P0.2 open.
+- 2026-07-10 — Linux mount IDs are treated as ephemeral traversal generations, never durable
+  volume identity. Stable root identity is persisted separately so a normal reboot or remount
+  does not silently replace the intended root.
+- 2026-07-10 — Output changes clear the active playback session; they do not attempt a
+  best-effort transfer between unlike output implementations.
+- 2026-07-10 — Generation filtering prevents stale receiver events from mutating Tributary.
+  Ordered Chromecast command side effects and authoritative MPD state remain P1.7 and P1.8.
+- 2026-07-10 — The remaining `cargo audit` warnings are unmaintained transitive dependencies,
+  not known vulnerabilities; their owners and 2026-10-10 review deadline are recorded under
+  P0.8.
+
+## Completed work log
+
+Add one line per completed task:
+
+| Date | Task | Commit/PR | Notes |
+|---|---|---|---|
+| 2026-07-10 | P0.1 | Current worktree | Transactional, deterministic, retry-safe migration with focused upgrade fixtures. |
+| 2026-07-10 | P0.3 | Current worktree | Owned DAAP registry, generation-safe sync, live URL resolution, and exactly-once shutdown. |
+| 2026-07-10 | P0.4 | Current worktree | Stable queue/session identity, generation-filtered events, and deterministic output reset. |
+| 2026-07-10 | P0.5 | Current worktree | One setup-time sidebar handler with current-item resolution and recycling tests. |
+| 2026-07-10 | P0.6 | Current worktree | Immutable release inputs and publication-only repository credentials. |
+| 2026-07-10 | P0.8 | Current worktree | Patched dependency graph and time-bounded informational advisory dispositions. |

--- a/docs/task.md
+++ b/docs/task.md
@@ -41,15 +41,20 @@ Acceptance criteria: upgrading a v0.5.0-style database always yields a unique co
 - [x] Skip stale deletion for any root whose traversal was incomplete.
 - [x] Correctly reconcile a healthy root containing zero audio files.
 - [x] Define and persist availability/mount identity for removable or network roots.
+- [x] Replace reboot/remount-sensitive legacy device identities with a versioned, root-owned
+  marker; create markers only on explicitly configured roots, convert only a still-matching
+  legacy root, and make the fresh marker-backed conversion scan non-destructive.
+- [x] Load persisted root authorization once per watcher batch, prefer the most-specific root,
+  and retain fail-closed invalidation for the rest of the batch.
 - [x] Add tests for missing, empty, permission-denied, partially unreadable, and overlapping
-  roots.
+  roots, plus marker corruption/duplication/conversion and watcher-cache invalidation.
 - [ ] Add an explicit trust/re-enrollment flow for roots inherited from a pre-identity database;
   content similarity is not accepted as proof of physical volume identity.
 - [ ] Pin reconciliation and watcher mutations to a root handle or equivalent mount generation
   on every supported platform; Linux has mount-instance guards, while portable Unix ABA
   resistance remains incomplete.
-- [ ] Record implementation: safety core is in the current worktree with 32 focused tests;
-  explicit legacy trust and portable root pinning remain open.
+- [x] Record implementation: safety core and review follow-ups are in PR #68 with 44 focused
+  tests; explicit legacy trust and portable root pinning remain open.
 
 Acceptance criteria: Tributary never deletes persisted track metadata based on an incomplete
 view of a library root, while intentional offline deletion is eventually reflected.
@@ -371,8 +376,14 @@ Record scope or design decisions here so deferred work is explicit.
   existing metadata are intentionally not made deletion-authoritative from content heuristics;
   explicit trust UX and portable root-handle pinning keep P0.2 open.
 - 2026-07-10 — Linux mount IDs are treated as ephemeral traversal generations, never durable
-  volume identity. Stable root identity is persisted separately so a normal reboot or remount
-  does not silently replace the intended root.
+  volume identity. Stable root identity is now a versioned marker stored on the library root,
+  so a normal reboot or remount does not silently replace the intended root. Duplicate,
+  malformed, oversized, symlink/reparse-point, and non-regular markers fail closed through a
+  bounded single-handle read; legacy conversion never indexes or deletes rows on its first
+  marker-backed scan.
+- 2026-07-11 — Watcher events share one deepest-root-first persisted authorization snapshot per
+  debounced batch. Root-marker control events and failed identity probes invalidate that
+  snapshot before database I/O, so later events in the batch remain fail closed.
 - 2026-07-10 — Output changes clear the active playback session; they do not attempt a
   best-effort transfer between unlike output implementations.
 - 2026-07-10 — Generation filtering prevents stale receiver events from mutating Tributary.

--- a/src/audio/airplay_output.rs
+++ b/src/audio/airplay_output.rs
@@ -37,10 +37,11 @@
 //! - **Seeking is not supported** for live RAOP streams.
 
 use std::process::Child;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use super::output::{AudioOutput, OutputType};
-use super::{PlayerEvent, PlayerState};
+use super::{PlayerEvent, PlayerEventGeneration, PlayerState};
 
 use gst::prelude::*;
 use gstreamer as gst;
@@ -75,6 +76,7 @@ pub struct AirPlayOutput {
     port: u16,
     /// Event sender for relaying state changes to the GTK main thread.
     event_tx: async_channel::Sender<PlayerEvent>,
+    event_generation: AtomicU64,
     /// Cached volume level (0.0–1.0).
     volume: f64,
     /// Active session, if any.  `Mutex` (not `RefCell`) because the
@@ -105,6 +107,7 @@ impl AirPlayOutput {
             host: host.to_string(),
             port,
             event_tx,
+            event_generation: AtomicU64::new(0),
             // Seed from the current slider value so switching to this device
             // doesn't reset the effective volume to maximum (0 dB) on the
             // first track load.
@@ -126,6 +129,10 @@ impl AirPlayOutput {
         self.session.lock().unwrap_or_else(|p| p.into_inner())
     }
 
+    fn event_generation(&self) -> PlayerEventGeneration {
+        PlayerEventGeneration::from_raw(self.event_generation.load(Ordering::SeqCst))
+    }
+
     /// Linear 0.0–1.0 volume → RAOP dB scale (-30.0 = quiet, 0.0 = max).
     fn volume_to_db(linear: f64) -> f64 {
         if linear <= 0.0 {
@@ -143,11 +150,12 @@ impl AirPlayOutput {
         let host = &self.host;
         let port = self.port;
         let volume = self.volume;
+        let generation = self.event_generation();
 
         // Try GStreamer raopsink first.
         match Self::build_raop_pipeline(host, port, uri, volume) {
             Ok(pipeline) => {
-                let bus_watch = self.attach_bus_watch(&pipeline)?;
+                let bus_watch = self.attach_bus_watch(&pipeline, generation)?;
                 pipeline
                     .set_state(gst::State::Paused)
                     .map_err(|e| format!("RAOP pipeline preroll failed: {e}"))?;
@@ -165,7 +173,7 @@ impl AirPlayOutput {
                 let (pipeline, sps_child, stdin_file) =
                     Self::build_shairport_pipeline(host, port, uri)
                         .map_err(|e2| format!("Both AirPlay paths failed: {e1}; {e2}"))?;
-                let bus_watch = self.attach_bus_watch(&pipeline)?;
+                let bus_watch = self.attach_bus_watch(&pipeline, generation)?;
                 pipeline
                     .set_state(gst::State::Paused)
                     .map_err(|e| format!("shairport-sync pipeline preroll failed: {e}"))?;
@@ -198,6 +206,7 @@ impl AirPlayOutput {
     fn attach_bus_watch(
         &self,
         pipeline: &gst::Pipeline,
+        generation: PlayerEventGeneration,
     ) -> Result<gst::bus::BusWatchGuard, String> {
         let bus = pipeline
             .bus()
@@ -208,7 +217,7 @@ impl AirPlayOutput {
             use gst::MessageView;
             match msg.view() {
                 MessageView::Eos(..) => {
-                    let _ = tx.try_send(PlayerEvent::TrackEnded);
+                    let _ = tx.try_send(PlayerEvent::ended(generation));
                 }
                 MessageView::Error(err) => {
                     error!(
@@ -216,7 +225,10 @@ impl AirPlayOutput {
                         debug = ?err.debug(),
                         "AirPlay pipeline error"
                     );
-                    let _ = tx.try_send(PlayerEvent::Error(format!("AirPlay: {}", err.error())));
+                    let _ = tx.try_send(PlayerEvent::error(
+                        generation,
+                        format!("AirPlay: {}", err.error()),
+                    ));
                 }
                 MessageView::StateChanged(s) => {
                     if let Some(pipeline) = pipeline_weak.upgrade() {
@@ -231,7 +243,7 @@ impl AirPlayOutput {
                                 gst::State::VoidPending => None,
                             };
                             if let Some(state) = mapped {
-                                let _ = tx.try_send(PlayerEvent::StateChanged(state));
+                                let _ = tx.try_send(PlayerEvent::state(generation, state));
                             }
                         }
                     }
@@ -396,22 +408,28 @@ impl AudioOutput for AirPlayOutput {
 
     fn load_uri(&self, uri: &str) {
         info!("AirPlay: loading URI");
+        let generation = self.event_generation();
         let _ = self
             .event_tx
-            .try_send(PlayerEvent::StateChanged(PlayerState::Buffering));
+            .try_send(PlayerEvent::state(generation, PlayerState::Buffering));
 
         if let Err(e) = self.open_session(uri) {
             error!(error = %e, "AirPlay: failed to open session");
-            let _ = self.event_tx.try_send(PlayerEvent::Error(e));
+            let _ = self.event_tx.try_send(PlayerEvent::error(generation, e));
             let _ = self
                 .event_tx
-                .try_send(PlayerEvent::StateChanged(PlayerState::Stopped));
+                .try_send(PlayerEvent::state(generation, PlayerState::Stopped));
         } else {
             // `open_session` only prerolls the pipeline to Paused; like every
             // other output, `load_uri` must actually start playback, so drive
             // it to Playing now that buffers are prerolled.
             self.set_pipeline_state(gst::State::Playing);
         }
+    }
+
+    fn set_event_generation(&self, generation: PlayerEventGeneration) {
+        self.event_generation
+            .store(generation.as_raw(), Ordering::SeqCst);
     }
 
     fn play(&self) {
@@ -427,9 +445,10 @@ impl AudioOutput for AirPlayOutput {
     fn stop(&self) {
         debug!("AirPlay: stop");
         self.close_session();
-        let _ = self
-            .event_tx
-            .try_send(PlayerEvent::StateChanged(PlayerState::Stopped));
+        let _ = self.event_tx.try_send(PlayerEvent::state(
+            self.event_generation(),
+            PlayerState::Stopped,
+        ));
     }
 
     fn toggle_play_pause(&self) {

--- a/src/audio/chromecast_output.rs
+++ b/src/audio/chromecast_output.rs
@@ -46,7 +46,7 @@ use std::sync::{Arc, Mutex};
 
 use super::cast_http_server::CastHttpServer;
 use super::output::{AudioOutput, OutputType};
-use super::{PlayerEvent, PlayerState};
+use super::{PlayerEvent, PlayerEventGeneration, PlayerState};
 
 use tracing::{debug, error, info, warn};
 
@@ -72,6 +72,8 @@ pub struct ChromecastOutput {
     port: u16,
     /// Event sender for relaying state changes to the GTK main thread.
     event_tx: async_channel::Sender<PlayerEvent>,
+    /// UI playback generation captured by each asynchronous Cast operation.
+    event_generation: AtomicU64,
     /// Cached volume level (0.0–1.0).
     volume: f64,
     /// Shared playback state — updated optimistically on commands and
@@ -113,6 +115,7 @@ impl ChromecastOutput {
             host: host.to_string(),
             port,
             event_tx,
+            event_generation: AtomicU64::new(0),
             // Seed from the current slider value so switching to this device
             // doesn't reset the effective volume to maximum.
             volume: initial_volume.clamp(0.0, 1.0),
@@ -136,6 +139,10 @@ impl ChromecastOutput {
     pub fn with_runtime(mut self, handle: tokio::runtime::Handle) -> Self {
         self.rt_handle = Some(handle);
         self
+    }
+
+    fn event_generation(&self) -> PlayerEventGeneration {
+        PlayerEventGeneration::from_raw(self.event_generation.load(Ordering::SeqCst))
     }
 
     /// Resolve a URI for Chromecast playback.
@@ -199,6 +206,7 @@ impl ChromecastOutput {
         let host = self.host.clone();
         let port = self.port;
         let tx = self.event_tx.clone();
+        let event_generation = self.event_generation();
         let volume = self.volume;
         let state = Arc::clone(&self.current_state);
 
@@ -213,7 +221,10 @@ impl ChromecastOutput {
             Ok(u) => u,
             Err(e) => {
                 error!(error = %e, "Failed to resolve URI for casting");
-                let _ = tx.try_send(PlayerEvent::Error(format!("Chromecast: {e}")));
+                let _ = tx.try_send(PlayerEvent::error(
+                    event_generation,
+                    format!("Chromecast: {e}"),
+                ));
                 return;
             }
         };
@@ -226,13 +237,17 @@ impl ChromecastOutput {
                 volume,
                 tx.clone(),
                 state.clone(),
+                event_generation,
                 &generation,
                 my_generation,
             ) {
                 Ok(()) => {}
                 Err(e) => {
                     error!(error = %e, "Chromecast: media load failed");
-                    let _ = tx.try_send(PlayerEvent::Error(format!("Chromecast: {e}")));
+                    let _ = tx.try_send(PlayerEvent::error(
+                        event_generation,
+                        format!("Chromecast: {e}"),
+                    ));
                     if let Ok(mut s) = state.lock() {
                         *s = PlayerState::Stopped;
                     }
@@ -251,6 +266,7 @@ impl ChromecastOutput {
         volume: f64,
         tx: async_channel::Sender<PlayerEvent>,
         state: Arc<Mutex<PlayerState>>,
+        event_generation: PlayerEventGeneration,
         generation: &AtomicU64,
         my_generation: u64,
     ) -> Result<(), String> {
@@ -348,7 +364,7 @@ impl ChromecastOutput {
         if let Ok(mut s) = state.lock() {
             *s = PlayerState::Playing;
         }
-        let _ = tx.try_send(PlayerEvent::StateChanged(PlayerState::Playing));
+        let _ = tx.try_send(PlayerEvent::state(event_generation, PlayerState::Playing));
 
         // ── Persistent connection: heartbeat + position polling ──────
         //
@@ -393,10 +409,11 @@ impl ChromecastOutput {
                                     .map(|d| (d as f64 * 1000.0) as u64)
                                     .unwrap_or(0);
 
-                                let _ = tx.try_send(PlayerEvent::PositionChanged {
+                                let _ = tx.try_send(PlayerEvent::position(
+                                    event_generation,
                                     position_ms,
                                     duration_ms,
-                                });
+                                ));
                             }
 
                             // Authoritative state from the device.
@@ -415,7 +432,8 @@ impl ChromecastOutput {
                                     prev
                                 };
                                 if prev != new_state {
-                                    let _ = tx.try_send(PlayerEvent::StateChanged(new_state));
+                                    let _ = tx
+                                        .try_send(PlayerEvent::state(event_generation, new_state));
                                 }
                             }
 
@@ -427,7 +445,7 @@ impl ChromecastOutput {
                                     if let Ok(mut s) = state.lock() {
                                         *s = PlayerState::Stopped;
                                     }
-                                    let _ = tx.try_send(PlayerEvent::TrackEnded);
+                                    let _ = tx.try_send(PlayerEvent::ended(event_generation));
                                     break;
                                 }
                                 Some(
@@ -439,8 +457,10 @@ impl ChromecastOutput {
                                     if let Ok(mut s) = state.lock() {
                                         *s = PlayerState::Stopped;
                                     }
-                                    let _ = tx
-                                        .try_send(PlayerEvent::StateChanged(PlayerState::Stopped));
+                                    let _ = tx.try_send(PlayerEvent::state(
+                                        event_generation,
+                                        PlayerState::Stopped,
+                                    ));
                                     break;
                                 }
                                 None => {
@@ -482,11 +502,12 @@ impl ChromecastOutput {
         let host = self.host.clone();
         let port = self.port;
         let tx = self.event_tx.clone();
+        let generation = self.event_generation();
 
         std::thread::spawn(move || {
             if let Err(e) = Self::send_cast_command_sync(&host, port, command) {
                 warn!(error = %e, "Chromecast: command failed");
-                let _ = tx.try_send(PlayerEvent::Error(format!("Chromecast: {e}")));
+                let _ = tx.try_send(PlayerEvent::error(generation, format!("Chromecast: {e}")));
             }
         });
     }
@@ -634,9 +655,15 @@ impl AudioOutput for ChromecastOutput {
         self.cast_media(uri);
 
         // Optimistically signal buffering.
-        let _ = self
-            .event_tx
-            .try_send(PlayerEvent::StateChanged(PlayerState::Buffering));
+        let _ = self.event_tx.try_send(PlayerEvent::state(
+            self.event_generation(),
+            PlayerState::Buffering,
+        ));
+    }
+
+    fn set_event_generation(&self, generation: PlayerEventGeneration) {
+        self.event_generation
+            .store(generation.as_raw(), Ordering::SeqCst);
     }
 
     fn play(&self) {
@@ -664,9 +691,10 @@ impl AudioOutput for ChromecastOutput {
             *s = PlayerState::Stopped;
         }
         self.send_cast_command(CastCommand::Stop);
-        let _ = self
-            .event_tx
-            .try_send(PlayerEvent::StateChanged(PlayerState::Stopped));
+        let _ = self.event_tx.try_send(PlayerEvent::state(
+            self.event_generation(),
+            PlayerState::Stopped,
+        ));
     }
 
     fn toggle_play_pause(&self) {
@@ -694,11 +722,15 @@ impl AudioOutput for ChromecastOutput {
         let port = self.port;
         let vol = self.volume;
         let tx = self.event_tx.clone();
+        let generation = self.event_generation();
 
         std::thread::spawn(move || {
             if let Err(e) = Self::send_cast_command_sync(&host, port, CastCommand::Volume(vol)) {
                 warn!(error = %e, "Chromecast: volume command failed");
-                let _ = tx.try_send(PlayerEvent::Error(format!("Chromecast volume: {e}")));
+                let _ = tx.try_send(PlayerEvent::error(
+                    generation,
+                    format!("Chromecast volume: {e}"),
+                ));
             }
         });
     }

--- a/src/audio/local_output.rs
+++ b/src/audio/local_output.rs
@@ -5,7 +5,7 @@
 //! the system's speakers or headphones via a GStreamer `playbin3` pipeline.
 
 use super::output::{AudioOutput, OutputType};
-use super::{Player, PlayerState};
+use super::{Player, PlayerEventGeneration, PlayerState};
 
 /// Local GStreamer output — delegates to the existing [`Player`].
 pub struct LocalOutput {
@@ -34,6 +34,10 @@ impl AudioOutput for LocalOutput {
 
     fn load_uri(&self, uri: &str) {
         self.player.load_uri(uri);
+    }
+
+    fn set_event_generation(&self, generation: PlayerEventGeneration) {
+        self.player.set_event_generation(generation);
     }
 
     fn play(&self) {

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -29,7 +29,7 @@ pub mod local_output;
 pub mod mpd_output;
 pub mod output;
 
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::time::Duration;
 
@@ -40,17 +40,84 @@ use tracing::{debug, error, info, warn};
 
 // ── Events ──────────────────────────────────────────────────────────────
 
-/// Events emitted by the player, delivered on the GTK main thread.
+/// Monotonic identity of the playback load that owns a [`PlayerEvent`].
+///
+/// Outputs capture this value when a URI is loaded (or an asynchronous command
+/// is started). The UI accepts an event only while the corresponding playback
+/// session generation is still current, so delayed EOS/state/error events from
+/// a superseded track or output cannot mutate the new session.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct PlayerEventGeneration(u64);
+
+impl PlayerEventGeneration {
+    pub(crate) fn next(self) -> Self {
+        Self(self.0.wrapping_add(1))
+    }
+
+    pub(crate) fn from_raw(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub(crate) fn as_raw(self) -> u64 {
+        self.0
+    }
+}
+
+/// Events emitted by an output, delivered on the GTK main thread.
 #[derive(Debug, Clone)]
 pub enum PlayerEvent {
     /// The pipeline transitioned to a new coarse state.
-    StateChanged(PlayerState),
+    StateChanged {
+        generation: PlayerEventGeneration,
+        state: PlayerState,
+    },
     /// Periodic position tick (values in milliseconds).
-    PositionChanged { position_ms: u64, duration_ms: u64 },
+    PositionChanged {
+        generation: PlayerEventGeneration,
+        position_ms: u64,
+        duration_ms: u64,
+    },
     /// The current stream reached its natural end.
-    TrackEnded,
+    TrackEnded { generation: PlayerEventGeneration },
     /// A pipeline error occurred.
-    Error(String),
+    Error {
+        generation: PlayerEventGeneration,
+        message: String,
+    },
+}
+
+impl PlayerEvent {
+    pub fn state(generation: PlayerEventGeneration, state: PlayerState) -> Self {
+        Self::StateChanged { generation, state }
+    }
+
+    pub fn position(generation: PlayerEventGeneration, position_ms: u64, duration_ms: u64) -> Self {
+        Self::PositionChanged {
+            generation,
+            position_ms,
+            duration_ms,
+        }
+    }
+
+    pub fn ended(generation: PlayerEventGeneration) -> Self {
+        Self::TrackEnded { generation }
+    }
+
+    pub fn error(generation: PlayerEventGeneration, message: impl Into<String>) -> Self {
+        Self::Error {
+            generation,
+            message: message.into(),
+        }
+    }
+
+    pub fn generation(&self) -> PlayerEventGeneration {
+        match self {
+            Self::StateChanged { generation, .. }
+            | Self::PositionChanged { generation, .. }
+            | Self::TrackEnded { generation }
+            | Self::Error { generation, .. } => *generation,
+        }
+    }
 }
 
 /// Coarse playback state visible to the rest of the application.
@@ -73,12 +140,16 @@ pub struct Player {
     playbin: gst::Element,
     volume: f64,
     event_tx: async_channel::Sender<PlayerEvent>,
+    /// Generation assigned by the playback session before each URI load.
+    event_generation: Rc<Cell<PlayerEventGeneration>>,
     /// Holds the latest volume awaiting a debounced disk write, or `None`
     /// when no write is scheduled.  Keeps slider-drag volume changes off
     /// the main-thread hot path (see [`Player::save_volume_debounced`]).
     volume_save_pending: Rc<Cell<Option<f64>>>,
-    /// Dropping this guard removes the bus watch — must stay alive.
-    _bus_watch: gst::bus::BusWatchGuard,
+    /// The watch is replaced on every URI load. Each watch captures that
+    /// load's generation, so even an already-queued message from the previous
+    /// pipeline incarnation remains identifiable as stale.
+    bus_watch: RefCell<Option<gst::bus::BusWatchGuard>>,
 }
 
 impl Player {
@@ -145,15 +216,16 @@ impl Player {
 
         let (event_tx, event_rx) = async_channel::unbounded();
 
-        let bus_watch = Self::attach_bus_watch(&playbin, &event_tx)?;
-        Self::start_position_timer(&playbin, &event_tx);
+        let event_generation = Rc::new(Cell::new(PlayerEventGeneration::default()));
+        Self::start_position_timer(&playbin, &event_tx, Rc::clone(&event_generation));
 
         let player = Self {
             playbin,
             volume,
             event_tx,
+            event_generation,
             volume_save_pending: Rc::new(Cell::new(None)),
-            _bus_watch: bus_watch,
+            bus_watch: RefCell::new(None),
         };
 
         Ok((player, event_rx))
@@ -167,17 +239,40 @@ impl Player {
     /// spinner while the pipeline transitions to `Playing`.
     pub fn load_uri(&self, uri: &str) {
         tracing::debug!("Loading track");
+        // Remove the previous generation's watch before driving that pipeline
+        // to NULL. Flush the bus during teardown as well: otherwise a queued
+        // EOS from the old URI could be consumed by the newly attached watch
+        // and inherit the new generation despite originating from the old
+        // pipeline incarnation.
+        self.bus_watch.borrow_mut().take();
+        if let Some(bus) = self.playbin.bus() {
+            bus.set_flushing(true);
+        }
         let _ = self.playbin.set_state(gst::State::Null);
         self.playbin.set_property("uri", uri);
         // Re-apply volume — the NULL transition resets it to 1.0.
         self.playbin
             .set_property("volume", slider_to_pipeline(self.volume));
+        if let Some(bus) = self.playbin.bus() {
+            bus.set_flushing(false);
+        }
 
         // Signal buffering immediately — the bus watch will send
         // `Playing` once the pipeline actually reaches that state.
+        let generation = self.event_generation.get();
+        match Self::attach_bus_watch(&self.playbin, &self.event_tx, generation) {
+            Ok(watch) => *self.bus_watch.borrow_mut() = Some(watch),
+            Err(error) => {
+                let _ = self
+                    .event_tx
+                    .try_send(PlayerEvent::error(generation, error.to_string()));
+                return;
+            }
+        }
+
         if let Err(e) = self
             .event_tx
-            .try_send(PlayerEvent::StateChanged(PlayerState::Buffering))
+            .try_send(PlayerEvent::state(generation, PlayerState::Buffering))
         {
             warn!(error = %e, "dropped Buffering event — UI consumer may be stalled");
         }
@@ -200,10 +295,17 @@ impl Player {
     /// Stop playback and reset the pipeline to NULL.
     pub fn stop(&self) {
         debug!("stop");
+        self.bus_watch.borrow_mut().take();
+        if let Some(bus) = self.playbin.bus() {
+            // Leave the idle bus flushing until the next load; the explicit
+            // scoped Stopped event below is the only stop notification needed.
+            bus.set_flushing(true);
+        }
         let _ = self.playbin.set_state(gst::State::Null);
+        let generation = self.event_generation.get();
         if let Err(e) = self
             .event_tx
-            .try_send(PlayerEvent::StateChanged(PlayerState::Stopped))
+            .try_send(PlayerEvent::state(generation, PlayerState::Stopped))
         {
             warn!(error = %e, "dropped Stopped event — UI consumer may be stalled");
         }
@@ -227,6 +329,11 @@ impl Player {
             gst::SeekFlags::FLUSH | gst::SeekFlags::KEY_UNIT,
             gst::ClockTime::from_mseconds(position_ms),
         );
+    }
+
+    /// Associate subsequently emitted events with a playback-session load.
+    pub fn set_event_generation(&self, generation: PlayerEventGeneration) {
+        self.event_generation.set(generation);
     }
 
     // ── Volume ──────────────────────────────────────────────────────
@@ -304,6 +411,7 @@ impl Player {
     fn attach_bus_watch(
         playbin: &gst::Element,
         event_tx: &async_channel::Sender<PlayerEvent>,
+        generation: PlayerEventGeneration,
     ) -> anyhow::Result<gst::bus::BusWatchGuard> {
         let bus = playbin
             .bus()
@@ -318,7 +426,7 @@ impl Player {
             match msg.view() {
                 MessageView::Eos(_) => {
                     info!("End of stream");
-                    if let Err(e) = tx.try_send(PlayerEvent::TrackEnded) {
+                    if let Err(e) = tx.try_send(PlayerEvent::ended(generation)) {
                         warn!(error = %e, "dropped TrackEnded event — UI consumer may be stalled");
                     }
                 }
@@ -330,7 +438,9 @@ impl Player {
                         debug = ?err.debug(),
                         "Pipeline error"
                     );
-                    if let Err(e) = tx.try_send(PlayerEvent::Error(err.error().to_string())) {
+                    if let Err(e) =
+                        tx.try_send(PlayerEvent::error(generation, err.error().to_string()))
+                    {
                         warn!(error = %e, "dropped Error event — UI consumer may be stalled");
                     }
                 }
@@ -352,7 +462,7 @@ impl Player {
                             pending = ?sc.pending(),
                             "Pipeline state changed"
                         );
-                        let _ = tx.try_send(PlayerEvent::StateChanged(new_state));
+                        let _ = tx.try_send(PlayerEvent::state(generation, new_state));
                     }
                 }
 
@@ -360,7 +470,7 @@ impl Player {
                     let percent = buffering.percent();
                     debug!(percent, "Buffering");
                     if percent < 100 {
-                        let _ = tx.try_send(PlayerEvent::StateChanged(PlayerState::Buffering));
+                        let _ = tx.try_send(PlayerEvent::state(generation, PlayerState::Buffering));
                     }
                     // When buffering reaches 100%, GStreamer will emit a
                     // StateChanged → Playing message, so we don't need to
@@ -381,7 +491,11 @@ impl Player {
     /// playing and sends [`PlayerEvent::PositionChanged`].
     ///
     /// The timer self-cancels when the playbin is dropped (weak ref).
-    fn start_position_timer(playbin: &gst::Element, event_tx: &async_channel::Sender<PlayerEvent>) {
+    fn start_position_timer(
+        playbin: &gst::Element,
+        event_tx: &async_channel::Sender<PlayerEvent>,
+        event_generation: Rc<Cell<PlayerEventGeneration>>,
+    ) {
         let playbin_weak = playbin.downgrade();
         let tx = event_tx.clone();
 
@@ -401,10 +515,11 @@ impl Player {
                         .query_duration::<gst::ClockTime>()
                         .map(|d| d.mseconds())
                         .unwrap_or(0);
-                    let _ = tx.try_send(PlayerEvent::PositionChanged {
-                        position_ms: pos.mseconds(),
-                        duration_ms: dur,
-                    });
+                    let _ = tx.try_send(PlayerEvent::position(
+                        event_generation.get(),
+                        pos.mseconds(),
+                        dur,
+                    ));
                 }
             }
 

--- a/src/audio/mpd_output.rs
+++ b/src/audio/mpd_output.rs
@@ -30,12 +30,13 @@
 
 use std::io::{BufRead, BufReader, Write};
 use std::net::{TcpStream, ToSocketAddrs};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use tracing::{debug, error, info, warn};
 
 use super::output::{AudioOutput, OutputType};
-use super::{PlayerEvent, PlayerState};
+use super::{PlayerEvent, PlayerEventGeneration, PlayerState};
 
 /// Timeout for TCP connect and individual read/write operations.
 const TCP_TIMEOUT: Duration = Duration::from_secs(5);
@@ -52,6 +53,7 @@ pub struct MpdOutput {
     port: u16,
     /// Event sender for relaying state changes to the GTK main thread.
     event_tx: async_channel::Sender<PlayerEvent>,
+    event_generation: AtomicU64,
     /// Cached volume level (0.0–1.0).  MPD manages its own volume,
     /// so this is only used to satisfy the `AudioOutput::volume()` query.
     volume: f64,
@@ -74,6 +76,7 @@ impl MpdOutput {
             host: host.to_string(),
             port,
             event_tx,
+            event_generation: AtomicU64::new(0),
             volume: 1.0,
         }
     }
@@ -123,13 +126,18 @@ impl MpdOutput {
         let port = self.port;
         let cmds = commands.to_string();
         let tx = self.event_tx.clone();
+        let generation = self.event_generation();
 
         std::thread::spawn(move || {
             if let Err(e) = Self::send_commands_sync(&host, port, &cmds) {
                 error!(error = %e, "MPD command failed");
-                let _ = tx.try_send(PlayerEvent::Error(format!("MPD: {e}")));
+                let _ = tx.try_send(PlayerEvent::error(generation, format!("MPD: {e}")));
             }
         });
+    }
+
+    fn event_generation(&self) -> PlayerEventGeneration {
+        PlayerEventGeneration::from_raw(self.event_generation.load(Ordering::SeqCst))
     }
 
     /// Synchronous command sender (runs on background thread).
@@ -249,9 +257,15 @@ impl AudioOutput for MpdOutput {
 
         // Optimistically signal buffering — the UI will update when
         // position ticks arrive (or an error is reported).
-        let _ = self
-            .event_tx
-            .try_send(PlayerEvent::StateChanged(PlayerState::Buffering));
+        let _ = self.event_tx.try_send(PlayerEvent::state(
+            self.event_generation(),
+            PlayerState::Buffering,
+        ));
+    }
+
+    fn set_event_generation(&self, generation: PlayerEventGeneration) {
+        self.event_generation
+            .store(generation.as_raw(), Ordering::SeqCst);
     }
 
     fn play(&self) {
@@ -264,9 +278,10 @@ impl AudioOutput for MpdOutput {
 
     fn stop(&self) {
         self.send_commands("stop");
-        let _ = self
-            .event_tx
-            .try_send(PlayerEvent::StateChanged(PlayerState::Stopped));
+        let _ = self.event_tx.try_send(PlayerEvent::state(
+            self.event_generation(),
+            PlayerState::Stopped,
+        ));
     }
 
     fn toggle_play_pause(&self) {

--- a/src/audio/output.rs
+++ b/src/audio/output.rs
@@ -28,7 +28,7 @@
 //! (local, Subsonic, Jellyfin, Plex, DAAP, radio) are managed by the
 //! sidebar and are completely independent of the active output.
 
-use super::PlayerState;
+use super::{PlayerEventGeneration, PlayerState};
 
 /// Identifies the type of an audio output for UI purposes (icon, label).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -73,6 +73,13 @@ pub trait AudioOutput {
     ///
     /// `uri` may be a `file:///…` path or an `http(s)://…` stream URL.
     fn load_uri(&self, uri: &str);
+
+    /// Tag subsequent events with the playback load that owns them.
+    ///
+    /// The UI calls this immediately before `load_uri`. Implementations must
+    /// capture the current value when starting asynchronous work rather than
+    /// reading it only when that work eventually emits an event.
+    fn set_event_generation(&self, generation: PlayerEventGeneration);
 
     /// Resume playback from a paused state.
     fn play(&self);

--- a/src/daap/backend.rs
+++ b/src/daap/backend.rs
@@ -2,13 +2,15 @@
 //!
 //! All metadata is held in memory — nothing touches the local SQLite DB.
 //! The full library is fetched during [`DaapBackend::connect`] and
-//! cached for fast browsing.  Streaming URLs include the DAAP session-id
-//! so GStreamer can fetch audio directly.
+//! cached for fast browsing. Cached tracks contain credential-free
+//! `daap://` references; the live retained session resolves those to
+//! authenticated HTTP URLs immediately before media is consumed.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU8, Ordering};
 
 use async_trait::async_trait;
-use tokio::sync::RwLock;
+use tokio::sync::{Notify, RwLock};
 use tracing::info;
 use url::Url;
 use uuid::Uuid;
@@ -31,9 +33,8 @@ struct LibraryCache {
     artists: Vec<Artist>,
     /// Tributary UUID → index in `tracks`.
     track_by_uuid: HashMap<Uuid, usize>,
-    /// DAAP item ID → Tributary UUID.
-    #[allow(dead_code)]
-    daap_id_to_uuid: HashMap<u32, Uuid>,
+    /// Tributary UUID → DAAP item ID.
+    track_to_daap_id: HashMap<Uuid, u32>,
 }
 
 impl LibraryCache {
@@ -43,7 +44,7 @@ impl LibraryCache {
             albums: Vec::new(),
             artists: Vec::new(),
             track_by_uuid: HashMap::new(),
-            daap_id_to_uuid: HashMap::new(),
+            track_to_daap_id: HashMap::new(),
         }
     }
 }
@@ -60,6 +61,20 @@ pub struct DaapBackend {
     display_name: String,
     client: DaapClient,
     cache: RwLock<LibraryCache>,
+    /// Opaque identifier embedded in UI-facing `daap://` media references.
+    /// It identifies this live session without exposing the bearer session ID.
+    session_key: Uuid,
+    /// Shared exactly-once state for explicit disconnect and controlled shutdown.
+    disconnect: std::sync::Arc<DisconnectLifecycle>,
+}
+
+const SESSION_CONNECTED: u8 = 0;
+const SESSION_DISCONNECTING: u8 = 1;
+const SESSION_DISCONNECTED: u8 = 2;
+
+struct DisconnectLifecycle {
+    state: AtomicU8,
+    complete: Notify,
 }
 
 impl DaapBackend {
@@ -81,9 +96,19 @@ impl DaapBackend {
             display_name: name.to_string(),
             client,
             cache: RwLock::new(LibraryCache::empty()),
+            session_key: Uuid::new_v4(),
+            disconnect: std::sync::Arc::new(DisconnectLifecycle {
+                state: AtomicU8::new(SESSION_CONNECTED),
+                complete: Notify::new(),
+            }),
         };
 
-        backend.refresh_library().await?;
+        if let Err(error) = backend.refresh_library().await {
+            // The handshake already created a server-side session. A failed
+            // initial sync has no owner to close it later, so do that here.
+            backend.disconnect().await;
+            return Err(error);
+        }
 
         Ok(backend)
     }
@@ -96,7 +121,7 @@ impl DaapBackend {
 
         let mut all_tracks = Vec::new();
         let mut track_by_uuid = HashMap::new();
-        let mut daap_id_to_uuid = HashMap::new();
+        let mut track_to_daap_id = HashMap::new();
 
         // Aggregation maps for artists and albums.
         // Key: name (lowercased for dedup), Value: (display_name, metadata).
@@ -132,8 +157,11 @@ impl DaapBackend {
             let artist_uuid = deterministic_uuid_from_name(&artist_name);
             let album_uuid = deterministic_uuid_from_name(&album_title);
 
-            let stream_url = self.client.stream_url(daap_id, &format);
-            let cover_art_url = self.client.cover_art_url(daap_id);
+            // Keep the session bearer credential out of long-lived UI model
+            // values. These opaque references are resolved through the live
+            // retained backend immediately before playback/artwork fetch.
+            let stream_url = self.media_reference_url("stream", daap_id, Some(&format));
+            let cover_art_url = self.media_reference_url("artwork", daap_id, None);
 
             let duration_secs = duration_ms.map(|ms| u64::from(ms) / 1000);
 
@@ -163,7 +191,7 @@ impl DaapBackend {
 
             let idx = all_tracks.len();
             track_by_uuid.insert(track_uuid, idx);
-            daap_id_to_uuid.insert(daap_id, track_uuid);
+            track_to_daap_id.insert(track_uuid, daap_id);
             all_tracks.push(track);
 
             // ── Aggregate artist ────────────────────────────────────
@@ -236,30 +264,95 @@ impl DaapBackend {
             albums: all_albums,
             artists: all_artists,
             track_by_uuid,
-            daap_id_to_uuid,
+            track_to_daap_id,
         };
 
         Ok(())
     }
 
     /// Return all tracks from the cache as Tributary `Track` models.
-    /// Used by the integration layer to send a RemoteSync to the UI.
+    /// Used by the integration layer to send a generation-scoped sync to the UI.
     pub async fn all_tracks(&self) -> Vec<Track> {
         self.cache.read().await.tracks.clone()
     }
 
-    /// Send a best-effort logout to the DAAP server.
-    pub async fn disconnect(&self) {
-        self.client.logout().await;
+    /// Send one best-effort logout request to the DAAP server.
+    ///
+    /// Returns `true` only for the owner that initiated shutdown. Repeated
+    /// explicit disconnects and shutdown races wait for that owner and then
+    /// return `false` without issuing another request.
+    pub async fn disconnect(&self) -> bool {
+        let owns_logout = self
+            .disconnect
+            .state
+            .compare_exchange(
+                SESSION_CONNECTED,
+                SESSION_DISCONNECTING,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok();
+
+        if owns_logout {
+            // Detach the request from this caller so cancellation cannot leave
+            // the session permanently stuck in DISCONNECTING. The shared
+            // lifecycle remains owned by the task and all waiters.
+            let client = self.client.clone();
+            let disconnect = std::sync::Arc::clone(&self.disconnect);
+            tokio::spawn(async move {
+                client.logout().await;
+                disconnect
+                    .state
+                    .store(SESSION_DISCONNECTED, Ordering::Release);
+                disconnect.complete.notify_waiters();
+            });
+        }
+
+        loop {
+            let completion = self.disconnect.complete.notified();
+            tokio::pin!(completion);
+            completion.as_mut().enable();
+            if self.disconnect.state.load(Ordering::Acquire) == SESSION_DISCONNECTED {
+                return owns_logout;
+            }
+            completion.await;
+        }
     }
 
-    /// Build the logout URL for this session (used by the eject button).
-    pub fn logout_url(&self) -> String {
-        format!(
-            "{}/logout?session-id={}",
-            self.client.base_url().as_str().trim_end_matches('/'),
-            self.client.session_id()
-        )
+    /// Opaque key identifying this particular live session.
+    pub(super) fn session_key(&self) -> Uuid {
+        self.session_key
+    }
+
+    /// Resolve one stream URL from the current live session.
+    pub(super) fn stream_url_for_item(&self, song_id: u32, format: &str) -> BackendResult<Url> {
+        self.ensure_connected()?;
+        Ok(self.client.stream_url(song_id, format))
+    }
+
+    /// Resolve one artwork URL from the current live session.
+    pub(super) fn artwork_url_for_item(&self, song_id: u32) -> BackendResult<Url> {
+        self.ensure_connected()?;
+        Ok(self.client.cover_art_url(song_id))
+    }
+
+    fn ensure_connected(&self) -> BackendResult<()> {
+        if self.disconnect.state.load(Ordering::Acquire) != SESSION_CONNECTED {
+            return Err(BackendError::ConnectionFailed {
+                message: "DAAP source is disconnected".to_string(),
+                source: None,
+            });
+        }
+        Ok(())
+    }
+
+    fn media_reference_url(&self, kind: &str, song_id: u32, format: Option<&str>) -> Url {
+        let mut url = Url::parse(&format!("daap://{}/{kind}/{song_id}", self.session_key))
+            .expect("DAAP media reference components are always valid");
+        if let Some(format) = format {
+            url.query_pairs_mut().append_pair("format", format);
+        }
+        url
     }
 }
 
@@ -392,21 +485,22 @@ impl crate::architecture::MediaBackend for DaapBackend {
 
     async fn get_stream_url(&self, track_id: &Uuid) -> BackendResult<Url> {
         let cache = self.cache.read().await;
-        let idx = cache
-            .track_by_uuid
-            .get(track_id)
-            .ok_or_else(|| BackendError::NotFound {
-                entity_type: "track".into(),
-                id: *track_id,
-            })?;
-        let track = &cache.tracks[*idx];
-        track.stream_url.clone().ok_or_else(|| {
-            BackendError::Internal(anyhow::anyhow!("Track {} has no stream URL", track_id))
-        })
+        let song_id =
+            cache
+                .track_to_daap_id
+                .get(track_id)
+                .ok_or_else(|| BackendError::NotFound {
+                    entity_type: "track".into(),
+                    id: *track_id,
+                })?;
+        let idx = cache.track_by_uuid[track_id];
+        let format = cache.tracks[idx].format.as_deref().unwrap_or("mp3");
+        self.stream_url_for_item(*song_id, format)
     }
 
     async fn get_cover_art(&self, _album_id: &Uuid) -> BackendResult<Option<Url>> {
-        // DAAP cover art requires a separate endpoint; deferred to a future phase.
+        // DAAP artwork is item-scoped rather than album-scoped. Track models
+        // carry an opaque item reference that playback resolves live.
         Ok(None)
     }
 
@@ -420,26 +514,6 @@ impl crate::architecture::MediaBackend for DaapBackend {
             total_artists: cache.artists.len() as u64,
             total_duration_secs: total_duration,
         })
-    }
-}
-
-// ── Drop: best-effort logout ────────────────────────────────────────────
-
-impl Drop for DaapBackend {
-    fn drop(&mut self) {
-        let url = format!(
-            "{}/logout?session-id={}",
-            self.client.base_url().as_str().trim_end_matches('/'),
-            self.client.session_id()
-        );
-        let http = self.client.http_clone();
-        // Guard against missing runtime — during process shutdown the
-        // tokio runtime may already be dropped.
-        if let Ok(handle) = tokio::runtime::Handle::try_current() {
-            handle.spawn(async move {
-                let _ = http.get(&url).send().await;
-            });
-        }
     }
 }
 

--- a/src/daap/client.rs
+++ b/src/daap/client.rs
@@ -55,6 +55,7 @@ daap.songyear,daap.songformat,daap.songbitrate,daap.songsamplerate,\
 daap.songdatemodified";
 
 /// Holds DAAP session state and a reusable `reqwest::Client`.
+#[derive(Clone)]
 pub struct DaapClient {
     base_url: Url,
     session_id: u32,
@@ -396,7 +397,13 @@ impl DaapClient {
             self.base_url.as_str().trim_end_matches('/'),
             self.session_id
         );
-        match self.http.get(&url).send().await {
+        match self
+            .http
+            .get(&url)
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+        {
             // lgtm[rs/cleartext-transmission] DAAP uses plaintext HTTP by design.
             Ok(_) => info!("DAAP logout OK"),
             Err(e) => warn!(error = %e, "DAAP logout failed (best-effort)"),

--- a/src/daap/mod.rs
+++ b/src/daap/mod.rs
@@ -22,5 +22,10 @@
 pub mod backend;
 pub mod client;
 pub mod dmap;
+pub mod session;
 
 pub use backend::DaapBackend;
+pub use session::{
+    begin_connect, begin_shutdown, is_current_session, release_source, resolve_media_url,
+    shutdown_all,
+};

--- a/src/daap/session.rs
+++ b/src/daap/session.rs
@@ -1,0 +1,895 @@
+//! Ownership registry for live DAAP sessions.
+//!
+//! DAAP is stateful: media URLs remain authorized only while the backend
+//! that owns the login session is alive. The UI retains connected backends
+//! here and stores credential-free `daap://` references in its track models.
+//! Those references are resolved to authenticated HTTP URLs only when media
+//! is about to be consumed.
+
+use std::collections::{HashMap, HashSet};
+use std::ops::Deref;
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
+
+use futures::future::join_all;
+use tokio::sync::Notify;
+use url::Url;
+use uuid::Uuid;
+
+use crate::architecture::backend::BackendResult;
+use crate::architecture::error::BackendError;
+
+use super::DaapBackend;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum RegistryGate {
+    #[default]
+    Running,
+    ShuttingDown,
+    ShutDown,
+}
+
+struct ActiveSession {
+    generation: u64,
+    backend: Arc<DaapBackend>,
+}
+
+#[derive(Default)]
+struct SessionRegistry {
+    gate: RegistryGate,
+    next_generation: u64,
+    latest_generation: HashMap<String, u64>,
+    pending_attempts: HashSet<(String, u64)>,
+    by_source: HashMap<String, ActiveSession>,
+    by_session: HashMap<Uuid, Arc<DaapBackend>>,
+    /// Backends displaced or released but not yet fully logged out. Keeping
+    /// ownership here lets controlled shutdown join every in-flight logout.
+    retiring: HashMap<Uuid, Arc<DaapBackend>>,
+}
+
+fn registry() -> &'static Mutex<SessionRegistry> {
+    static REGISTRY: OnceLock<Mutex<SessionRegistry>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(SessionRegistry::default()))
+}
+
+fn registry_notify() -> &'static Notify {
+    static NOTIFY: OnceLock<Notify> = OnceLock::new();
+    NOTIFY.get_or_init(Notify::new)
+}
+
+fn lock_registry() -> MutexGuard<'static, SessionRegistry> {
+    registry()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// A generation-scoped connection attempt registered before network I/O.
+/// Shutdown waits for every live attempt to finish or be dropped.
+pub struct ConnectionAttempt {
+    source_key: String,
+    generation: u64,
+    completed: bool,
+}
+
+impl ConnectionAttempt {
+    /// Whether this remains the newest allowed attempt for its source.
+    pub fn is_latest(&self) -> bool {
+        let sessions = lock_registry();
+        sessions.gate == RegistryGate::Running
+            && sessions.latest_generation.get(&self.source_key) == Some(&self.generation)
+    }
+
+    /// Install the connected backend only if this attempt remains current.
+    /// Displaced and rejected backends are logged out before this returns.
+    pub async fn retain(mut self, backend: DaapBackend) -> Option<RetainedSession> {
+        let backend = Arc::new(backend);
+        let session_key = backend.session_key();
+
+        let (accepted, replaced) = {
+            let mut sessions = lock_registry();
+            sessions
+                .pending_attempts
+                .remove(&(self.source_key.clone(), self.generation));
+            self.completed = true;
+
+            let accepted = sessions.gate == RegistryGate::Running
+                && sessions.latest_generation.get(&self.source_key) == Some(&self.generation);
+
+            if accepted {
+                let replaced = sessions.by_source.insert(
+                    self.source_key.clone(),
+                    ActiveSession {
+                        generation: self.generation,
+                        backend: Arc::clone(&backend),
+                    },
+                );
+                if let Some(previous) = &replaced {
+                    sessions.by_session.remove(&previous.backend.session_key());
+                    sessions.retiring.insert(
+                        previous.backend.session_key(),
+                        Arc::clone(&previous.backend),
+                    );
+                }
+                sessions
+                    .by_session
+                    .insert(session_key, Arc::clone(&backend));
+                (true, replaced.map(|entry| entry.backend))
+            } else {
+                sessions.retiring.insert(session_key, Arc::clone(&backend));
+                (false, None)
+            }
+        };
+        registry_notify().notify_waiters();
+
+        if let Some(previous) = replaced {
+            disconnect_tracked(previous).await;
+        }
+
+        if !accepted {
+            disconnect_tracked(backend).await;
+            return None;
+        }
+
+        Some(RetainedSession {
+            source_key: self.source_key.clone(),
+            generation: self.generation,
+            session_key,
+            backend,
+        })
+    }
+}
+
+impl Drop for ConnectionAttempt {
+    fn drop(&mut self) {
+        if self.completed {
+            return;
+        }
+        let mut sessions = lock_registry();
+        sessions
+            .pending_attempts
+            .remove(&(self.source_key.clone(), self.generation));
+        if sessions.gate == RegistryGate::Running
+            && sessions.latest_generation.get(&self.source_key) == Some(&self.generation)
+        {
+            if let Some(active_generation) = sessions
+                .by_source
+                .get(&self.source_key)
+                .map(|entry| entry.generation)
+            {
+                sessions
+                    .latest_generation
+                    .insert(self.source_key.clone(), active_generation);
+            } else {
+                sessions.latest_generation.remove(&self.source_key);
+            }
+        }
+        drop(sessions);
+        registry_notify().notify_waiters();
+    }
+}
+
+/// A retained backend plus the generation needed to validate queued UI work.
+#[derive(Clone)]
+pub struct RetainedSession {
+    source_key: String,
+    generation: u64,
+    session_key: Uuid,
+    backend: Arc<DaapBackend>,
+}
+
+impl RetainedSession {
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    pub fn session_key(&self) -> Uuid {
+        self.session_key
+    }
+
+    pub fn is_current(&self) -> bool {
+        is_current_session(&self.source_key, self.generation, self.session_key)
+    }
+}
+
+impl Deref for RetainedSession {
+    type Target = DaapBackend;
+
+    fn deref(&self) -> &Self::Target {
+        &self.backend
+    }
+}
+
+/// Ownership transferred out of the active source map. The registry keeps a
+/// second reference until [`ReleasedSession::disconnect`] or shutdown joins it.
+pub struct ReleasedSession {
+    backend: Arc<DaapBackend>,
+}
+
+impl ReleasedSession {
+    pub async fn disconnect(self) -> bool {
+        disconnect_tracked(self.backend).await
+    }
+}
+
+/// Register an attempt before starting the DAAP handshake. Returns `None`
+/// after controlled shutdown has closed the connection gate.
+pub fn begin_connect(source_key: String) -> Option<ConnectionAttempt> {
+    let generation = {
+        let mut sessions = lock_registry();
+        if sessions.gate != RegistryGate::Running {
+            return None;
+        }
+        sessions.next_generation = sessions.next_generation.wrapping_add(1).max(1);
+        let generation = sessions.next_generation;
+        sessions
+            .latest_generation
+            .insert(source_key.clone(), generation);
+        sessions
+            .pending_attempts
+            .insert((source_key.clone(), generation));
+        generation
+    };
+    registry_notify().notify_waiters();
+    Some(ConnectionAttempt {
+        source_key,
+        generation,
+        completed: false,
+    })
+}
+
+/// Invalidate pending attempts and transfer an active source into registry-
+/// owned retirement before scheduling its logout.
+pub fn release_source(source_key: &str) -> Option<ReleasedSession> {
+    let backend = {
+        let mut sessions = lock_registry();
+        sessions.latest_generation.remove(source_key);
+        let entry = sessions.by_source.remove(source_key)?;
+        sessions.by_session.remove(&entry.backend.session_key());
+        sessions
+            .retiring
+            .insert(entry.backend.session_key(), Arc::clone(&entry.backend));
+        entry.backend
+    };
+    registry_notify().notify_waiters();
+    Some(ReleasedSession { backend })
+}
+
+/// Verify that a queued DAAP sync still belongs to the current source owner.
+pub fn is_current_session(source_key: &str, generation: u64, session_key: Uuid) -> bool {
+    let sessions = lock_registry();
+    if sessions.gate != RegistryGate::Running {
+        return false;
+    }
+    sessions.latest_generation.get(source_key) == Some(&generation)
+        && sessions.by_source.get(source_key).is_some_and(|entry| {
+            entry.generation == generation && entry.backend.session_key() == session_key
+        })
+}
+
+/// Close the registry gate synchronously so no connection can begin or become
+/// active after the GTK close callback schedules asynchronous shutdown.
+pub fn begin_shutdown() {
+    let changed = {
+        let mut sessions = lock_registry();
+        if sessions.gate != RegistryGate::Running {
+            false
+        } else {
+            sessions.gate = RegistryGate::ShuttingDown;
+            sessions.latest_generation.clear();
+            sessions.by_session.clear();
+            let active = std::mem::take(&mut sessions.by_source);
+            for entry in active.into_values() {
+                sessions
+                    .retiring
+                    .insert(entry.backend.session_key(), entry.backend);
+            }
+            true
+        }
+    };
+    if changed {
+        registry_notify().notify_waiters();
+    }
+}
+
+/// Explicitly close every active, retiring, and in-flight connection during
+/// controlled shutdown. This does not return until registry ownership is empty.
+pub async fn shutdown_all() {
+    begin_shutdown();
+
+    loop {
+        let changed = registry_notify().notified();
+        tokio::pin!(changed);
+        changed.as_mut().enable();
+        let (pending, backends) = {
+            let sessions = lock_registry();
+            (
+                sessions.pending_attempts.len(),
+                sessions.retiring.values().cloned().collect::<Vec<_>>(),
+            )
+        };
+
+        if pending == 0 && backends.is_empty() {
+            lock_registry().gate = RegistryGate::ShutDown;
+            registry_notify().notify_waiters();
+            return;
+        }
+
+        if backends.is_empty() {
+            changed.await;
+            continue;
+        }
+
+        join_all(backends.iter().map(|backend| backend.disconnect())).await;
+        {
+            let mut sessions = lock_registry();
+            for backend in &backends {
+                sessions.retiring.remove(&backend.session_key());
+            }
+        }
+        registry_notify().notify_waiters();
+    }
+}
+
+async fn disconnect_tracked(backend: Arc<DaapBackend>) -> bool {
+    let disconnected = backend.disconnect().await;
+    lock_registry().retiring.remove(&backend.session_key());
+    registry_notify().notify_waiters();
+    disconnected
+}
+
+/// Resolve a credential-free DAAP media reference through its retained live
+/// session. Non-DAAP URLs are returned as `None` so callers can pass them
+/// through unchanged.
+pub fn resolve_media_url(reference: &Url) -> BackendResult<Option<Url>> {
+    if reference.scheme() != "daap" {
+        return Ok(None);
+    }
+
+    let session_key = reference
+        .host_str()
+        .ok_or_else(|| invalid_reference("missing session key"))?
+        .parse::<Uuid>()
+        .map_err(|_| invalid_reference("invalid session key"))?;
+
+    let mut segments = reference
+        .path_segments()
+        .ok_or_else(|| invalid_reference("missing media path"))?;
+    let kind = segments
+        .next()
+        .ok_or_else(|| invalid_reference("missing media kind"))?;
+    let song_id = segments
+        .next()
+        .ok_or_else(|| invalid_reference("missing item ID"))?
+        .parse::<u32>()
+        .map_err(|_| invalid_reference("invalid item ID"))?;
+    if segments.next().is_some() {
+        return Err(invalid_reference("unexpected media path component"));
+    }
+
+    let backend = lock_registry()
+        .by_session
+        .get(&session_key)
+        .cloned()
+        .ok_or_else(|| BackendError::ConnectionFailed {
+            message: "DAAP source is no longer connected".to_string(),
+            source: None,
+        })?;
+
+    match kind {
+        "stream" => {
+            let format = reference
+                .query_pairs()
+                .find_map(|(key, value)| (key == "format").then(|| value.into_owned()))
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| invalid_reference("missing stream format"))?;
+            backend.stream_url_for_item(song_id, &format).map(Some)
+        }
+        "artwork" => backend.artwork_url_for_item(song_id).map(Some),
+        _ => Err(invalid_reference("unknown media kind")),
+    }
+}
+
+fn invalid_reference(detail: &str) -> BackendError {
+    BackendError::ParseError {
+        message: format!("Invalid DAAP media reference: {detail}"),
+        source: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    use crate::architecture::backend::MediaBackend;
+
+    use super::*;
+
+    static REGISTRY_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    struct MockDaapServer {
+        base_url: String,
+        requests: Arc<Mutex<Vec<String>>>,
+        task: tokio::task::JoinHandle<()>,
+    }
+
+    impl MockDaapServer {
+        async fn start() -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind mock DAAP server");
+            let address = listener.local_addr().expect("mock address");
+            let requests = Arc::new(Mutex::new(Vec::new()));
+            let requests_for_task = Arc::clone(&requests);
+
+            let task = tokio::spawn(async move {
+                while let Ok((mut stream, _)) = listener.accept().await {
+                    let requests = Arc::clone(&requests_for_task);
+                    tokio::spawn(async move {
+                        let mut request = vec![0_u8; 16 * 1024];
+                        let Ok(read) = stream.read(&mut request).await else {
+                            return;
+                        };
+                        if read == 0 {
+                            return;
+                        }
+                        let request = String::from_utf8_lossy(&request[..read]);
+                        let path = request.split_whitespace().nth(1).unwrap_or("/").to_string();
+                        requests
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner)
+                            .push(path.clone());
+
+                        let (status, content_type, body) = response_for(&path);
+                        let headers = format!(
+                            "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                            body.len()
+                        );
+                        let _ = stream.write_all(headers.as_bytes()).await;
+                        let _ = stream.write_all(&body).await;
+                    });
+                }
+            });
+
+            Self {
+                base_url: format!("http://{address}"),
+                requests,
+                task,
+            }
+        }
+
+        fn paths(&self) -> Vec<String> {
+            self.requests
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone()
+        }
+    }
+
+    impl Drop for MockDaapServer {
+        fn drop(&mut self) {
+            self.task.abort();
+        }
+    }
+
+    async fn reset_registry() {
+        shutdown_all().await;
+        *lock_registry() = SessionRegistry::default();
+        registry_notify().notify_waiters();
+    }
+
+    fn logout_count(server: &MockDaapServer) -> usize {
+        server
+            .paths()
+            .iter()
+            .filter(|path| path.starts_with("/logout?"))
+            .count()
+    }
+
+    #[tokio::test]
+    async fn lifecycle_retains_session_resolves_media_and_logs_out_once() {
+        let _registry_guard = REGISTRY_TEST_LOCK.lock().await;
+        reset_registry().await;
+        let server = MockDaapServer::start().await;
+        let backend = DaapBackend::connect("Mock DAAP", &server.base_url, None)
+            .await
+            .expect("connect and sync");
+        let tracks = backend.all_tracks().await;
+        assert_eq!(tracks.len(), 1);
+
+        let stream_reference = tracks[0]
+            .stream_url
+            .as_ref()
+            .expect("opaque stream reference");
+        let artwork_reference = tracks[0]
+            .cover_art_url
+            .as_ref()
+            .expect("opaque artwork reference");
+        assert_eq!(stream_reference.scheme(), "daap");
+        assert_eq!(artwork_reference.scheme(), "daap");
+        assert!(!stream_reference.as_str().contains("session-id"));
+
+        let direct_stream = backend
+            .get_stream_url(&tracks[0].id)
+            .await
+            .expect("resolve backend stream URL");
+        assert_eq!(direct_stream.scheme(), "http");
+        assert!(direct_stream.as_str().contains("session-id=42"));
+        let retained = begin_connect(server.base_url.clone())
+            .expect("open connection gate")
+            .retain(backend)
+            .await
+            .expect("retain current session");
+        let generation = retained.generation();
+        let session_key = retained.session_key();
+        assert!(retained.is_current());
+        drop(retained);
+
+        // The registry, rather than a temporary sync task, owns the backend.
+        let stream_url = resolve_media_url(stream_reference)
+            .expect("resolve stream reference")
+            .expect("DAAP URL");
+        assert_eq!(
+            stream_url
+                .query_pairs()
+                .find(|(key, _)| key == "session-id")
+                .unwrap()
+                .1,
+            "42"
+        );
+        let body = reqwest::get(stream_url)
+            .await
+            .expect("play mock stream")
+            .bytes()
+            .await
+            .expect("read mock stream");
+        assert_eq!(body.as_ref(), b"mock audio");
+
+        let artwork_url = resolve_media_url(artwork_reference)
+            .expect("resolve artwork reference")
+            .expect("DAAP URL");
+        assert!(artwork_url.as_str().contains("session-id=42"));
+
+        let owned = release_source(&server.base_url).expect("retained source");
+        assert!(!is_current_session(
+            &server.base_url,
+            generation,
+            session_key
+        ));
+        assert!(resolve_media_url(stream_reference).is_err());
+        assert!(owned.disconnect().await);
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let paths = server.paths();
+        assert_eq!(
+            paths
+                .iter()
+                .filter(|path| path.starts_with("/logout?"))
+                .count(),
+            1
+        );
+        assert!(paths.iter().any(|path| path.starts_with("/server-info")));
+        assert!(paths.iter().any(|path| path.starts_with("/login")));
+        assert!(paths.iter().any(|path| path.starts_with("/update?")));
+        assert!(paths.iter().any(|path| path.starts_with("/databases?")));
+        assert!(paths
+            .iter()
+            .any(|path| path.starts_with("/databases/1/items?")));
+        assert!(paths
+            .iter()
+            .any(|path| path.starts_with("/databases/1/items/9.mp3?")));
+
+        reset_registry().await;
+    }
+
+    #[tokio::test]
+    async fn controlled_shutdown_logs_out_each_retained_session_once() {
+        let _registry_guard = REGISTRY_TEST_LOCK.lock().await;
+        reset_registry().await;
+        let server = MockDaapServer::start().await;
+        let backend = DaapBackend::connect("Shutdown DAAP", &server.base_url, None)
+            .await
+            .expect("connect and sync");
+        let source_key = format!("shutdown:{}", server.base_url);
+        let retained = begin_connect(source_key)
+            .expect("open connection gate")
+            .retain(backend)
+            .await
+            .expect("retain current session");
+        drop(retained);
+
+        shutdown_all().await;
+        shutdown_all().await;
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(logout_count(&server), 1);
+        assert!(begin_connect("after-shutdown".to_string()).is_none());
+
+        reset_registry().await;
+    }
+
+    #[tokio::test]
+    async fn replacement_logs_out_displaced_session_once() {
+        let _registry_guard = REGISTRY_TEST_LOCK.lock().await;
+        reset_registry().await;
+        let first_server = MockDaapServer::start().await;
+        let second_server = MockDaapServer::start().await;
+        let source_key = "daap://logical-source".to_string();
+
+        let first_backend = DaapBackend::connect("First", &first_server.base_url, None)
+            .await
+            .expect("connect first session");
+        let first = begin_connect(source_key.clone())
+            .expect("open first attempt")
+            .retain(first_backend)
+            .await
+            .expect("retain first session");
+        let first_generation = first.generation();
+        let first_session_key = first.session_key();
+
+        let second_backend = DaapBackend::connect("Second", &second_server.base_url, None)
+            .await
+            .expect("connect second session");
+        let second = begin_connect(source_key.clone())
+            .expect("open replacement attempt")
+            .retain(second_backend)
+            .await
+            .expect("retain replacement session");
+
+        assert!(!is_current_session(
+            &source_key,
+            first_generation,
+            first_session_key
+        ));
+        assert!(second.is_current());
+        assert_eq!(logout_count(&first_server), 1);
+        assert_eq!(logout_count(&second_server), 0);
+
+        release_source(&source_key)
+            .expect("release replacement")
+            .disconnect()
+            .await;
+        assert_eq!(logout_count(&second_server), 1);
+        reset_registry().await;
+    }
+
+    #[tokio::test]
+    async fn queued_sync_token_is_rejected_after_same_source_replacement() {
+        let _registry_guard = REGISTRY_TEST_LOCK.lock().await;
+        reset_registry().await;
+        let first_server = MockDaapServer::start().await;
+        let second_server = MockDaapServer::start().await;
+        let source_key = "daap://queued-sync-source".to_string();
+
+        let first_backend = DaapBackend::connect("First", &first_server.base_url, None)
+            .await
+            .expect("connect first session");
+        let first = begin_connect(source_key.clone())
+            .expect("open first attempt")
+            .retain(first_backend)
+            .await
+            .expect("retain first session");
+        // This pair models the ownership token stored in a queued DaapSync.
+        let queued_generation = first.generation();
+        let queued_session_key = first.session_key();
+        let queued_reference = first.all_tracks().await[0]
+            .stream_url
+            .clone()
+            .expect("queued stream reference");
+        assert!(is_current_session(
+            &source_key,
+            queued_generation,
+            queued_session_key
+        ));
+
+        let second_backend = DaapBackend::connect("Second", &second_server.base_url, None)
+            .await
+            .expect("connect replacement session");
+        let second = begin_connect(source_key.clone())
+            .expect("open replacement attempt")
+            .retain(second_backend)
+            .await
+            .expect("retain replacement session");
+
+        assert!(!is_current_session(
+            &source_key,
+            queued_generation,
+            queued_session_key
+        ));
+        assert!(resolve_media_url(&queued_reference).is_err());
+        assert!(is_current_session(
+            &source_key,
+            second.generation(),
+            second.session_key()
+        ));
+
+        release_source(&source_key)
+            .expect("release replacement")
+            .disconnect()
+            .await;
+        reset_registry().await;
+    }
+
+    #[tokio::test]
+    async fn retain_racing_shutdown_cannot_escape_registry_ownership() {
+        let _registry_guard = REGISTRY_TEST_LOCK.lock().await;
+        reset_registry().await;
+        let server = MockDaapServer::start().await;
+        let source_key = "daap://retain-shutdown-race".to_string();
+        let attempt = begin_connect(source_key).expect("open connection attempt");
+        let backend = DaapBackend::connect("Racing", &server.base_url, None)
+            .await
+            .expect("connect session");
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+
+        let retain_barrier = Arc::clone(&barrier);
+        let retain_task = tokio::spawn(async move {
+            retain_barrier.wait().await;
+            attempt.retain(backend).await
+        });
+        let shutdown_task = tokio::spawn(async move {
+            barrier.wait().await;
+            shutdown_all().await;
+        });
+
+        let (retained, shutdown) = tokio::time::timeout(Duration::from_secs(2), async move {
+            tokio::join!(retain_task, shutdown_task)
+        })
+        .await
+        .expect("retain/shutdown race completed");
+        shutdown.expect("shutdown task");
+        if let Some(retained) = retained.expect("retain task") {
+            assert!(!retained.is_current());
+        }
+        assert_eq!(logout_count(&server), 1);
+        {
+            let sessions = lock_registry();
+            assert_eq!(sessions.gate, RegistryGate::ShutDown);
+            assert!(sessions.pending_attempts.is_empty());
+            assert!(sessions.by_source.is_empty());
+            assert!(sessions.retiring.is_empty());
+        }
+
+        reset_registry().await;
+    }
+
+    #[tokio::test]
+    async fn release_racing_shutdown_logs_out_once_and_is_joined() {
+        let _registry_guard = REGISTRY_TEST_LOCK.lock().await;
+        reset_registry().await;
+        let server = MockDaapServer::start().await;
+        let source_key = "daap://release-shutdown-race".to_string();
+        let backend = DaapBackend::connect("Racing", &server.base_url, None)
+            .await
+            .expect("connect session");
+        let retained = begin_connect(source_key.clone())
+            .expect("open connection attempt")
+            .retain(backend)
+            .await
+            .expect("retain session");
+        drop(retained);
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+
+        let release_barrier = Arc::clone(&barrier);
+        let release_task = tokio::spawn(async move {
+            release_barrier.wait().await;
+            if let Some(released) = release_source(&source_key) {
+                released.disconnect().await;
+            }
+        });
+        let shutdown_task = tokio::spawn(async move {
+            barrier.wait().await;
+            shutdown_all().await;
+        });
+
+        let (release, shutdown) = tokio::time::timeout(Duration::from_secs(2), async move {
+            tokio::join!(release_task, shutdown_task)
+        })
+        .await
+        .expect("release/shutdown race completed");
+        release.expect("release task");
+        shutdown.expect("shutdown task");
+        assert_eq!(logout_count(&server), 1);
+        {
+            let sessions = lock_registry();
+            assert_eq!(sessions.gate, RegistryGate::ShutDown);
+            assert!(sessions.by_source.is_empty());
+            assert!(sessions.retiring.is_empty());
+        }
+
+        reset_registry().await;
+    }
+
+    #[tokio::test]
+    async fn dropping_backend_does_not_perform_network_logout() {
+        let server = MockDaapServer::start().await;
+        let backend = DaapBackend::connect("Mock DAAP", &server.base_url, None)
+            .await
+            .expect("connect and sync");
+        drop(backend);
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            server
+                .paths()
+                .iter()
+                .filter(|path| path.starts_with("/logout?"))
+                .count(),
+            0
+        );
+    }
+
+    fn response_for(path: &str) -> (&'static str, &'static str, Vec<u8>) {
+        if path.starts_with("/server-info") {
+            let children = [tlv_u32(b"mstt", 200), tlv(b"minm", b"Mock DAAP")].concat();
+            return (
+                "200 OK",
+                "application/x-dmap-tagged",
+                tlv(b"msrv", &children),
+            );
+        }
+        if path.starts_with("/login") {
+            return (
+                "200 OK",
+                "application/x-dmap-tagged",
+                tlv(b"mlog", &tlv_u32(b"mlid", 42)),
+            );
+        }
+        if path.starts_with("/update?") {
+            return (
+                "200 OK",
+                "application/x-dmap-tagged",
+                tlv(b"mupd", &tlv_u32(b"musr", 7)),
+            );
+        }
+        if path.starts_with("/databases?") {
+            let database = [tlv_u32(b"miid", 1), tlv(b"minm", b"Music")].concat();
+            let listing = tlv(b"mlcl", &tlv(b"mlit", &database));
+            return (
+                "200 OK",
+                "application/x-dmap-tagged",
+                tlv(b"avdb", &listing),
+            );
+        }
+        if path.starts_with("/databases/1/items?") {
+            let track = [
+                tlv_u32(b"miid", 9),
+                tlv(b"minm", b"Lifecycle Song"),
+                tlv(b"asar", b"Mock Artist"),
+                tlv(b"asal", b"Mock Album"),
+                tlv(b"asfm", b"mp3"),
+            ]
+            .concat();
+            let listing = tlv(b"mlcl", &tlv(b"mlit", &track));
+            return (
+                "200 OK",
+                "application/x-dmap-tagged",
+                tlv(b"adbs", &listing),
+            );
+        }
+        if path.starts_with("/databases/1/items/9.mp3?") {
+            return ("200 OK", "audio/mpeg", b"mock audio".to_vec());
+        }
+        if path.starts_with("/databases/1/items/9/extra_data/artwork?") {
+            return ("200 OK", "image/png", b"mock artwork".to_vec());
+        }
+        if path.starts_with("/logout?") {
+            return ("200 OK", "application/x-dmap-tagged", Vec::new());
+        }
+        ("404 Not Found", "text/plain", b"not found".to_vec())
+    }
+
+    fn tlv(tag: &[u8; 4], payload: &[u8]) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(8 + payload.len());
+        bytes.extend_from_slice(tag);
+        bytes.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+        bytes.extend_from_slice(payload);
+        bytes
+    }
+
+    fn tlv_u32(tag: &[u8; 4], value: u32) -> Vec<u8> {
+        tlv(tag, &value.to_be_bytes())
+    }
+}

--- a/src/db/entities/library_root.rs
+++ b/src/db/entities/library_root.rs
@@ -1,0 +1,23 @@
+//! SeaORM entity for persisted library-root availability state.
+
+use sea_orm::entity::prelude::*;
+
+/// The `library_roots` table records the filesystem identity observed for a
+/// configured root. Reconciliation uses it to distinguish an intentionally
+/// empty mounted library from an empty mountpoint whose volume is absent.
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "library_roots")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub path: String,
+    pub device_id: Option<String>,
+    pub identity_confirmed: bool,
+    pub is_available: bool,
+    pub last_scan_complete: bool,
+    pub last_checked_at: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/src/db/entities/mod.rs
+++ b/src/db/entities/mod.rs
@@ -1,5 +1,6 @@
 //! Database entity definitions.
 
+pub mod library_root;
 pub mod playlist;
 pub mod playlist_entry;
 pub mod track;

--- a/src/db/migration/m20250104_000004_unique_entry_position.rs
+++ b/src/db/migration/m20250104_000004_unique_entry_position.rs
@@ -7,6 +7,9 @@
 //! resolved and the index can be created safely.
 
 use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::{Statement, TransactionTrait};
+
+const UNIQUE_POSITION_INDEX: &str = "idx_playlist_entries_playlist_position_unique";
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;
@@ -14,54 +17,228 @@ pub struct Migration;
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        // Step 1 — renumber. For each entry, its new position is the count of
-        // sibling entries (same playlist) that sort before it under the total
-        // order (position, id). That yields a gap-free, duplicate-free
-        // `0..N` sequence per playlist. A plain correlated subquery is used
-        // (rather than a window function) for the broadest SQLite support.
-        manager
-            .get_connection()
-            .execute_unprepared(
-                "UPDATE playlist_entries
-                 SET position = (
-                     SELECT COUNT(*)
-                     FROM playlist_entries AS sibling
-                     WHERE sibling.playlist_id = playlist_entries.playlist_id
-                       AND (
-                             sibling.position < playlist_entries.position
-                          OR (sibling.position = playlist_entries.position
-                              AND sibling.id < playlist_entries.id)
-                       )
-                 )",
-            )
-            .await?;
+        // SeaORM wraps PostgreSQL migration batches in a transaction, but not
+        // SQLite ones. Own this transaction so a failed index creation cannot
+        // leave the preceding position rewrite applied.
+        let transaction = manager.get_connection().begin().await?;
+        let result = {
+            let manager = SchemaManager::new(&transaction);
+            normalize_positions_and_create_index(&manager).await
+        };
 
-        // Step 2 — now that positions are unique, enforce it.
-        manager
-            .create_index(
-                Index::create()
-                    .name("idx_playlist_entries_playlist_position_unique")
-                    .table(PlaylistEntries::Table)
-                    .col(PlaylistEntries::PlaylistId)
-                    .col(PlaylistEntries::Position)
-                    .unique()
-                    .to_owned(),
-            )
-            .await?;
-
-        Ok(())
+        match result {
+            Ok(()) => transaction.commit().await,
+            Err(error) => {
+                transaction.rollback().await?;
+                Err(error)
+            }
+        }
     }
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
             .drop_index(
                 Index::drop()
-                    .name("idx_playlist_entries_playlist_position_unique")
+                    .name(UNIQUE_POSITION_INDEX)
                     .table(PlaylistEntries::Table)
+                    .if_exists()
                     .to_owned(),
             )
             .await
     }
+}
+
+/// Normalize positions from an immutable snapshot, then enforce uniqueness.
+///
+/// SQLite's `UPDATE` statement does not provide snapshot isolation between a
+/// target row and a correlated subquery that reads the same table. Computing
+/// every rank in a temporary table first prevents earlier row updates from
+/// changing the rank of later rows. The `(position, id)` ordering preserves
+/// the existing playlist order and resolves duplicate positions
+/// deterministically.
+async fn normalize_positions_and_create_index(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    match existing_unique_position_index(manager).await? {
+        ExistingIndex::Missing => {}
+        ExistingIndex::Correct => return Ok(()),
+        ExistingIndex::Conflicting(detail) => {
+            return Err(DbErr::Migration(format!(
+                "Index {UNIQUE_POSITION_INDEX} already exists but does not match the required \
+                 UNIQUE(playlist_id, position) index: {detail}"
+            )));
+        }
+    }
+
+    manager
+        .get_connection()
+        .execute_unprepared(
+            "CREATE TEMP TABLE tributary_playlist_position_snapshot (
+                 entry_id TEXT PRIMARY KEY NOT NULL,
+                 normalized_position INTEGER NOT NULL
+             )",
+        )
+        .await?;
+
+    manager
+        .get_connection()
+        .execute_unprepared(
+            "INSERT INTO tributary_playlist_position_snapshot (
+                 entry_id,
+                 normalized_position
+             )
+             SELECT current.id,
+                    (
+                        SELECT COUNT(*)
+                        FROM playlist_entries AS sibling
+                        WHERE sibling.playlist_id = current.playlist_id
+                          AND (
+                                sibling.position < current.position
+                             OR (sibling.position = current.position
+                                 AND sibling.id < current.id)
+                          )
+                    )
+             FROM playlist_entries AS current",
+        )
+        .await?;
+
+    manager
+        .get_connection()
+        .execute_unprepared(
+            "UPDATE playlist_entries
+             SET position = (
+                 SELECT snapshot.normalized_position
+                 FROM tributary_playlist_position_snapshot AS snapshot
+                 WHERE snapshot.entry_id = playlist_entries.id
+             )",
+        )
+        .await?;
+
+    manager
+        .create_index(
+            Index::create()
+                .name(UNIQUE_POSITION_INDEX)
+                .table(PlaylistEntries::Table)
+                .col(PlaylistEntries::PlaylistId)
+                .col(PlaylistEntries::Position)
+                .unique()
+                .to_owned(),
+        )
+        .await?;
+
+    manager
+        .get_connection()
+        .execute_unprepared("DROP TABLE tributary_playlist_position_snapshot")
+        .await?;
+
+    Ok(())
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ExistingIndex {
+    Missing,
+    Correct,
+    Conflicting(String),
+}
+
+/// Inspect the named SQLite index without relying on `CREATE INDEX IF NOT
+/// EXISTS`, which would silently accept a same-name non-unique or wrong-column
+/// index. A correctly shaped index is accepted only when the data also has the
+/// normalized `0..N` invariant produced by this migration.
+async fn existing_unique_position_index(
+    manager: &SchemaManager<'_>,
+) -> Result<ExistingIndex, DbErr> {
+    let backend = manager.get_database_backend();
+    let connection = manager.get_connection();
+
+    let owner = connection
+        .query_one(Statement::from_string(
+            backend,
+            format!(
+                "SELECT tbl_name
+                 FROM sqlite_master
+                 WHERE type = 'index'
+                   AND name = '{UNIQUE_POSITION_INDEX}'"
+            ),
+        ))
+        .await?;
+    let Some(owner) = owner else {
+        return Ok(ExistingIndex::Missing);
+    };
+
+    let table: String = owner.try_get("", "tbl_name")?;
+    if table != "playlist_entries" {
+        return Ok(ExistingIndex::Conflicting(format!(
+            "it belongs to table {table}"
+        )));
+    }
+
+    let index_rows = connection
+        .query_all(Statement::from_string(
+            backend,
+            "PRAGMA index_list('playlist_entries')".to_string(),
+        ))
+        .await?;
+    let Some(index_row) = index_rows.into_iter().find(|row| {
+        row.try_get::<String>("", "name")
+            .is_ok_and(|name| name == UNIQUE_POSITION_INDEX)
+    }) else {
+        return Ok(ExistingIndex::Conflicting(
+            "SQLite did not expose metadata for the named index".to_string(),
+        ));
+    };
+
+    let is_unique: i32 = index_row.try_get("", "unique")?;
+    let is_partial: i32 = index_row.try_get("", "partial").unwrap_or_default();
+
+    let mut columns = connection
+        .query_all(Statement::from_string(
+            backend,
+            format!("PRAGMA index_info('{UNIQUE_POSITION_INDEX}')"),
+        ))
+        .await?
+        .into_iter()
+        .map(|row| {
+            Ok::<_, DbErr>((
+                row.try_get::<i32>("", "seqno")?,
+                row.try_get::<Option<String>>("", "name")?,
+            ))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    columns.sort_by_key(|(sequence, _)| *sequence);
+    let column_names = columns
+        .into_iter()
+        .map(|(_, name)| name)
+        .collect::<Vec<_>>();
+    let expected_columns = vec![
+        Some("playlist_id".to_string()),
+        Some("position".to_string()),
+    ];
+
+    if is_unique != 1 || is_partial != 0 || column_names != expected_columns {
+        return Ok(ExistingIndex::Conflicting(format!(
+            "unique={is_unique}, partial={is_partial}, columns={column_names:?}"
+        )));
+    }
+
+    let invalid_positions = connection
+        .query_one(Statement::from_string(
+            backend,
+            "SELECT 1 AS invalid
+             FROM playlist_entries
+             GROUP BY playlist_id
+             HAVING MIN(position) <> 0
+                 OR MAX(position) <> COUNT(*) - 1
+                 OR COUNT(DISTINCT position) <> COUNT(*)
+             LIMIT 1"
+                .to_string(),
+        ))
+        .await?;
+    if invalid_positions.is_some() {
+        return Ok(ExistingIndex::Conflicting(
+            "playlist positions are not normalized to contiguous 0..N sequences".to_string(),
+        ));
+    }
+
+    Ok(ExistingIndex::Correct)
 }
 
 /// Column identifiers for the `playlist_entries` table.
@@ -70,4 +247,331 @@ enum PlaylistEntries {
     Table,
     PlaylistId,
     Position,
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm_migration::sea_orm::{
+        ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement,
+    };
+
+    use super::*;
+    use crate::db::migration::Migrator;
+
+    async fn database_before_position_migration() -> DatabaseConnection {
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("open in-memory database");
+        Migrator::up(&db, Some(3))
+            .await
+            .expect("apply migrations preceding position normalization");
+        db
+    }
+
+    async fn insert_playlist(db: &DatabaseConnection, id: &str) {
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO playlists (id, name, created_at, updated_at)
+             VALUES (?, ?, '2026-07-10T00:00:00Z', '2026-07-10T00:00:00Z')",
+            [id.into(), format!("Playlist {id}").into()],
+        ))
+        .await
+        .expect("insert playlist");
+    }
+
+    async fn try_insert_entry(
+        db: &DatabaseConnection,
+        playlist_id: &str,
+        id: &str,
+        position: i32,
+    ) -> Result<(), DbErr> {
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO playlist_entries (id, playlist_id, position)
+             VALUES (?, ?, ?)",
+            [id.into(), playlist_id.into(), position.into()],
+        ))
+        .await
+        .map(|_| ())
+    }
+
+    async fn insert_entry(db: &DatabaseConnection, playlist_id: &str, id: &str, position: i32) {
+        try_insert_entry(db, playlist_id, id, position)
+            .await
+            .expect("insert playlist entry");
+    }
+
+    async fn positions(db: &DatabaseConnection, playlist_id: &str) -> Vec<(String, i32)> {
+        db.query_all(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "SELECT id, position
+             FROM playlist_entries
+             WHERE playlist_id = ?
+             ORDER BY position, id",
+            [playlist_id.into()],
+        ))
+        .await
+        .expect("query playlist positions")
+        .into_iter()
+        .map(|row| {
+            (
+                row.try_get("", "id").expect("entry id"),
+                row.try_get("", "position").expect("entry position"),
+            )
+        })
+        .collect()
+    }
+
+    async fn apply_position_migration(db: &DatabaseConnection) -> Result<(), DbErr> {
+        Migrator::up(db, Some(1)).await
+    }
+
+    async fn migration_is_applied(db: &DatabaseConnection) -> bool {
+        let migration_name = Migration.name().to_string();
+        Migrator::get_migration_models(db)
+            .await
+            .expect("query migration ledger")
+            .iter()
+            .any(|migration| migration.version == migration_name)
+    }
+
+    #[tokio::test]
+    async fn normalizes_gaps_without_following_row_insertion_order() {
+        let db = database_before_position_migration().await;
+        insert_playlist(&db, "playlist-a").await;
+
+        // Insert in reverse order to reproduce the original migration's
+        // read-after-write failure. Position, not row insertion order, is the
+        // intended playlist order.
+        insert_entry(&db, "playlist-a", "entry-c", 30).await;
+        insert_entry(&db, "playlist-a", "entry-b", 20).await;
+        insert_entry(&db, "playlist-a", "entry-a", 10).await;
+
+        apply_position_migration(&db)
+            .await
+            .expect("position migration succeeds");
+
+        assert_eq!(
+            positions(&db, "playlist-a").await,
+            vec![
+                ("entry-a".to_owned(), 0),
+                ("entry-b".to_owned(), 1),
+                ("entry-c".to_owned(), 2),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn resolves_duplicate_positions_with_a_deterministic_tie_breaker() {
+        let db = database_before_position_migration().await;
+        insert_playlist(&db, "playlist-a").await;
+
+        insert_entry(&db, "playlist-a", "entry-c", 10).await;
+        insert_entry(&db, "playlist-a", "entry-a", 10).await;
+        insert_entry(&db, "playlist-a", "entry-b", 3).await;
+
+        apply_position_migration(&db)
+            .await
+            .expect("position migration succeeds");
+
+        assert_eq!(
+            positions(&db, "playlist-a").await,
+            vec![
+                ("entry-b".to_owned(), 0),
+                ("entry-a".to_owned(), 1),
+                ("entry-c".to_owned(), 2),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn normalizes_each_playlist_independently() {
+        let db = database_before_position_migration().await;
+        insert_playlist(&db, "playlist-a").await;
+        insert_playlist(&db, "playlist-b").await;
+
+        insert_entry(&db, "playlist-a", "a-second", 9).await;
+        insert_entry(&db, "playlist-b", "b-second", 100).await;
+        insert_entry(&db, "playlist-a", "a-first", -4).await;
+        insert_entry(&db, "playlist-b", "b-first", 100).await;
+
+        apply_position_migration(&db)
+            .await
+            .expect("position migration succeeds");
+
+        assert_eq!(
+            positions(&db, "playlist-a").await,
+            vec![("a-first".to_owned(), 0), ("a-second".to_owned(), 1)]
+        );
+        assert_eq!(
+            positions(&db, "playlist-b").await,
+            vec![("b-first".to_owned(), 0), ("b-second".to_owned(), 1)]
+        );
+    }
+
+    #[tokio::test]
+    async fn migrates_an_empty_table_and_enforces_unique_positions() {
+        let db = database_before_position_migration().await;
+
+        apply_position_migration(&db)
+            .await
+            .expect("empty position migration succeeds");
+
+        insert_playlist(&db, "playlist-a").await;
+        insert_entry(&db, "playlist-a", "entry-a", 0).await;
+        let duplicate = try_insert_entry(&db, "playlist-a", "entry-b", 0).await;
+        assert!(duplicate.is_err(), "unique position index must be active");
+    }
+
+    #[tokio::test]
+    async fn retries_after_schema_commit_before_migration_ledger_insert() {
+        let db = database_before_position_migration().await;
+        insert_playlist(&db, "playlist-a").await;
+        insert_entry(&db, "playlist-a", "entry-c", 30).await;
+        insert_entry(&db, "playlist-a", "entry-a", 10).await;
+        insert_entry(&db, "playlist-a", "entry-b", 20).await;
+
+        // Apply the schema change directly, simulating a process that commits
+        // Migration::up and exits before SeaORM inserts its ledger row.
+        let manager = SchemaManager::new(&db);
+        Migration
+            .up(&manager)
+            .await
+            .expect("commit migration schema change directly");
+        assert!(!migration_is_applied(&db).await);
+        assert_eq!(
+            positions(&db, "playlist-a").await,
+            vec![
+                ("entry-a".to_owned(), 0),
+                ("entry-b".to_owned(), 1),
+                ("entry-c".to_owned(), 2),
+            ]
+        );
+
+        // The normal migrator retries `up`, recognizes the exact index and
+        // normalized data, and records the previously missing ledger entry.
+        apply_position_migration(&db)
+            .await
+            .expect("retry already-committed migration");
+        assert!(migration_is_applied(&db).await);
+        assert!(
+            try_insert_entry(&db, "playlist-a", "entry-d", 2)
+                .await
+                .is_err(),
+            "the accepted index must still enforce uniqueness"
+        );
+    }
+
+    #[tokio::test]
+    async fn correctly_shaped_index_does_not_hide_unnormalized_positions() {
+        let db = database_before_position_migration().await;
+        insert_playlist(&db, "playlist-a").await;
+        insert_entry(&db, "playlist-a", "entry-a", 10).await;
+        insert_entry(&db, "playlist-a", "entry-b", 20).await;
+        let original_positions = positions(&db, "playlist-a").await;
+        db.execute_unprepared(
+            "CREATE UNIQUE INDEX idx_playlist_entries_playlist_position_unique
+             ON playlist_entries (playlist_id, position)",
+        )
+        .await
+        .expect("create correctly shaped index over gapped data");
+
+        let error = apply_position_migration(&db)
+            .await
+            .expect_err("gapped positions must not be accepted as already migrated");
+        assert!(
+            error.to_string().contains("positions are not normalized"),
+            "unexpected migration error: {error}"
+        );
+        assert_eq!(positions(&db, "playlist-a").await, original_positions);
+        assert!(!migration_is_applied(&db).await);
+    }
+
+    #[tokio::test]
+    async fn failed_index_creation_rolls_back_position_updates_and_can_be_retried() {
+        let db = database_before_position_migration().await;
+        insert_playlist(&db, "playlist-a").await;
+        insert_entry(&db, "playlist-a", "entry-c", 30).await;
+        insert_entry(&db, "playlist-a", "entry-b", 20).await;
+        insert_entry(&db, "playlist-a", "entry-a", 10).await;
+        let original_positions = positions(&db, "playlist-a").await;
+
+        // Reserve the migration's index name with a different, non-unique
+        // index. Strict metadata inspection must reject it without rewriting
+        // positions or silently treating it as the required index.
+        db.execute_unprepared(
+            "CREATE INDEX idx_playlist_entries_playlist_position_unique
+             ON playlist_entries (id)",
+        )
+        .await
+        .expect("create conflicting index");
+
+        let error = apply_position_migration(&db)
+            .await
+            .expect_err("conflicting index must fail the migration");
+        assert!(
+            error.to_string().contains("does not match the required"),
+            "unexpected migration error: {error}"
+        );
+        assert_eq!(positions(&db, "playlist-a").await, original_positions);
+
+        let snapshot_count: i64 = db
+            .query_one(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT COUNT(*) AS count
+                 FROM sqlite_temp_master
+                 WHERE type = 'table'
+                   AND name = 'tributary_playlist_position_snapshot'",
+            ))
+            .await
+            .expect("query temporary schema")
+            .expect("count row")
+            .try_get("", "count")
+            .expect("snapshot count");
+        assert_eq!(snapshot_count, 0, "rollback must remove the snapshot table");
+
+        db.execute_unprepared("DROP INDEX idx_playlist_entries_playlist_position_unique")
+            .await
+            .expect("remove conflicting index");
+        apply_position_migration(&db)
+            .await
+            .expect("migration can be retried after a rollback");
+        assert_eq!(
+            positions(&db, "playlist-a").await,
+            vec![
+                ("entry-a".to_owned(), 0),
+                ("entry-b".to_owned(), 1),
+                ("entry-c".to_owned(), 2),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn down_succeeds_when_index_is_already_missing_and_when_repeated() {
+        let db = database_before_position_migration().await;
+        apply_position_migration(&db)
+            .await
+            .expect("apply position migration");
+        assert!(migration_is_applied(&db).await);
+
+        // Simulate a committed DROP INDEX followed by a missing ledger delete.
+        db.execute_unprepared("DROP INDEX idx_playlist_entries_playlist_position_unique")
+            .await
+            .expect("pre-drop migration index");
+        Migrator::down(&db, Some(1))
+            .await
+            .expect("finish partially applied down migration");
+        assert!(!migration_is_applied(&db).await);
+
+        // Direct repeated teardown is also a no-op.
+        let manager = SchemaManager::new(&db);
+        Migration
+            .down(&manager)
+            .await
+            .expect("repeat already-completed down migration");
+        Migration
+            .down(&manager)
+            .await
+            .expect("repeat down migration again");
+    }
 }

--- a/src/db/migration/m20250710_000005_create_library_roots.rs
+++ b/src/db/migration/m20250710_000005_create_library_roots.rs
@@ -1,0 +1,138 @@
+//! Migration: persist availability and filesystem identity for library roots.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(LibraryRoots::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(LibraryRoots::Path)
+                            .string()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(LibraryRoots::DeviceId).string().null())
+                    .col(
+                        ColumnDef::new(LibraryRoots::IdentityConfirmed)
+                            .boolean()
+                            .not_null()
+                            .default(false),
+                    )
+                    .col(
+                        ColumnDef::new(LibraryRoots::IsAvailable)
+                            .boolean()
+                            .not_null()
+                            .default(false),
+                    )
+                    .col(
+                        ColumnDef::new(LibraryRoots::LastScanComplete)
+                            .boolean()
+                            .not_null()
+                            .default(false),
+                    )
+                    .col(
+                        ColumnDef::new(LibraryRoots::LastCheckedAt)
+                            .string()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(
+                Table::drop()
+                    .table(LibraryRoots::Table)
+                    .if_exists()
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum LibraryRoots {
+    Table,
+    Path,
+    DeviceId,
+    IdentityConfirmed,
+    IsAvailable,
+    LastScanComplete,
+    LastCheckedAt,
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm_migration::sea_orm::{ConnectionTrait, Database, DatabaseConnection};
+
+    use super::*;
+    use crate::db::migration::Migrator;
+
+    async fn migrated_database() -> DatabaseConnection {
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("open in-memory database");
+        Migrator::up(&db, None).await.expect("apply all migrations");
+        db
+    }
+
+    async fn migration_is_applied(db: &DatabaseConnection) -> bool {
+        let migration_name = Migration.name().to_string();
+        Migrator::get_migration_models(db)
+            .await
+            .expect("query migration ledger")
+            .iter()
+            .any(|migration| migration.version == migration_name)
+    }
+
+    #[tokio::test]
+    async fn down_can_be_repeated_after_the_table_is_gone() {
+        let db = migrated_database().await;
+        let manager = SchemaManager::new(&db);
+
+        Migration
+            .down(&manager)
+            .await
+            .expect("drop library roots table");
+        assert!(!manager
+            .has_table("library_roots")
+            .await
+            .expect("inspect library roots table"));
+        Migration
+            .down(&manager)
+            .await
+            .expect("repeat library roots teardown");
+    }
+
+    #[tokio::test]
+    async fn migrator_finishes_a_partially_applied_down() {
+        let db = migrated_database().await;
+        assert!(migration_is_applied(&db).await);
+
+        // Simulate the table DROP committing before the migration ledger row
+        // is removed, then let the normal migrator retry the down operation.
+        db.execute_unprepared("DROP TABLE library_roots")
+            .await
+            .expect("pre-drop library roots table");
+        Migrator::down(&db, Some(1))
+            .await
+            .expect("finish partially applied library roots down");
+        assert!(!migration_is_applied(&db).await);
+
+        let manager = SchemaManager::new(&db);
+        assert!(!manager
+            .has_table("library_roots")
+            .await
+            .expect("inspect library roots table"));
+    }
+}

--- a/src/db/migration/mod.rs
+++ b/src/db/migration/mod.rs
@@ -6,6 +6,7 @@ mod m20250101_000001_create_tables;
 mod m20250102_000002_create_playlists;
 mod m20250103_000003_add_album_artist;
 mod m20250104_000004_unique_entry_position;
+mod m20250710_000005_create_library_roots;
 
 pub struct Migrator;
 
@@ -17,6 +18,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20250102_000002_create_playlists::Migration),
             Box::new(m20250103_000003_add_album_artist::Migration),
             Box::new(m20250104_000004_unique_entry_position::Migration),
+            Box::new(m20250710_000005_create_library_roots::Migration),
         ]
     }
 }

--- a/src/local/engine.rs
+++ b/src/local/engine.rs
@@ -4,6 +4,8 @@
 //! to the GTK main thread via `async_channel`.
 
 use std::collections::{HashMap, HashSet};
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -125,6 +127,7 @@ struct RootScan {
     audio_files: Vec<PathBuf>,
     errors: Vec<String>,
     device_id: Option<String>,
+    mount_generation: Option<u64>,
     reconciliation_authoritative: bool,
     content_authorized: bool,
 }
@@ -135,8 +138,187 @@ impl RootScan {
     }
 }
 
+const ROOT_IDENTITY_FILE: &str = ".tributary-root-id";
+const ROOT_IDENTITY_PREFIX: &str = "marker:v1:";
+
+fn root_identity_path(root: &Path) -> PathBuf {
+    root.join(ROOT_IDENTITY_FILE)
+}
+
+fn parse_root_marker(contents: &str) -> std::io::Result<String> {
+    let value = contents.strip_suffix('\n').unwrap_or(contents);
+    if value.is_empty() || value.contains(char::is_whitespace) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "library root marker has invalid whitespace",
+        ));
+    }
+    let Some(uuid) = value.strip_prefix(ROOT_IDENTITY_PREFIX) else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "library root marker has an unsupported format",
+        ));
+    };
+    let uuid = Uuid::parse_str(uuid).map_err(|error| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("library root marker has an invalid UUID: {error}"),
+        )
+    })?;
+    Ok(format!("{ROOT_IDENTITY_PREFIX}{uuid}"))
+}
+
 #[cfg(unix)]
-fn filesystem_identity(path: &Path) -> std::io::Result<String> {
+fn open_root_marker(path: &Path) -> std::io::Result<File> {
+    use rustix::fs::{Mode, OFlags};
+
+    let descriptor = rustix::fs::open(
+        path,
+        OFlags::RDONLY | OFlags::CLOEXEC | OFlags::NOFOLLOW | OFlags::NONBLOCK,
+        Mode::empty(),
+    )
+    .map_err(std::io::Error::from)?;
+    Ok(File::from(descriptor))
+}
+
+#[cfg(windows)]
+fn open_root_marker(path: &Path) -> std::io::Result<File> {
+    use std::os::windows::fs::{MetadataExt, OpenOptionsExt};
+
+    // Open the reparse point itself instead of following it, then reject every
+    // reparse-point flavor (not only ordinary symlinks) from handle metadata.
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    let file = OpenOptions::new()
+        .read(true)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)?;
+    if file.metadata()?.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "library root marker must not be a reparse point",
+        ));
+    }
+    Ok(file)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn open_root_marker(path: &Path) -> std::io::Result<File> {
+    OpenOptions::new().read(true).open(path)
+}
+
+fn read_root_marker(root: &Path) -> std::io::Result<Option<String>> {
+    let path = root_identity_path(root);
+    let mut file = match open_root_marker(&path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    let metadata = file.metadata()?;
+    if !metadata.is_file() || metadata.len() > 128 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("unsafe library root marker: {}", path.display()),
+        ));
+    }
+
+    // Bound the read independently of metadata: a concurrent writer cannot
+    // bypass the size check after the handle has been validated.
+    let mut contents = Vec::with_capacity(metadata.len() as usize);
+    (&mut file).take(129).read_to_end(&mut contents)?;
+    if contents.len() > 128 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "library root marker exceeds 128 bytes",
+        ));
+    }
+    let contents = std::str::from_utf8(&contents).map_err(|error| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("library root marker is not UTF-8: {error}"),
+        )
+    })?;
+    parse_root_marker(contents).map(Some)
+}
+
+struct RootMarkerCreation {
+    identity: String,
+    created: bool,
+}
+
+fn create_root_marker(root: &Path) -> std::io::Result<RootMarkerCreation> {
+    if let Some(identity) = read_root_marker(root)? {
+        return Ok(RootMarkerCreation {
+            identity,
+            created: false,
+        });
+    }
+
+    let identity = format!("{ROOT_IDENTITY_PREFIX}{}", Uuid::new_v4());
+    let path = root_identity_path(root);
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+
+    let mut file = match options.open(&path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            let identity = read_root_marker(root)?.ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "library root marker appeared but could not be read",
+                )
+            })?;
+            return Ok(RootMarkerCreation {
+                identity,
+                created: false,
+            });
+        }
+        Err(error) => return Err(error),
+    };
+
+    let write_result = file
+        .write_all(format!("{identity}\n").as_bytes())
+        .and_then(|()| file.sync_all());
+    drop(file);
+    // Do not remove by path on failure: another process may have replaced the
+    // entry after this handle was opened. A partial marker safely fails closed.
+    write_result?;
+
+    let observed = read_root_marker(root)?.ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "library root marker disappeared after creation",
+        )
+    })?;
+    if observed != identity {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "library root marker changed during creation",
+        ));
+    }
+    Ok(RootMarkerCreation {
+        identity,
+        created: true,
+    })
+}
+
+fn is_marker_identity(identity: &str) -> bool {
+    identity.starts_with(ROOT_IDENTITY_PREFIX)
+}
+
+fn is_legacy_identity(identity: &str) -> bool {
+    identity.starts_with("unix:")
+        || identity.starts_with("windows:")
+        || identity.starts_with("path:")
+}
+
+#[cfg(unix)]
+fn legacy_filesystem_identity(path: &Path) -> std::io::Result<String> {
     use std::os::unix::fs::MetadataExt;
 
     let metadata = std::fs::metadata(path)?;
@@ -147,6 +329,28 @@ fn filesystem_identity(path: &Path) -> std::io::Result<String> {
         metadata.dev(),
         metadata.ino()
     ))
+}
+
+#[cfg(windows)]
+fn legacy_filesystem_identity(path: &Path) -> std::io::Result<String> {
+    use std::os::windows::fs::MetadataExt;
+
+    let metadata = std::fs::metadata(path)?;
+    let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    Ok(format!(
+        "windows:{}:{}",
+        canonical.to_string_lossy(),
+        metadata.creation_time()
+    ))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn legacy_filesystem_identity(path: &Path) -> std::io::Result<String> {
+    Ok(format!("path:{}", path.canonicalize()?.to_string_lossy()))
+}
+
+fn filesystem_identity(path: &Path) -> std::io::Result<String> {
+    read_root_marker(path)?.map_or_else(|| legacy_filesystem_identity(path), Ok)
 }
 
 #[cfg(target_os = "linux")]
@@ -165,7 +369,10 @@ fn filesystem_boundary_id(path: &Path) -> std::io::Result<u64> {
 }
 
 #[cfg(not(unix))]
+#[allow(clippy::unnecessary_wraps)]
 fn filesystem_boundary_id(_path: &Path) -> std::io::Result<u64> {
+    // Keep the fallible signature shared with Unix so callers fail closed when
+    // a platform-specific boundary probe is added here.
     Ok(0)
 }
 
@@ -200,9 +407,11 @@ fn root_mount_generation(path: &Path) -> std::io::Result<u64> {
 }
 
 #[cfg(not(target_os = "linux"))]
+#[allow(clippy::unnecessary_wraps)]
 fn root_mount_generation(_path: &Path) -> std::io::Result<u64> {
     // Other platforms still use the stable pre/post filesystem identity. A
-    // constant generation keeps the shared traversal implementation portable.
+    // constant generation and shared fallible signature keep the traversal
+    // implementation portable without weakening Linux's generation checks.
     Ok(0)
 }
 
@@ -317,7 +526,10 @@ fn mounted_subroots(configured_roots: &[PathBuf]) -> std::io::Result<Vec<PathBuf
 }
 
 #[cfg(not(target_os = "linux"))]
+#[allow(clippy::unnecessary_wraps)]
 fn mounted_subroots(_configured_roots: &[PathBuf]) -> std::io::Result<Vec<PathBuf>> {
+    // The fallible return type is part of the cross-platform fail-closed scan
+    // contract even though only Linux currently has mount-table discovery.
     Ok(Vec::new())
 }
 
@@ -359,28 +571,6 @@ fn expanded_scan_roots_with_mounts(
     roots.sort_unstable();
     roots.dedup();
     roots
-}
-
-#[cfg(windows)]
-fn filesystem_identity(path: &Path) -> std::io::Result<String> {
-    use std::os::windows::fs::MetadataExt;
-
-    let metadata = std::fs::metadata(path)?;
-    let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-    // A mounted volume exposes the mounted root's creation time, while an
-    // absent directory mount exposes the underlying mountpoint's metadata.
-    // Drive-letter and UNC roots become inaccessible when unavailable, which
-    // makes their traversal incomplete before this identity is consulted.
-    Ok(format!(
-        "windows:{}:{}",
-        canonical.to_string_lossy(),
-        metadata.creation_time()
-    ))
-}
-
-#[cfg(not(any(unix, windows)))]
-fn filesystem_identity(path: &Path) -> std::io::Result<String> {
-    Ok(format!("path:{}", path.canonicalize()?.to_string_lossy()))
 }
 
 fn scan_root(root: PathBuf) -> RootScan {
@@ -427,6 +617,7 @@ where
             root,
             audio_files: Vec::new(),
             device_id: None,
+            mount_generation: None,
             reconciliation_authoritative: false,
             content_authorized: false,
         };
@@ -443,6 +634,7 @@ where
                 root,
                 audio_files: Vec::new(),
                 device_id: None,
+                mount_generation: None,
                 reconciliation_authoritative: false,
                 content_authorized: false,
             };
@@ -460,6 +652,7 @@ where
                 root,
                 audio_files: Vec::new(),
                 device_id,
+                mount_generation: None,
                 reconciliation_authoritative: false,
                 content_authorized: false,
             };
@@ -559,6 +752,7 @@ where
         audio_files,
         errors,
         device_id,
+        mount_generation: Some(mount_generation),
         reconciliation_authoritative: false,
         content_authorized: false,
     }
@@ -587,6 +781,39 @@ fn root_scan_for_path<'a>(path: &Path, root_scans: &'a [RootScan]) -> Option<&'a
         .iter()
         .filter(|scan| path.starts_with(&scan.root))
         .max_by_key(|scan| scan.root.components().count())
+}
+
+/// Recheck the most-specific authorized root for one pending initial-scan
+/// write. A failed probe invalidates that root for every later file in this
+/// scan; callers persist the returned root's unavailable state.
+fn revalidate_scan_root_for_path(
+    path: &Path,
+    root_scans: &mut [RootScan],
+) -> (bool, Option<PathBuf>) {
+    let Some(index) = root_scans
+        .iter()
+        .enumerate()
+        .filter(|(_, scan)| path.starts_with(&scan.root))
+        .max_by_key(|(_, scan)| scan.root.components().count())
+        .map(|(index, _)| index)
+    else {
+        return (false, None);
+    };
+    let scan = &mut root_scans[index];
+    if !scan.content_authorized {
+        return (false, None);
+    }
+    let matches = scan.device_id.as_deref().is_some_and(|expected| {
+        is_marker_identity(expected)
+            && filesystem_identity(&scan.root).is_ok_and(|observed| observed == expected)
+    });
+    if matches {
+        return (true, None);
+    }
+
+    scan.content_authorized = false;
+    scan.reconciliation_authoritative = false;
+    (false, Some(scan.root.clone()))
 }
 
 fn most_specific_root_for_path<'a>(path: &Path, roots: &'a [PathBuf]) -> Option<&'a Path> {
@@ -626,6 +853,9 @@ fn reconciliation_is_authoritative(
     let Some(observed_device_id) = scan.device_id.as_deref() else {
         return false;
     };
+    if !is_marker_identity(observed_device_id) {
+        return false;
+    }
 
     previous.is_some_and(|state| {
         state.identity_confirmed && state.device_id.as_deref() == Some(observed_device_id)
@@ -644,7 +874,19 @@ fn scan_confirms_identity(
     previous: Option<&library_root::Model>,
     existing_track_count: usize,
 ) -> bool {
-    if !scan.is_complete() || scan.device_id.is_none() || scan.audio_files.is_empty() {
+    scan_confirms_identity_for_scope(scan, previous, existing_track_count, true)
+}
+
+fn scan_confirms_identity_for_scope(
+    scan: &RootScan,
+    previous: Option<&library_root::Model>,
+    existing_track_count: usize,
+    allow_new_enrollment: bool,
+) -> bool {
+    if !scan.is_complete()
+        || !scan.device_id.as_deref().is_some_and(is_marker_identity)
+        || scan.audio_files.is_empty()
+    {
         return false;
     }
 
@@ -654,7 +896,140 @@ fn scan_confirms_identity(
         }
     }
 
-    existing_track_count == 0
+    allow_new_enrollment && existing_track_count == 0
+}
+
+/// Bind a complete, explicitly configured root to a durable marker.
+///
+/// Existing pre-marker identities are converted only while the legacy probe
+/// still matches the persisted value. The conversion scan is never allowed to
+/// delete rows; the next complete marker-backed scan establishes authority.
+#[derive(Debug, Eq, PartialEq)]
+enum RootIdentityPreparation {
+    Unchanged,
+    MarkerCreated {
+        identity: String,
+        legacy_conversion: bool,
+    },
+}
+
+fn prepare_durable_root_identity(
+    scan: &mut RootScan,
+    previous: Option<&library_root::Model>,
+    existing_track_count: usize,
+    explicitly_configured: bool,
+) -> RootIdentityPreparation {
+    if !scan.is_complete() {
+        return RootIdentityPreparation::Unchanged;
+    }
+
+    let previous_legacy_matches = explicitly_configured
+        && previous.is_some_and(|state| {
+            state.identity_confirmed
+                && state.device_id.as_deref().is_some_and(is_legacy_identity)
+                && legacy_filesystem_identity(&scan.root).ok().as_deref()
+                    == state.device_id.as_deref()
+        });
+    let is_new_enrollment = explicitly_configured
+        && !previous.is_some_and(|state| state.identity_confirmed)
+        && existing_track_count == 0
+        && !scan.audio_files.is_empty();
+    let needs_marker = scan.device_id.as_deref().is_some_and(is_legacy_identity)
+        && (previous_legacy_matches || is_new_enrollment);
+
+    if !needs_marker {
+        return RootIdentityPreparation::Unchanged;
+    }
+
+    // Retain both probes across creation. A marker written to a root that was
+    // replaced after traversal must never bless the replacement volume.
+    let before_legacy = match legacy_filesystem_identity(&scan.root) {
+        Ok(identity) => identity,
+        Err(error) => {
+            scan.errors.push(format!(
+                "failed to re-identify library root before marker creation {}: {error}",
+                scan.root.display()
+            ));
+            return RootIdentityPreparation::Unchanged;
+        }
+    };
+    let before_generation = match root_mount_generation(&scan.root) {
+        Ok(generation) => generation,
+        Err(error) => {
+            scan.errors.push(format!(
+                "failed to identify library root mount before marker creation {}: {error}",
+                scan.root.display()
+            ));
+            return RootIdentityPreparation::Unchanged;
+        }
+    };
+    if scan.device_id.as_deref() != Some(before_legacy.as_str())
+        || scan.mount_generation != Some(before_generation)
+    {
+        scan.errors.push(format!(
+            "library root identity or mount changed before marker creation: {}",
+            scan.root.display()
+        ));
+        return RootIdentityPreparation::Unchanged;
+    }
+
+    let creation = match create_root_marker(&scan.root) {
+        Ok(creation) => creation,
+        Err(error) => {
+            scan.errors.push(format!(
+                "failed to create durable library root identity {}: {error}",
+                scan.root.display()
+            ));
+            return RootIdentityPreparation::Unchanged;
+        }
+    };
+    if !creation.created {
+        scan.errors.push(format!(
+            "library root marker appeared during enrollment: {}",
+            scan.root.display()
+        ));
+        return RootIdentityPreparation::Unchanged;
+    }
+
+    let legacy_stable =
+        legacy_filesystem_identity(&scan.root).is_ok_and(|identity| identity == before_legacy);
+    let generation_stable =
+        root_mount_generation(&scan.root).is_ok_and(|generation| generation == before_generation);
+    if !legacy_stable || !generation_stable {
+        scan.errors.push(format!(
+            "library root changed while creating its durable identity: {}",
+            scan.root.display()
+        ));
+        return RootIdentityPreparation::Unchanged;
+    }
+
+    scan.device_id = Some(creation.identity.clone());
+    RootIdentityPreparation::MarkerCreated {
+        identity: creation.identity,
+        legacy_conversion: previous_legacy_matches,
+    }
+}
+
+fn reject_duplicate_marker_identities(root_scans: &mut [RootScan]) {
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for identity in root_scans
+        .iter()
+        .filter_map(|scan| scan.device_id.as_deref())
+        .filter(|identity| is_marker_identity(identity))
+    {
+        *counts.entry(identity.to_string()).or_default() += 1;
+    }
+
+    for scan in root_scans {
+        if scan.device_id.as_ref().is_some_and(|identity| {
+            is_marker_identity(identity) && counts.get(identity).copied().unwrap_or_default() > 1
+        }) {
+            scan.errors.push(format!(
+                "duplicate library root marker detected at {}",
+                scan.root.display()
+            ));
+        }
+    }
 }
 
 async fn persist_root_scan_status(
@@ -733,6 +1108,69 @@ async fn initial_scan(
     })
     .await?;
 
+    // Preload existing rows once so the per-file loop can decide needs_update
+    // from memory instead of issuing one SELECT per file. The same snapshot is
+    // reused for the stale-removal pass below.
+    let existing_by_path: HashMap<&str, &track::Model> = existing_tracks
+        .iter()
+        .map(|model| (model.file_path.as_str(), model))
+        .collect();
+    let persisted_by_path: HashMap<&str, &library_root::Model> = persisted_roots
+        .iter()
+        .map(|state| (state.path.as_str(), state))
+        .collect();
+    let evidence_roots: Vec<PathBuf> = root_scans.iter().map(|scan| scan.root.clone()).collect();
+    let mut conversion_roots = HashSet::new();
+
+    // Marker creation happens only for roots the user explicitly configured.
+    // Always discard the pre-marker traversal and rescan through the newly
+    // created marker before deciding whether any content may be trusted.
+    for scan in &mut root_scans {
+        let root_path = scan.root.to_string_lossy();
+        let previous = persisted_by_path.get(root_path.as_ref()).copied();
+        let existing_track_count = existing_tracks
+            .iter()
+            .filter(|row| {
+                most_specific_root_for_path(Path::new(&row.file_path), &evidence_roots)
+                    == Some(scan.root.as_path())
+            })
+            .count();
+        let explicitly_configured = configured_dirs.binary_search(&scan.root).is_ok();
+
+        let RootIdentityPreparation::MarkerCreated {
+            identity,
+            legacy_conversion,
+        } = prepare_durable_root_identity(
+            scan,
+            previous,
+            existing_track_count,
+            explicitly_configured,
+        )
+        else {
+            continue;
+        };
+
+        let root = scan.root.clone();
+        let exclusions = evidence_roots.clone();
+        let mut marker_scan =
+            tokio::task::spawn_blocking(move || scan_root_with_exclusions(root, &exclusions))
+                .await?;
+        if marker_scan.device_id.as_deref() != Some(identity.as_str()) {
+            marker_scan.errors.push(format!(
+                "library root marker changed before marker-backed rescan completed: {}",
+                marker_scan.root.display()
+            ));
+        }
+        if legacy_conversion && marker_scan.is_complete() {
+            conversion_roots.insert(marker_scan.root.clone());
+        }
+        *scan = marker_scan;
+    }
+
+    // Detect copies only after enrollment/rescans so markers created during
+    // this scan participate in the same fail-closed duplicate check.
+    reject_duplicate_marker_identities(&mut root_scans);
+
     for scan in &root_scans {
         if scan.is_complete() {
             debug!(
@@ -752,19 +1190,6 @@ async fn initial_scan(
         }
     }
 
-    // Preload existing rows once so the per-file loop can decide needs_update
-    // from memory instead of issuing one SELECT per file. The same snapshot is
-    // reused for the stale-removal pass below.
-    let existing_by_path: HashMap<&str, &track::Model> = existing_tracks
-        .iter()
-        .map(|model| (model.file_path.as_str(), model))
-        .collect();
-    let persisted_by_path: HashMap<&str, &library_root::Model> = persisted_roots
-        .iter()
-        .map(|state| (state.path.as_str(), state))
-        .collect();
-    let evidence_roots: Vec<PathBuf> = root_scans.iter().map(|scan| scan.root.clone()).collect();
-
     for scan in &mut root_scans {
         let root_path = scan.root.to_string_lossy();
         let previous = persisted_by_path.get(root_path.as_ref()).copied();
@@ -775,8 +1200,17 @@ async fn initial_scan(
                     == Some(scan.root.as_path())
             })
             .count();
-        let confirms_identity = scan_confirms_identity(scan, previous, existing_track_count);
-        scan.reconciliation_authoritative = reconciliation_is_authoritative(scan, previous);
+        let conversion_scan = conversion_roots.contains(&scan.root) && scan.is_complete();
+        let explicitly_configured = configured_dirs.binary_search(&scan.root).is_ok();
+        let confirms_identity = conversion_scan
+            || scan_confirms_identity_for_scope(
+                scan,
+                previous,
+                existing_track_count,
+                explicitly_configured,
+            );
+        scan.reconciliation_authoritative =
+            !conversion_scan && reconciliation_is_authoritative(scan, previous);
 
         if !scan.reconciliation_authoritative && scan.is_complete() {
             warn!(
@@ -789,13 +1223,17 @@ async fn initial_scan(
         if confirms_identity && !previous.is_some_and(|state| state.identity_confirmed) {
             info!(root = %scan.root.display(), device_id = ?scan.device_id, "Established library root identity for future reconciliation");
         }
+        if conversion_scan {
+            info!(root = %scan.root.display(), device_id = ?scan.device_id, "Converted legacy root identity; deletion deferred until the next complete scan");
+        }
 
         // If availability state cannot be persisted, fail closed for this
         // scan: retaining stale metadata is safer than deleting it without a
         // durable device identity for the next startup.
         match persist_root_scan_status(db, scan, previous, confirms_identity).await {
             Ok(()) => {
-                scan.content_authorized = scan.reconciliation_authoritative || confirms_identity;
+                scan.content_authorized =
+                    scan.reconciliation_authoritative || (confirms_identity && !conversion_scan);
             }
             Err(error) => {
                 warn!(root = %scan.root.display(), %error, "Failed to persist library root state");
@@ -829,12 +1267,32 @@ async fn initial_scan(
         };
 
         if needs_update {
+            let (identity_allows_parse, invalidated_root) =
+                revalidate_scan_root_for_path(path, &mut root_scans);
+            if let Some(root) = invalidated_root {
+                mark_root_path_unavailable(db, &root).await;
+                warn!(root = %root.display(), path = %path.display(), "Library root changed before parsing — remaining initial-scan writes disabled");
+            }
+            if !identity_allows_parse {
+                continue;
+            }
+
             let p = path.clone();
             let parse_result =
                 tokio::task::spawn_blocking(move || tag_parser::parse_audio_file(&p)).await;
 
             match parse_result {
                 Ok(Ok(parsed)) => {
+                    let (identity_allows_upsert, invalidated_root) =
+                        revalidate_scan_root_for_path(path, &mut root_scans);
+                    if let Some(root) = invalidated_root {
+                        mark_root_path_unavailable(db, &root).await;
+                        warn!(root = %root.display(), path = %path.display(), "Library root changed while parsing — remaining initial-scan writes disabled");
+                    }
+                    if !identity_allows_upsert {
+                        continue;
+                    }
+
                     // During the initial scan we do NOT emit a TrackUpserted
                     // per file: the single FullSync below delivers the complete
                     // snapshot, avoiding O(n^2) UI work plus a full track-list
@@ -857,6 +1315,30 @@ async fn initial_scan(
         if scanned % 50 == 0 || scanned == total {
             let _ = tx.send(LibraryEvent::ScanProgress(scanned, total)).await;
         }
+    }
+
+    // Parsing can outlive a removable-media transition. Revalidate each
+    // authoritative marker immediately before the destructive phase; a
+    // changed, removed, or unreadable marker disables every stale deletion
+    // for that root.
+    for scan in &mut root_scans {
+        if !scan.reconciliation_authoritative {
+            continue;
+        }
+        let identity_still_matches = scan.device_id.as_deref().is_some_and(|expected| {
+            filesystem_identity(&scan.root).is_ok_and(|observed| observed == expected)
+        });
+        if identity_still_matches {
+            continue;
+        }
+        scan.reconciliation_authoritative = false;
+        if let Some(state) = persisted_by_path
+            .get(scan.root.to_string_lossy().as_ref())
+            .copied()
+        {
+            mark_root_unavailable(db, state).await;
+        }
+        warn!(root = %scan.root.display(), "Library root marker changed before reconciliation — stale deletion disabled");
     }
 
     // Remove DB entries for files no longer on disk. Reuse the preloaded
@@ -936,22 +1418,59 @@ async fn initial_scan(
 // Filesystem watcher
 // ---------------------------------------------------------------------------
 
-async fn persisted_root_for_path(
-    db: &DatabaseConnection,
-    music_dirs: &[PathBuf],
-    path: &Path,
-) -> anyhow::Result<Option<(PathBuf, library_root::Model)>> {
-    let states = library_root::Entity::find().all(db).await?;
-    Ok(states
-        .into_iter()
-        .filter_map(|state| {
-            let root = PathBuf::from(&state.path);
-            let is_configured_scope = music_dirs
-                .iter()
-                .any(|configured| root.starts_with(configured));
-            (is_configured_scope && path.starts_with(&root)).then_some((root, state))
-        })
-        .max_by_key(|(root, _)| root.components().count()))
+#[derive(Debug)]
+struct WatcherRootEntry {
+    root: PathBuf,
+    state: library_root::Model,
+}
+
+#[derive(Debug)]
+struct WatcherRootCache {
+    entries: Vec<WatcherRootEntry>,
+}
+
+impl WatcherRootCache {
+    fn from_models(states: Vec<library_root::Model>, music_dirs: &[PathBuf]) -> Self {
+        let mut entries: Vec<WatcherRootEntry> = states
+            .into_iter()
+            .filter_map(|state| {
+                let root = PathBuf::from(&state.path);
+                music_dirs
+                    .iter()
+                    .any(|configured| root.starts_with(configured))
+                    .then_some(WatcherRootEntry { root, state })
+            })
+            .collect();
+        entries.sort_by_key(|entry| std::cmp::Reverse(entry.root.components().count()));
+        Self { entries }
+    }
+
+    async fn load(db: &DatabaseConnection, music_dirs: &[PathBuf]) -> anyhow::Result<Self> {
+        Ok(Self::from_models(
+            library_root::Entity::find().all(db).await?,
+            music_dirs,
+        ))
+    }
+
+    fn root_for_path(&self, path: &Path) -> Option<(usize, PathBuf, library_root::Model)> {
+        self.entries
+            .iter()
+            .enumerate()
+            .find(|(_, entry)| path.starts_with(&entry.root))
+            .map(|(index, entry)| (index, entry.root.clone(), entry.state.clone()))
+    }
+
+    fn exact_root(&self, root: &Path) -> Option<usize> {
+        self.entries.iter().position(|entry| entry.root == root)
+    }
+
+    fn invalidate(&mut self, index: usize) -> Option<library_root::Model> {
+        let entry = self.entries.get_mut(index)?;
+        entry.state.is_available = false;
+        entry.state.last_scan_complete = false;
+        entry.state.last_checked_at = Utc::now().to_rfc3339();
+        Some(entry.state.clone())
+    }
 }
 
 fn crosses_untracked_nested_mount(root: &Path, path: &Path, music_dirs: &[PathBuf]) -> bool {
@@ -978,12 +1497,38 @@ async fn mark_root_unavailable(db: &DatabaseConnection, state: &library_root::Mo
     }
 }
 
+async fn mark_root_path_unavailable(db: &DatabaseConnection, root: &Path) {
+    let root_path = root.to_string_lossy().into_owned();
+    match library_root::Entity::find_by_id(root_path).one(db).await {
+        Ok(Some(state)) => mark_root_unavailable(db, &state).await,
+        Ok(None) => {
+            warn!(root = %root.display(), "Could not find library root state to mark unavailable");
+        }
+        Err(error) => {
+            warn!(root = %root.display(), %error, "Could not load library root state to mark unavailable");
+        }
+    }
+}
+
+async fn mark_cached_root_unavailable(
+    db: &DatabaseConnection,
+    roots: &mut WatcherRootCache,
+    index: usize,
+) {
+    // Invalidate memory before awaiting SQLite. The remainder of this batch
+    // must fail closed even if persisting the status itself fails.
+    if let Some(state) = roots.invalidate(index) {
+        mark_root_unavailable(db, &state).await;
+    }
+}
+
 async fn root_identity_allows_content(
     db: &DatabaseConnection,
+    roots: &mut WatcherRootCache,
     music_dirs: &[PathBuf],
     path: &Path,
 ) -> anyhow::Result<bool> {
-    let Some((root, root_state)) = persisted_root_for_path(db, music_dirs, path).await? else {
+    let Some((root_index, root, root_state)) = roots.root_for_path(path) else {
         return Ok(false);
     };
     if crosses_untracked_nested_mount(&root, path, music_dirs) {
@@ -996,10 +1541,13 @@ async fn root_identity_allows_content(
     let Some(expected_identity) = root_state.device_id.as_deref() else {
         return Ok(false);
     };
+    if !is_marker_identity(expected_identity) {
+        return Ok(false);
+    }
 
     let matches = filesystem_identity(&root).is_ok_and(|identity| identity == expected_identity);
     if !matches {
-        mark_root_unavailable(db, &root_state).await;
+        mark_cached_root_unavailable(db, roots, root_index).await;
     }
     Ok(matches)
 }
@@ -1008,14 +1556,16 @@ async fn root_identity_allows_content(
 /// identity remains stable across the database transaction.
 async fn delete_track_if_root_stable(
     db: &DatabaseConnection,
+    roots: &mut WatcherRootCache,
     music_dirs: &[PathBuf],
     path: &Path,
 ) -> anyhow::Result<bool> {
-    delete_track_if_root_stable_with_probe(db, music_dirs, path, filesystem_identity).await
+    delete_track_if_root_stable_with_probe(db, roots, music_dirs, path, filesystem_identity).await
 }
 
 async fn delete_track_if_root_stable_with_probe<F>(
     db: &DatabaseConnection,
+    roots: &mut WatcherRootCache,
     music_dirs: &[PathBuf],
     path: &Path,
     mut identity_probe: F,
@@ -1030,7 +1580,7 @@ where
         return Ok(false);
     }
 
-    let Some((root, root_state)) = persisted_root_for_path(db, music_dirs, path).await? else {
+    let Some((root_index, root, root_state)) = roots.root_for_path(path) else {
         return Ok(false);
     };
     if crosses_untracked_nested_mount(&root, path, music_dirs) {
@@ -1043,9 +1593,12 @@ where
     let Some(expected_identity) = root_state.device_id.clone() else {
         return Ok(false);
     };
+    if !is_marker_identity(&expected_identity) {
+        return Ok(false);
+    }
 
     if !identity_probe(&root).is_ok_and(|identity| identity == expected_identity) {
-        mark_root_unavailable(db, &root_state).await;
+        mark_cached_root_unavailable(db, roots, root_index).await;
         return Ok(false);
     }
 
@@ -1067,12 +1620,27 @@ where
         || !identity_probe(&root).is_ok_and(|identity| identity == expected_identity)
     {
         transaction.rollback().await?;
-        mark_root_unavailable(db, &root_state).await;
+        mark_cached_root_unavailable(db, roots, root_index).await;
         return Ok(false);
     }
 
     transaction.commit().await?;
     Ok(true)
+}
+
+fn marker_event_invalidates_root(kind: notify::EventKind) -> bool {
+    use notify::event::{MetadataKind, ModifyKind};
+    use notify::EventKind;
+
+    // Reading the marker is part of every authorization probe and some
+    // backends report open/read/close (or the resulting atime update) through
+    // the same watcher. Those observations must not invalidate the identity
+    // they just verified. Every potentially mutating or unknown event remains
+    // fail-closed.
+    !matches!(
+        kind,
+        EventKind::Access(_) | EventKind::Modify(ModifyKind::Metadata(MetadataKind::AccessTime))
+    )
 }
 
 async fn watch_directories(
@@ -1126,10 +1694,34 @@ async fn watch_directories(
         // debounce window into path sets.
         let mut upsert_paths: HashSet<PathBuf> = HashSet::new();
         let mut remove_paths: HashSet<PathBuf> = HashSet::new();
+        let mut identity_changed_roots: HashSet<PathBuf> = HashSet::new();
 
-        let mut collect_event = |event: notify::Event| {
+        let mut collect_event = |mut event: notify::Event| {
             use notify::event::{ModifyKind, RenameMode};
             use notify::EventKind;
+
+            let marker_invalidates_root = marker_event_invalidates_root(event.kind);
+
+            // The root marker is a control file, not media. Any create,
+            // content/identity change, rename, removal, or unknown event
+            // invalidates cached authorization and requires a future complete
+            // scan before watcher writes resume. Read/access events are
+            // expected from identity probes and are ignored.
+            event.paths.retain(|path| {
+                if path
+                    .file_name()
+                    .is_some_and(|name| name == ROOT_IDENTITY_FILE)
+                {
+                    if marker_invalidates_root {
+                        if let Some(root) = path.parent() {
+                            identity_changed_roots.insert(root.to_path_buf());
+                        }
+                    }
+                    false
+                } else {
+                    true
+                }
+            });
 
             // Classify each path as a removal or an upsert. A rename is
             // delivered as Modify(Name(...)) rather than Remove: the "from"
@@ -1193,11 +1785,34 @@ async fn watch_directories(
             }
         }
 
+        if remove_paths.is_empty() && upsert_paths.is_empty() && identity_changed_roots.is_empty() {
+            continue;
+        }
+
+        // Root state changes only during scans and watcher processing today.
+        // Load one snapshot per debounced batch and mutate it fail-closed as
+        // identities are invalidated, eliminating O(files) root-table reads.
+        let mut root_cache = match WatcherRootCache::load(db.as_ref(), music_dirs).await {
+            Ok(cache) => cache,
+            Err(error) => {
+                warn!(%error, "Could not load library root state; watcher batch rejected");
+                continue;
+            }
+        };
+
+        for root in identity_changed_roots {
+            if let Some(index) = root_cache.exact_root(&root) {
+                mark_cached_root_unavailable(db.as_ref(), &mut root_cache, index).await;
+                warn!(root = %root.display(), "Library root marker changed — watcher writes disabled until rescan");
+            }
+        }
+
         // Process removals.
         for path in &remove_paths {
             let path_str = path.to_string_lossy().to_string();
             debug!(path = %path_str, "File removed (debounced)");
-            match delete_track_if_root_stable(db.as_ref(), music_dirs, path).await {
+            match delete_track_if_root_stable(db.as_ref(), &mut root_cache, music_dirs, path).await
+            {
                 Ok(true) => {
                     let _ = tx.send(LibraryEvent::TrackRemoved(path_str)).await;
                 }
@@ -1210,13 +1825,15 @@ async fn watch_directories(
             }
         }
 
-        // Process upserts concurrently.
+        // Process upserts from the shared, batch-scoped root snapshot.
         if !upsert_paths.is_empty() {
             debug!(count = upsert_paths.len(), "Processing debounced upserts");
             let paths: Vec<PathBuf> = upsert_paths.into_iter().collect();
 
             for path in paths {
-                match root_identity_allows_content(db.as_ref(), music_dirs, &path).await {
+                match root_identity_allows_content(db.as_ref(), &mut root_cache, music_dirs, &path)
+                    .await
+                {
                     Ok(true) => {}
                     Ok(false) => {
                         warn!(path = %path.display(), "Ignored change from an unconfirmed or changed library root");
@@ -1234,9 +1851,14 @@ async fn watch_directories(
                     // stale DB row instead of leaving an orphan that fails to
                     // play.
                     let path_str = path.to_string_lossy().to_string();
-                    if delete_track_if_root_stable(db.as_ref(), music_dirs, &path)
-                        .await
-                        .unwrap_or_else(|error| {
+                    if delete_track_if_root_stable(
+                        db.as_ref(),
+                        &mut root_cache,
+                        music_dirs,
+                        &path,
+                    )
+                    .await
+                    .unwrap_or_else(|error| {
                             warn!(path = %path.display(), %error, "Failed to process missing watched path safely");
                             false
                         })
@@ -1251,9 +1873,14 @@ async fn watch_directories(
                         // Parsing can take long enough for a removable/network
                         // volume to disappear or be replaced. Revalidate the
                         // root immediately before touching persisted metadata.
-                        if !root_identity_allows_content(db.as_ref(), music_dirs, &path)
-                            .await
-                            .unwrap_or(false)
+                        if !root_identity_allows_content(
+                            db.as_ref(),
+                            &mut root_cache,
+                            music_dirs,
+                            &path,
+                        )
+                        .await
+                        .unwrap_or(false)
                         {
                             warn!(path = %path.display(), "Library root changed while parsing — upsert discarded");
                             continue;
@@ -1424,6 +2051,249 @@ mod tests {
     }
 
     #[test]
+    fn durable_root_marker_is_created_once_and_reused() {
+        let directory = TestDirectory::new("root-marker");
+        let legacy = filesystem_identity(directory.path()).expect("observe legacy identity");
+        assert!(is_legacy_identity(&legacy));
+
+        let created = create_root_marker(directory.path()).expect("create root marker");
+        assert!(created.created);
+        assert!(is_marker_identity(&created.identity));
+        let reused = create_root_marker(directory.path()).expect("reuse root marker");
+        assert!(!reused.created);
+        assert_eq!(reused.identity, created.identity);
+        assert_eq!(
+            filesystem_identity(directory.path()).expect("observe durable identity"),
+            created.identity
+        );
+    }
+
+    #[test]
+    fn malformed_root_marker_fails_closed() {
+        let directory = TestDirectory::new("invalid-root-marker");
+        std::fs::write(root_identity_path(directory.path()), "not-a-root-id\n")
+            .expect("write invalid marker");
+
+        assert!(filesystem_identity(directory.path()).is_err());
+        let scan = scan_root(directory.path().to_path_buf());
+        assert!(!scan.is_complete());
+        assert!(scan.device_id.is_none());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn fifo_root_marker_fails_closed_without_blocking() {
+        use rustix::fs::{mkfifoat, Mode, CWD};
+
+        let directory = TestDirectory::new("fifo-root-marker");
+        mkfifoat(
+            CWD,
+            root_identity_path(directory.path()),
+            Mode::RUSR | Mode::WUSR,
+        )
+        .expect("create marker FIFO");
+
+        assert!(read_root_marker(directory.path()).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_root_marker_fails_closed() {
+        use std::os::unix::fs::symlink;
+
+        let directory = TestDirectory::new("symlink-root-marker");
+        let target = directory.path().join("marker-target");
+        std::fs::write(
+            &target,
+            format!("{ROOT_IDENTITY_PREFIX}{}\n", Uuid::new_v4()),
+        )
+        .expect("write marker target");
+        symlink(&target, root_identity_path(directory.path())).expect("symlink marker");
+
+        assert!(filesystem_identity(directory.path()).is_err());
+    }
+
+    #[test]
+    fn legacy_conversion_creates_marker_but_defers_deletion() {
+        let directory = TestDirectory::new("legacy-marker-conversion");
+        std::fs::write(directory.path().join("song.mp3"), []).expect("create audio fixture");
+        let mut scan = scan_root(directory.path().to_path_buf());
+        let previous = persisted_root_state(&scan, scan.device_id.clone());
+        assert!(scan.device_id.as_deref().is_some_and(is_legacy_identity));
+
+        assert!(matches!(
+            prepare_durable_root_identity(&mut scan, Some(&previous), 1, true),
+            RootIdentityPreparation::MarkerCreated {
+                legacy_conversion: true,
+                ..
+            }
+        ));
+        assert!(scan.device_id.as_deref().is_some_and(is_marker_identity));
+        assert!(!reconciliation_is_authoritative(&scan, Some(&previous)));
+    }
+
+    #[test]
+    fn new_root_enrollment_creates_durable_marker() {
+        let directory = TestDirectory::new("new-marker-enrollment");
+        std::fs::write(directory.path().join("song.mp3"), []).expect("create audio fixture");
+        let mut scan = scan_root(directory.path().to_path_buf());
+
+        assert!(matches!(
+            prepare_durable_root_identity(&mut scan, None, 0, true),
+            RootIdentityPreparation::MarkerCreated {
+                legacy_conversion: false,
+                ..
+            }
+        ));
+        assert!(scan.device_id.as_deref().is_some_and(is_marker_identity));
+        assert!(scan_confirms_identity(&scan, None, 0));
+    }
+
+    #[test]
+    fn discovered_nested_root_is_not_modified_or_auto_enrolled() {
+        let directory = TestDirectory::new("discovered-markerless-root");
+        std::fs::write(directory.path().join("song.mp3"), []).expect("create audio fixture");
+        let mut scan = scan_root(directory.path().to_path_buf());
+
+        assert_eq!(
+            prepare_durable_root_identity(&mut scan, None, 0, false),
+            RootIdentityPreparation::Unchanged
+        );
+        assert!(!root_identity_path(directory.path()).exists());
+        assert!(!scan_confirms_identity_for_scope(&scan, None, 0, false));
+    }
+
+    #[test]
+    fn mount_change_before_marker_creation_aborts_enrollment() {
+        let directory = TestDirectory::new("marker-mount-race");
+        std::fs::write(directory.path().join("song.mp3"), []).expect("create audio fixture");
+        let mut scan = scan_root(directory.path().to_path_buf());
+        scan.mount_generation = scan
+            .mount_generation
+            .map(|generation| generation.wrapping_add(1));
+
+        assert_eq!(
+            prepare_durable_root_identity(&mut scan, None, 0, true),
+            RootIdentityPreparation::Unchanged
+        );
+        assert!(!root_identity_path(directory.path()).exists());
+        assert!(!scan.is_complete());
+    }
+
+    #[test]
+    fn initial_scan_root_revalidation_disables_remaining_writes() {
+        let directory = TestDirectory::new("initial-scan-marker-race");
+        let audio_path = directory.path().join("song.mp3");
+        std::fs::write(&audio_path, []).expect("create audio fixture");
+        create_root_marker(directory.path()).expect("create durable root identity");
+        let mut scans = vec![scan_root(directory.path().to_path_buf())];
+        scans[0].content_authorized = true;
+
+        assert_eq!(
+            revalidate_scan_root_for_path(&audio_path, &mut scans),
+            (true, None)
+        );
+        std::fs::write(
+            root_identity_path(directory.path()),
+            format!("{ROOT_IDENTITY_PREFIX}{}\n", Uuid::new_v4()),
+        )
+        .expect("replace root identity");
+        assert_eq!(
+            revalidate_scan_root_for_path(&audio_path, &mut scans),
+            (false, Some(directory.path().to_path_buf()))
+        );
+        assert!(!scans[0].content_authorized);
+        assert!(!scans[0].reconciliation_authoritative);
+        assert_eq!(
+            revalidate_scan_root_for_path(&audio_path, &mut scans),
+            (false, None)
+        );
+    }
+
+    #[test]
+    fn duplicate_root_markers_make_every_copy_incomplete() {
+        let first = TestDirectory::new("duplicate-marker-first");
+        let second = TestDirectory::new("duplicate-marker-second");
+        let identity = create_root_marker(first.path())
+            .expect("create first marker")
+            .identity;
+        std::fs::write(root_identity_path(second.path()), format!("{identity}\n"))
+            .expect("copy marker");
+        let mut scans = vec![
+            scan_root(first.path().to_path_buf()),
+            scan_root(second.path().to_path_buf()),
+        ];
+
+        reject_duplicate_marker_identities(&mut scans);
+
+        assert!(scans.iter().all(|scan| !scan.is_complete()));
+    }
+
+    #[test]
+    fn watcher_root_cache_prefers_specific_roots_and_retains_invalidation() {
+        let parent = PathBuf::from("/music");
+        let child = parent.join("removable");
+        let state = |root: &Path| library_root::Model {
+            path: root.to_string_lossy().into_owned(),
+            device_id: Some(format!("{ROOT_IDENTITY_PREFIX}{}", Uuid::new_v4())),
+            identity_confirmed: true,
+            is_available: true,
+            last_scan_complete: true,
+            last_checked_at: "2026-07-10T00:00:00Z".to_string(),
+        };
+        let mut cache = WatcherRootCache::from_models(
+            vec![state(&parent), state(&child), state(Path::new("/other"))],
+            std::slice::from_ref(&parent),
+        );
+
+        let (child_index, selected_root, selected_state) = cache
+            .root_for_path(&child.join("album/song.flac"))
+            .expect("select nested root");
+        assert_eq!(selected_root, child);
+        assert!(selected_state.is_available);
+        assert!(cache.invalidate(child_index).is_some());
+
+        let (_, selected_root, selected_state) = cache
+            .root_for_path(&child.join("album/other.flac"))
+            .expect("retain nested root");
+        assert_eq!(selected_root, child);
+        assert!(!selected_state.is_available);
+        assert!(!selected_state.last_scan_complete);
+        assert!(cache
+            .root_for_path(&parent.join("parent-song.flac"))
+            .is_some_and(|(_, root, state)| root == parent && state.is_available));
+        assert!(cache.root_for_path(Path::new("/other/song.flac")).is_none());
+    }
+
+    #[test]
+    fn marker_access_events_do_not_invalidate_root_identity() {
+        use notify::event::{
+            AccessKind, AccessMode, CreateKind, DataChange, MetadataKind, ModifyKind, RemoveKind,
+        };
+        use notify::EventKind;
+
+        assert!(!marker_event_invalidates_root(EventKind::Access(
+            AccessKind::Open(AccessMode::Read)
+        )));
+        assert!(!marker_event_invalidates_root(EventKind::Access(
+            AccessKind::Read
+        )));
+        assert!(!marker_event_invalidates_root(EventKind::Modify(
+            ModifyKind::Metadata(MetadataKind::AccessTime)
+        )));
+        assert!(marker_event_invalidates_root(EventKind::Create(
+            CreateKind::File
+        )));
+        assert!(marker_event_invalidates_root(EventKind::Modify(
+            ModifyKind::Data(DataChange::Content)
+        )));
+        assert!(marker_event_invalidates_root(EventKind::Remove(
+            RemoveKind::File
+        )));
+        assert!(marker_event_invalidates_root(EventKind::Any));
+    }
+
+    #[test]
     fn missing_root_is_incomplete_and_never_authoritative() {
         let directory = TestDirectory::new("missing");
         let missing = directory.path().join("not-mounted");
@@ -1442,6 +2312,7 @@ mod tests {
     #[test]
     fn healthy_empty_root_is_authoritative() {
         let directory = TestDirectory::new("empty");
+        create_root_marker(directory.path()).expect("create durable root identity");
         let mut scan = scan_root(directory.path().to_path_buf());
         let previous = persisted_root_state(&scan, scan.device_id.clone());
         scan.reconciliation_authoritative = reconciliation_is_authoritative(&scan, Some(&previous));
@@ -1587,6 +2458,7 @@ mod tests {
             audio_files: Vec::new(),
             errors: vec!["simulated permission error".to_string()],
             device_id: Some("simulated-device".to_string()),
+            mount_generation: Some(0),
             reconciliation_authoritative: false,
             content_authorized: false,
         };
@@ -1606,6 +2478,14 @@ mod tests {
         let directory = TestDirectory::new("permission-denied");
         std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o000))
             .expect("remove root permissions");
+
+        // Privileged containers can retain directory access despite mode 000.
+        // In that environment no permission-denied traversal can be exercised.
+        if std::fs::read_dir(directory.path()).is_ok() {
+            std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o700))
+                .expect("restore root permissions");
+            return;
+        }
 
         let scan = scan_root(directory.path().to_path_buf());
 
@@ -1631,6 +2511,14 @@ mod tests {
         std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000))
             .expect("remove nested permissions");
 
+        // Root and capability-enabled CI containers can bypass Unix mode bits.
+        // Skip the assertion when this fixture cannot induce a read failure.
+        if std::fs::read_dir(&locked).is_ok() {
+            std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o700))
+                .expect("restore nested permissions");
+            return;
+        }
+
         let scan = scan_root(directory.path().to_path_buf());
 
         std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o700))
@@ -1653,6 +2541,7 @@ mod tests {
     #[test]
     fn matching_persisted_device_authorizes_an_empty_root() {
         let directory = TestDirectory::new("matching-device");
+        create_root_marker(directory.path()).expect("create durable root identity");
         let scan = scan_root(directory.path().to_path_buf());
         let previous = persisted_root_state(&scan, scan.device_id.clone());
 
@@ -1744,6 +2633,7 @@ mod tests {
             audio_files: Vec::new(),
             errors: Vec::new(),
             device_id: Some("underlying-mountpoint".to_string()),
+            mount_generation: Some(0),
             reconciliation_authoritative: false,
             content_authorized: false,
         };
@@ -1761,7 +2651,8 @@ mod tests {
             root: root.clone(),
             audio_files: vec![root.join("song.mp3")],
             errors: Vec::new(),
-            device_id: Some("real-volume".to_string()),
+            device_id: Some(format!("{ROOT_IDENTITY_PREFIX}{}", Uuid::new_v4())),
+            mount_generation: Some(0),
             reconciliation_authoritative: false,
             content_authorized: false,
         };
@@ -1898,16 +2789,19 @@ mod tests {
     #[test]
     fn mount_generation_change_between_scans_keeps_stable_identity_authoritative() {
         let directory = TestDirectory::new("mount-generation-reboot");
+        let identity = format!("{ROOT_IDENTITY_PREFIX}{}", Uuid::new_v4());
+        let first_identity = identity.clone();
         let first_scan = scan_root_with_probes_and_exclusions(
             directory.path().to_path_buf(),
-            |_| Ok("stable-volume".to_string()),
+            move |_| Ok(first_identity.clone()),
             |_| Ok(41),
             &[],
         );
         let previous = persisted_root_state(&first_scan, first_scan.device_id.clone());
+        let second_identity = identity;
         let second_scan = scan_root_with_probes_and_exclusions(
             directory.path().to_path_buf(),
-            |_| Ok("stable-volume".to_string()),
+            move |_| Ok(second_identity.clone()),
             |_| Ok(99),
             &[],
         );
@@ -1979,11 +2873,16 @@ mod tests {
         Migrator::up(&db, None).await.expect("run migrations");
 
         let directory = TestDirectory::new("watcher-identity-race");
+        create_root_marker(directory.path()).expect("create durable root identity");
         let scan = scan_root(directory.path().to_path_buf());
         let expected_identity = scan.device_id.clone().expect("root identity");
         persist_root_scan_status(&db, &scan, None, true)
             .await
             .expect("persist confirmed root");
+        let music_dirs = vec![directory.path().to_path_buf()];
+        let mut root_cache = WatcherRootCache::load(&db, &music_dirs)
+            .await
+            .expect("load watcher root state");
 
         let removed_path = directory.path().join("removed.mp3");
         let model = track::Model {
@@ -2015,7 +2914,8 @@ mod tests {
         let stable_identity = expected_identity.clone();
         assert!(!delete_track_if_root_stable_with_probe(
             &db,
-            &[directory.path().to_path_buf()],
+            &mut root_cache,
+            &music_dirs,
             &removed_path,
             move |_| Ok(stable_identity.clone()),
         )
@@ -2032,7 +2932,8 @@ mod tests {
         let first_identity = expected_identity.clone();
         let removed = delete_track_if_root_stable_with_probe(
             &db,
-            &[directory.path().to_path_buf()],
+            &mut root_cache,
+            &music_dirs,
             &removed_path,
             move |_| {
                 let call = probe_calls.get();

--- a/src/local/engine.rs
+++ b/src/local/engine.rs
@@ -10,7 +10,10 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
-use sea_orm::{ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, Set};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, Set,
+    TransactionTrait,
+};
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
@@ -18,7 +21,7 @@ use walkdir::WalkDir;
 
 use super::tag_parser::{self, ParsedTrack};
 use crate::architecture::models::Track;
-use crate::db::entities::track;
+use crate::db::entities::{library_root, track};
 
 // ---------------------------------------------------------------------------
 // LibraryEvent — messages sent to GTK main thread
@@ -32,6 +35,14 @@ pub enum LibraryEvent {
     /// Tracks from a remote backend, keyed by source (e.g. server URL).
     RemoteSync {
         source_key: String,
+        tracks: Vec<Track>,
+    },
+    /// Tracks from a generation-scoped DAAP session. The GTK receiver
+    /// validates this ownership token before publishing the tracks.
+    DaapSync {
+        source_key: String,
+        generation: u64,
+        session_key: Uuid,
         tracks: Vec<Track>,
     },
     /// A single track was added or updated.
@@ -102,67 +113,704 @@ impl LibraryEngine {
 // Initial scan
 // ---------------------------------------------------------------------------
 
+/// The result of enumerating one configured library root.
+///
+/// Keeping completeness separate from the discovered files is important: an
+/// empty directory is a complete, authoritative view, while a directory that
+/// yielded some files plus a traversal error is not. Only the former may be
+/// used to remove stale database rows.
+#[derive(Debug)]
+struct RootScan {
+    root: PathBuf,
+    audio_files: Vec<PathBuf>,
+    errors: Vec<String>,
+    device_id: Option<String>,
+    reconciliation_authoritative: bool,
+    content_authorized: bool,
+}
+
+impl RootScan {
+    fn is_complete(&self) -> bool {
+        self.errors.is_empty()
+    }
+}
+
+#[cfg(unix)]
+fn filesystem_identity(path: &Path) -> std::io::Result<String> {
+    use std::os::unix::fs::MetadataExt;
+
+    let metadata = std::fs::metadata(path)?;
+    let filesystem = rustix::fs::statvfs(path).map_err(std::io::Error::from)?;
+    Ok(format!(
+        "unix:{}:{}:{}",
+        filesystem.f_fsid,
+        metadata.dev(),
+        metadata.ino()
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn filesystem_boundary_id(path: &Path) -> std::io::Result<u64> {
+    // A bind mount can share `st_dev` with its parent while still being an
+    // independent availability scope. The per-mount ID catches that boundary
+    // even if it appeared after the initial mount-table snapshot.
+    root_mount_generation(path)
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn filesystem_boundary_id(path: &Path) -> std::io::Result<u64> {
+    use std::os::unix::fs::MetadataExt;
+
+    Ok(std::fs::metadata(path)?.dev())
+}
+
+#[cfg(not(unix))]
+fn filesystem_boundary_id(_path: &Path) -> std::io::Result<u64> {
+    Ok(0)
+}
+
+/// Return the current Linux mount instance for `path`.
+///
+/// Unlike the persisted filesystem identity, this value is intentionally
+/// ephemeral: unmounting and remounting the same volume produces a new mount
+/// ID even when its fsid, device number, and root inode are unchanged. Comparing
+/// it before and after traversal closes that ABA window without making a normal
+/// remount permanently invalidate the persisted library-root identity.
+#[cfg(target_os = "linux")]
+fn root_mount_generation(path: &Path) -> std::io::Result<u64> {
+    use rustix::fs::{AtFlags, StatxFlags, CWD};
+
+    if let Ok(stat) = rustix::fs::statx(CWD, path, AtFlags::empty(), StatxFlags::MNT_ID) {
+        if stat.stx_mask & StatxFlags::MNT_ID.bits() != 0 {
+            return Ok(stat.stx_mnt_id);
+        }
+    }
+
+    // `STATX_MNT_ID` was added after statx itself. Fall back to mountinfo on
+    // older kernels or restricted containers rather than silently dropping
+    // the generation check.
+    let canonical = path.canonicalize()?;
+    let contents = std::fs::read_to_string("/proc/self/mountinfo")?;
+    mount_generation_from_mountinfo(&contents, &canonical)?.ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("no Linux mount scope contains {}", canonical.display()),
+        )
+    })
+}
+
+#[cfg(not(target_os = "linux"))]
+fn root_mount_generation(_path: &Path) -> std::io::Result<u64> {
+    // Other platforms still use the stable pre/post filesystem identity. A
+    // constant generation keeps the shared traversal implementation portable.
+    Ok(0)
+}
+
+#[cfg(target_os = "linux")]
+fn decode_mountinfo_path(field: &str) -> std::io::Result<PathBuf> {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
+    let bytes = field.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'\\' && index + 3 < bytes.len() {
+            let octal = &bytes[index + 1..index + 4];
+            if octal.iter().all(|byte| matches!(byte, b'0'..=b'7')) {
+                decoded.push((octal[0] - b'0') * 64 + (octal[1] - b'0') * 8 + (octal[2] - b'0'));
+                index += 4;
+                continue;
+            }
+        }
+        if bytes[index] == b'\\' {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("invalid mountinfo path escape in {field:?}"),
+            ));
+        }
+        decoded.push(bytes[index]);
+        index += 1;
+    }
+    Ok(PathBuf::from(OsString::from_vec(decoded)))
+}
+
+#[cfg(target_os = "linux")]
+fn parse_mountinfo(contents: &str) -> std::io::Result<Vec<(u64, PathBuf)>> {
+    let mut records = Vec::new();
+    for (line_index, line) in contents.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let fields: Vec<&str> = line.split_whitespace().collect();
+        let separator = fields.iter().position(|field| *field == "-");
+        if fields.len() < 10
+            || !separator.is_some_and(|index| index >= 6 && fields.len() >= index + 4)
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("malformed mountinfo line {}", line_index + 1),
+            ));
+        }
+        let mount_id = fields[0].parse::<u64>().map_err(|error| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "invalid mount ID on mountinfo line {}: {error}",
+                    line_index + 1
+                ),
+            )
+        })?;
+        let mountpoint = decode_mountinfo_path(fields[4])?;
+        if !mountpoint.is_absolute() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "non-absolute mountpoint on mountinfo line {}",
+                    line_index + 1
+                ),
+            ));
+        }
+        records.push((mount_id, mountpoint));
+    }
+    if records.is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "mountinfo contained no mount records",
+        ));
+    }
+    Ok(records)
+}
+
+#[cfg(target_os = "linux")]
+fn mount_generation_from_mountinfo(contents: &str, path: &Path) -> std::io::Result<Option<u64>> {
+    Ok(parse_mountinfo(contents)?
+        .into_iter()
+        .filter(|(_, mountpoint)| path.starts_with(mountpoint))
+        .max_by_key(|(_, mountpoint)| mountpoint.components().count())
+        .map(|(mount_id, _)| mount_id))
+}
+
+#[cfg(target_os = "linux")]
+fn mounted_subroots_from_mountinfo(
+    contents: &str,
+    configured_roots: &[PathBuf],
+) -> std::io::Result<Vec<PathBuf>> {
+    let mut roots: Vec<PathBuf> = parse_mountinfo(contents)?
+        .into_iter()
+        .map(|(_, mountpoint)| mountpoint)
+        .filter(|mountpoint| {
+            configured_roots
+                .iter()
+                .any(|root| mountpoint != root && mountpoint.starts_with(root))
+        })
+        .collect();
+    roots.sort_unstable();
+    roots.dedup();
+    Ok(roots)
+}
+
+#[cfg(target_os = "linux")]
+fn mounted_subroots(configured_roots: &[PathBuf]) -> std::io::Result<Vec<PathBuf>> {
+    std::fs::read_to_string("/proc/self/mountinfo")
+        .and_then(|contents| mounted_subroots_from_mountinfo(&contents, configured_roots))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn mounted_subroots(_configured_roots: &[PathBuf]) -> std::io::Result<Vec<PathBuf>> {
+    Ok(Vec::new())
+}
+
+fn expanded_scan_roots(
+    configured_roots: &[PathBuf],
+    persisted_roots: &[library_root::Model],
+) -> std::io::Result<Vec<PathBuf>> {
+    expanded_scan_roots_with_mount_result(
+        configured_roots,
+        persisted_roots,
+        mounted_subroots(configured_roots),
+    )
+}
+
+fn expanded_scan_roots_with_mount_result(
+    configured_roots: &[PathBuf],
+    persisted_roots: &[library_root::Model],
+    mounted_roots: std::io::Result<Vec<PathBuf>>,
+) -> std::io::Result<Vec<PathBuf>> {
+    mounted_roots.map(|mounted_roots| {
+        expanded_scan_roots_with_mounts(configured_roots, persisted_roots, mounted_roots)
+    })
+}
+
+fn expanded_scan_roots_with_mounts(
+    configured_roots: &[PathBuf],
+    persisted_roots: &[library_root::Model],
+    mounted_roots: Vec<PathBuf>,
+) -> Vec<PathBuf> {
+    let mut roots = configured_roots.to_vec();
+    roots.extend(mounted_roots);
+    roots.extend(persisted_roots.iter().filter_map(|state| {
+        let path = PathBuf::from(&state.path);
+        configured_roots
+            .iter()
+            .any(|configured| path.starts_with(configured))
+            .then_some(path)
+    }));
+    roots.sort_unstable();
+    roots.dedup();
+    roots
+}
+
+#[cfg(windows)]
+fn filesystem_identity(path: &Path) -> std::io::Result<String> {
+    use std::os::windows::fs::MetadataExt;
+
+    let metadata = std::fs::metadata(path)?;
+    let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    // A mounted volume exposes the mounted root's creation time, while an
+    // absent directory mount exposes the underlying mountpoint's metadata.
+    // Drive-letter and UNC roots become inaccessible when unavailable, which
+    // makes their traversal incomplete before this identity is consulted.
+    Ok(format!(
+        "windows:{}:{}",
+        canonical.to_string_lossy(),
+        metadata.creation_time()
+    ))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn filesystem_identity(path: &Path) -> std::io::Result<String> {
+    Ok(format!("path:{}", path.canonicalize()?.to_string_lossy()))
+}
+
+fn scan_root(root: PathBuf) -> RootScan {
+    scan_root_with_probes_and_exclusions(root, filesystem_identity, root_mount_generation, &[])
+}
+
+fn scan_root_with_identity_probe<F>(root: PathBuf, identity_probe: F) -> RootScan
+where
+    F: FnMut(&Path) -> std::io::Result<String>,
+{
+    scan_root_with_probes_and_exclusions(root, identity_probe, root_mount_generation, &[])
+}
+
+fn scan_root_with_exclusions(root: PathBuf, all_roots: &[PathBuf]) -> RootScan {
+    let exclusions: Vec<PathBuf> = all_roots
+        .iter()
+        .filter(|candidate| candidate.as_path() != root && candidate.starts_with(&root))
+        .cloned()
+        .collect();
+    scan_root_with_probes_and_exclusions(
+        root,
+        filesystem_identity,
+        root_mount_generation,
+        &exclusions,
+    )
+}
+
+fn scan_root_with_probes_and_exclusions<F, G>(
+    root: PathBuf,
+    mut identity_probe: F,
+    mut mount_generation_probe: G,
+    exclusions: &[PathBuf],
+) -> RootScan
+where
+    F: FnMut(&Path) -> std::io::Result<String>,
+    G: FnMut(&Path) -> std::io::Result<u64>,
+{
+    if !root.is_dir() {
+        return RootScan {
+            errors: vec![format!(
+                "library root does not exist or is not a directory: {}",
+                root.display()
+            )],
+            root,
+            audio_files: Vec::new(),
+            device_id: None,
+            reconciliation_authoritative: false,
+            content_authorized: false,
+        };
+    }
+
+    let device_id = match identity_probe(&root) {
+        Ok(identity) => Some(identity),
+        Err(error) => {
+            return RootScan {
+                errors: vec![format!(
+                    "failed to identify library root {}: {error}",
+                    root.display()
+                )],
+                root,
+                audio_files: Vec::new(),
+                device_id: None,
+                reconciliation_authoritative: false,
+                content_authorized: false,
+            };
+        }
+    };
+
+    let mount_generation = match mount_generation_probe(&root) {
+        Ok(generation) => generation,
+        Err(error) => {
+            return RootScan {
+                errors: vec![format!(
+                    "failed to identify library root mount generation {}: {error}",
+                    root.display()
+                )],
+                root,
+                audio_files: Vec::new(),
+                device_id,
+                reconciliation_authoritative: false,
+                content_authorized: false,
+            };
+        }
+    };
+
+    let mut audio_files = Vec::new();
+    let mut errors = Vec::new();
+    let root_boundary = match filesystem_boundary_id(&root) {
+        Ok(boundary) => Some(boundary),
+        Err(error) => {
+            errors.push(format!(
+                "failed to identify library root boundary {}: {error}",
+                root.display()
+            ));
+            None
+        }
+    };
+
+    let mut entries = WalkDir::new(&root)
+        // Do NOT follow symlinks: the notify watcher does not follow them
+        // either, so following here would index files (via symlinked
+        // subtrees) that are never watched for changes, and could index one
+        // physical file under multiple paths as duplicate rows.
+        .follow_links(false)
+        .into_iter();
+    while let Some(entry) = entries.next() {
+        match entry {
+            Ok(entry) if entry.depth() > 0 && entry.file_type().is_dir() => {
+                if exclusions.iter().any(|path| path == entry.path()) {
+                    entries.skip_current_dir();
+                    continue;
+                }
+                if let Some(root_id) = root_boundary {
+                    match filesystem_boundary_id(entry.path()) {
+                        Ok(entry_id) if root_id != entry_id => {
+                            errors.push(format!(
+                                "nested filesystem requires its own configured root: {}",
+                                entry.path().display()
+                            ));
+                            entries.skip_current_dir();
+                        }
+                        Ok(_) => {}
+                        Err(error) => {
+                            errors.push(format!(
+                                "failed to identify filesystem boundary {}: {error}",
+                                entry.path().display()
+                            ));
+                            entries.skip_current_dir();
+                        }
+                    }
+                } else {
+                    // A root whose boundary could not be established is never
+                    // authoritative, but avoid crossing any child scope while
+                    // collecting diagnostics from the rest of the traversal.
+                    if entry.depth() > 0 {
+                        errors.push(format!(
+                            "skipping directory without a trusted root boundary: {}",
+                            entry.path().display()
+                        ));
+                        entries.skip_current_dir();
+                    }
+                }
+            }
+            Ok(entry) if entry.file_type().is_file() && tag_parser::is_audio_file(entry.path()) => {
+                audio_files.push(entry.into_path());
+            }
+            Ok(_) => {}
+            Err(error) => errors.push(error.to_string()),
+        }
+    }
+
+    match mount_generation_probe(&root) {
+        Ok(generation) if generation == mount_generation => {}
+        Ok(generation) => errors.push(format!(
+            "library root mount generation changed during traversal (before={mount_generation}, after={generation})"
+        )),
+        Err(error) => errors.push(format!(
+            "failed to re-identify library root mount generation {} after traversal: {error}",
+            root.display()
+        )),
+    }
+
+    match identity_probe(&root) {
+        Ok(identity) if Some(&identity) == device_id.as_ref() => {}
+        Ok(identity) => errors.push(format!(
+            "library root identity changed during traversal (before={device_id:?}, after={identity})"
+        )),
+        Err(error) => errors.push(format!(
+            "failed to re-identify library root {} after traversal: {error}",
+            root.display()
+        )),
+    }
+
+    RootScan {
+        root,
+        audio_files,
+        errors,
+        device_id,
+        reconciliation_authoritative: false,
+        content_authorized: false,
+    }
+}
+
+fn collect_audio_files(root_scans: &[RootScan]) -> Vec<PathBuf> {
+    let mut audio_files: Vec<PathBuf> = root_scans
+        .iter()
+        .filter(|scan| scan.content_authorized)
+        .flat_map(|scan| scan.audio_files.iter().cloned())
+        .collect();
+
+    // The same file is visible through every configured ancestor root. Scan
+    // it once even if the user's configuration contains overlapping roots.
+    audio_files.sort_unstable();
+    audio_files.dedup();
+    audio_files
+}
+
+/// Return the most specific configured root containing `path`.
+///
+/// Choosing the deepest root ensures an explicitly configured unavailable
+/// child protects its rows even when an available parent also contains it.
+fn root_scan_for_path<'a>(path: &Path, root_scans: &'a [RootScan]) -> Option<&'a RootScan> {
+    root_scans
+        .iter()
+        .filter(|scan| path.starts_with(&scan.root))
+        .max_by_key(|scan| scan.root.components().count())
+}
+
+fn most_specific_root_for_path<'a>(path: &Path, roots: &'a [PathBuf]) -> Option<&'a Path> {
+    roots
+        .iter()
+        .map(PathBuf::as_path)
+        .filter(|root| path.starts_with(root))
+        .max_by_key(|root| root.components().count())
+}
+
+fn should_remove_stale_track(
+    path: &Path,
+    on_disk_paths: &HashSet<String>,
+    root_scans: &[RootScan],
+) -> bool {
+    if on_disk_paths.contains(path.to_string_lossy().as_ref()) {
+        return false;
+    }
+
+    root_scan_for_path(path, root_scans)
+        .is_some_and(|scan| scan.is_complete() && scan.reconciliation_authoritative)
+}
+
+/// Decide whether a complete scan may authoritatively remove stale rows.
+///
+/// An explicitly established filesystem identity must match the current root.
+/// New observations never authorize deletion in the same scan: enrollment
+/// and reconciliation authority are deliberately separate states.
+fn reconciliation_is_authoritative(
+    scan: &RootScan,
+    previous: Option<&library_root::Model>,
+) -> bool {
+    if !scan.is_complete() {
+        return false;
+    }
+
+    let Some(observed_device_id) = scan.device_id.as_deref() else {
+        return false;
+    };
+
+    previous.is_some_and(|state| {
+        state.identity_confirmed && state.device_id.as_deref() == Some(observed_device_id)
+    })
+}
+
+/// Decide whether this scan establishes a root identity for future scans.
+///
+/// A brand-new root can be enrolled only when it has content and no existing
+/// metadata can be harmed. A legacy root with rows is deliberately left
+/// unconfirmed until an explicit-trust UX can resolve the intended volume:
+/// even a complete path/size/mtime clone cannot prove physical identity. A
+/// different device never silently replaces a confirmed identity.
+fn scan_confirms_identity(
+    scan: &RootScan,
+    previous: Option<&library_root::Model>,
+    existing_track_count: usize,
+) -> bool {
+    if !scan.is_complete() || scan.device_id.is_none() || scan.audio_files.is_empty() {
+        return false;
+    }
+
+    if let Some(state) = previous {
+        if state.identity_confirmed {
+            return state.device_id.as_deref() == scan.device_id.as_deref();
+        }
+    }
+
+    existing_track_count == 0
+}
+
+async fn persist_root_scan_status(
+    db: &DatabaseConnection,
+    scan: &RootScan,
+    previous: Option<&library_root::Model>,
+    confirms_identity: bool,
+) -> anyhow::Result<()> {
+    let was_confirmed = previous.is_some_and(|state| state.identity_confirmed);
+    let recorded_device_id = if confirms_identity {
+        scan.device_id.clone()
+    } else if was_confirmed || !scan.is_complete() {
+        previous.and_then(|state| state.device_id.clone())
+    } else {
+        // Keep the latest untrusted observation for diagnostics, but it never
+        // authorizes deletion until a later scan explicitly confirms it.
+        scan.device_id.clone()
+    };
+    let identity_confirmed = was_confirmed || confirms_identity;
+    let is_available =
+        scan.is_complete() && (scan.reconciliation_authoritative || confirms_identity);
+    let last_checked_at = Utc::now().to_rfc3339();
+
+    if let Some(state) = previous {
+        let mut active: library_root::ActiveModel = state.clone().into();
+        active.device_id = Set(recorded_device_id);
+        active.identity_confirmed = Set(identity_confirmed);
+        active.is_available = Set(is_available);
+        active.last_scan_complete = Set(scan.is_complete());
+        active.last_checked_at = Set(last_checked_at);
+        active.update(db).await?;
+    } else {
+        library_root::ActiveModel {
+            path: Set(scan.root.to_string_lossy().into_owned()),
+            device_id: Set(recorded_device_id),
+            identity_confirmed: Set(identity_confirmed),
+            is_available: Set(is_available),
+            last_scan_complete: Set(scan.is_complete()),
+            last_checked_at: Set(last_checked_at),
+        }
+        .insert(db)
+        .await?;
+    }
+
+    Ok(())
+}
+
 async fn initial_scan(
     db: &DatabaseConnection,
     music_dirs: &[PathBuf],
     tx: &async_channel::Sender<LibraryEvent>,
 ) -> anyhow::Result<()> {
-    let dirs = music_dirs.to_vec();
+    let mut configured_dirs = music_dirs.to_vec();
+    configured_dirs.sort_unstable();
+    configured_dirs.dedup();
 
-    // Missing directories are skipped silently by WalkDir below; warn so an
-    // unexpectedly empty library is easy to diagnose.
-    for dir in music_dirs {
-        if !dir.is_dir() {
-            warn!(dir = %dir.display(), "Library folder does not exist — skipping scan");
-        }
-    }
+    // Load persisted roots before enumeration so previously-seen nested
+    // mounts remain independent reconciliation scopes even while unmounted.
+    let existing_tracks = track::Entity::find().all(db).await?;
+    let persisted_roots = library_root::Entity::find().all(db).await?;
+    let dirs = expanded_scan_roots(&configured_dirs, &persisted_roots).map_err(|error| {
+        anyhow::anyhow!(
+            "failed to inspect mounted library scopes; scan disabled to protect metadata: {error}"
+        )
+    })?;
+    let all_roots = dirs.clone();
 
-    // Collect audio files from ALL directories (blocking I/O in spawn_blocking)
-    let audio_files: Vec<PathBuf> = tokio::task::spawn_blocking(move || {
-        dirs.iter()
-            .flat_map(|dir| {
-                WalkDir::new(dir)
-                    // Do NOT follow symlinks: the notify watcher does not
-                    // follow them either, so following here would index files
-                    // (via symlinked subtrees) that are never watched for
-                    // changes, and could index one physical file under
-                    // multiple paths as duplicate rows.
-                    .follow_links(false)
-                    .into_iter()
-                    .filter_map(|e| e.ok())
-                    .filter(|e| e.file_type().is_file())
-                    .filter(|e| tag_parser::is_audio_file(e.path()))
-                    .map(|e| e.into_path())
-            })
-            .collect()
+    // Collect a separate traversal result for every root. Never infer scan
+    // completeness from the number of audio files: a healthy empty directory
+    // is authoritative, while even a single WalkDir error makes that root's
+    // view incomplete and therefore unsafe for stale deletion.
+    let mut root_scans = tokio::task::spawn_blocking(move || {
+        dirs.into_iter()
+            .map(|root| scan_root_with_exclusions(root, &all_roots))
+            .collect::<Vec<_>>()
     })
     .await?;
 
-    let total = audio_files.len() as u64;
-    info!(total, "Found audio files to scan");
-
-    // Determine which configured roots were actually scanned. A root that is
-    // missing or yielded zero files (e.g. an unmounted external/network drive
-    // whose mountpoint still exists as an empty directory) must NOT trigger
-    // stale-removal of its tracks below — otherwise a temporarily-unavailable
-    // library would be silently purged from the DB, destroying play counts,
-    // date_added and stable track identity.
-    let mut unavailable_roots: Vec<&Path> = Vec::new();
-    for dir in music_dirs {
-        let has_files = audio_files.iter().any(|p| p.starts_with(dir));
-        if !dir.is_dir() || !has_files {
-            unavailable_roots.push(dir.as_path());
+    for scan in &root_scans {
+        if scan.is_complete() {
+            debug!(
+                root = %scan.root.display(),
+                files = scan.audio_files.len(),
+                "Library root traversal complete"
+            );
+        } else {
+            warn!(
+                root = %scan.root.display(),
+                errors = scan.errors.len(),
+                "Library root traversal incomplete — stale deletion disabled"
+            );
+            for traversal_error in &scan.errors {
+                warn!(root = %scan.root.display(), error = %traversal_error, "Library traversal error");
+            }
         }
     }
 
     // Preload existing rows once so the per-file loop can decide needs_update
     // from memory instead of issuing one SELECT per file. The same snapshot is
     // reused for the stale-removal pass below.
-    let existing_tracks = track::Entity::find().all(db).await?;
     let existing_by_path: HashMap<&str, &track::Model> = existing_tracks
         .iter()
-        .map(|m| (m.file_path.as_str(), m))
+        .map(|model| (model.file_path.as_str(), model))
         .collect();
+    let persisted_by_path: HashMap<&str, &library_root::Model> = persisted_roots
+        .iter()
+        .map(|state| (state.path.as_str(), state))
+        .collect();
+    let evidence_roots: Vec<PathBuf> = root_scans.iter().map(|scan| scan.root.clone()).collect();
+
+    for scan in &mut root_scans {
+        let root_path = scan.root.to_string_lossy();
+        let previous = persisted_by_path.get(root_path.as_ref()).copied();
+        let existing_track_count = existing_tracks
+            .iter()
+            .filter(|row| {
+                most_specific_root_for_path(Path::new(&row.file_path), &evidence_roots)
+                    == Some(scan.root.as_path())
+            })
+            .count();
+        let confirms_identity = scan_confirms_identity(scan, previous, existing_track_count);
+        scan.reconciliation_authoritative = reconciliation_is_authoritative(scan, previous);
+
+        if !scan.reconciliation_authoritative && scan.is_complete() {
+            warn!(
+                root = %scan.root.display(),
+                observed_device_id = ?scan.device_id,
+                expected_device_id = ?previous.and_then(|state| state.device_id.as_deref()),
+                "Library root identity is unestablished or changed — stale deletion disabled"
+            );
+        }
+        if confirms_identity && !previous.is_some_and(|state| state.identity_confirmed) {
+            info!(root = %scan.root.display(), device_id = ?scan.device_id, "Established library root identity for future reconciliation");
+        }
+
+        // If availability state cannot be persisted, fail closed for this
+        // scan: retaining stale metadata is safer than deleting it without a
+        // durable device identity for the next startup.
+        match persist_root_scan_status(db, scan, previous, confirms_identity).await {
+            Ok(()) => {
+                scan.content_authorized = scan.reconciliation_authoritative || confirms_identity;
+            }
+            Err(error) => {
+                warn!(root = %scan.root.display(), %error, "Failed to persist library root state");
+                scan.reconciliation_authoritative = false;
+                scan.content_authorized = false;
+            }
+        }
+        if !scan.content_authorized && !scan.audio_files.is_empty() {
+            warn!(root = %scan.root.display(), "Ignoring files from an unconfirmed or changed library root");
+        }
+    }
+
+    let audio_files = collect_audio_files(&root_scans);
+    let total = audio_files.len() as u64;
+    info!(total, "Found authorized audio files to scan");
 
     let mut scanned: u64 = 0;
     let mut on_disk_paths = HashSet::new();
@@ -216,16 +864,8 @@ async fn initial_scan(
     // skipped rather than aborting the whole scan, so a transient DB hiccup
     // can't discard the FullSync/ScanComplete that follow.
     for row in &existing_tracks {
-        if on_disk_paths.contains(&row.file_path) {
-            continue;
-        }
-        // Skip rows under a root that wasn't successfully scanned, so a
-        // temporarily-unavailable directory doesn't wipe its tracks.
         let row_path = Path::new(&row.file_path);
-        if unavailable_roots
-            .iter()
-            .any(|&root| row_path.starts_with(root))
-        {
+        if !should_remove_stale_track(row_path, &on_disk_paths, &root_scans) {
             continue;
         }
         info!(path = %row.file_path, "Removing stale track from database");
@@ -295,6 +935,145 @@ async fn initial_scan(
 // ---------------------------------------------------------------------------
 // Filesystem watcher
 // ---------------------------------------------------------------------------
+
+async fn persisted_root_for_path(
+    db: &DatabaseConnection,
+    music_dirs: &[PathBuf],
+    path: &Path,
+) -> anyhow::Result<Option<(PathBuf, library_root::Model)>> {
+    let states = library_root::Entity::find().all(db).await?;
+    Ok(states
+        .into_iter()
+        .filter_map(|state| {
+            let root = PathBuf::from(&state.path);
+            let is_configured_scope = music_dirs
+                .iter()
+                .any(|configured| root.starts_with(configured));
+            (is_configured_scope && path.starts_with(&root)).then_some((root, state))
+        })
+        .max_by_key(|(root, _)| root.components().count()))
+}
+
+fn crosses_untracked_nested_mount(root: &Path, path: &Path, music_dirs: &[PathBuf]) -> bool {
+    match mounted_subroots(music_dirs) {
+        Ok(mountpoints) => mountpoints
+            .into_iter()
+            .filter(|mountpoint| path.starts_with(mountpoint))
+            .max_by_key(|mountpoint| mountpoint.components().count())
+            .is_some_and(|mountpoint| !root.starts_with(mountpoint)),
+        Err(error) => {
+            warn!(%error, "Could not inspect mounted library scopes; watcher event rejected");
+            true
+        }
+    }
+}
+
+async fn mark_root_unavailable(db: &DatabaseConnection, state: &library_root::Model) {
+    let mut active: library_root::ActiveModel = state.clone().into();
+    active.is_available = Set(false);
+    active.last_scan_complete = Set(false);
+    active.last_checked_at = Set(Utc::now().to_rfc3339());
+    if let Err(error) = active.update(db).await {
+        warn!(root = %state.path, %error, "Failed to mark library root unavailable");
+    }
+}
+
+async fn root_identity_allows_content(
+    db: &DatabaseConnection,
+    music_dirs: &[PathBuf],
+    path: &Path,
+) -> anyhow::Result<bool> {
+    let Some((root, root_state)) = persisted_root_for_path(db, music_dirs, path).await? else {
+        return Ok(false);
+    };
+    if crosses_untracked_nested_mount(&root, path, music_dirs) {
+        return Ok(false);
+    }
+    if !root_state.identity_confirmed || !root_state.is_available || !root_state.last_scan_complete
+    {
+        return Ok(false);
+    }
+    let Some(expected_identity) = root_state.device_id.as_deref() else {
+        return Ok(false);
+    };
+
+    let matches = filesystem_identity(&root).is_ok_and(|identity| identity == expected_identity);
+    if !matches {
+        mark_root_unavailable(db, &root_state).await;
+    }
+    Ok(matches)
+}
+
+/// Delete a watcher-reported missing path only while its confirmed root
+/// identity remains stable across the database transaction.
+async fn delete_track_if_root_stable(
+    db: &DatabaseConnection,
+    music_dirs: &[PathBuf],
+    path: &Path,
+) -> anyhow::Result<bool> {
+    delete_track_if_root_stable_with_probe(db, music_dirs, path, filesystem_identity).await
+}
+
+async fn delete_track_if_root_stable_with_probe<F>(
+    db: &DatabaseConnection,
+    music_dirs: &[PathBuf],
+    path: &Path,
+    mut identity_probe: F,
+) -> anyhow::Result<bool>
+where
+    F: FnMut(&Path) -> std::io::Result<String>,
+{
+    // Debounced remove events can outlive a quick remount or file recreate.
+    // Never delete metadata when the path is present again, and fail closed
+    // when existence itself cannot be determined.
+    if !matches!(path.try_exists(), Ok(false)) {
+        return Ok(false);
+    }
+
+    let Some((root, root_state)) = persisted_root_for_path(db, music_dirs, path).await? else {
+        return Ok(false);
+    };
+    if crosses_untracked_nested_mount(&root, path, music_dirs) {
+        return Ok(false);
+    }
+    if !root_state.identity_confirmed || !root_state.is_available || !root_state.last_scan_complete
+    {
+        return Ok(false);
+    }
+    let Some(expected_identity) = root_state.device_id.clone() else {
+        return Ok(false);
+    };
+
+    if !identity_probe(&root).is_ok_and(|identity| identity == expected_identity) {
+        mark_root_unavailable(db, &root_state).await;
+        return Ok(false);
+    }
+
+    let transaction = db.begin().await?;
+    let path_key = path.to_string_lossy().into_owned();
+    let row = track::Entity::find()
+        .filter(track::Column::FilePath.eq(&path_key))
+        .one(&transaction)
+        .await?;
+    let Some(row) = row else {
+        transaction.rollback().await?;
+        return Ok(false);
+    };
+    track::Entity::delete_by_id(&row.id)
+        .exec(&transaction)
+        .await?;
+
+    if !matches!(path.try_exists(), Ok(false))
+        || !identity_probe(&root).is_ok_and(|identity| identity == expected_identity)
+    {
+        transaction.rollback().await?;
+        mark_root_unavailable(db, &root_state).await;
+        return Ok(false);
+    }
+
+    transaction.commit().await?;
+    Ok(true)
+}
 
 async fn watch_directories(
     db: &Arc<DatabaseConnection>,
@@ -418,14 +1197,17 @@ async fn watch_directories(
         for path in &remove_paths {
             let path_str = path.to_string_lossy().to_string();
             debug!(path = %path_str, "File removed (debounced)");
-            if let Ok(Some(row)) = track::Entity::find()
-                .filter(track::Column::FilePath.eq(&path_str))
-                .one(db.as_ref())
-                .await
-            {
-                let _ = track::Entity::delete_by_id(&row.id).exec(db.as_ref()).await;
+            match delete_track_if_root_stable(db.as_ref(), music_dirs, path).await {
+                Ok(true) => {
+                    let _ = tx.send(LibraryEvent::TrackRemoved(path_str)).await;
+                }
+                Ok(false) => {
+                    warn!(path = %path.display(), "Ignored removal without a stable confirmed library root");
+                }
+                Err(error) => {
+                    warn!(path = %path.display(), %error, "Failed to process watched removal safely");
+                }
             }
-            let _ = tx.send(LibraryEvent::TrackRemoved(path_str)).await;
         }
 
         // Process upserts concurrently.
@@ -434,6 +1216,17 @@ async fn watch_directories(
             let paths: Vec<PathBuf> = upsert_paths.into_iter().collect();
 
             for path in paths {
+                match root_identity_allows_content(db.as_ref(), music_dirs, &path).await {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        warn!(path = %path.display(), "Ignored change from an unconfirmed or changed library root");
+                        continue;
+                    }
+                    Err(error) => {
+                        warn!(path = %path.display(), %error, "Failed to verify watched library root");
+                        continue;
+                    }
+                }
                 if !path.exists() {
                     // Backstop: a debounced "upsert" whose file no longer
                     // exists is really a move/rename away (or a delete the
@@ -441,12 +1234,13 @@ async fn watch_directories(
                     // stale DB row instead of leaving an orphan that fails to
                     // play.
                     let path_str = path.to_string_lossy().to_string();
-                    if let Ok(Some(row)) = track::Entity::find()
-                        .filter(track::Column::FilePath.eq(&path_str))
-                        .one(db.as_ref())
+                    if delete_track_if_root_stable(db.as_ref(), music_dirs, &path)
                         .await
+                        .unwrap_or_else(|error| {
+                            warn!(path = %path.display(), %error, "Failed to process missing watched path safely");
+                            false
+                        })
                     {
-                        let _ = track::Entity::delete_by_id(&row.id).exec(db.as_ref()).await;
                         let _ = tx.send(LibraryEvent::TrackRemoved(path_str)).await;
                     }
                     continue;
@@ -454,6 +1248,16 @@ async fn watch_directories(
                 let p = path.clone();
                 match tokio::task::spawn_blocking(move || tag_parser::parse_audio_file(&p)).await {
                     Ok(Ok(parsed)) => {
+                        // Parsing can take long enough for a removable/network
+                        // volume to disappear or be replaced. Revalidate the
+                        // root immediately before touching persisted metadata.
+                        if !root_identity_allows_content(db.as_ref(), music_dirs, &path)
+                            .await
+                            .unwrap_or(false)
+                        {
+                            warn!(path = %path.display(), "Library root changed while parsing — upsert discarded");
+                            continue;
+                        }
                         let path_str = parsed.file_path.clone();
                         let existing = track::Entity::find()
                             .filter(track::Column::FilePath.eq(&path_str))
@@ -595,6 +1399,674 @@ pub fn db_model_to_track(model: &track::Model) -> Track {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct TestDirectory {
+        path: PathBuf,
+    }
+
+    impl TestDirectory {
+        fn new(label: &str) -> Self {
+            let path =
+                std::env::temp_dir().join(format!("tributary-engine-{label}-{}", Uuid::new_v4()));
+            std::fs::create_dir_all(&path).expect("create test directory");
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    #[test]
+    fn missing_root_is_incomplete_and_never_authoritative() {
+        let directory = TestDirectory::new("missing");
+        let missing = directory.path().join("not-mounted");
+
+        let scan = scan_root(missing.clone());
+
+        assert!(!scan.is_complete());
+        assert!(scan.audio_files.is_empty());
+        assert!(!should_remove_stale_track(
+            &missing.join("remembered.flac"),
+            &HashSet::new(),
+            &[scan]
+        ));
+    }
+
+    #[test]
+    fn healthy_empty_root_is_authoritative() {
+        let directory = TestDirectory::new("empty");
+        let mut scan = scan_root(directory.path().to_path_buf());
+        let previous = persisted_root_state(&scan, scan.device_id.clone());
+        scan.reconciliation_authoritative = reconciliation_is_authoritative(&scan, Some(&previous));
+
+        assert!(scan.is_complete());
+        assert!(scan.audio_files.is_empty());
+        assert!(should_remove_stale_track(
+            &directory.path().join("deleted-while-offline.mp3"),
+            &HashSet::new(),
+            &[scan]
+        ));
+    }
+
+    #[test]
+    fn rows_outside_configured_roots_are_not_removed() {
+        let configured = TestDirectory::new("configured");
+        let unrelated = TestDirectory::new("unrelated");
+        let mut scan = scan_root(configured.path().to_path_buf());
+        scan.reconciliation_authoritative = true;
+
+        assert!(!should_remove_stale_track(
+            &unrelated.path().join("remembered.flac"),
+            &HashSet::new(),
+            &[scan]
+        ));
+    }
+
+    #[test]
+    fn overlapping_roots_scan_each_audio_path_once() {
+        let directory = TestDirectory::new("overlap");
+        let nested = directory.path().join("nested");
+        std::fs::create_dir(&nested).expect("create nested root");
+        let audio_path = nested.join("song.mp3");
+        std::fs::write(&audio_path, []).expect("create audio fixture");
+
+        let mut scans = vec![
+            scan_root(directory.path().to_path_buf()),
+            scan_root(nested.clone()),
+        ];
+        for scan in &mut scans {
+            scan.content_authorized = true;
+        }
+
+        assert_eq!(collect_audio_files(&scans), vec![audio_path]);
+    }
+
+    #[test]
+    fn configured_child_root_is_excluded_from_parent_and_scanned_independently() {
+        let directory = TestDirectory::new("configured-child");
+        let child = directory.path().join("child");
+        std::fs::create_dir(&child).expect("create child root");
+        let audio_path = child.join("song.mp3");
+        std::fs::write(&audio_path, []).expect("create audio fixture");
+        let roots = vec![directory.path().to_path_buf(), child.clone()];
+
+        let parent_scan = scan_root_with_exclusions(directory.path().to_path_buf(), &roots);
+        let child_scan = scan_root_with_exclusions(child, &roots);
+
+        assert!(parent_scan.audio_files.is_empty());
+        assert_eq!(child_scan.audio_files, vec![audio_path]);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn mountinfo_discovers_same_device_bind_mounts_and_decodes_paths() {
+        let configured = vec![PathBuf::from("/music")];
+        let mountinfo = "31 20 8:1 / / rw,relatime - ext4 /dev/root rw\n\
+                         32 31 8:1 /library /music/Bind\\040Mount rw,relatime - ext4 /dev/root rw\n\
+                         33 31 8:2 / /other rw,relatime - ext4 /dev/other rw\n";
+
+        assert_eq!(
+            mounted_subroots_from_mountinfo(mountinfo, &configured).expect("parse valid mountinfo"),
+            vec![PathBuf::from("/music/Bind Mount")]
+        );
+        assert_eq!(
+            mount_generation_from_mountinfo(
+                mountinfo,
+                Path::new("/music/Bind Mount/album/song.flac")
+            )
+            .expect("parse valid mountinfo"),
+            Some(32)
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn malformed_mountinfo_fails_closed() {
+        let configured = vec![PathBuf::from("/music")];
+
+        assert!(
+            mounted_subroots_from_mountinfo("not-a-mount-record /music/bind", &configured).is_err()
+        );
+        assert!(
+            mounted_subroots_from_mountinfo("32 31 8:1 / /music/bind rw -", &configured).is_err()
+        );
+        assert!(mounted_subroots_from_mountinfo(
+            "32 31 8:1 / /music/Bad\\Escape rw - ext4 /dev/root rw",
+            &configured
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn mount_discovery_failure_aborts_root_expansion() {
+        let configured = vec![PathBuf::from("/music")];
+        let result = expanded_scan_roots_with_mount_result(
+            &configured,
+            &[],
+            Err(std::io::Error::other("simulated mountinfo failure")),
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn persisted_nested_root_remains_a_separate_scope_while_unmounted() {
+        let configured = vec![PathBuf::from("/music")];
+        let persisted = vec![library_root::Model {
+            path: "/music/removable".to_string(),
+            device_id: Some("remembered-volume".to_string()),
+            identity_confirmed: true,
+            is_available: false,
+            last_scan_complete: false,
+            last_checked_at: "2026-07-10T00:00:00Z".to_string(),
+        }];
+
+        assert_eq!(
+            expanded_scan_roots_with_mounts(&configured, &persisted, Vec::new()),
+            vec![PathBuf::from("/music"), PathBuf::from("/music/removable")]
+        );
+    }
+
+    #[test]
+    fn most_specific_incomplete_root_protects_overlapping_rows() {
+        let directory = TestDirectory::new("overlap-incomplete");
+        let nested = directory.path().join("nested");
+        std::fs::create_dir(&nested).expect("create nested root");
+
+        let mut parent_scan = scan_root(directory.path().to_path_buf());
+        parent_scan.reconciliation_authoritative = true;
+        let child_scan = RootScan {
+            root: nested.clone(),
+            audio_files: Vec::new(),
+            errors: vec!["simulated permission error".to_string()],
+            device_id: Some("simulated-device".to_string()),
+            reconciliation_authoritative: false,
+            content_authorized: false,
+        };
+
+        assert!(!should_remove_stale_track(
+            &nested.join("remembered.flac"),
+            &HashSet::new(),
+            &[parent_scan, child_scan]
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn permission_denied_root_is_incomplete() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = TestDirectory::new("permission-denied");
+        std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o000))
+            .expect("remove root permissions");
+
+        let scan = scan_root(directory.path().to_path_buf());
+
+        // Restore permissions before asserting so the fixture can always be
+        // removed, even when the assertion fails.
+        std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o700))
+            .expect("restore root permissions");
+        assert!(!scan.is_complete());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn partially_unreadable_root_keeps_discovered_files_but_is_incomplete() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = TestDirectory::new("partially-unreadable");
+        let readable_audio = directory.path().join("readable.flac");
+        std::fs::write(&readable_audio, []).expect("create readable audio fixture");
+
+        let locked = directory.path().join("locked");
+        std::fs::create_dir(&locked).expect("create locked directory");
+        std::fs::write(locked.join("hidden.flac"), []).expect("create hidden audio fixture");
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000))
+            .expect("remove nested permissions");
+
+        let scan = scan_root(directory.path().to_path_buf());
+
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o700))
+            .expect("restore nested permissions");
+        assert!(!scan.is_complete());
+        assert_eq!(scan.audio_files, vec![readable_audio]);
+    }
+
+    fn persisted_root_state(scan: &RootScan, device_id: Option<String>) -> library_root::Model {
+        library_root::Model {
+            path: scan.root.to_string_lossy().into_owned(),
+            device_id,
+            identity_confirmed: true,
+            is_available: true,
+            last_scan_complete: true,
+            last_checked_at: "2026-07-10T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn matching_persisted_device_authorizes_an_empty_root() {
+        let directory = TestDirectory::new("matching-device");
+        let scan = scan_root(directory.path().to_path_buf());
+        let previous = persisted_root_state(&scan, scan.device_id.clone());
+
+        assert!(reconciliation_is_authoritative(&scan, Some(&previous)));
+    }
+
+    #[test]
+    fn changed_device_identity_blocks_stale_deletion() {
+        let directory = TestDirectory::new("changed-device");
+        let scan = scan_root(directory.path().to_path_buf());
+        let previous = persisted_root_state(&scan, Some("different-device".to_string()));
+
+        assert!(!reconciliation_is_authoritative(&scan, Some(&previous)));
+    }
+
+    #[test]
+    fn legacy_empty_root_with_tracks_bootstraps_conservatively() {
+        let directory = TestDirectory::new("legacy-empty");
+        let scan = scan_root(directory.path().to_path_buf());
+
+        assert!(!reconciliation_is_authoritative(&scan, None));
+        assert!(!scan_confirms_identity(&scan, None, 1));
+    }
+
+    #[test]
+    fn ambiguous_small_legacy_root_stays_unconfirmed() {
+        let directory = TestDirectory::new("legacy-content");
+        std::fs::write(directory.path().join("present.mp3"), []).expect("create audio fixture");
+        let scan = scan_root(directory.path().to_path_buf());
+
+        assert!(!reconciliation_is_authoritative(&scan, None));
+        assert!(!scan_confirms_identity(&scan, None, 1));
+        assert!(!scan_confirms_identity(&scan, None, 2));
+    }
+
+    #[test]
+    fn complete_multi_track_legacy_clone_stays_unconfirmed() {
+        let directory = TestDirectory::new("legacy-complete-evidence");
+        std::fs::write(directory.path().join("present.mp3"), []).expect("create audio fixture");
+        let scan = scan_root(directory.path().to_path_buf());
+
+        assert!(!scan_confirms_identity(&scan, None, 3));
+        assert!(!scan_confirms_identity(&scan, None, 4));
+    }
+
+    #[test]
+    fn absent_untracked_nested_rows_keep_legacy_parent_unconfirmed() {
+        let directory = TestDirectory::new("legacy-absent-nested");
+        std::fs::write(directory.path().join("present.mp3"), []).expect("create audio fixture");
+        let mut scan = scan_root(directory.path().to_path_buf());
+        let unconfirmed = library_root::Model {
+            path: directory.path().to_string_lossy().into_owned(),
+            device_id: scan.device_id.clone(),
+            identity_confirmed: false,
+            is_available: false,
+            last_scan_complete: true,
+            last_checked_at: "2026-07-10T00:00:00Z".to_string(),
+        };
+
+        // Observed parent content must not let the parent claim rows remembered
+        // below an absent, not-yet-discovered nested mount.
+        assert!(!scan_confirms_identity(&scan, None, 10));
+        assert!(!scan_confirms_identity(&scan, Some(&unconfirmed), 10));
+        scan.reconciliation_authoritative =
+            reconciliation_is_authoritative(&scan, Some(&unconfirmed));
+        assert!(!should_remove_stale_track(
+            &directory.path().join("removable/missing.flac"),
+            &HashSet::new(),
+            &[scan]
+        ));
+    }
+
+    #[test]
+    fn new_empty_mountpoint_does_not_enroll_or_authorize_deletion() {
+        let directory = TestDirectory::new("empty-mountpoint");
+        let scan = scan_root(directory.path().to_path_buf());
+
+        assert!(!scan_confirms_identity(&scan, None, 0));
+        assert!(!reconciliation_is_authoritative(&scan, None));
+    }
+
+    #[test]
+    fn empty_mountpoint_real_volume_unmount_cycle_never_trusts_mountpoint() {
+        let directory = TestDirectory::new("mount-cycle");
+        let root = directory.path().to_path_buf();
+
+        let empty_mountpoint = RootScan {
+            root: root.clone(),
+            audio_files: Vec::new(),
+            errors: Vec::new(),
+            device_id: Some("underlying-mountpoint".to_string()),
+            reconciliation_authoritative: false,
+            content_authorized: false,
+        };
+        assert!(!scan_confirms_identity(&empty_mountpoint, None, 0));
+
+        let unconfirmed_mountpoint = library_root::Model {
+            path: root.to_string_lossy().into_owned(),
+            device_id: empty_mountpoint.device_id.clone(),
+            identity_confirmed: false,
+            is_available: false,
+            last_scan_complete: true,
+            last_checked_at: "2026-07-10T00:00:00Z".to_string(),
+        };
+        let mounted_volume = RootScan {
+            root: root.clone(),
+            audio_files: vec![root.join("song.mp3")],
+            errors: Vec::new(),
+            device_id: Some("real-volume".to_string()),
+            reconciliation_authoritative: false,
+            content_authorized: false,
+        };
+        assert!(scan_confirms_identity(
+            &mounted_volume,
+            Some(&unconfirmed_mountpoint),
+            0
+        ));
+        assert!(!reconciliation_is_authoritative(
+            &mounted_volume,
+            Some(&unconfirmed_mountpoint)
+        ));
+
+        let confirmed_volume = library_root::Model {
+            path: root.to_string_lossy().into_owned(),
+            device_id: mounted_volume.device_id.clone(),
+            identity_confirmed: true,
+            is_available: true,
+            last_scan_complete: true,
+            last_checked_at: "2026-07-10T00:01:00Z".to_string(),
+        };
+        assert!(!reconciliation_is_authoritative(
+            &empty_mountpoint,
+            Some(&confirmed_volume)
+        ));
+        assert!(!scan_confirms_identity(
+            &empty_mountpoint,
+            Some(&confirmed_volume),
+            1
+        ));
+    }
+
+    #[test]
+    fn confirmed_identity_is_never_replaced_by_different_volume_content() {
+        let directory = TestDirectory::new("replacement-volume");
+        std::fs::write(directory.path().join("replacement.mp3"), [])
+            .expect("create replacement fixture");
+        let scan = scan_root(directory.path().to_path_buf());
+        let previous = persisted_root_state(&scan, Some("intended-volume".to_string()));
+
+        assert!(!reconciliation_is_authoritative(&scan, Some(&previous)));
+        assert!(!scan_confirms_identity(&scan, Some(&previous), 4));
+    }
+
+    #[test]
+    fn unconfirmed_replacement_files_cannot_self_enroll_across_scans() {
+        let directory = TestDirectory::new("unconfirmed-replacement");
+        std::fs::write(directory.path().join("replacement.mp3"), [])
+            .expect("create replacement fixture");
+        let mut replacement_scan = scan_root(directory.path().to_path_buf());
+        let unconfirmed = library_root::Model {
+            path: directory.path().to_string_lossy().into_owned(),
+            device_id: replacement_scan.device_id.clone(),
+            identity_confirmed: false,
+            is_available: false,
+            last_scan_complete: true,
+            last_checked_at: "2026-07-10T00:00:00Z".to_string(),
+        };
+
+        // Existing metadata belongs to the intended volume, but none of the
+        // replacement volume's paths match it. The replacement is neither
+        // enrolled nor indexed, so it cannot manufacture a matching row that
+        // would let a later scan confirm itself.
+        for _ in 0..2 {
+            assert!(!scan_confirms_identity(
+                &replacement_scan,
+                Some(&unconfirmed),
+                4
+            ));
+            assert!(!reconciliation_is_authoritative(
+                &replacement_scan,
+                Some(&unconfirmed)
+            ));
+            replacement_scan.content_authorized = false;
+            assert!(collect_audio_files(std::slice::from_ref(&replacement_scan)).is_empty());
+        }
+        assert!(!scan_confirms_identity(
+            &replacement_scan,
+            Some(&unconfirmed),
+            10
+        ));
+    }
+
+    #[test]
+    fn identity_change_during_traversal_marks_scan_incomplete() {
+        use std::cell::Cell;
+
+        let directory = TestDirectory::new("identity-race");
+        std::fs::write(directory.path().join("song.mp3"), []).expect("create audio fixture");
+        let calls = Cell::new(0);
+        let scan = scan_root_with_identity_probe(directory.path().to_path_buf(), |_| {
+            let call = calls.get();
+            calls.set(call + 1);
+            Ok(if call == 0 {
+                "mounted-volume"
+            } else {
+                "underlying-mountpoint"
+            }
+            .to_string())
+        });
+
+        assert!(!scan.is_complete());
+        assert!(scan
+            .errors
+            .iter()
+            .any(|error| error.contains("identity changed during traversal")));
+    }
+
+    #[test]
+    fn mount_generation_change_during_traversal_marks_scan_incomplete() {
+        use std::cell::Cell;
+
+        let directory = TestDirectory::new("mount-generation-race");
+        std::fs::write(directory.path().join("song.mp3"), []).expect("create audio fixture");
+        let calls = Cell::new(0);
+        let scan = scan_root_with_probes_and_exclusions(
+            directory.path().to_path_buf(),
+            |_| Ok("stable-volume".to_string()),
+            |_| {
+                let call = calls.get();
+                calls.set(call + 1);
+                Ok(if call == 0 { 41 } else { 42 })
+            },
+            &[],
+        );
+
+        assert!(!scan.is_complete());
+        assert!(scan
+            .errors
+            .iter()
+            .any(|error| error.contains("mount generation changed during traversal")));
+    }
+
+    #[test]
+    fn mount_generation_change_between_scans_keeps_stable_identity_authoritative() {
+        let directory = TestDirectory::new("mount-generation-reboot");
+        let first_scan = scan_root_with_probes_and_exclusions(
+            directory.path().to_path_buf(),
+            |_| Ok("stable-volume".to_string()),
+            |_| Ok(41),
+            &[],
+        );
+        let previous = persisted_root_state(&first_scan, first_scan.device_id.clone());
+        let second_scan = scan_root_with_probes_and_exclusions(
+            directory.path().to_path_buf(),
+            |_| Ok("stable-volume".to_string()),
+            |_| Ok(99),
+            &[],
+        );
+
+        assert!(first_scan.is_complete());
+        assert!(second_scan.is_complete());
+        assert!(reconciliation_is_authoritative(
+            &second_scan,
+            Some(&previous)
+        ));
+    }
+
+    #[tokio::test]
+    async fn root_identity_and_availability_are_persisted() {
+        use sea_orm::Database;
+        use sea_orm_migration::MigratorTrait;
+
+        use crate::db::migration::Migrator;
+
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("open in-memory database");
+        Migrator::up(&db, None).await.expect("run migrations");
+
+        let directory = TestDirectory::new("persisted-state");
+        let mut scan = scan_root(directory.path().to_path_buf());
+        persist_root_scan_status(&db, &scan, None, true)
+            .await
+            .expect("persist available root");
+
+        let stored = library_root::Entity::find_by_id(scan.root.to_string_lossy().into_owned())
+            .one(&db)
+            .await
+            .expect("query root state")
+            .expect("root state exists");
+        assert_eq!(stored.device_id, scan.device_id);
+        assert!(stored.identity_confirmed);
+        assert!(stored.is_available);
+        assert!(stored.last_scan_complete);
+
+        scan.errors.push("simulated traversal error".to_string());
+        scan.reconciliation_authoritative = false;
+        persist_root_scan_status(&db, &scan, Some(&stored), false)
+            .await
+            .expect("persist unavailable root");
+
+        let updated = library_root::Entity::find_by_id(scan.root.to_string_lossy().into_owned())
+            .one(&db)
+            .await
+            .expect("query updated root state")
+            .expect("updated root state exists");
+        assert_eq!(updated.device_id, stored.device_id);
+        assert!(!updated.is_available);
+        assert!(!updated.last_scan_complete);
+    }
+
+    #[tokio::test]
+    async fn watcher_removal_rolls_back_if_root_identity_changes() {
+        use std::cell::Cell;
+
+        use sea_orm::Database;
+        use sea_orm_migration::MigratorTrait;
+
+        use crate::db::migration::Migrator;
+
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("open in-memory database");
+        Migrator::up(&db, None).await.expect("run migrations");
+
+        let directory = TestDirectory::new("watcher-identity-race");
+        let scan = scan_root(directory.path().to_path_buf());
+        let expected_identity = scan.device_id.clone().expect("root identity");
+        persist_root_scan_status(&db, &scan, None, true)
+            .await
+            .expect("persist confirmed root");
+
+        let removed_path = directory.path().join("removed.mp3");
+        let model = track::Model {
+            id: "watcher-race-track".to_string(),
+            file_path: removed_path.to_string_lossy().into_owned(),
+            title: "Removed".to_string(),
+            artist_name: "Artist".to_string(),
+            album_artist_name: None,
+            album_title: "Album".to_string(),
+            genre: None,
+            year: None,
+            track_number: None,
+            disc_number: None,
+            duration_secs: None,
+            bitrate_kbps: None,
+            sample_rate_hz: None,
+            format: Some("MP3".to_string()),
+            play_count: 0,
+            date_added: "2026-07-10T00:00:00Z".to_string(),
+            date_modified: "2026-07-10T00:00:00Z".to_string(),
+            file_size_bytes: None,
+        };
+        let active: track::ActiveModel = model.into();
+        active.insert(&db).await.expect("insert remembered track");
+
+        // A debounced removal that outlives a quick recreate/remount must not
+        // delete the now-live path even when the root identity matches.
+        std::fs::write(&removed_path, []).expect("recreate watched path");
+        let stable_identity = expected_identity.clone();
+        assert!(!delete_track_if_root_stable_with_probe(
+            &db,
+            &[directory.path().to_path_buf()],
+            &removed_path,
+            move |_| Ok(stable_identity.clone()),
+        )
+        .await
+        .expect("ignore stale removal"));
+        std::fs::remove_file(&removed_path).expect("remove recreated watched path");
+        assert!(track::Entity::find_by_id("watcher-race-track")
+            .one(&db)
+            .await
+            .expect("query recreated track")
+            .is_some());
+
+        let probe_calls = Cell::new(0);
+        let first_identity = expected_identity.clone();
+        let removed = delete_track_if_root_stable_with_probe(
+            &db,
+            &[directory.path().to_path_buf()],
+            &removed_path,
+            move |_| {
+                let call = probe_calls.get();
+                probe_calls.set(call + 1);
+                Ok(if call == 0 {
+                    first_identity.clone()
+                } else {
+                    "underlying-mountpoint".to_string()
+                })
+            },
+        )
+        .await
+        .expect("process removal");
+
+        assert!(!removed);
+        assert!(track::Entity::find_by_id("watcher-race-track")
+            .one(&db)
+            .await
+            .expect("query remembered track")
+            .is_some());
+
+        let root_state =
+            library_root::Entity::find_by_id(directory.path().to_string_lossy().into_owned())
+                .one(&db)
+                .await
+                .expect("query root state")
+                .expect("root state exists");
+        assert!(!root_state.is_available);
+        assert!(root_state.identity_confirmed);
+        assert_eq!(
+            root_state.device_id.as_deref(),
+            Some(expected_identity.as_str())
+        );
+    }
 
     #[test]
     fn test_db_model_to_track_basic() {

--- a/src/ui/album_art.rs
+++ b/src/ui/album_art.rs
@@ -5,7 +5,7 @@
 //! - Fetching remote album art URLs (Subsonic, Jellyfin, Plex cover art)
 //! - A persistent background worker thread with generation-based staleness detection
 
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::OnceLock;
 
 use gtk::glib;
@@ -13,12 +13,30 @@ use gtk::glib;
 /// Global generation counter for album art requests.  Incremented on
 /// every track change; the worker checks this before sending results
 /// back to the GTK thread so stale fetches are silently dropped.
-static ART_GENERATION: AtomicU32 = AtomicU32::new(0);
+static ART_GENERATION: AtomicU64 = AtomicU64::new(0);
+
+fn next_generation() -> u64 {
+    ART_GENERATION
+        .fetch_add(1, Ordering::Relaxed)
+        .wrapping_add(1)
+}
+
+fn generation_is_current(generation: u64) -> bool {
+    ART_GENERATION.load(Ordering::Relaxed) == generation
+}
+
+/// Invalidate every in-flight local extraction and remote fetch.
+///
+/// Playback resets call this before installing the generic placeholder so a
+/// late worker result cannot restore artwork from the stopped/previous item.
+pub fn invalidate() {
+    next_generation();
+}
 
 /// Request sent to the album art worker thread.
 struct ArtRequest {
     url: String,
-    generation: u32,
+    generation: u64,
     reply_tx: async_channel::Sender<Vec<u8>>,
 }
 
@@ -92,6 +110,7 @@ fn art_worker_tx() -> Option<&'static std::sync::mpsc::Sender<ArtRequest>> {
 /// Tag reading is performed on a background thread to avoid blocking
 /// the GTK main loop — large FLAC files can take hundreds of ms to parse.
 pub fn update_album_art(image: &gtk::Image, uri: &str) {
+    let generation = next_generation();
     // Only attempt extraction for local file:// URIs.
     let path = match url::Url::parse(uri) {
         Ok(u) if u.scheme() == "file" => match u.to_file_path() {
@@ -116,13 +135,18 @@ pub fn update_album_art(image: &gtk::Image, uri: &str) {
     // Extract album art bytes on a background thread to avoid blocking GTK.
     std::thread::spawn(move || {
         if let Some(bytes) = extract_album_art_bytes(&path) {
-            let _ = tx.send_blocking(bytes);
+            if generation_is_current(generation) {
+                let _ = tx.send_blocking(bytes);
+            }
         }
     });
 
     // Receive on the GTK main thread and create the texture.
     glib::MainContext::default().spawn_local(async move {
         if let Ok(data) = rx.recv().await {
+            if !generation_is_current(generation) {
+                return;
+            }
             let bytes = glib::Bytes::from(&data);
             if let Ok(texture) = gtk::gdk::Texture::from_bytes(&bytes) {
                 image.set_paintable(Some(&texture));
@@ -345,9 +369,7 @@ pub fn fetch_remote_album_art(image: &gtk::Image, cover_art_url: &str) {
 
     // Bump the generation counter so any in-flight fetch for the
     // previous track is discarded when it completes.
-    let generation = ART_GENERATION
-        .fetch_add(1, Ordering::Relaxed)
-        .wrapping_add(1);
+    let generation = next_generation();
 
     let url = cover_art_url.to_string();
     let image = image.clone();
@@ -373,7 +395,7 @@ pub fn fetch_remote_album_art(image: &gtk::Image, cover_art_url: &str) {
         if let Ok(data) = reply_rx.recv().await {
             // Double-check generation in case another track was selected
             // while we were waiting for the channel.
-            if ART_GENERATION.load(Ordering::Relaxed) == generation {
+            if generation_is_current(generation) {
                 let bytes = glib::Bytes::from(&data);
                 if let Ok(texture) = gtk::gdk::Texture::from_bytes(&bytes) {
                     image.set_paintable(Some(&texture));
@@ -381,4 +403,19 @@ pub fn fetch_remote_album_art(image: &gtk::Image, cover_art_url: &str) {
             }
         }
     });
+}
+
+#[cfg(test)]
+mod generation_tests {
+    use super::*;
+
+    #[test]
+    fn reset_invalidates_local_and_remote_artwork_results() {
+        let stale_generation = next_generation();
+        assert!(generation_is_current(stale_generation));
+
+        invalidate();
+
+        assert!(!generation_is_current(stale_generation));
+    }
 }

--- a/src/ui/discovery_handler.rs
+++ b/src/ui/discovery_handler.rs
@@ -28,6 +28,7 @@ pub fn setup_discovery(state: &WindowState, output_list: &gtk::ListBox) {
     let browser_state = state.browser_state.clone();
     let status_label = state.status_label.clone();
     let column_view = state.column_view.clone();
+    let pending_connection = state.pending_connection.clone();
     let output_list = output_list.clone();
 
     glib::MainContext::default().spawn_local(async move {
@@ -101,6 +102,10 @@ pub fn setup_discovery(state: &WindowState, output_list: &gtk::ListBox) {
                 }
 
                 crate::discovery::DiscoveryEvent::Lost { url, service_type } => {
+                    if pending_connection.borrow().as_deref() == Some(url.as_str()) {
+                        *pending_connection.borrow_mut() = None;
+                    }
+
                     // ── Chromecast devices: remove from output selector ──
                     if service_type == "chromecast" {
                         handle_chromecast_lost(&output_list, &url);
@@ -119,10 +124,22 @@ pub fn setup_discovery(state: &WindowState, output_list: &gtk::ListBox) {
                         continue;
                     }
 
+                    // mDNS disappearance invalidates a DAAP session even for
+                    // manually saved rows. Transfer ownership immediately so
+                    // queued sync work is generation-rejected and logout is
+                    // tracked by controlled shutdown.
+                    if service_type == "daap" {
+                        if let Some(session) = crate::daap::release_source(&url) {
+                            rt_handle.spawn(async move {
+                                session.disconnect().await;
+                            });
+                        }
+                    }
+
                     info!(
                         url = %url,
                         backend = %service_type,
-                        "Removing lost server from sidebar"
+                        "Handling lost server discovery event"
                     );
 
                     // Find the sidebar entry for this URL.
@@ -131,6 +148,33 @@ pub fn setup_discovery(state: &WindowState, output_list: &gtk::ListBox) {
                             if src.server_url() == url {
                                 // Never auto-remove manually-added servers.
                                 if src.manually_added() {
+                                    if service_type == "daap" {
+                                        let was_active = *active_source_key.borrow() == url;
+                                        source_tracks.borrow_mut().remove(&url);
+                                        src.set_connected(false);
+                                        src.set_connecting(false);
+                                        src.set_icon_name("network-server-symbolic");
+                                        let src = src.clone();
+                                        store.remove(i);
+                                        store.insert(i, &src);
+
+                                        if was_active {
+                                            *active_source_key.borrow_mut() = "local".to_string();
+                                            sidebar_selection.set_selected(1);
+                                            let st = source_tracks.borrow();
+                                            let local_tracks =
+                                                st.get("local").cloned().unwrap_or_default();
+                                            window::display_tracks(
+                                                &local_tracks,
+                                                &track_store,
+                                                &master_tracks,
+                                                &browser_widget,
+                                                &browser_state,
+                                                &status_label,
+                                                &column_view,
+                                            );
+                                        }
+                                    }
                                     break;
                                 }
                                 // If connected and still the active source,

--- a/src/ui/objects/source_object.rs
+++ b/src/ui/objects/source_object.rs
@@ -26,8 +26,6 @@ mod imp {
         pub connected: Cell<bool>,
         /// Whether an authentication attempt is in progress.
         pub connecting: Cell<bool>,
-        /// DAAP logout URL for session cleanup on disconnect.
-        pub logout_url: RefCell<String>,
         /// Whether this server requires a password to connect.
         /// `true` = password required (default), `false` = open/passwordless.
         pub requires_password: Cell<bool>,
@@ -131,14 +129,6 @@ impl SourceObject {
 
     pub fn set_connecting(&self, val: bool) {
         self.imp().connecting.set(val);
-    }
-
-    pub fn logout_url(&self) -> String {
-        self.imp().logout_url.borrow().clone()
-    }
-
-    pub fn set_logout_url(&self, url: &str) {
-        self.imp().logout_url.replace(url.to_string());
     }
 
     pub fn requires_password(&self) -> bool {

--- a/src/ui/objects/track_object.rs
+++ b/src/ui/objects/track_object.rs
@@ -1,9 +1,12 @@
 //! `TrackObject` — GObject wrapper for displaying tracks in `GtkColumnView`.
 
 use std::cell::{Cell, RefCell};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use gtk::glib;
 use gtk::subclass::prelude::*;
+
+static NEXT_ROW_INSTANCE_ID: AtomicU64 = AtomicU64::new(1);
 
 // ---------------------------------------------------------------------------
 // Inner (private) implementation
@@ -13,6 +16,12 @@ mod imp {
 
     #[derive(Debug, Default)]
     pub struct TrackObject {
+        /// Stable backend-provided track identifier.  Sources without a
+        /// native identifier fall back to the playable URI in `track_id()`.
+        pub track_id: RefCell<String>,
+        /// Identity of this concrete UI row instance. Duplicate playlist
+        /// entries share `track_id` but receive distinct row IDs.
+        pub row_instance_id: Cell<u64>,
         pub track_number: Cell<u32>,
         /// Disc number (0 = unset, mirrors `Track::disc_number == None`).
         pub disc_number: Cell<u32>,
@@ -69,6 +78,8 @@ impl TrackObject {
     ) -> Self {
         let obj: Self = glib::Object::builder().build();
         let imp = obj.imp();
+        imp.row_instance_id
+            .set(NEXT_ROW_INSTANCE_ID.fetch_add(1, Ordering::Relaxed));
         imp.track_number.set(track_number);
         imp.title.replace(title.to_string());
         imp.duration_secs.set(duration_secs);
@@ -87,6 +98,31 @@ impl TrackObject {
 
     pub fn track_number(&self) -> u32 {
         self.imp().track_number.get()
+    }
+    /// Stable identifier used by playback sessions.
+    ///
+    /// Architecture-backed tracks set their backend UUID explicitly.  UI-only
+    /// sources such as USB scans retain stable identity through their URI.
+    pub fn track_id(&self) -> String {
+        let id = self.imp().track_id.borrow().clone();
+        if id.is_empty() {
+            self.uri()
+        } else {
+            id
+        }
+    }
+    /// Identity used only to reselect this concrete queue occurrence in GTK.
+    /// It is deliberately separate from the stable backend track identity.
+    pub fn row_instance_id(&self) -> u64 {
+        let id = self.imp().row_instance_id.get();
+        if id != 0 {
+            return id;
+        }
+        // Be defensive for objects constructed through the raw GObject
+        // builder rather than `TrackObject::new`.
+        let id = NEXT_ROW_INSTANCE_ID.fetch_add(1, Ordering::Relaxed);
+        self.imp().row_instance_id.set(id);
+        id
     }
     pub fn disc_number(&self) -> u32 {
         self.imp().disc_number.get()
@@ -138,6 +174,10 @@ impl TrackObject {
         self.imp().cover_art_url.replace(url.to_string());
     }
 
+    pub fn set_track_id(&self, id: &str) {
+        self.imp().track_id.replace(id.to_string());
+    }
+
     pub fn set_album_artist(&self, name: &str) {
         self.imp().album_artist.replace(name.to_string());
     }
@@ -185,5 +225,28 @@ impl TrackObject {
         } else {
             String::new()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn track(uri: &str) -> TrackObject {
+        TrackObject::new(
+            1, "Title", 60, "Artist", "Album", "", 0, "", 0, 0, 0, "", uri,
+        )
+    }
+
+    #[test]
+    fn duplicate_track_rows_have_distinct_instance_identity() {
+        let first = track("file:///same.flac");
+        let duplicate = track("file:///same.flac");
+        first.set_track_id("stable-track-id");
+        duplicate.set_track_id("stable-track-id");
+
+        assert_eq!(first.track_id(), duplicate.track_id());
+        assert_ne!(first.row_instance_id(), duplicate.row_instance_id());
+        assert_eq!(first.row_instance_id(), first.clone().row_instance_id());
     }
 }

--- a/src/ui/output_switch.rs
+++ b/src/ui/output_switch.rs
@@ -16,23 +16,55 @@ use crate::audio::output::AudioOutput;
 use crate::audio::PlayerEvent;
 
 use super::output_dialogs::load_saved_outputs;
+use super::playback::PlaybackSession;
+
+/// Stable identity for a selectable output endpoint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OutputTarget {
+    Local,
+    Mpd { host: String, port: u16 },
+    AirPlay { host: String, port: u16 },
+    Chromecast { host: String, port: u16 },
+}
+
+fn output_change_required(active: &OutputTarget, requested: &OutputTarget) -> bool {
+    active != requested
+}
+
+fn prepare_output_change(
+    active: &OutputTarget,
+    requested: &OutputTarget,
+    session: &mut PlaybackSession,
+) -> bool {
+    if !output_change_required(active, requested) {
+        return false;
+    }
+    session.clear();
+    true
+}
 
 /// Wire the output selector popover: switching between local, MPD,
 /// AirPlay, and Chromecast outputs.
 ///
 /// This function does not use `WindowState` because it operates on audio
 /// output state only, not track/sidebar state.
+#[allow(clippy::too_many_arguments)]
 pub fn setup_output_selector(
     output_list: &gtk::ListBox,
     output_button: &gtk::MenuButton,
     active_output: &Rc<RefCell<Box<dyn AudioOutput>>>,
     parked_local: &Rc<RefCell<Option<Box<dyn AudioOutput>>>>,
+    active_target: &Rc<RefCell<OutputTarget>>,
+    playback_session: &Rc<RefCell<PlaybackSession>>,
+    clear_playback_ui: Rc<dyn Fn()>,
     event_sender: &async_channel::Sender<PlayerEvent>,
     volume_scale: &gtk::Scale,
     rt_handle: &tokio::runtime::Handle,
 ) {
     let active_output = active_output.clone();
     let parked_local = parked_local.clone();
+    let active_target = active_target.clone();
+    let playback_session = playback_session.clone();
     let event_sender = event_sender.clone();
     let volume_scale = volume_scale.clone();
     let output_button = output_button.clone();
@@ -42,8 +74,36 @@ pub fn setup_output_selector(
     output_list.connect_row_activated(move |list_box, activated_row| {
         let idx = activated_row.index();
 
-        // ── Stop the current output before switching ──────────
+        let Some(requested_target) = target_for_row(list_box, activated_row) else {
+            return;
+        };
+
+        // Selecting the already-active endpoint must not stop or otherwise
+        // perturb playback.
+        let should_change = prepare_output_change(
+            &active_target.borrow(),
+            &requested_target,
+            &mut playback_session.borrow_mut(),
+        );
+        if !should_change {
+            update_checkmarks(list_box, idx);
+            if let Some(popover) = output_button.popover() {
+                popover.popdown();
+            }
+            return;
+        }
+
+        // Output changes deliberately clear rather than implicitly transfer a
+        // session. This avoids leaving a queue cursor attached to an output
+        // that has no media loaded.
+        let previous_output_type = active_output.borrow().output_type();
+        info!(
+            ?previous_output_type,
+            ?requested_target,
+            "Changing audio output"
+        );
         active_output.borrow().stop();
+        clear_playback_ui();
 
         if idx == 0 {
             // ── Switch to "My Computer" (LocalOutput) ─────────
@@ -103,6 +163,8 @@ pub fn setup_output_selector(
             }
         }
 
+        *active_target.borrow_mut() = requested_target;
+
         // ── Update checkmark visibility on all rows ───────────
         update_checkmarks(list_box, idx);
 
@@ -111,6 +173,46 @@ pub fn setup_output_selector(
             popover.popdown();
         }
     });
+}
+
+fn target_for_row(
+    list_box: &gtk::ListBox,
+    activated_row: &gtk::ListBoxRow,
+) -> Option<OutputTarget> {
+    let idx = activated_row.index();
+    if idx == 0 {
+        return Some(OutputTarget::Local);
+    }
+
+    let icon = row_icon_name(activated_row);
+    let host_port = activated_row.widget_name().to_string();
+    if icon == "video-display-symbolic" {
+        let (host, port) = parse_host_port(&host_port, 8009);
+        return Some(OutputTarget::Chromecast { host, port });
+    }
+    if icon == "network-wireless-symbolic" {
+        let (host, port) = parse_host_port(&host_port, 7000);
+        return Some(OutputTarget::AirPlay { host, port });
+    }
+
+    let saved = load_saved_outputs();
+    let mpd_idx = mpd_index_before_row(list_box, idx);
+    saved.get(mpd_idx).map(|entry| OutputTarget::Mpd {
+        host: entry.host.clone(),
+        port: entry.port,
+    })
+}
+
+fn row_icon_name(row: &gtk::ListBoxRow) -> gtk::glib::GString {
+    row.first_child()
+        .and_then(|inner| inner.downcast::<gtk::Box>().ok())
+        .and_then(|row_box| {
+            row_box
+                .first_child()
+                .and_then(|image| image.downcast::<gtk::Image>().ok())
+        })
+        .and_then(|icon| icon.icon_name())
+        .unwrap_or_default()
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -222,12 +324,26 @@ fn handle_mpd_switch(
     volume_scale: &gtk::Scale,
 ) {
     let saved = load_saved_outputs();
-    // Count only MPD rows (network-server-symbolic) before this one,
-    // excluding index 0 = "My Computer", to get the saved_idx. AirPlay
-    // (network-wireless-symbolic) and Chromecast (video-display-symbolic)
-    // rows must NOT be counted: load_saved_outputs() contains MPD entries
-    // only, so counting any discovered cast/AirPlay row would inflate
-    // mpd_idx and select the wrong server (or silently fail to switch).
+    let mpd_idx = mpd_index_before_row(list_box, idx);
+
+    if let Some(entry) = saved.get(mpd_idx) {
+        park_local_if_needed(active_output, parked_local, event_sender);
+
+        let mpd = MpdOutput::new(&entry.name, &entry.host, entry.port, event_sender.clone());
+        *active_output.borrow_mut() = Box::new(mpd);
+        info!(
+            name = %entry.name,
+            host = %entry.host,
+            port = entry.port,
+            "Switched to MPD output"
+        );
+
+        volume_scale.set_sensitive(false);
+    }
+}
+
+/// Count MPD rows before `idx`, excluding local and discovered receiver rows.
+fn mpd_index_before_row(list_box: &gtk::ListBox, idx: i32) -> usize {
     let mut mpd_idx = 0usize;
     let mut child = list_box.first_child();
     let mut row_count = 0i32;
@@ -250,21 +366,7 @@ fn handle_mpd_switch(
         row_count += 1;
         child = c.next_sibling();
     }
-
-    if let Some(entry) = saved.get(mpd_idx) {
-        park_local_if_needed(active_output, parked_local, event_sender);
-
-        let mpd = MpdOutput::new(&entry.name, &entry.host, entry.port, event_sender.clone());
-        *active_output.borrow_mut() = Box::new(mpd);
-        info!(
-            name = %entry.name,
-            host = %entry.host,
-            port = entry.port,
-            "Switched to MPD output"
-        );
-
-        volume_scale.set_sensitive(false);
-    }
+    mpd_idx
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -325,5 +427,69 @@ fn update_checkmarks(list_box: &gtk::ListBox, active_idx: i32) {
         }
         row_idx += 1;
         child = c.next_sibling();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reselecting_current_output_is_a_no_op() {
+        let current = OutputTarget::Local;
+        assert!(!output_change_required(&current, &OutputTarget::Local));
+
+        let current = OutputTarget::Mpd {
+            host: "music.local".to_string(),
+            port: 6600,
+        };
+        assert!(!output_change_required(&current, &current));
+    }
+
+    #[test]
+    fn endpoint_identity_distinguishes_real_output_changes() {
+        let first = OutputTarget::Chromecast {
+            host: "192.0.2.10".to_string(),
+            port: 8009,
+        };
+        let second = OutputTarget::Chromecast {
+            host: "192.0.2.11".to_string(),
+            port: 8009,
+        };
+        assert!(output_change_required(&first, &second));
+        assert!(output_change_required(&first, &OutputTarget::Local));
+    }
+
+    #[test]
+    fn real_output_change_clears_but_reselection_preserves_session() {
+        let queue_item = super::super::playback::QueueItem::external(
+            "file:///tmp/example.flac".to_string(),
+            "Example".to_string(),
+            "Artist".to_string(),
+            "Album".to_string(),
+        );
+        let mut session = PlaybackSession::default();
+        assert!(session.replace_queue(vec![queue_item.clone()], 0));
+        let event_from_current_output =
+            PlayerEvent::ended(crate::audio::PlayerEventGeneration::default());
+        assert!(session.accepts_event_generation(event_from_current_output.generation()));
+
+        assert!(!prepare_output_change(
+            &OutputTarget::Local,
+            &OutputTarget::Local,
+            &mut session,
+        ));
+        assert!(session.has_current());
+
+        assert!(prepare_output_change(
+            &OutputTarget::Local,
+            &OutputTarget::AirPlay {
+                host: "speaker.local".to_string(),
+                port: 7000,
+            },
+            &mut session,
+        ));
+        assert!(!session.has_current());
+        assert!(!session.accepts_event_generation(event_from_current_output.generation()));
     }
 }

--- a/src/ui/playback.rs
+++ b/src/ui/playback.rs
@@ -7,16 +7,286 @@
 //! - [`format_ms`] — format milliseconds as `m:ss` or `h:mm:ss`
 
 use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
 use std::rc::Rc;
 
 use adw::prelude::*;
 use tracing::warn;
 
-use crate::audio::output::{AudioOutput, OutputType};
+use crate::audio::output::AudioOutput;
+use crate::audio::PlayerEventGeneration;
 use crate::ui::header_bar::RepeatMode;
 use crate::ui::objects::TrackObject;
 
 use super::album_art;
+
+/// Stable identity of a track inside the source that supplied its queue.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct PlaybackIdentity {
+    pub source_id: String,
+    pub track_id: String,
+}
+
+/// Immutable metadata captured when a playback queue is created.
+///
+/// Keeping this snapshot outside GTK's mutable sort/filter models means view
+/// changes cannot silently retarget Next, Previous, repeat, or EOS handling.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct QueueItem {
+    pub identity: PlaybackIdentity,
+    /// Zero-based occurrence of this stable track identity in the captured
+    /// source queue. Playlist entries may intentionally reference one track
+    /// more than once; this disambiguates row selection without changing the
+    /// stable source/track identity used for playback ownership.
+    occurrence: usize,
+    /// Concrete GTK row captured with the queue. This distinguishes duplicate
+    /// playlist entries while that source model is alive; `occurrence` remains
+    /// a fallback if the view is rebuilt with fresh row objects.
+    row_instance_id: Option<u64>,
+    uri: String,
+    title: String,
+    artist: String,
+    album: String,
+    cover_art_url: String,
+}
+
+impl QueueItem {
+    fn from_track(source_id: &str, track: &TrackObject, occurrence: usize) -> Self {
+        Self {
+            identity: PlaybackIdentity {
+                source_id: source_id.to_string(),
+                track_id: track.track_id(),
+            },
+            occurrence,
+            row_instance_id: Some(track.row_instance_id()),
+            uri: track.uri(),
+            title: track.title(),
+            artist: track.artist(),
+            album: track.album(),
+            cover_art_url: track.cover_art_url(),
+        }
+    }
+
+    pub(crate) fn external(uri: String, title: String, artist: String, album: String) -> Self {
+        Self {
+            identity: PlaybackIdentity {
+                source_id: "external".to_string(),
+                track_id: uri.clone(),
+            },
+            occurrence: 0,
+            row_instance_id: None,
+            uri,
+            title,
+            artist,
+            album,
+            cover_art_url: String::new(),
+        }
+    }
+
+    pub fn uri(&self) -> &str {
+        &self.uri
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ShuffleState {
+    /// Items visited in this shuffle cycle, ending with the current item.
+    history: Vec<usize>,
+    /// Items not yet visited in this cycle.
+    remaining: Vec<usize>,
+}
+
+/// Playback-owned queue and cursor.
+///
+/// A session is replaced only when the user explicitly starts a track (or an
+/// external file), reaches the unrepeated end, stops playback, or changes the
+/// output target. Sorting, filtering, and sidebar navigation never mutate it.
+/// Sequential Next/Previous follow snapshot order; repeat-all wraps that
+/// snapshot. Shuffle visits every snapshot item once per cycle, Previous walks
+/// shuffle history, and repeat-all starts a new shuffled cycle. Repeat-one is
+/// an EOS policy implemented by [`replay_current`], so manual Next still moves.
+#[derive(Clone, Debug, Default)]
+pub struct PlaybackSession {
+    queue: Vec<QueueItem>,
+    current_index: Option<usize>,
+    shuffle: Option<ShuffleState>,
+    event_generation: PlayerEventGeneration,
+}
+
+impl PlaybackSession {
+    pub(crate) fn replace_queue(&mut self, queue: Vec<QueueItem>, start_index: usize) -> bool {
+        if queue.get(start_index).is_none() {
+            return false;
+        }
+        self.queue = queue;
+        self.current_index = Some(start_index);
+        self.shuffle = None;
+        true
+    }
+
+    pub fn clear(&mut self) {
+        self.queue.clear();
+        self.current_index = None;
+        self.shuffle = None;
+        self.event_generation = self.event_generation.next();
+    }
+
+    pub fn has_current(&self) -> bool {
+        self.current().is_some()
+    }
+
+    pub fn current(&self) -> Option<&QueueItem> {
+        self.current_index.and_then(|index| self.queue.get(index))
+    }
+
+    pub fn current_identity(&self) -> Option<&PlaybackIdentity> {
+        self.current().map(|item| &item.identity)
+    }
+
+    fn begin_event_generation(&mut self) -> PlayerEventGeneration {
+        self.event_generation = self.event_generation.next();
+        self.event_generation
+    }
+
+    pub fn accepts_event_generation(&self, generation: PlayerEventGeneration) -> bool {
+        self.has_current() && self.event_generation == generation
+    }
+
+    fn initialize_shuffle(&mut self) {
+        let Some(current) = self.current_index else {
+            return;
+        };
+        let mut remaining: Vec<usize> = (0..self.queue.len())
+            .filter(|&index| index != current)
+            .collect();
+        fastrand::shuffle(&mut remaining);
+        self.shuffle = Some(ShuffleState {
+            history: vec![current],
+            remaining,
+        });
+    }
+
+    fn advance(&mut self, repeat_mode: RepeatMode, shuffle: bool) -> Option<usize> {
+        let current = self.current_index?;
+
+        if !shuffle {
+            self.shuffle = None;
+            let next = current + 1;
+            let selected = if next < self.queue.len() {
+                next
+            } else if repeat_mode == RepeatMode::All {
+                0
+            } else {
+                return None;
+            };
+            self.current_index = Some(selected);
+            return Some(selected);
+        }
+
+        if self.shuffle.is_none() {
+            self.initialize_shuffle();
+        }
+
+        let state = self.shuffle.as_mut()?;
+        if state.remaining.is_empty() {
+            if repeat_mode != RepeatMode::All {
+                return None;
+            }
+            state.remaining = (0..self.queue.len())
+                .filter(|&index| index != current)
+                .collect();
+            fastrand::shuffle(&mut state.remaining);
+
+            // A one-item queue repeats itself under repeat-all.
+            if state.remaining.is_empty() {
+                return Some(current);
+            }
+        }
+
+        let selected = state.remaining.pop()?;
+        state.history.push(selected);
+        self.current_index = Some(selected);
+        Some(selected)
+    }
+
+    fn previous(&mut self, repeat_mode: RepeatMode, shuffle: bool) -> Option<usize> {
+        let current = self.current_index?;
+
+        if !shuffle {
+            self.shuffle = None;
+            let selected = if current > 0 {
+                current - 1
+            } else if repeat_mode == RepeatMode::All {
+                self.queue.len().checked_sub(1)?
+            } else {
+                return None;
+            };
+            self.current_index = Some(selected);
+            return Some(selected);
+        }
+
+        if self.shuffle.is_none() {
+            self.initialize_shuffle();
+        }
+        let state = self.shuffle.as_mut()?;
+        if state.history.len() > 1 {
+            if let Some(departed) = state.history.pop() {
+                state.remaining.push(departed);
+            }
+            let selected = *state.history.last()?;
+            self.current_index = Some(selected);
+            return Some(selected);
+        }
+
+        if repeat_mode != RepeatMode::All {
+            return None;
+        }
+
+        let mut candidates: Vec<usize> = (0..self.queue.len())
+            .filter(|&index| index != current)
+            .collect();
+        fastrand::shuffle(&mut candidates);
+        let selected = candidates.pop().unwrap_or(current);
+        state.history = vec![selected];
+        state.remaining = candidates;
+        self.current_index = Some(selected);
+        Some(selected)
+    }
+}
+
+/// Debounce state for the play-button buffering spinner.
+///
+/// A reset or newer player state increments the token. Timeout callbacks keep
+/// their original token and therefore become harmless no-ops when playback is
+/// stopped, reaches EOS, changes output, or advances to another track.
+#[derive(Debug, Default)]
+pub struct BufferingTracker {
+    generation: Cell<u64>,
+    buffering: Cell<bool>,
+}
+
+impl BufferingTracker {
+    pub fn begin(&self) -> u64 {
+        let generation = self.invalidate();
+        self.buffering.set(true);
+        generation
+    }
+
+    pub fn invalidate(&self) -> u64 {
+        let generation = self.generation.get().wrapping_add(1);
+        self.generation.set(generation);
+        self.buffering.set(false);
+        generation
+    }
+
+    pub fn is_current(&self, generation: u64) -> bool {
+        self.buffering.get() && self.generation.get() == generation
+    }
+
+    pub fn is_buffering(&self) -> bool {
+        self.buffering.get()
+    }
+}
 
 /// Shared state for playback operations.
 ///
@@ -24,38 +294,144 @@ use super::album_art;
 /// tracks, update the now-playing UI, and track the current position.
 pub struct PlaybackContext {
     pub model: gtk::SortListModel,
+    pub active_source_key: Rc<RefCell<String>>,
     pub active_output: Rc<RefCell<Box<dyn AudioOutput>>>,
-    /// Parking slot for the local output when a remote output is active.
-    /// Used by the Chromecast `file://` fallback to restore local playback.
-    pub parked_local: Rc<RefCell<Option<Box<dyn AudioOutput>>>>,
     pub album_art: gtk::Image,
     pub title_label: gtk::Label,
     pub artist_label: gtk::Label,
     pub media_ctrl: Rc<RefCell<Option<crate::desktop_integration::MediaController>>>,
-    pub current_pos: Rc<Cell<Option<u32>>>,
+    pub session: Rc<RefCell<PlaybackSession>>,
     /// The tracklist `ColumnView` — used to scroll the currently
     /// playing row into view on track change so the user doesn't lose
     /// their place when sequential / shuffled playback advances.
     pub column_view: gtk::ColumnView,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PlayRequest {
+    Resume,
+    StartAt(u32),
+    Unavailable,
+}
+
+fn resolve_play_request(has_current: bool, item_count: u32, shuffle: bool) -> PlayRequest {
+    if has_current {
+        return PlayRequest::Resume;
+    }
+    if item_count == 0 {
+        return PlayRequest::Unavailable;
+    }
+    PlayRequest::StartAt(if shuffle {
+        fastrand::u32(..item_count)
+    } else {
+        0
+    })
+}
+
 /// Try to play the track at `position` in the given model.
 ///
-/// Uses the `SortListModel` so positions match the visible sorted order.
-/// Updates the now-playing labels, the OS media overlay metadata, and
-/// the `current_pos` tracker.  Returns `true` on success.
+/// Captures the visible sorted model as an immutable playback queue, then
+/// starts the selected item. Later view mutations do not alter that queue.
 pub fn play_track_at(position: u32, ctx: &PlaybackContext) -> bool {
-    let Some(item) = ctx.model.item(position) else {
+    let source_id = ctx.active_source_key.borrow().clone();
+    let mut selected_index = None;
+    let mut queue = Vec::with_capacity(ctx.model.n_items() as usize);
+    let mut occurrences: HashMap<PlaybackIdentity, usize> = HashMap::new();
+
+    for model_index in 0..ctx.model.n_items() {
+        let Some(track) = ctx.model.item(model_index).and_downcast::<TrackObject>() else {
+            continue;
+        };
+        if model_index == position {
+            selected_index = Some(queue.len());
+        }
+        let identity = PlaybackIdentity {
+            source_id: source_id.clone(),
+            track_id: track.track_id(),
+        };
+        let occurrence = occurrences.entry(identity).or_default();
+        queue.push(QueueItem::from_track(&source_id, &track, *occurrence));
+        *occurrence += 1;
+    }
+
+    let Some(selected_index) = selected_index else {
         return false;
     };
-    let Some(track) = item.downcast_ref::<TrackObject>() else {
-        return false;
-    };
-    let uri = track.uri();
-    if uri.is_empty() {
+    if queue[selected_index].uri.is_empty() {
         warn!("Track has no playable URI");
         return false;
     }
+
+    let previous = ctx.session.borrow().clone();
+    if !ctx
+        .session
+        .borrow_mut()
+        .replace_queue(queue, selected_index)
+    {
+        return false;
+    }
+
+    if play_current(ctx) {
+        true
+    } else {
+        *ctx.session.borrow_mut() = previous;
+        false
+    }
+}
+
+/// Resume the session's current item, or create a new queue from the visible
+/// model when playback is idle (including after an OS Stop action).
+pub fn play_or_start(ctx: &PlaybackContext, shuffle: bool) -> bool {
+    match resolve_play_request(
+        ctx.session.borrow().has_current(),
+        ctx.model.n_items(),
+        shuffle,
+    ) {
+        PlayRequest::Resume => {
+            ctx.active_output.borrow().play();
+            true
+        }
+        PlayRequest::StartAt(position) => play_track_at(position, ctx),
+        PlayRequest::Unavailable => false,
+    }
+}
+
+/// Header/OS-toggle behavior: toggle a loaded item, otherwise start a queue.
+pub fn toggle_or_start(ctx: &PlaybackContext, shuffle: bool) -> bool {
+    if ctx.session.borrow().has_current() {
+        ctx.active_output.borrow().toggle_play_pause();
+        true
+    } else {
+        play_or_start(ctx, shuffle)
+    }
+}
+
+/// Invalidate the session before stopping the output so synchronously emitted
+/// Stopped events are already stale. The caller owns the widget reset.
+pub fn stop_playback(ctx: &PlaybackContext) {
+    ctx.session.borrow_mut().clear();
+    ctx.active_output.borrow().stop();
+}
+
+/// Load the current immutable queue item and refresh now-playing UI.
+fn play_current(ctx: &PlaybackContext) -> bool {
+    let session = ctx.session.borrow();
+    let Some(item) = session.current().cloned() else {
+        return false;
+    };
+    let identity = session.current_identity().cloned();
+    drop(session);
+    if item.uri.is_empty() {
+        warn!("Track has no playable URI");
+        return false;
+    }
+    let playback_uri = match resolve_live_media_reference(item.uri()) {
+        Ok(uri) => uri,
+        Err(error) => {
+            warn!(error = %error, "Could not resolve track through its live source session");
+            return false;
+        }
+    };
 
     // Local (`file://`) library tracks are cast to the device by the
     // Chromecast output itself, which serves them over its embedded LAN
@@ -64,40 +440,117 @@ pub fn play_track_at(position: u32, ctx: &PlaybackContext) -> bool {
 
     tracing::debug!("Playing track");
 
-    ctx.active_output.borrow().load_uri(&uri);
-    let title = track.title();
-    ctx.title_label.set_label(&title);
-    ctx.title_label.set_tooltip_text(Some(&title));
-    let artist_album = format!("{} \u{2014} {}", track.artist(), track.album());
+    let generation = ctx.session.borrow_mut().begin_event_generation();
+    ctx.active_output.borrow().set_event_generation(generation);
+    ctx.active_output.borrow().load_uri(&playback_uri);
+    ctx.title_label.set_label(&item.title);
+    ctx.title_label.set_tooltip_text(Some(&item.title));
+    let artist_album = format!("{} \u{2014} {}", item.artist, item.album);
     ctx.artist_label.set_label(&artist_album);
     ctx.artist_label.set_tooltip_text(Some(&artist_album));
-    ctx.current_pos.set(Some(position));
 
-    // Scroll the playing row into view. FOCUS gives keyboard nav a
-    // sensible jumping-off point; SELECT keeps the visible selection
-    // consistent with what's actually playing.
-    ctx.column_view.scroll_to(
-        position,
-        None,
-        gtk::ListScrollFlags::FOCUS | gtk::ListScrollFlags::SELECT,
-        None,
-    );
+    // Scroll only when the queue's source and item are present in the current
+    // view. Navigation still works when the user is viewing another source or
+    // has filtered the playing item out.
+    if identity
+        .as_ref()
+        .is_some_and(|identity| *ctx.active_source_key.borrow() == identity.source_id)
+    {
+        if let Some(position) = find_queue_item_position(
+            ctx.model.n_items(),
+            identity.as_ref().map_or("", |identity| &identity.track_id),
+            item.occurrence,
+            item.row_instance_id,
+            |index| {
+                ctx.model
+                    .item(index)
+                    .and_downcast::<TrackObject>()
+                    .map(|track| (track.row_instance_id(), track.track_id()))
+            },
+        ) {
+            ctx.column_view.scroll_to(
+                position,
+                None,
+                gtk::ListScrollFlags::FOCUS | gtk::ListScrollFlags::SELECT,
+                None,
+            );
+        }
+    }
 
     // ── Update album art ─────────────────────────────────────────
-    let cover_art_url = track.cover_art_url();
-    if !cover_art_url.is_empty() {
-        // Remote track with a cover art URL — fetch asynchronously.
-        album_art::fetch_remote_album_art(&ctx.album_art, &cover_art_url);
+    if !item.cover_art_url.is_empty() {
+        // Remote track with a cover art URL — resolve session-scoped
+        // references immediately before fetching.
+        match resolve_live_media_reference(&item.cover_art_url) {
+            Ok(cover_art_url) => {
+                album_art::fetch_remote_album_art(&ctx.album_art, &cover_art_url);
+            }
+            Err(error) => {
+                warn!(error = %error, "Could not resolve artwork through its live source session");
+                album_art::invalidate();
+                ctx.album_art
+                    .set_icon_name(Some("audio-x-generic-symbolic"));
+            }
+        }
     } else {
         // Local track — extract from embedded tags.
-        album_art::update_album_art(&ctx.album_art, &uri);
+        album_art::update_album_art(&ctx.album_art, &playback_uri);
     }
 
     if let Some(ref mut ctrl) = *ctx.media_ctrl.borrow_mut() {
-        ctrl.update_metadata(&track.title(), &track.artist(), &track.album());
+        ctrl.update_metadata(&item.title, &item.artist, &item.album);
+        // The OS transports have no buffering state. Publish Playing when a
+        // load is accepted and let a later Paused/Stopped event correct it.
+        ctrl.update_playback(true);
     }
 
     true
+}
+
+fn find_queue_item_position(
+    item_count: u32,
+    track_id: &str,
+    target_occurrence: usize,
+    row_instance_id: Option<u64>,
+    mut item_at: impl FnMut(u32) -> Option<(u64, String)>,
+) -> Option<u32> {
+    let items: Vec<Option<(u64, String)>> = (0..item_count).map(&mut item_at).collect();
+    if let Some(row_instance_id) = row_instance_id {
+        if let Some(position) = items.iter().position(|item| {
+            item.as_ref()
+                .is_some_and(|(candidate, _)| *candidate == row_instance_id)
+        }) {
+            return u32::try_from(position).ok();
+        }
+    }
+
+    let mut occurrence = 0usize;
+    for (index, item) in items.into_iter().enumerate() {
+        if item.as_ref().map(|(_, id)| id.as_str()) != Some(track_id) {
+            continue;
+        }
+        if occurrence == target_occurrence {
+            return u32::try_from(index).ok();
+        }
+        occurrence += 1;
+    }
+    None
+}
+
+/// Resolve credential-free source references while passing ordinary media
+/// URLs through unchanged. DAAP resolution only reads retained in-memory
+/// session state and constructs a URL; it performs no network I/O.
+fn resolve_live_media_reference(reference: &str) -> Result<String, String> {
+    if !reference.starts_with("daap:") {
+        return Ok(reference.to_string());
+    }
+
+    let reference = url::Url::parse(reference)
+        .map_err(|error| format!("Invalid DAAP media reference: {error}"))?;
+    crate::daap::resolve_media_url(&reference)
+        .map_err(|error| error.to_string())?
+        .map(|url| url.to_string())
+        .ok_or_else(|| "DAAP media reference was not recognized".to_string())
 }
 
 /// Advance to the next track, respecting shuffle and repeat-all.
@@ -105,38 +558,19 @@ pub fn play_track_at(position: u32, ctx: &PlaybackContext) -> bool {
 /// Returns `true` if a new track was loaded, `false` if we've reached
 /// the end (caller should reset to idle).
 pub fn advance_track(ctx: &PlaybackContext, repeat_mode: RepeatMode, shuffle: bool) -> bool {
-    let n = ctx.model.n_items();
-    if n == 0 {
+    let previous = ctx.session.borrow().clone();
+    if ctx
+        .session
+        .borrow_mut()
+        .advance(repeat_mode, shuffle)
+        .is_none()
+    {
         return false;
     }
-
-    if shuffle {
-        // Pick a random track, avoiding the current one if possible.
-        let pos = if n > 1 {
-            let cur = ctx.current_pos.get().unwrap_or(u32::MAX);
-            loop {
-                let r = fastrand::u32(..n);
-                if r != cur {
-                    break r;
-                }
-            }
-        } else {
-            0
-        };
-        return play_track_at(pos, ctx);
-    }
-
-    // Sequential advance.
-    let Some(pos) = ctx.current_pos.get() else {
-        return play_track_at(0, ctx);
-    };
-
-    let next = pos + 1;
-    if next < n {
-        play_track_at(next, ctx)
-    } else if repeat_mode == RepeatMode::All && n > 0 {
-        play_track_at(0, ctx)
+    if play_current(ctx) {
+        true
     } else {
+        *ctx.session.borrow_mut() = previous;
         false
     }
 }
@@ -147,41 +581,40 @@ pub fn advance_track(ctx: &PlaybackContext, repeat_mode: RepeatMode, shuffle: bo
 /// has no "restart current track if past N seconds" behaviour — that
 /// heuristic belongs to the UI/key callers, which know what threshold
 /// they want to use. Returns `true` if a new track was loaded.
-pub fn previous_track(ctx: &PlaybackContext, repeat_mode: RepeatMode) -> bool {
-    let n = ctx.model.n_items();
-    if n == 0 {
+pub fn previous_track(ctx: &PlaybackContext, repeat_mode: RepeatMode, shuffle: bool) -> bool {
+    let previous = ctx.session.borrow().clone();
+    if ctx
+        .session
+        .borrow_mut()
+        .previous(repeat_mode, shuffle)
+        .is_none()
+    {
         return false;
     }
-
-    let Some(pos) = ctx.current_pos.get() else {
-        // Nothing playing — start from the top of the list.
-        return play_track_at(0, ctx);
-    };
-
-    if pos > 0 {
-        play_track_at(pos - 1, ctx)
-    } else if repeat_mode == RepeatMode::All {
-        play_track_at(n - 1, ctx)
+    if play_current(ctx) {
+        true
     } else {
+        *ctx.session.borrow_mut() = previous;
         false
     }
+}
+
+/// Replay the current queue item without consulting the mutable view.
+pub fn replay_current(ctx: &PlaybackContext) -> bool {
+    play_current(ctx)
 }
 
 /// Play a local file directly, bypassing the library tracklist.
 ///
 /// Used by the OS "Open With" / `xdg-open` handler.  Reads tags via
 /// lofty, updates the now-playing UI (labels, album art, OS media
-/// overlay), and asks the active output to play the file.  Sets
-/// `current_pos` to `None` because the file is not part of `ctx.model`,
-/// so Next/Previous fall back to "start from the top of the list" —
-/// which is the right behaviour after the user has finished listening
-/// to the file they opened from outside.
+/// overlay), and asks the active output to play the file. The file becomes a
+/// one-item external playback queue, so Next/Previous cannot jump into an
+/// unrelated visible source after it ends.
 ///
 /// Returns `true` if playback was initiated, `false` if the file could
 /// not be parsed or has no playable URI representation.
 pub fn play_local_file(path: &std::path::Path, ctx: &PlaybackContext) -> bool {
-    use crate::ui::album_art;
-
     let parsed = match crate::local::tag_parser::parse_audio_file(path) {
         Ok(p) => p,
         Err(e) => {
@@ -191,34 +624,24 @@ pub fn play_local_file(path: &std::path::Path, ctx: &PlaybackContext) -> bool {
     };
 
     let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-    let uri = format!("file://{}", canonical.display());
-
-    // Chromecast can't play file:// — restore the parked local output
-    // first, mirroring the guard in play_track_at.
-    let is_chromecast = ctx.active_output.borrow().output_type() == OutputType::Chromecast;
-    if is_chromecast {
-        tracing::info!("Open With: Chromecast cannot play local files — switching to local output");
-        if let Some(local) = ctx.parked_local.borrow_mut().take() {
-            *ctx.active_output.borrow_mut() = local;
-        }
+    let Ok(uri) = url::Url::from_file_path(&canonical) else {
+        warn!(path = %path.display(), "Open With: path cannot be represented as a file URI");
+        return false;
+    };
+    let item = QueueItem::external(
+        uri.to_string(),
+        parsed.title,
+        parsed.artist_name,
+        parsed.album_title,
+    );
+    let previous = ctx.session.borrow().clone();
+    if !ctx.session.borrow_mut().replace_queue(vec![item], 0) {
+        return false;
     }
-
-    ctx.active_output.borrow().load_uri(&uri);
-    ctx.active_output.borrow().play();
-
-    ctx.title_label.set_label(&parsed.title);
-    ctx.title_label.set_tooltip_text(Some(&parsed.title));
-    let artist_album = format!("{} \u{2014} {}", parsed.artist_name, parsed.album_title);
-    ctx.artist_label.set_label(&artist_album);
-    ctx.artist_label.set_tooltip_text(Some(&artist_album));
-    album_art::update_album_art(&ctx.album_art, &uri);
-
-    if let Some(ref mut ctrl) = *ctx.media_ctrl.borrow_mut() {
-        ctrl.update_metadata(&parsed.title, &parsed.artist_name, &parsed.album_title);
+    if !play_current(ctx) {
+        *ctx.session.borrow_mut() = previous;
+        return false;
     }
-
-    // The file isn't in ctx.model, so the position cursor doesn't apply.
-    ctx.current_pos.set(None);
 
     tracing::info!(path = %path.display(), "Open With: playback started");
     true
@@ -234,5 +657,262 @@ pub fn format_ms(ms: u64) -> String {
         format!("{hours}:{mins:02}:{secs:02}")
     } else {
         format!("{mins}:{secs:02}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    fn item(source: &str, id: &str) -> QueueItem {
+        QueueItem {
+            identity: PlaybackIdentity {
+                source_id: source.to_string(),
+                track_id: id.to_string(),
+            },
+            occurrence: 0,
+            row_instance_id: None,
+            uri: format!("https://media.invalid/{id}"),
+            title: id.to_string(),
+            artist: "Artist".to_string(),
+            album: "Album".to_string(),
+            cover_art_url: String::new(),
+        }
+    }
+
+    fn ids(session: &PlaybackSession) -> Vec<String> {
+        session
+            .queue
+            .iter()
+            .map(|entry| entry.identity.track_id.clone())
+            .collect()
+    }
+
+    #[test]
+    fn sorting_the_view_does_not_reorder_the_playback_snapshot() {
+        let mut session = PlaybackSession::default();
+        assert!(session.replace_queue(
+            vec![item("local", "a"), item("local", "b"), item("local", "c")],
+            1,
+        ));
+
+        // This represents the independent GTK view after a descending sort.
+        let sorted_view = ["c", "b", "a"];
+        assert_eq!(sorted_view[0], "c");
+        assert_eq!(ids(&session), ["a", "b", "c"]);
+
+        assert_eq!(session.advance(RepeatMode::Off, false), Some(2));
+        assert_eq!(session.current_identity().unwrap().track_id, "c");
+    }
+
+    #[test]
+    fn filtering_the_view_does_not_remove_items_from_the_playback_snapshot() {
+        let mut session = PlaybackSession::default();
+        assert!(session.replace_queue(
+            vec![item("local", "a"), item("local", "b"), item("local", "c")],
+            0,
+        ));
+
+        // The playing queue still contains B even if the current view does not.
+        let filtered_view = ["a", "c"];
+        assert!(!filtered_view.contains(&"b"));
+        assert_eq!(session.advance(RepeatMode::Off, false), Some(1));
+        assert_eq!(session.current_identity().unwrap().track_id, "b");
+    }
+
+    #[test]
+    fn source_navigation_does_not_change_playing_source_or_track() {
+        let mut session = PlaybackSession::default();
+        assert!(session.replace_queue(vec![item("local", "track-a")], 0));
+
+        let active_view_source = "remote-server";
+        assert_ne!(
+            session.current_identity().unwrap().source_id,
+            active_view_source
+        );
+        assert_eq!(session.current_identity().unwrap().source_id, "local");
+        assert_eq!(session.current_identity().unwrap().track_id, "track-a");
+    }
+
+    #[test]
+    fn sequential_previous_and_repeat_all_use_snapshot_boundaries() {
+        let mut session = PlaybackSession::default();
+        assert!(session.replace_queue(
+            vec![
+                item("source", "a"),
+                item("source", "b"),
+                item("source", "c")
+            ],
+            2,
+        ));
+
+        assert_eq!(session.advance(RepeatMode::Off, false), None);
+        assert_eq!(session.current_identity().unwrap().track_id, "c");
+        assert_eq!(session.advance(RepeatMode::All, false), Some(0));
+        assert_eq!(session.current_identity().unwrap().track_id, "a");
+        assert_eq!(session.previous(RepeatMode::All, false), Some(2));
+        assert_eq!(session.current_identity().unwrap().track_id, "c");
+    }
+
+    #[test]
+    fn eos_repeat_policies_are_bound_to_the_snapshot_cursor() {
+        let queue = vec![item("source", "a"), item("source", "b")];
+
+        let mut repeat_one = PlaybackSession::default();
+        assert!(repeat_one.replace_queue(queue.clone(), 1));
+        // EOS repeat-one calls replay_current and does not move the cursor.
+        let replayed = repeat_one.current_identity().cloned();
+        assert_eq!(replayed.unwrap().track_id, "b");
+
+        let mut repeat_off = PlaybackSession::default();
+        assert!(repeat_off.replace_queue(queue.clone(), 1));
+        assert_eq!(repeat_off.advance(RepeatMode::Off, false), None);
+
+        let mut repeat_all = PlaybackSession::default();
+        assert!(repeat_all.replace_queue(queue, 1));
+        assert_eq!(repeat_all.advance(RepeatMode::All, false), Some(0));
+        assert_eq!(repeat_all.current_identity().unwrap().track_id, "a");
+    }
+
+    #[test]
+    fn shuffle_visits_each_snapshot_item_once_before_repeat() {
+        let mut session = PlaybackSession::default();
+        assert!(session.replace_queue(
+            vec![
+                item("source", "a"),
+                item("source", "b"),
+                item("source", "c")
+            ],
+            0,
+        ));
+
+        let mut visited = HashSet::from(["a".to_string()]);
+        for _ in 0..2 {
+            assert!(session.advance(RepeatMode::Off, true).is_some());
+            visited.insert(session.current_identity().unwrap().track_id.clone());
+        }
+        assert_eq!(visited, HashSet::from(["a".into(), "b".into(), "c".into()]));
+        assert_eq!(session.advance(RepeatMode::Off, true), None);
+
+        // Repeat-all starts another shuffle cycle instead of ending.
+        assert!(session.advance(RepeatMode::All, true).is_some());
+    }
+
+    #[test]
+    fn shuffled_previous_follows_play_history() {
+        let mut session = PlaybackSession::default();
+        assert!(session.replace_queue(
+            vec![
+                item("source", "a"),
+                item("source", "b"),
+                item("source", "c")
+            ],
+            0,
+        ));
+        assert!(session.advance(RepeatMode::Off, true).is_some());
+        let previous_id = session.current_identity().unwrap().track_id.clone();
+        assert!(session.advance(RepeatMode::Off, true).is_some());
+        assert!(session.previous(RepeatMode::Off, true).is_some());
+        assert_eq!(session.current_identity().unwrap().track_id, previous_id);
+    }
+
+    #[test]
+    fn external_file_is_a_one_item_queue() {
+        let mut session = PlaybackSession::default();
+        let external = QueueItem::external(
+            "file:///tmp/example.flac".to_string(),
+            "Example".to_string(),
+            "Artist".to_string(),
+            "Album".to_string(),
+        );
+        assert!(session.replace_queue(vec![external], 0));
+        assert_eq!(session.current_identity().unwrap().source_id, "external");
+        assert_eq!(session.advance(RepeatMode::Off, false), None);
+        assert_eq!(session.advance(RepeatMode::All, false), Some(0));
+    }
+
+    #[test]
+    fn clearing_a_session_removes_queue_identity() {
+        let mut session = PlaybackSession::default();
+        assert!(session.replace_queue(vec![item("local", "a")], 0));
+        session.clear();
+        assert!(!session.has_current());
+        assert!(session.queue.is_empty());
+    }
+
+    #[test]
+    fn stale_player_events_are_rejected_after_track_change_and_reset() {
+        let mut session = PlaybackSession::default();
+        assert!(session.replace_queue(vec![item("local", "a"), item("local", "b")], 0));
+        let first_generation = session.begin_event_generation();
+        let stale_eos = crate::audio::PlayerEvent::ended(first_generation);
+        assert!(session.accepts_event_generation(stale_eos.generation()));
+
+        assert_eq!(session.advance(RepeatMode::Off, false), Some(1));
+        let second_generation = session.begin_event_generation();
+        assert!(!session.accepts_event_generation(stale_eos.generation()));
+        assert!(session.accepts_event_generation(second_generation));
+
+        session.clear();
+        assert!(!session.accepts_event_generation(second_generation));
+    }
+
+    #[test]
+    fn buffering_reset_invalidates_timer_and_state() {
+        let tracker = BufferingTracker::default();
+        let stale_timer = tracker.begin();
+        assert!(tracker.is_current(stale_timer));
+        assert!(tracker.is_buffering());
+
+        tracker.invalidate();
+
+        assert!(!tracker.is_current(stale_timer));
+        assert!(!tracker.is_buffering());
+    }
+
+    #[test]
+    fn os_stop_then_play_starts_a_fresh_visible_queue() {
+        let mut session = PlaybackSession::default();
+        assert!(session.replace_queue(vec![item("local", "a")], 0));
+        assert_eq!(
+            resolve_play_request(session.has_current(), 3, false),
+            PlayRequest::Resume
+        );
+
+        session.clear();
+
+        assert_eq!(
+            resolve_play_request(session.has_current(), 3, false),
+            PlayRequest::StartAt(0)
+        );
+    }
+
+    #[test]
+    fn duplicate_track_occurrences_keep_stable_identity_but_select_distinct_rows() {
+        let mut first = item("playlist:one", "same-track");
+        first.row_instance_id = Some(11);
+        let mut second = first.clone();
+        second.occurrence = 1;
+        second.row_instance_id = Some(22);
+        let mut session = PlaybackSession::default();
+        assert!(session.replace_queue(vec![first, second], 1));
+
+        assert_eq!(session.current_identity().unwrap().track_id, "same-track");
+        assert_eq!(session.current().map(|item| item.occurrence), Some(1));
+        assert_eq!(
+            find_queue_item_position(4, "same-track", 1, Some(22), |index| {
+                [
+                    (11, "same-track"),
+                    (12, "other"),
+                    (22, "same-track"),
+                    (33, "same-track"),
+                ]
+                .get(index as usize)
+                .map(|(row_id, track_id)| (*row_id, (*track_id).to_string()))
+            }),
+            Some(2)
+        );
     }
 }

--- a/src/ui/radio.rs
+++ b/src/ui/radio.rs
@@ -2,7 +2,7 @@
 //!
 //! Extracted from `window.rs` to keep radio-specific logic isolated.
 
-use std::cell::{Cell, RefCell};
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
@@ -70,7 +70,7 @@ pub fn apply_radio_columns(column_view: &gtk::ColumnView, radio: bool) {
 /// Mapping: name→title, country→artist, tags→genre, codec→format,
 /// bitrate→bitrate, url_resolved→uri.
 pub fn radio_station_to_track_object(station: &crate::radio::RadioStation) -> TrackObject {
-    TrackObject::new(
+    let track = TrackObject::new(
         0,                // track_number (unused for radio)
         &station.name,    // title = station name
         0,                // duration_secs (live stream)
@@ -84,7 +84,9 @@ pub fn radio_station_to_track_object(station: &crate::radio::RadioStation) -> Tr
         0,                // play_count (unused)
         &station.codec,   // format = codec
         &station.url_resolved,
-    )
+    );
+    track.set_track_id(&station.stationuuid);
+    track
 }
 
 /// Handle the "Stations Near Me" radio source with geolocation consent.
@@ -101,7 +103,6 @@ pub fn handle_radio_nearme(
     column_view: gtk::ColumnView,
     active_source_key: Rc<RefCell<String>>,
     sidebar_selection: gtk::SingleSelection,
-    current_pos: Rc<Cell<Option<u32>>>,
     source_tracks: Rc<RefCell<HashMap<String, Vec<TrackObject>>>>,
 ) {
     let location_enabled = app_config.borrow().location_enabled;
@@ -117,7 +118,6 @@ pub fn handle_radio_nearme(
                 browser_state,
                 status_label,
                 column_view,
-                current_pos,
             );
         }
         Some(false) => {
@@ -173,7 +173,6 @@ pub fn handle_radio_nearme(
             let column_view = column_view.clone();
             let active_source_key = active_source_key.clone();
             let sidebar_selection = sidebar_selection.clone();
-            let current_pos = current_pos.clone();
             let source_tracks = source_tracks.clone();
 
             dialog.connect_response(None, move |_dialog, response| {
@@ -194,7 +193,6 @@ pub fn handle_radio_nearme(
                         browser_state.clone(),
                         status_label.clone(),
                         column_view.clone(),
-                        current_pos.clone(),
                     );
                 } else {
                     // Save decline.
@@ -253,7 +251,6 @@ fn fetch_and_display_nearme(
     browser_state: browser::BrowserState,
     status_label: gtk::Label,
     column_view: gtk::ColumnView,
-    current_pos: Rc<Cell<Option<u32>>>,
 ) {
     let (stations_tx, stations_rx) = async_channel::bounded::<String>(1);
 
@@ -346,7 +343,6 @@ fn fetch_and_display_nearme(
                 &status_label,
                 &column_view,
             );
-            current_pos.set(None);
         }
     });
 }

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -13,7 +13,7 @@ use super::objects::SourceObject;
 use tracing::debug;
 
 /// Playlist action emitted from the sidebar context menu.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PlaylistAction {
     /// Create a new regular playlist.
     CreateRegular,
@@ -29,6 +29,120 @@ pub enum PlaylistAction {
     ImportPlaylist,
     /// Export a playlist to an XSPF file (id).
     ExportPlaylist(String),
+}
+
+/// Action represented by the recycled row's trailing button.
+#[derive(Debug, PartialEq, Eq)]
+enum SidebarButtonAction {
+    OpenPlaylistMenu,
+    Disconnect(String),
+    Delete(String),
+}
+
+/// Resolve the trailing-button action from the source bound right now.
+///
+/// This intentionally derives no state from an earlier `bind` invocation:
+/// `GtkListItem` widgets are recycled, and several connection flows force a
+/// remove/reinsert to refresh a row.
+fn sidebar_button_action(source: &SourceObject) -> Option<SidebarButtonAction> {
+    if source.is_header() {
+        return (source.name() == "Playlists").then_some(SidebarButtonAction::OpenPlaylistMenu);
+    }
+
+    if source.connecting() {
+        return None;
+    }
+
+    if source.backend_type() == "daap" && source.connected() {
+        return Some(SidebarButtonAction::Disconnect(source.server_url()));
+    }
+
+    if source.manually_added() && (source.connected() || !source.server_url().is_empty()) {
+        return Some(SidebarButtonAction::Delete(source.server_url()));
+    }
+
+    None
+}
+
+fn configure_action_button(button: &gtk::Button, action: Option<&SidebarButtonAction>) {
+    match action {
+        Some(SidebarButtonAction::OpenPlaylistMenu) => {
+            button.set_icon_name("list-add-symbolic");
+            button.set_tooltip_text(Some("New playlist"));
+            button.set_visible(true);
+        }
+        Some(SidebarButtonAction::Disconnect(_)) => {
+            button.set_icon_name("media-eject-symbolic");
+            button.set_tooltip_text(Some("Disconnect"));
+            button.set_visible(true);
+        }
+        Some(SidebarButtonAction::Delete(_)) => {
+            button.set_icon_name("user-trash-symbolic");
+            button.set_tooltip_text(Some("Remove server"));
+            button.set_visible(true);
+        }
+        None => {
+            button.set_tooltip_text(None);
+            button.set_visible(false);
+        }
+    }
+}
+
+/// Emit a non-menu row action. Returns `true` when the playlist menu should
+/// be opened instead.
+fn emit_sidebar_button_action(
+    action: SidebarButtonAction,
+    disconnect_tx: &async_channel::Sender<String>,
+    delete_tx: &async_channel::Sender<String>,
+) -> bool {
+    match action {
+        SidebarButtonAction::OpenPlaylistMenu => true,
+        SidebarButtonAction::Disconnect(source_key) => {
+            let _ = disconnect_tx.try_send(source_key);
+            false
+        }
+        SidebarButtonAction::Delete(source_key) => {
+            let _ = delete_tx.try_send(source_key);
+            false
+        }
+    }
+}
+
+fn playlist_creation_menu() -> gio::Menu {
+    let menu = gio::Menu::new();
+    menu.append(Some("New Playlist"), Some("pl-add.create-regular"));
+    menu.append(Some("New Smart Playlist"), Some("pl-add.create-smart"));
+    menu.append(Some("Import Playlist\u{2026}"), Some("pl-add.import"));
+    menu
+}
+
+fn playlist_creation_action_group(
+    tx: &async_channel::Sender<PlaylistAction>,
+) -> gio::SimpleActionGroup {
+    let action_group = gio::SimpleActionGroup::new();
+
+    let tx_regular = tx.clone();
+    let regular = gio::SimpleAction::new("create-regular", None);
+    regular.connect_activate(move |_, _| {
+        let _ = tx_regular.try_send(PlaylistAction::CreateRegular);
+    });
+    action_group.add_action(&regular);
+
+    let tx_smart = tx.clone();
+    let smart = gio::SimpleAction::new("create-smart", None);
+    smart.connect_activate(move |_, _| {
+        let _ = tx_smart.try_send(PlaylistAction::CreateSmart);
+    });
+    action_group.add_action(&smart);
+
+    let tx_import = tx.clone();
+    let import = gio::SimpleAction::new("import", None);
+    import.connect_activate(move |_, _| {
+        let _ = tx_import.try_send(PlaylistAction::ImportPlaylist);
+    });
+    action_group.add_action(&import);
+
+    action_group
 }
 
 /// Build the source sidebar.
@@ -76,6 +190,8 @@ pub fn build_sidebar(
     {
         let store_for_setup = store.clone();
         let tx_for_setup = playlist_action_tx.clone();
+        let disconnect_tx_for_setup = disconnect_tx.clone();
+        let delete_tx_for_setup = delete_tx.clone();
         factory.connect_setup(move |_, list_item| {
             let list_item = list_item
                 .downcast_ref::<gtk::ListItem>()
@@ -101,7 +217,7 @@ pub fn build_sidebar(
                 .hexpand(true)
                 .ellipsize(gtk::pango::EllipsizeMode::End)
                 .build();
-            // Action button: eject (DAAP) or trash (manual) — reused widget.
+            // Action button: playlist add, DAAP eject, or manual trash.
             let action_btn = gtk::Button::builder()
                 .css_classes(["flat", "circular"])
                 .visible(false)
@@ -112,6 +228,35 @@ pub fn build_sidebar(
             row_box.append(&label);
             row_box.append(&action_btn);
             list_item.set_child(Some(&row_box));
+
+            // Connect the recycled button exactly once. Resolve the current
+            // item on every click so a prior binding cannot retain authority
+            // to delete or disconnect its source.
+            let playlist_menu = playlist_creation_menu();
+            let playlist_actions = playlist_creation_action_group(&tx_for_setup);
+            action_btn.insert_action_group("pl-add", Some(&playlist_actions));
+
+            let list_item_for_action = list_item.downgrade();
+            let disconnect_tx = disconnect_tx_for_setup.clone();
+            let delete_tx = delete_tx_for_setup.clone();
+            action_btn.connect_clicked(move |button| {
+                let Some(list_item) = list_item_for_action.upgrade() else {
+                    return;
+                };
+                let Some(source) = list_item.item().and_downcast::<SourceObject>() else {
+                    return;
+                };
+                let Some(action) = sidebar_button_action(&source) else {
+                    return;
+                };
+
+                if emit_sidebar_button_action(action, &disconnect_tx, &delete_tx) {
+                    let popover = gtk::PopoverMenu::from_model(Some(&playlist_menu));
+                    popover.set_parent(button);
+                    popover.connect_closed(|popover| popover.unparent());
+                    popover.popup();
+                }
+            });
 
             // Per-row right-click gesture.
             //
@@ -160,22 +305,8 @@ pub fn build_sidebar(
                     }
                 }
 
-                let action_group = gtk::gio::SimpleActionGroup::new();
+                let action_group = playlist_creation_action_group(&tx_for_gesture);
                 let pid = src.playlist_id();
-
-                let tx = tx_for_gesture.clone();
-                let create_reg = gtk::gio::SimpleAction::new("create-regular", None);
-                create_reg.connect_activate(move |_, _| {
-                    let _ = tx.try_send(PlaylistAction::CreateRegular);
-                });
-                action_group.add_action(&create_reg);
-
-                let tx = tx_for_gesture.clone();
-                let create_smart = gtk::gio::SimpleAction::new("create-smart", None);
-                create_smart.connect_activate(move |_, _| {
-                    let _ = tx.try_send(PlaylistAction::CreateSmart);
-                });
-                action_group.add_action(&create_smart);
 
                 let tx = tx_for_gesture.clone();
                 let pid_clone = pid.clone();
@@ -202,13 +333,6 @@ pub fn build_sidebar(
                 action_group.add_action(&edit_smart);
 
                 let tx = tx_for_gesture.clone();
-                let import = gtk::gio::SimpleAction::new("import", None);
-                import.connect_activate(move |_, _| {
-                    let _ = tx.try_send(PlaylistAction::ImportPlaylist);
-                });
-                action_group.add_action(&import);
-
-                let tx = tx_for_gesture.clone();
                 let pid_clone = pid.clone();
                 let export = gtk::gio::SimpleAction::new("export", None);
                 export.connect_activate(move |_, _| {
@@ -229,9 +353,6 @@ pub fn build_sidebar(
     }
 
     {
-        let disconnect_tx = disconnect_tx.clone();
-        let delete_tx = delete_tx.clone();
-        let playlist_action_tx = playlist_action_tx.clone();
         factory.connect_bind(move |_, list_item| {
             let list_item = list_item
                 .downcast_ref::<gtk::ListItem>()
@@ -272,53 +393,6 @@ pub fn build_sidebar(
                 label.set_ellipsize(gtk::pango::EllipsizeMode::None);
                 list_item.set_activatable(false);
                 list_item.set_selectable(false);
-
-                // Show a "+" button on the Playlists header for creating
-                // new playlists (most discoverable entry point).
-                if obj.name() == "Playlists" {
-                    action_btn.set_icon_name("list-add-symbolic");
-                    action_btn.set_tooltip_text(Some("New playlist"));
-                    action_btn.set_visible(true);
-                    let tx = playlist_action_tx.clone();
-                    action_btn.connect_clicked(move |btn| {
-                        // Build a small popover menu with playlist actions.
-                        let menu = gtk::gio::Menu::new();
-                        menu.append(Some("New Playlist"), Some("pl-add.create-regular"));
-                        menu.append(Some("New Smart Playlist"), Some("pl-add.create-smart"));
-                        menu.append(Some("Import Playlist\u{2026}"), Some("pl-add.import"));
-
-                        let ag = gtk::gio::SimpleActionGroup::new();
-
-                        let tx_reg = tx.clone();
-                        let reg = gtk::gio::SimpleAction::new("create-regular", None);
-                        reg.connect_activate(move |_, _| {
-                            let _ = tx_reg.try_send(PlaylistAction::CreateRegular);
-                        });
-                        ag.add_action(&reg);
-
-                        let tx_smart = tx.clone();
-                        let smart = gtk::gio::SimpleAction::new("create-smart", None);
-                        smart.connect_activate(move |_, _| {
-                            let _ = tx_smart.try_send(PlaylistAction::CreateSmart);
-                        });
-                        ag.add_action(&smart);
-
-                        let tx_import = tx.clone();
-                        let import = gtk::gio::SimpleAction::new("import", None);
-                        import.connect_activate(move |_, _| {
-                            let _ = tx_import.try_send(PlaylistAction::ImportPlaylist);
-                        });
-                        ag.add_action(&import);
-
-                        btn.insert_action_group("pl-add", Some(&ag));
-
-                        let popover = gtk::PopoverMenu::from_model(Some(&menu));
-                        popover.set_parent(btn);
-                        popover.popup();
-                    });
-                } else {
-                    action_btn.set_visible(false);
-                }
             } else {
                 label.remove_css_class("heading");
                 label.set_margin_top(0);
@@ -331,7 +405,6 @@ pub fn build_sidebar(
                     // Auth in progress — show spinner instead of icon.
                     icon.set_visible(false);
                     spinner.set_visible(true);
-                    action_btn.set_visible(false);
                     label.add_css_class("dim-label");
                 } else if !obj.connected() && !obj.server_url().is_empty() {
                     // Discovered/manual but not yet authenticated.
@@ -346,57 +419,22 @@ pub fn build_sidebar(
                         label.remove_css_class("dim-label");
                     }
                     spinner.set_visible(false);
-
-                    // Show trash button for manually-added (disconnected) servers.
-                    if obj.manually_added() {
-                        action_btn.set_icon_name("user-trash-symbolic");
-                        action_btn.set_tooltip_text(Some("Remove server"));
-                        action_btn.set_visible(true);
-                        let tx = delete_tx.clone();
-                        let source_key = obj.server_url();
-                        action_btn.connect_clicked(move |_| {
-                            let _ = tx.try_send(source_key.clone());
-                        });
-                    } else {
-                        action_btn.set_visible(false);
-                    }
                 } else {
                     // Connected or local source — normal icon.
                     icon.set_visible(true);
                     icon.set_icon_name(Some(&obj.icon_name()));
                     spinner.set_visible(false);
                     label.remove_css_class("dim-label");
-
-                    if obj.backend_type() == "daap" && obj.connected() {
-                        // Show eject button for connected DAAP sources.
-                        action_btn.set_icon_name("media-eject-symbolic");
-                        action_btn.set_tooltip_text(Some("Disconnect"));
-                        action_btn.set_visible(true);
-                        let tx = disconnect_tx.clone();
-                        let source_key = obj.server_url();
-                        action_btn.connect_clicked(move |_| {
-                            let _ = tx.try_send(source_key.clone());
-                        });
-                    } else if obj.manually_added() && obj.connected() {
-                        // Show trash button for connected manually-added servers.
-                        action_btn.set_icon_name("user-trash-symbolic");
-                        action_btn.set_tooltip_text(Some("Remove server"));
-                        action_btn.set_visible(true);
-                        let tx = delete_tx.clone();
-                        let source_key = obj.server_url();
-                        action_btn.connect_clicked(move |_| {
-                            let _ = tx.try_send(source_key.clone());
-                        });
-                    } else {
-                        action_btn.set_visible(false);
-                    }
                 }
             }
+
+            let action = sidebar_button_action(&obj);
+            configure_action_button(&action_btn, action.as_ref());
         });
     }
 
-    // Unbind: hide the action button to prevent signal accumulation
-    // when list items are recycled.
+    // Reset presentation on unbind. The click handler itself is row-lifetime
+    // state connected once during setup and needs no bind-time cleanup.
     factory.connect_unbind(|_, list_item| {
         let list_item = list_item
             .downcast_ref::<gtk::ListItem>()
@@ -467,4 +505,102 @@ pub fn build_sidebar(
         add_button,
         playlist_action_rx,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+
+    use super::*;
+
+    fn assert_empty<T>(receiver: &async_channel::Receiver<T>) {
+        assert!(
+            receiver.try_recv().is_err(),
+            "one click must not enqueue an additional action"
+        );
+    }
+
+    #[test]
+    fn recycled_item_dispatches_once_for_only_the_current_source() {
+        let (disconnect_tx, disconnect_rx) = async_channel::unbounded();
+        let (delete_tx, delete_rx) = async_channel::unbounded();
+        let current = RefCell::new(None::<SourceObject>);
+
+        // This single closure models the one setup-time click handler. Tests
+        // change only its current binding, including an explicit unbind.
+        let click = || {
+            let source = current.borrow();
+            let Some(action) = source.as_ref().and_then(sidebar_button_action) else {
+                return false;
+            };
+            emit_sidebar_button_action(action, &disconnect_tx, &delete_tx)
+        };
+
+        let manual_a = SourceObject::manual("Manual A", "subsonic", "https://a.example");
+        current.replace(Some(manual_a.clone()));
+        assert!(!click());
+        assert_eq!(delete_rx.try_recv().unwrap(), "https://a.example");
+        assert_empty(&delete_rx);
+        assert_empty(&disconnect_rx);
+
+        // Forced remove/reinsert first unbinds the list item. A click while
+        // unbound cannot invoke the source captured by the previous binding.
+        current.replace(None);
+        assert!(!click());
+        assert_empty(&delete_rx);
+        assert_empty(&disconnect_rx);
+
+        // Reinsert the same object in its transient connecting state. The
+        // stale delete action must still be absent.
+        manual_a.set_connecting(true);
+        current.replace(Some(manual_a.clone()));
+        assert!(!click());
+        assert_empty(&delete_rx);
+        assert_empty(&disconnect_rx);
+
+        // A second forced reinsert of the same actionable source must still
+        // produce one delete, not one per historical bind.
+        current.replace(None);
+        manual_a.set_connecting(false);
+        current.replace(Some(manual_a));
+        assert!(!click());
+        assert_eq!(delete_rx.try_recv().unwrap(), "https://a.example");
+        assert_empty(&delete_rx);
+        assert_empty(&disconnect_rx);
+
+        // Recycle the item for a different connected DAAP source. Only that
+        // source's eject event is emitted; Manual A is never deleted again.
+        let daap_b = SourceObject::discovered("DAAP B", "daap", "http://b.example:3689");
+        daap_b.set_connected(true);
+        current.replace(Some(daap_b));
+        assert!(!click());
+        assert_eq!(disconnect_rx.try_recv().unwrap(), "http://b.example:3689");
+        assert_empty(&disconnect_rx);
+        assert_empty(&delete_rx);
+
+        // Recycle once more for the Playlists header. The click opens its
+        // menu and emits no server action.
+        current.replace(Some(SourceObject::header("Playlists")));
+        assert!(click());
+        assert_empty(&disconnect_rx);
+        assert_empty(&delete_rx);
+    }
+
+    #[test]
+    fn playlist_creation_actions_emit_exactly_once() {
+        let (tx, rx) = async_channel::unbounded();
+        let group = playlist_creation_action_group(&tx);
+
+        group.activate_action("create-regular", None);
+        assert_eq!(rx.try_recv().unwrap(), PlaylistAction::CreateRegular);
+        assert_empty(&rx);
+
+        group.activate_action("create-smart", None);
+        assert_eq!(rx.try_recv().unwrap(), PlaylistAction::CreateSmart);
+        assert_empty(&rx);
+
+        group.activate_action("import", None);
+        assert_eq!(rx.try_recv().unwrap(), PlaylistAction::ImportPlaylist);
+        assert_empty(&rx);
+    }
 }

--- a/src/ui/source_connect.rs
+++ b/src/ui/source_connect.rs
@@ -19,6 +19,15 @@ use super::tracklist;
 use super::window::{arch_track_to_object, display_tracks};
 use super::window_state::WindowState;
 
+enum RemoteLibrarySnapshot {
+    Standard(Vec<crate::architecture::models::Track>),
+    Daap {
+        tracks: Vec<crate::architecture::models::Track>,
+        generation: u64,
+        session_key: uuid::Uuid,
+    },
+}
+
 /// Wire the sidebar selection-changed signal.
 ///
 /// This function owns all the logic for switching between sources when
@@ -38,7 +47,6 @@ pub fn setup_source_connect(state: &WindowState) {
     let browser_state = state.browser_state.clone();
     let status_label = state.status_label.clone();
     let column_view = state.column_view.clone();
-    let current_pos = state.current_pos.clone();
     let app_config = state.app_config.clone();
     let sidebar_store = state.sidebar_store.clone();
     let pending_connection = state.pending_connection.clone();
@@ -111,7 +119,6 @@ pub fn setup_source_connect(state: &WindowState) {
                 &status_label,
                 &column_view,
             );
-            current_pos.set(None);
             return;
         }
 
@@ -141,7 +148,6 @@ pub fn setup_source_connect(state: &WindowState) {
             let browser_state = browser_state.clone();
             let status_label = status_label.clone();
             let column_view = column_view.clone();
-            let current_pos = current_pos.clone();
             let pid = playlist_id.clone();
 
             let (tracks_tx, tracks_rx) = async_channel::bounded::<String>(1);
@@ -192,7 +198,6 @@ pub fn setup_source_connect(state: &WindowState) {
                         &status_label,
                         &column_view,
                     );
-                    current_pos.set(None);
                 }
             });
             return;
@@ -228,7 +233,6 @@ pub fn setup_source_connect(state: &WindowState) {
                     &status_label,
                     &column_view,
                 );
-                current_pos.set(None);
             } else {
                 // Scan on a background thread to avoid blocking UI.
                 let mount = mount_point.clone();
@@ -241,7 +245,6 @@ pub fn setup_source_connect(state: &WindowState) {
                 let status_label = status_label.clone();
                 let column_view = column_view.clone();
                 let active_source_key = active_source_key.clone();
-                let current_pos = current_pos.clone();
 
                 // Serialisable track data for cross-thread transfer.
                 // TrackObject is a GObject (not Send), so we send
@@ -330,7 +333,6 @@ pub fn setup_source_connect(state: &WindowState) {
                             &status_label,
                             &column_view,
                         );
-                        current_pos.set(None);
                     }
                 });
             }
@@ -351,7 +353,6 @@ pub fn setup_source_connect(state: &WindowState) {
             track_store.remove_all();
             tracklist::update_status(&status_label, &[]);
             *master_tracks.borrow_mut() = Vec::new();
-            current_pos.set(None);
 
             // Handle "Stations Near Me" with geo consent.
             if backend_type == "radio-nearme" {
@@ -365,7 +366,6 @@ pub fn setup_source_connect(state: &WindowState) {
                 let column_view = column_view.clone();
                 let active_source_key = active_source_key.clone();
                 let sidebar_selection = sel.clone();
-                let current_pos = current_pos.clone();
                 let source_tracks = source_tracks.clone();
                 let win = win.clone();
 
@@ -381,7 +381,6 @@ pub fn setup_source_connect(state: &WindowState) {
                     column_view,
                     active_source_key,
                     sidebar_selection,
-                    current_pos,
                     source_tracks,
                 );
             } else {
@@ -394,7 +393,6 @@ pub fn setup_source_connect(state: &WindowState) {
                 let browser_state = browser_state.clone();
                 let status_label = status_label.clone();
                 let column_view = column_view.clone();
-                let current_pos = current_pos.clone();
 
                 let (stations_tx, stations_rx) = async_channel::bounded::<String>(1);
 
@@ -424,7 +422,6 @@ pub fn setup_source_connect(state: &WindowState) {
                             &status_label,
                             &column_view,
                         );
-                        current_pos.set(None);
                     }
                 });
             }
@@ -456,7 +453,6 @@ pub fn setup_source_connect(state: &WindowState) {
                 &status_label,
                 &column_view,
             );
-            current_pos.set(None);
             return;
         }
 
@@ -551,13 +547,27 @@ pub fn setup_source_connect(state: &WindowState) {
             let server_name = name_for_closure.clone();
             rt_handle.spawn(async move {
                 info!(server = %server_url, "Connecting to passwordless DAAP server...");
+                let Some(attempt) = crate::daap::begin_connect(server_url.clone()) else {
+                    tracing::debug!(server = %server_url, "Skipping DAAP connect during shutdown");
+                    return;
+                };
                 match crate::daap::DaapBackend::connect(&server_name, &server_url, None).await {
                     Ok(backend) => {
-                        let tracks = backend.all_tracks().await;
+                        let Some(session) = attempt.retain(backend).await else {
+                            tracing::debug!(server = %server_url, "DAAP connect was superseded");
+                            return;
+                        };
+                        let tracks = session.all_tracks().await;
+                        if !session.is_current() {
+                            tracing::debug!(server = %server_url, "DAAP sync was superseded");
+                            return;
+                        }
                         info!(count = tracks.len(), "DAAP library fetched (no password)");
                         let _ = engine_tx
-                            .send(LibraryEvent::RemoteSync {
+                            .send(LibraryEvent::DaapSync {
                                 source_key: server_url,
+                                generation: session.generation(),
+                                session_key: session.session_key(),
                                 tracks,
                             })
                             .await;
@@ -565,6 +575,10 @@ pub fn setup_source_connect(state: &WindowState) {
                     Err(crate::architecture::error::BackendError::AuthenticationFailed {
                         ..
                     }) => {
+                        if !attempt.is_latest() {
+                            tracing::debug!(server = %server_url, "Ignoring superseded DAAP authentication failure");
+                            return;
+                        }
                         info!(
                             server = %server_url,
                             "DAAP server requires a password — re-prompting via auth dialog"
@@ -572,6 +586,10 @@ pub fn setup_source_connect(state: &WindowState) {
                         let _ = auth_needed_tx.send(()).await;
                     }
                     Err(e) => {
+                        if !attempt.is_latest() {
+                            tracing::debug!(server = %server_url, "Ignoring superseded DAAP connection failure");
+                            return;
+                        }
                         tracing::error!(error = %e, "DAAP connection failed");
                         let _ = engine_tx
                             .send(LibraryEvent::Error(format!("DAAP auth failed: {e}")))
@@ -657,7 +675,7 @@ pub fn setup_source_connect(state: &WindowState) {
 
                 rt_handle.spawn(async move {
                     let result: Result<
-                        Vec<crate::architecture::models::Track>,
+                        Option<RemoteLibrarySnapshot>,
                         crate::architecture::error::BackendError,
                     > = match backend_type.as_str() {
                         "jellyfin" => {
@@ -676,7 +694,9 @@ pub fn setup_source_connect(state: &WindowState) {
                                     )
                                     .await
                                     {
-                                        Ok(backend) => Ok(backend.all_tracks().await),
+                                        Ok(backend) => Ok(Some(RemoteLibrarySnapshot::Standard(
+                                            backend.all_tracks().await,
+                                        ))),
                                         Err(e) => Err(e),
                                     }
                                 }
@@ -699,7 +719,9 @@ pub fn setup_source_connect(state: &WindowState) {
                                     )
                                     .await
                                     {
-                                        Ok(backend) => Ok(backend.all_tracks().await),
+                                        Ok(backend) => Ok(Some(RemoteLibrarySnapshot::Standard(
+                                            backend.all_tracks().await,
+                                        ))),
                                         Err(e) => Err(e),
                                     }
                                 }
@@ -713,15 +735,33 @@ pub fn setup_source_connect(state: &WindowState) {
                             } else {
                                 Some(pass.as_str())
                             };
-                            match crate::daap::DaapBackend::connect(
-                                &server_name,
-                                &server_url,
-                                password,
-                            )
-                            .await
-                            {
-                                Ok(backend) => Ok(backend.all_tracks().await),
-                                Err(e) => Err(e),
+                            match crate::daap::begin_connect(server_url.clone()) {
+                                None => Ok(None),
+                                Some(attempt) => match crate::daap::DaapBackend::connect(
+                                    &server_name,
+                                    &server_url,
+                                    password,
+                                )
+                                .await
+                                {
+                                    Ok(backend) => match attempt.retain(backend).await {
+                                        Some(session) => {
+                                            let tracks = session.all_tracks().await;
+                                            if session.is_current() {
+                                                Ok(Some(RemoteLibrarySnapshot::Daap {
+                                                    tracks,
+                                                    generation: session.generation(),
+                                                    session_key: session.session_key(),
+                                                }))
+                                            } else {
+                                                Ok(None)
+                                            }
+                                        }
+                                        None => Ok(None),
+                                    },
+                                    Err(_) if !attempt.is_latest() => Ok(None),
+                                    Err(error) => Err(error),
+                                }
                             }
                         }
                         _ => {
@@ -735,26 +775,56 @@ pub fn setup_source_connect(state: &WindowState) {
                             )
                             .await
                             {
-                                Ok(backend) => Ok(backend.all_tracks().await),
+                                Ok(backend) => Ok(Some(RemoteLibrarySnapshot::Standard(
+                                    backend.all_tracks().await,
+                                ))),
                                 Err(e) => Err(e),
                             }
                         }
                     };
 
                     match result {
-                        Ok(tracks) => {
+                        Ok(Some(snapshot)) => {
+                            let (count, event) = match snapshot {
+                                RemoteLibrarySnapshot::Standard(tracks) => {
+                                    let count = tracks.len();
+                                    (
+                                        count,
+                                        LibraryEvent::RemoteSync {
+                                            source_key: server_url,
+                                            tracks,
+                                        },
+                                    )
+                                }
+                                RemoteLibrarySnapshot::Daap {
+                                    tracks,
+                                    generation,
+                                    session_key,
+                                } => {
+                                    let count = tracks.len();
+                                    (
+                                        count,
+                                        LibraryEvent::DaapSync {
+                                            source_key: server_url,
+                                            generation,
+                                            session_key,
+                                            tracks,
+                                        },
+                                    )
+                                }
+                            };
                             info!(
                                 backend = %backend_type,
-                                count = tracks.len(),
+                                count,
                                 "Remote library fetched"
                             );
-                            let _ = engine_tx
-                                .send(LibraryEvent::RemoteSync {
-                                    source_key: server_url,
-                                    tracks,
-                                })
-                                .await;
+                            let _ = engine_tx.send(event).await;
                         }
+                        Ok(None) => tracing::debug!(
+                            backend = %backend_type,
+                            server = %server_url,
+                            "Remote connection was superseded or shutdown-gated"
+                        ),
                         Err(e) => {
                             tracing::error!(
                                 backend = %backend_type,

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -26,7 +26,10 @@ use super::persistence::{
     extract_hwnd, load_css, load_repeat_mode, load_shuffle, load_window_geometry,
     restore_sort_state, save_repeat_mode, save_shuffle, save_sort_state, save_window_geometry,
 };
-use super::playback::{advance_track, format_ms, play_track_at, previous_track, PlaybackContext};
+use super::playback::{
+    advance_track, format_ms, play_or_start, play_track_at, previous_track, replay_current,
+    stop_playback, toggle_or_start, BufferingTracker, PlaybackContext, PlaybackSession,
+};
 use super::preferences;
 use super::server_dialogs::{load_saved_servers, remove_saved_server, show_add_server_dialog};
 use super::sidebar;
@@ -138,7 +141,10 @@ pub fn build_window(
 
     if let Ok(url) = std::env::var("DAAP_URL") {
         ensure_category_header_vec(&mut sources, "daap");
-        let src = SourceObject::source("DAAP (env)", "daap", "network-server-symbolic");
+        // Keep the configured URL as the source identity so the retained
+        // session, generation-scoped sync event, sidebar row, and disconnect action all
+        // address the same owner.
+        let src = SourceObject::discovered("DAAP (env)", "daap", &url);
         sources.push(src);
         info!(url = %url, "DAAP server configured via env vars");
     }
@@ -205,13 +211,14 @@ pub fn build_window(
 
     // ── Shared playback state ────────────────────────────────────────
     let master_tracks: Rc<RefCell<Vec<TrackObject>>> = Rc::new(RefCell::new(Vec::new()));
-    let current_pos: Rc<Cell<Option<u32>>> = Rc::new(Cell::new(None));
+    let playback_session = Rc::new(RefCell::new(PlaybackSession::default()));
     let seeking = Rc::new(Cell::new(false));
+    let buffering_tracker = Rc::new(BufferingTracker::default());
 
     // ── Connection guard ─────────────────────────────────────────────
     // Tracks which server URL is currently being connected to, and the
     // sidebar position that was active before the connection attempt.
-    // Used to (a) only auto-select on RemoteSync if the source matches
+    // Used to (a) only auto-select on a remote sync if the source matches
     // the pending connection, and (b) revert the sidebar on failure.
     let pending_connection: Rc<RefCell<Option<String>>> = Rc::new(RefCell::new(None));
     let pre_connect_selection: Rc<Cell<u32>> = Rc::new(Cell::new(1)); // default: local (index 1)
@@ -226,9 +233,6 @@ pub fn build_window(
     let track_store_for_filter = track_store.clone();
     let status_label_for_filter = status_label.clone();
     let master_for_filter = master_tracks.clone();
-    let current_pos_for_filter = current_pos.clone();
-    let sort_model_for_filter = sort_model.clone();
-
     let app_config_for_filter = app_config.clone();
     let on_filter = Box::new(
         move |genre: Option<String>,
@@ -284,35 +288,12 @@ pub fn build_window(
                 .cloned()
                 .collect();
 
-            // Capture the currently-playing track's URI (if any) from the
-            // sorted model BEFORE rebuilding the store, so we can restore
-            // the playback position afterwards (see below).
-            let playing_uri = current_pos_for_filter.get().and_then(|pos| {
-                sort_model_for_filter
-                    .item(pos)
-                    .and_downcast::<TrackObject>()
-                    .map(|t| t.uri())
-            });
-
             // Replace the whole store in a single splice. This emits one
             // `items-changed` signal instead of N appends and keeps the rows'
-            // identity so the now-playing row can still be matched.
+            // identity. Playback navigation uses its own immutable queue and
+            // is deliberately unaffected by this view mutation.
             track_store_for_filter.splice(0, track_store_for_filter.n_items(), &filtered);
             tracklist::update_status(&status_label_for_filter, &filtered);
-
-            // Preserve the playback position across the filter: if the
-            // playing track is still visible, re-point `current_pos` at its
-            // new sorted index so sequential auto-advance keeps working;
-            // only clear it when the playing track was filtered out.
-            let new_pos = playing_uri.and_then(|uri| {
-                (0..sort_model_for_filter.n_items()).find(|&i| {
-                    sort_model_for_filter
-                        .item(i)
-                        .and_downcast::<TrackObject>()
-                        .is_some_and(|t| t.uri() == uri)
-                })
-            });
-            current_pos_for_filter.set(new_pos);
         },
     );
 
@@ -369,10 +350,39 @@ pub fn build_window(
         window.maximize();
     }
 
-    // Save window geometry on close.
-    window.connect_close_request(|w| {
+    // Save window geometry and explicitly close every retained DAAP session.
+    // Gate new connections synchronously, then let Tokio perform network I/O
+    // while GTK remains responsive. Once shutdown completes, close() re-enters
+    // this handler with `shutdown_complete` set and is allowed to proceed.
+    let shutdown_handle = rt_handle.clone();
+    let shutdown_started = Rc::new(Cell::new(false));
+    let shutdown_complete = Rc::new(Cell::new(false));
+    window.connect_close_request(move |w| {
         save_window_geometry(w);
-        glib::Propagation::Proceed
+        if shutdown_complete.get() {
+            return glib::Propagation::Proceed;
+        }
+
+        if !shutdown_started.replace(true) {
+            crate::daap::begin_shutdown();
+            let (done_tx, done_rx) = async_channel::bounded::<()>(1);
+            shutdown_handle.spawn(async move {
+                crate::daap::shutdown_all().await;
+                let _ = done_tx.send(()).await;
+            });
+
+            let window = w.clone();
+            let shutdown_complete = shutdown_complete.clone();
+            glib::MainContext::default().spawn_local(async move {
+                // A closed channel also unblocks the window if the runtime
+                // task unexpectedly terminates.
+                let _ = done_rx.recv().await;
+                shutdown_complete.set(true);
+                window.close();
+            });
+        }
+
+        glib::Propagation::Stop
     });
 
     // ── Start the library engine on tokio ────────────────────────────
@@ -493,19 +503,36 @@ pub fn build_window(
         let tx = engine_tx.clone();
         rt_handle.spawn(async move {
             info!(server = %url, "Connecting to DAAP server...");
+            let Some(attempt) = crate::daap::begin_connect(url.clone()) else {
+                tracing::debug!(server = %url, "Skipping DAAP connect during shutdown");
+                return;
+            };
             match crate::daap::DaapBackend::connect("DAAP", &url, password.as_deref()).await {
                 Ok(backend) => {
-                    let tracks: Vec<crate::architecture::models::Track> =
-                        backend.all_tracks().await;
+                    let Some(session) = attempt.retain(backend).await else {
+                        tracing::debug!(server = %url, "DAAP connect was superseded");
+                        return;
+                    };
+                    let tracks: Vec<crate::architecture::models::Track> = session.all_tracks().await;
+                    if !session.is_current() {
+                        tracing::debug!(server = %url, "DAAP sync was superseded");
+                        return;
+                    }
                     info!(count = tracks.len(), "DAAP library fetched");
                     let _ = tx
-                        .send(LibraryEvent::RemoteSync {
+                        .send(LibraryEvent::DaapSync {
                             source_key: url.clone(),
+                            generation: session.generation(),
+                            session_key: session.session_key(),
                             tracks,
                         })
                         .await;
                 }
                 Err(e) => {
+                    if !attempt.is_latest() {
+                        tracing::debug!(server = %url, "Ignoring superseded DAAP connection failure");
+                        return;
+                    }
                     tracing::error!(error = %e, "DAAP connection failed");
                     let _ = tx.send(LibraryEvent::Error(format!("DAAP: {e}"))).await;
                 }
@@ -523,7 +550,6 @@ pub fn build_window(
             master_tracks: master_tracks.clone(),
             source_tracks: source_tracks.clone(),
             active_source_key: active_source_key.clone(),
-            current_pos: current_pos.clone(),
             sidebar_store: sidebar_store.clone(),
             sidebar_selection: sidebar_selection.clone(),
             browser_widget: browser_widget.clone(),
@@ -579,10 +605,20 @@ pub fn build_window(
         let browser_state = browser_state.clone();
         let status_label = status_label.clone();
         let column_view = column_view.clone();
+        let rt_handle = rt_handle.clone();
 
         glib::MainContext::default().spawn_local(async move {
             while let Ok(source_key) = delete_rx.recv().await {
                 info!(source = %source_key, "Manual server delete requested");
+
+                // A connected DAAP source normally uses the eject action,
+                // but deletion must still transfer and close ownership if a
+                // stale/rebound row emits delete instead.
+                if let Some(backend) = crate::daap::release_source(&source_key) {
+                    rt_handle.spawn(async move {
+                        backend.disconnect().await;
+                    });
+                }
 
                 // Remove from servers.json.
                 remove_saved_server(&source_key);
@@ -642,24 +678,15 @@ pub fn build_window(
             while let Ok(source_key) = disconnect_rx.recv().await {
                 info!(source = %source_key, "DAAP disconnect requested");
 
-                // Best-effort logout: find the logout URL on the SourceObject.
-                for i in 0..sidebar_store.n_items() {
-                    if let Some(src) = sidebar_store.item(i).and_downcast_ref::<SourceObject>() {
-                        if src.server_url() == source_key {
-                            let logout_url = src.logout_url();
-                            if !logout_url.is_empty() {
-                                let rt = rt_handle.clone();
-                                rt.spawn(async move {
-                                    let client = reqwest::Client::builder()
-                                        .timeout(std::time::Duration::from_secs(5))
-                                        .build()
-                                        .unwrap_or_default();
-                                    let _ = client.get(&logout_url).send().await;
-                                });
-                            }
-                            break;
-                        }
-                    }
+                // Transfer ownership out of the live-session registry before
+                // updating the UI. This makes a subsequent fast reconnect
+                // independent of the old session's asynchronous logout.
+                if let Some(backend) = crate::daap::release_source(&source_key) {
+                    rt_handle.spawn(async move {
+                        backend.disconnect().await;
+                    });
+                } else {
+                    tracing::warn!(source = %source_key, "DAAP source had no retained session");
                 }
 
                 // 1. Remove from source_tracks map.
@@ -672,7 +699,6 @@ pub fn build_window(
                         if src.server_url() == source_key {
                             src.set_connected(false);
                             src.set_connecting(false);
-                            src.set_logout_url("");
                             src.set_icon_name("network-server-symbolic");
                             // Force rebind by remove + re-insert.
                             let src = src.clone();
@@ -720,7 +746,6 @@ pub fn build_window(
         master_tracks: master_tracks.clone(),
         source_tracks: source_tracks.clone(),
         active_source_key: active_source_key.clone(),
-        current_pos: current_pos.clone(),
         sidebar_store: sidebar_store.clone(),
         sidebar_selection: sidebar_selection.clone(),
         browser_widget: browser_widget.clone(),
@@ -775,6 +800,7 @@ pub fn build_window(
     let local_output = LocalOutput::new(player);
     let active_output: Rc<RefCell<Box<dyn AudioOutput>>> =
         Rc::new(RefCell::new(Box::new(local_output)));
+    let active_output_target = Rc::new(RefCell::new(super::output_switch::OutputTarget::Local));
 
     // Parking slot for the local output when an MPD output is active.
     // When switching to MPD we move the LocalOutput out of active_output
@@ -840,135 +866,154 @@ pub fn build_window(
     // into the spawn_local closure (cloned each iteration so the
     // PlaybackContext can be built fresh per event without moving the
     // captured Rc's out of the closure).
-    let media_ctrl: Rc<RefCell<Option<crate::desktop_integration::MediaController>>> = {
-        // The PlaybackContext takes a `media_ctrl` field that needs to
-        // be the same Rc the rest of the UI uses, so we declare the
-        // outer `Rc` first as `None`, build the controller, then store
-        // it inside.
-        let ctrl_slot: Rc<RefCell<Option<crate::desktop_integration::MediaController>>> =
-            Rc::new(RefCell::new(None));
+    let media_ctrl: Rc<RefCell<Option<crate::desktop_integration::MediaController>>> =
+        Rc::new(RefCell::new(None));
 
-        match crate::desktop_integration::MediaController::new(hwnd) {
-            Ok((ctrl, media_rx)) => {
-                *ctrl_slot.borrow_mut() = Some(ctrl);
+    // Every terminal/reset path uses this one operation. Besides resetting the
+    // visible controls it invalidates delayed spinner callbacks and both local
+    // and remote artwork workers before installing the idle placeholder.
+    let clear_playback_ui: Rc<dyn Fn()> = {
+        let play_button = hb.play_button.clone();
+        let title_label = hb.title_label.clone();
+        let artist_label = hb.artist_label.clone();
+        let album_art = hb.album_art.clone();
+        let progress_adj = hb.progress_adj.clone();
+        let position_label = hb.position_label.clone();
+        let duration_label = hb.duration_label.clone();
+        let seeking = seeking.clone();
+        let media_ctrl = media_ctrl.clone();
+        let buffering_tracker = buffering_tracker.clone();
+        Rc::new(move || {
+            buffering_tracker.invalidate();
+            play_button.set_child(Option::<&gtk::Widget>::None);
+            play_button.set_icon_name("media-playback-start-symbolic");
+            title_label.set_label("Not Playing");
+            title_label.set_tooltip_text(Option::<&str>::None);
+            artist_label.set_label("");
+            artist_label.set_tooltip_text(Option::<&str>::None);
+            super::album_art::invalidate();
+            album_art.set_icon_name(Some("audio-x-generic-symbolic"));
+            seeking.set(true);
+            progress_adj.set_value(0.0);
+            progress_adj.set_upper(1.0);
+            seeking.set(false);
+            position_label.set_label("0:00");
+            duration_label.set_label("0:00");
+            if let Some(ref mut ctrl) = *media_ctrl.borrow_mut() {
+                ctrl.set_stopped();
+            }
+        })
+    };
 
-                let active_output = active_output.clone();
-                let parked_local = parked_local.clone();
-                let album_art = hb.album_art.clone();
-                let title_label = hb.title_label.clone();
-                let artist_label = hb.artist_label.clone();
-                let sm = sort_model.clone();
-                let current_pos = current_pos.clone();
-                let repeat_mode = hb.repeat_mode.clone();
-                let shuffle = hb.shuffle_button.clone();
-                let ctrl_for_ctx = ctrl_slot.clone();
-                let column_view_for_keys = column_view.clone();
+    match crate::desktop_integration::MediaController::new(hwnd) {
+        Ok((ctrl, media_rx)) => {
+            *media_ctrl.borrow_mut() = Some(ctrl);
 
-                glib::MainContext::default().spawn_local(async move {
-                    while let Ok(action) = media_rx.recv().await {
-                        info!(?action, "OS media key");
-                        match action {
-                            MediaAction::Play => active_output.borrow().play(),
-                            MediaAction::Pause => active_output.borrow().pause(),
-                            MediaAction::Toggle => active_output.borrow().toggle_play_pause(),
-                            MediaAction::Stop => active_output.borrow().stop(),
-                            MediaAction::Next => {
-                                advance_track(
-                                    &PlaybackContext {
-                                        model: sm.clone(),
-                                        active_output: active_output.clone(),
-                                        parked_local: parked_local.clone(),
-                                        album_art: album_art.clone(),
-                                        title_label: title_label.clone(),
-                                        artist_label: artist_label.clone(),
-                                        media_ctrl: ctrl_for_ctx.clone(),
-                                        current_pos: current_pos.clone(),
-                                        column_view: column_view_for_keys.clone(),
-                                    },
-                                    repeat_mode.get(),
-                                    shuffle.is_active(),
-                                );
+            let active_output = active_output.clone();
+            let album_art = hb.album_art.clone();
+            let title_label = hb.title_label.clone();
+            let artist_label = hb.artist_label.clone();
+            let sm = sort_model.clone();
+            let active_source_key = active_source_key.clone();
+            let playback_session = playback_session.clone();
+            let repeat_mode = hb.repeat_mode.clone();
+            let shuffle = hb.shuffle_button.clone();
+            let ctrl_for_ctx = media_ctrl.clone();
+            let column_view_for_keys = column_view.clone();
+            let clear_playback_ui = clear_playback_ui.clone();
+
+            glib::MainContext::default().spawn_local(async move {
+                while let Ok(action) = media_rx.recv().await {
+                    info!(?action, "OS media key");
+                    let ctx = PlaybackContext {
+                        model: sm.clone(),
+                        active_source_key: active_source_key.clone(),
+                        active_output: active_output.clone(),
+                        album_art: album_art.clone(),
+                        title_label: title_label.clone(),
+                        artist_label: artist_label.clone(),
+                        media_ctrl: ctrl_for_ctx.clone(),
+                        session: playback_session.clone(),
+                        column_view: column_view_for_keys.clone(),
+                    };
+                    match action {
+                        MediaAction::Play => {
+                            if play_or_start(&ctx, shuffle.is_active()) {
+                                if let Some(ref mut ctrl) = *ctrl_for_ctx.borrow_mut() {
+                                    ctrl.update_playback(true);
+                                }
                             }
-                            MediaAction::Previous => {
-                                // Mirror the header-bar heuristic: if
-                                // we're past the restart threshold,
-                                // restart the current track; otherwise
-                                // step back.
-                                let position_ms = active_output.borrow().position_ms().unwrap_or(0);
-                                if position_ms > PREV_RESTART_THRESHOLD_MS {
+                        }
+                        MediaAction::Pause => {
+                            if playback_session.borrow().has_current() {
+                                active_output.borrow().pause();
+                                if let Some(ref mut ctrl) = *ctrl_for_ctx.borrow_mut() {
+                                    ctrl.update_playback(false);
+                                }
+                            }
+                        }
+                        MediaAction::Toggle => {
+                            toggle_or_start(&ctx, shuffle.is_active());
+                        }
+                        MediaAction::Stop => {
+                            stop_playback(&ctx);
+                            clear_playback_ui();
+                        }
+                        MediaAction::Next => {
+                            advance_track(&ctx, repeat_mode.get(), shuffle.is_active());
+                        }
+                        MediaAction::Previous => {
+                            // Mirror the header-bar heuristic: if we're past
+                            // the restart threshold, restart the current track.
+                            let position_ms = active_output.borrow().position_ms().unwrap_or(0);
+                            if position_ms > PREV_RESTART_THRESHOLD_MS {
+                                active_output.borrow().seek_to(0);
+                            } else {
+                                let stepped =
+                                    previous_track(&ctx, repeat_mode.get(), shuffle.is_active());
+                                if !stepped {
                                     active_output.borrow().seek_to(0);
-                                } else {
-                                    let stepped = previous_track(
-                                        &PlaybackContext {
-                                            model: sm.clone(),
-                                            active_output: active_output.clone(),
-                                            parked_local: parked_local.clone(),
-                                            album_art: album_art.clone(),
-                                            title_label: title_label.clone(),
-                                            artist_label: artist_label.clone(),
-                                            media_ctrl: ctrl_for_ctx.clone(),
-                                            current_pos: current_pos.clone(),
-                                            column_view: column_view_for_keys.clone(),
-                                        },
-                                        repeat_mode.get(),
-                                    );
-                                    if !stepped {
-                                        active_output.borrow().seek_to(0);
-                                    }
                                 }
                             }
                         }
                     }
-                });
-            }
-            Err(e) => {
-                warn!(error = %e, "Media controls unavailable — media keys disabled");
-            }
+                }
+            });
         }
-
-        ctrl_slot
-    };
+        Err(e) => {
+            warn!(error = %e, "Media controls unavailable — media keys disabled");
+        }
+    }
 
     // ── Wire play/pause button ──────────────────────────────────────
     // If nothing is playing, start from track 0 (or random if shuffle).
     {
         let active_output = active_output.clone();
-        let parked_local = parked_local.clone();
         let media_ctrl = media_ctrl.clone();
         let album_art = hb.album_art.clone();
         let title_label = hb.title_label.clone();
         let artist_label = hb.artist_label.clone();
         let sort_model = sort_model.clone();
-        let current_pos = current_pos.clone();
+        let active_source_key = active_source_key.clone();
+        let playback_session = playback_session.clone();
         let shuffle = hb.shuffle_button.clone();
         let column_view_c = column_view.clone();
 
         hb.play_button.connect_clicked(move |_| {
-            if current_pos.get().is_some() {
-                // Already have a track loaded — just toggle.
-                active_output.borrow().toggle_play_pause();
-            } else if sort_model.n_items() > 0 {
-                // Nothing playing — start from the list.
-                let pos = if shuffle.is_active() {
-                    fastrand::u32(..sort_model.n_items())
-                } else {
-                    0
-                };
-                play_track_at(
-                    pos,
-                    &PlaybackContext {
-                        model: sort_model.clone(),
-                        active_output: active_output.clone(),
-                        parked_local: parked_local.clone(),
-                        album_art: album_art.clone(),
-                        title_label: title_label.clone(),
-                        artist_label: artist_label.clone(),
-                        media_ctrl: media_ctrl.clone(),
-                        current_pos: current_pos.clone(),
-                        column_view: column_view_c.clone(),
-                    },
-                );
-            }
+            toggle_or_start(
+                &PlaybackContext {
+                    model: sort_model.clone(),
+                    active_source_key: active_source_key.clone(),
+                    active_output: active_output.clone(),
+                    album_art: album_art.clone(),
+                    title_label: title_label.clone(),
+                    artist_label: artist_label.clone(),
+                    media_ctrl: media_ctrl.clone(),
+                    session: playback_session.clone(),
+                    column_view: column_view_c.clone(),
+                },
+                shuffle.is_active(),
+            );
         });
     }
 
@@ -984,15 +1029,20 @@ pub fn build_window(
     });
 
     // ── Wire output selector row-click handler ──────────────────────
-    super::output_switch::setup_output_selector(
-        &hb.output_list,
-        &hb.output_button,
-        &active_output,
-        &parked_local,
-        &event_sender,
-        &hb.volume_scale,
-        &rt_handle,
-    );
+    {
+        super::output_switch::setup_output_selector(
+            &hb.output_list,
+            &hb.output_button,
+            &active_output,
+            &parked_local,
+            &active_output_target,
+            &playback_session,
+            clear_playback_ui.clone(),
+            &event_sender,
+            &hb.volume_scale,
+            &rt_handle,
+        );
+    }
 
     // ── Wire volume scale ───────────────────────────────────────────
     // Throttled (trailing): a slider drag emits a burst of value-changed
@@ -1079,22 +1129,22 @@ pub fn build_window(
         let title_label = hb.title_label.clone();
         let artist_label = hb.artist_label.clone();
         let sm = sort_model.clone();
-        let current_pos = current_pos.clone();
+        let active_source_key = active_source_key.clone();
+        let playback_session = playback_session.clone();
         let cv = column_view.clone();
 
-        let parked_local = parked_local.clone();
         column_view.connect_activate(move |_view, position| {
             play_track_at(
                 position,
                 &PlaybackContext {
                     model: sm.clone(),
+                    active_source_key: active_source_key.clone(),
                     active_output: active_output.clone(),
-                    parked_local: parked_local.clone(),
                     album_art: album_art.clone(),
                     title_label: title_label.clone(),
                     artist_label: artist_label.clone(),
                     media_ctrl: media_ctrl.clone(),
-                    current_pos: current_pos.clone(),
+                    session: playback_session.clone(),
                     column_view: cv.clone(),
                 },
             );
@@ -1110,7 +1160,6 @@ pub fn build_window(
         master_tracks: master_tracks.clone(),
         source_tracks: source_tracks.clone(),
         active_source_key: active_source_key.clone(),
-        current_pos: current_pos.clone(),
         sidebar_store: sidebar_store_for_events.clone(),
         sidebar_selection: sidebar_sel_for_events.clone(),
         browser_widget: browser_widget.clone(),
@@ -1131,23 +1180,23 @@ pub fn build_window(
         let title_label = hb.title_label.clone();
         let artist_label = hb.artist_label.clone();
         let sm = sort_model.clone();
-        let current_pos = current_pos.clone();
+        let active_source_key = active_source_key.clone();
+        let playback_session = playback_session.clone();
         let repeat_mode = hb.repeat_mode.clone();
         let shuffle = hb.shuffle_button.clone();
-        let parked_local = parked_local.clone();
         let cv = column_view.clone();
 
         hb.next_button.connect_clicked(move |_| {
             advance_track(
                 &PlaybackContext {
                     model: sm.clone(),
+                    active_source_key: active_source_key.clone(),
                     active_output: active_output.clone(),
-                    parked_local: parked_local.clone(),
                     album_art: album_art.clone(),
                     title_label: title_label.clone(),
                     artist_label: artist_label.clone(),
                     media_ctrl: media_ctrl.clone(),
-                    current_pos: current_pos.clone(),
+                    session: playback_session.clone(),
                     column_view: cv.clone(),
                 },
                 repeat_mode.get(),
@@ -1164,9 +1213,10 @@ pub fn build_window(
         let title_label = hb.title_label.clone();
         let artist_label = hb.artist_label.clone();
         let sm = sort_model.clone();
-        let current_pos = current_pos.clone();
-        let parked_local = parked_local.clone();
+        let active_source_key = active_source_key.clone();
+        let playback_session = playback_session.clone();
         let repeat_mode = hb.repeat_mode.clone();
+        let shuffle = hb.shuffle_button.clone();
         let cv = column_view.clone();
 
         hb.prev_button.connect_clicked(move |_| {
@@ -1180,16 +1230,17 @@ pub fn build_window(
             let stepped = previous_track(
                 &PlaybackContext {
                     model: sm.clone(),
+                    active_source_key: active_source_key.clone(),
                     active_output: active_output.clone(),
-                    parked_local: parked_local.clone(),
                     album_art: album_art.clone(),
                     title_label: title_label.clone(),
                     artist_label: artist_label.clone(),
                     media_ctrl: media_ctrl.clone(),
-                    current_pos: current_pos.clone(),
+                    session: playback_session.clone(),
                     column_view: cv.clone(),
                 },
                 repeat_mode.get(),
+                shuffle.is_active(),
             );
 
             // If we couldn't step back (track 0 with repeat off, or no
@@ -1214,10 +1265,12 @@ pub fn build_window(
         let seeking = seeking.clone();
         let media_ctrl = media_ctrl.clone();
         let active_output = active_output.clone();
-        let parked_local = parked_local.clone();
         let sm = sort_model.clone();
-        let current_pos = current_pos.clone();
+        let active_source_key = active_source_key.clone();
+        let playback_session = playback_session.clone();
         let cv = column_view.clone();
+        let buffering_tracker = buffering_tracker.clone();
+        let clear_playback_ui = clear_playback_ui.clone();
 
         // Pre-build a spinner widget for the buffering state.
         let buffering_spinner = gtk::Spinner::builder()
@@ -1230,49 +1283,50 @@ pub fn build_window(
         // longer than this threshold.  Increased from 100 ms to 300 ms
         // to prevent sub-100 ms blinking on fast-loading local files.
         const BUFFERING_DELAY_MS: u32 = 300;
-        // Generation counter — incremented on every state change so
-        // a stale timeout callback can detect it was superseded.
-        let buffering_gen: Rc<Cell<u32>> = Rc::new(Cell::new(0));
-        // Track whether we are in a buffering state so that
-        // PositionChanged can clear the spinner definitively.
-        let is_buffering: Rc<Cell<bool>> = Rc::new(Cell::new(false));
-
         glib::MainContext::default().spawn_local(async move {
             while let Ok(event) = player_rx.recv().await {
+                let event_generation = event.generation();
+                if !playback_session
+                    .borrow()
+                    .accepts_event_generation(event_generation)
+                {
+                    tracing::debug!(?event_generation, "Ignoring stale player event");
+                    continue;
+                }
                 match event {
-                    PlayerEvent::StateChanged(state) => {
-                        // Bump generation on every state change to
-                        // invalidate any pending buffering timer.
-                        let gen = buffering_gen.get().wrapping_add(1);
-                        buffering_gen.set(gen);
-
+                    PlayerEvent::StateChanged { state, .. } => {
                         match state {
                             PlayerState::Buffering => {
-                                is_buffering.set(true);
+                                let generation = buffering_tracker.begin();
                                 // Schedule the spinner after a short
                                 // delay — if Playing arrives first the
                                 // generation will have changed and the
                                 // callback becomes a no-op.
                                 let btn = play_btn.clone();
                                 let spinner = buffering_spinner.clone();
-                                let gen_rc = buffering_gen.clone();
+                                let tracker = buffering_tracker.clone();
+                                let session = playback_session.clone();
                                 glib::timeout_add_local_once(
                                     Duration::from_millis(BUFFERING_DELAY_MS as u64),
                                     move || {
-                                        if gen_rc.get() == gen {
+                                        if tracker.is_current(generation)
+                                            && session
+                                                .borrow()
+                                                .accepts_event_generation(event_generation)
+                                        {
                                             btn.set_child(Some(&spinner));
                                         }
                                     },
                                 );
                             }
                             PlayerState::Playing => {
-                                is_buffering.set(false);
+                                buffering_tracker.invalidate();
                                 // Restore icon: show pause.
                                 play_btn.set_child(Option::<&gtk::Widget>::None);
                                 play_btn.set_icon_name("media-playback-pause-symbolic");
                             }
                             _ => {
-                                is_buffering.set(false);
+                                buffering_tracker.invalidate();
                                 // Stopped or Paused: show play.
                                 play_btn.set_child(Option::<&gtk::Widget>::None);
                                 play_btn.set_icon_name("media-playback-start-symbolic");
@@ -1280,13 +1334,23 @@ pub fn build_window(
                         }
 
                         if let Some(ref mut ctrl) = *media_ctrl.borrow_mut() {
-                            ctrl.update_playback(state == PlayerState::Playing);
+                            match state {
+                                PlayerState::Playing => ctrl.update_playback(true),
+                                PlayerState::Paused | PlayerState::Stopped => {
+                                    ctrl.update_playback(false);
+                                }
+                                // OS media APIs do not expose Buffering. Keep
+                                // the optimistic Playing state published when
+                                // the session load was accepted.
+                                PlayerState::Buffering => {}
+                            }
                         }
                     }
 
                     PlayerEvent::PositionChanged {
                         position_ms,
                         duration_ms,
+                        ..
                     } => {
                         // If we receive a position tick while still in
                         // the buffering state, audio is actually playing
@@ -1294,10 +1358,8 @@ pub fn build_window(
                         // sure-fire fix for remote streams where GStreamer
                         // never sends a clean Playing state change after
                         // buffering completes.
-                        if is_buffering.get() {
-                            is_buffering.set(false);
-                            let gen = buffering_gen.get().wrapping_add(1);
-                            buffering_gen.set(gen);
+                        if buffering_tracker.is_buffering() {
+                            buffering_tracker.invalidate();
                             play_btn.set_child(Option::<&gtk::Widget>::None);
                             play_btn.set_icon_name("media-playback-pause-symbolic");
 
@@ -1328,41 +1390,39 @@ pub fn build_window(
                         }
                     }
 
-                    PlayerEvent::TrackEnded => {
+                    PlayerEvent::TrackEnded { .. } => {
+                        buffering_tracker.invalidate();
+                        play_btn.set_child(Option::<&gtk::Widget>::None);
                         let mode = repeat_mode.get();
 
                         // Repeat-one: replay the same track.
-                        if mode == RepeatMode::One {
-                            if let Some(pos) = current_pos.get() {
-                                play_track_at(
-                                    pos,
-                                    &PlaybackContext {
-                                        model: sm.clone(),
-                                        active_output: active_output.clone(),
-                                        parked_local: parked_local.clone(),
-                                        album_art: album_art.clone(),
-                                        title_label: title_label.clone(),
-                                        artist_label: artist_label.clone(),
-                                        media_ctrl: media_ctrl.clone(),
-                                        current_pos: current_pos.clone(),
-                                        column_view: cv.clone(),
-                                    },
-                                );
-                                continue;
-                            }
+                        if mode == RepeatMode::One
+                            && replay_current(&PlaybackContext {
+                                model: sm.clone(),
+                                active_source_key: active_source_key.clone(),
+                                active_output: active_output.clone(),
+                                album_art: album_art.clone(),
+                                title_label: title_label.clone(),
+                                artist_label: artist_label.clone(),
+                                media_ctrl: media_ctrl.clone(),
+                                session: playback_session.clone(),
+                                column_view: cv.clone(),
+                            })
+                        {
+                            continue;
                         }
 
                         // Auto-advance (shuffle-aware).
                         let advanced = advance_track(
                             &PlaybackContext {
                                 model: sm.clone(),
+                                active_source_key: active_source_key.clone(),
                                 active_output: active_output.clone(),
-                                parked_local: parked_local.clone(),
                                 album_art: album_art.clone(),
                                 title_label: title_label.clone(),
                                 artist_label: artist_label.clone(),
                                 media_ctrl: media_ctrl.clone(),
-                                current_pos: current_pos.clone(),
+                                session: playback_session.clone(),
                                 column_view: cv.clone(),
                             },
                             mode,
@@ -1370,33 +1430,23 @@ pub fn build_window(
                         );
 
                         if !advanced {
-                            // End of playlist — reset to idle.
-                            play_btn.set_icon_name("media-playback-start-symbolic");
-                            title_label.set_label("Not Playing");
-                            artist_label.set_label("");
-                            album_art.set_icon_name(Some("audio-x-generic-symbolic"));
-                            current_pos.set(None);
-
-                            seeking.set(true);
-                            progress_adj.set_value(0.0);
-                            progress_adj.set_upper(1.0);
-                            seeking.set(false);
-
-                            position_label.set_label("0:00");
-                            duration_label.set_label("0:00");
-
-                            if let Some(ref mut ctrl) = *media_ctrl.borrow_mut() {
-                                ctrl.set_stopped();
-                            }
+                            // End of playlist — invalidate the event generation
+                            // before resetting every async/visible UI surface.
+                            playback_session.borrow_mut().clear();
+                            clear_playback_ui();
                         }
                     }
 
-                    PlayerEvent::Error(msg) => {
-                        tracing::error!(error = %msg, "Player error");
+                    PlayerEvent::Error { message, .. } => {
+                        tracing::error!(error = %message, "Player error");
                         // On error, restore the play icon (stop the spinner
                         // if we were buffering).
+                        buffering_tracker.invalidate();
                         play_btn.set_child(Option::<&gtk::Widget>::None);
                         play_btn.set_icon_name("media-playback-start-symbolic");
+                        if let Some(ref mut ctrl) = *media_ctrl.borrow_mut() {
+                            ctrl.update_playback(false);
+                        }
                     }
                 }
             }
@@ -1444,13 +1494,13 @@ pub fn build_window(
     // look it up via `app.lookup_action`.
     {
         let active_output = active_output.clone();
-        let parked_local = parked_local.clone();
         let media_ctrl = media_ctrl.clone();
         let album_art = hb.album_art.clone();
         let title_label = hb.title_label.clone();
         let artist_label = hb.artist_label.clone();
         let sm = sort_model.clone();
-        let current_pos = current_pos.clone();
+        let active_source_key = active_source_key.clone();
+        let playback_session = playback_session.clone();
         let cv = column_view.clone();
 
         let play_pending = gtk::gio::SimpleAction::new("play-pending-files", None);
@@ -1464,13 +1514,13 @@ pub fn build_window(
             // a temp playlist is a separate feature.
             let ctx = super::playback::PlaybackContext {
                 model: sm.clone(),
+                active_source_key: active_source_key.clone(),
                 active_output: active_output.clone(),
-                parked_local: parked_local.clone(),
                 album_art: album_art.clone(),
                 title_label: title_label.clone(),
                 artist_label: artist_label.clone(),
                 media_ctrl: media_ctrl.clone(),
-                current_pos: current_pos.clone(),
+                session: playback_session.clone(),
                 column_view: cv.clone(),
             };
             for path in paths {
@@ -1541,7 +1591,6 @@ pub fn build_window(
             master_tracks: master_tracks.clone(),
             source_tracks: source_tracks.clone(),
             active_source_key: active_source_key.clone(),
-            current_pos: current_pos.clone(),
             sidebar_store: sidebar_store_for_events.clone(),
             sidebar_selection: sidebar_sel_for_events.clone(),
             browser_widget: browser_widget.clone(),
@@ -1630,6 +1679,31 @@ fn setup_library_events(
 
     glib::MainContext::default().spawn_local(async move {
         while let Ok(event) = engine_rx.recv().await {
+            // A DAAP connection can be replaced while its track snapshot is
+            // queued for GTK. Validate the generation at the publication
+            // boundary so an older session can never repopulate the source
+            // with references that its replacement already invalidated.
+            let event = match event {
+                LibraryEvent::DaapSync {
+                    source_key,
+                    generation,
+                    session_key,
+                    tracks,
+                } => {
+                    if !crate::daap::is_current_session(&source_key, generation, session_key) {
+                        tracing::debug!(
+                            source = %source_key,
+                            generation,
+                            %session_key,
+                            "Ignoring stale DAAP library sync"
+                        );
+                        continue;
+                    }
+                    LibraryEvent::RemoteSync { source_key, tracks }
+                }
+                event => event,
+            };
+
             match event {
                 LibraryEvent::FullSync(tracks) => {
                     info!(count = tracks.len(), "Received full library sync");
@@ -1906,6 +1980,10 @@ fn setup_library_events(
                     scan_spinner.set_spinning(false);
                     scan_spinner.set_visible(false);
                 }
+
+                LibraryEvent::DaapSync { .. } => {
+                    unreachable!("DAAP syncs are normalized before event dispatch")
+                }
             }
         }
     });
@@ -1942,6 +2020,8 @@ pub fn arch_track_to_object(t: &crate::architecture::models::Track) -> TrackObje
         t.format.as_deref().unwrap_or(""),
         &uri,
     );
+
+    obj.set_track_id(&t.id.to_string());
 
     // Propagate cover art URL for remote tracks.
     if let Some(ref art_url) = t.cover_art_url {

--- a/src/ui/window_state.rs
+++ b/src/ui/window_state.rs
@@ -54,11 +54,6 @@ pub struct WindowState {
     /// Used by: discovery_handler, source_connect, context_menu, window.
     pub active_source_key: Rc<RefCell<String>>,
 
-    /// Index of the currently-playing track in the sorted model.
-    /// `None` when nothing is playing.
-    /// Used by: source_connect, window (playback wiring).
-    pub current_pos: Rc<Cell<Option<u32>>>,
-
     // ── Sidebar ─────────────────────────────────────────────────────
     /// Sidebar backing store (list of `SourceObject`s with headers).
     /// Used by: discovery_handler, source_connect, playlist_actions, context_menu, window.


### PR DESCRIPTION
## Summary

- add the holistic code review and remediation tracker
- make the playlist-position migration transactional, deterministic, retry-safe, and fixture-tested
- introduce fail-closed library-root reconciliation state and Linux mount-topology guards
- retain DAAP sessions through playback and shut them down exactly once
- replace view-index playback identity with a stable queue/session generation
- prevent recycled sidebar rows from accumulating action handlers
- pin release tooling and dependencies, isolate release-write credentials, and honor validated immutable release refs
- update vulnerable dependency locks and document the remaining time-bounded audit warnings

## Why

The review found release-blocking risks across database upgrades, filesystem reconciliation, remote-session ownership, playback state, recycled GTK rows, and the release pipeline. The highest-impact failure modes included corrupt playlist ordering, deleting metadata from incomplete or wrong-volume scans, invalidating DAAP URLs immediately after sync, stale output events mutating current playback, and executing mutable release tooling with write credentials.

## Impact

Upgrades now preserve deterministic playlist ordering, established library roots fail closed when traversal or mount identity is ambiguous, DAAP and playback state have explicit ownership, and build jobs use immutable inputs with read-only credentials. The tracker records follow-on work rather than treating this batch as the end of the review.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --release -- -D warnings`
- `cargo test --all-targets` — 18 library + 198 binary tests
- `cargo test --release` — 18 library + 198 binary tests
- `cargo audit`
- `appstreamcli validate --no-net data/io.github.tributary.Tributary.metainfo.xml`
- targeted migration, reconciliation, DAAP lifecycle, sidebar recycling, and playback/output tests
- `git diff --check`

## Known remaining work

- P0.2: add explicit trust/re-enrollment for roots inherited from pre-identity databases and portable root-handle pinning
- P0.7: run the live manual-dispatch tag verification after the workflow is available on the default branch
- packaging dry runs remain outstanding
- the pre-existing desktop `AudioVideo` category warning remains tracked as P2.6

See `CODE_REVIEW_2026-07-10.md` and `docs/task.md` for the complete findings and progress ledger.
