### PR TITLE
Preserve playlist and rename identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4788,6 +4788,7 @@ dependencies = [
  "rust_cast",
  "rustix 1.1.4",
  "rustls",
+ "same-file",
  "sea-orm",
  "sea-orm-migration",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ lofty = "0.24"
 # Local backend — filesystem watching
 notify = "8"
 walkdir = "2"
+same-file = "1"
 
 # Thread bridging (GTK ↔ tokio)
 async-channel = "2"

--- a/docs/task.md
+++ b/docs/task.md
@@ -30,7 +30,7 @@ Status summary:
 - [x] Add migration fixtures for gaps, duplicates, reordered rows, multiple playlists, and
   an empty table.
 - [x] Verify a failed migration cannot leave partially updated positions.
-- [x] Record implementation: current worktree (commit pending); 10 focused migration tests.
+- [x] Record implementation: PR #68; 10 focused migration tests.
 
 Acceptance criteria: upgrading a v0.5.0-style database always yields a unique contiguous
 `0..N` position sequence per playlist without changing the intended order.
@@ -66,7 +66,7 @@ view of a library root, while intentional offline deletion is eventually reflect
 - [x] Populate and/or replace the explicit disconnect path with owned backend shutdown.
 - [x] Resolve stream/artwork URLs from the live session at playback time.
 - [x] Add a mock DAAP lifecycle test covering connect, sync, play, and disconnect.
-- [x] Record implementation: current worktree (commit pending); 7 focused lifecycle and
+- [x] Record implementation: PR #68; 7 focused lifecycle and
   replacement-race tests.
 
 Acceptance criteria: a DAAP session remains valid after library synchronization and is
@@ -80,7 +80,7 @@ logged out exactly once on explicit disconnect or controlled shutdown.
 - [x] Make reselecting the current output a no-op.
 - [x] Explicitly transfer or clear playback when the output target changes.
 - [x] Add tests for sort, filter, source change, output change, EOS, and external-file playback.
-- [x] Record implementation: current worktree (commit pending); 25 focused UI/output tests.
+- [x] Record implementation: PR #68; 25 focused UI/output tests.
 
 Acceptance criteria: view mutations never change the identity of the playing track or the
 meaning of queue navigation.
@@ -91,7 +91,7 @@ meaning of queue navigation.
 - [x] Ensure each click resolves only the currently bound `SourceObject`.
 - [x] Cover delete, DAAP eject, playlist creation, and forced remove/reinsert rebinds.
 - [x] Add a GTK test or focused harness that repeatedly recycles the same list item.
-- [x] Record implementation: current worktree (commit pending); focused recycling harness.
+- [x] Record implementation: PR #68; focused recycling harness.
 
 Acceptance criteria: one click emits exactly one action for the currently displayed row.
 
@@ -102,7 +102,7 @@ Acceptance criteria: one click emits exactly one action for the currently displa
 - [x] Set `persist-credentials: false` on build-job checkouts.
 - [x] Move `contents: write` to a minimal publication job.
 - [x] Give all build jobs `contents: read`.
-- [x] Record implementation: current worktree (commit pending); YAML, checksum, and contract
+- [x] Record implementation: PR #68; YAML, checksum, and contract
   checks passed locally.
 
 Acceptance criteria: release build jobs execute only repository or immutable verified code
@@ -115,7 +115,7 @@ and cannot access a repository write credential.
 - [x] Derive every package version from the checked-out source/tag.
 - [x] Reject a missing or malformed requested tag.
 - [ ] Add a dry-run/manual workflow test demonstrating that tag X builds tag X.
-- [ ] Record implementation: workflow contract implemented in the current worktree; live
+- [ ] Record implementation: workflow contract implemented in PR #68; live
   manual-dispatch verification pending after push.
 
 Acceptance criteria: all artifacts in a run are built from the same requested immutable ref
@@ -128,7 +128,7 @@ and carry the same version.
 - [x] Review the `anyhow`, `paste`, and `proc-macro-error2` warnings and document upstream
   disposition.
 - [x] Run `cargo audit` successfully.
-- [x] Record implementation: current worktree (commit pending); `cargo audit` passes with two
+- [x] Record implementation: PR #68; `cargo audit` passes with two
   documented informational warnings.
 
 Audit disposition recorded 2026-07-10:
@@ -146,11 +146,12 @@ explicitly justified and time-bounded.
 
 ### P1.1 Add the real playlist-entry track foreign key
 
-- [ ] Rebuild `playlist_entries` with `track_id -> tracks(id) ON DELETE SET NULL`.
-- [ ] Null existing dangling IDs before enabling the constraint.
-- [ ] Reconcile newly orphaned entries after scans and watcher insertions.
-- [ ] Test delete, rename, re-add, and full rebuild behavior.
-- [ ] Record implementation: _pending_
+- [x] Rebuild `playlist_entries` with `track_id -> tracks(id) ON DELETE SET NULL`.
+- [x] Null existing dangling IDs before enabling the constraint.
+- [x] Reconcile newly orphaned entries after scans and watcher insertions.
+- [x] Test delete, rename, re-add, and full rebuild behavior.
+- [x] Record implementation: current worktree (commit pending); 12 focused migration,
+  reconciliation, and watcher-batch tests.
 
 ### P1.2 Preserve identity across filesystem renames
 
@@ -218,6 +219,8 @@ explicitly justified and time-bounded.
 ### P1.9 Prevent stale async source rendering
 
 - [ ] Attach a source key/generation to playlist, radio, and remote loads.
+- [ ] Refresh an active playlist after watcher reconciliation without allowing a stale load to
+  replace a newer source selection.
 - [ ] Cache completed results even when no longer active.
 - [ ] Render only if the requested source remains selected.
 - [ ] Reuse the active-key guard pattern already present in USB loading.
@@ -238,6 +241,8 @@ explicitly justified and time-bounded.
 
 ### P2.2 Make playlist import/export transactional and deterministic
 
+- [ ] Define supported source formats and provide adapters or actionable conversion guidance
+  for Apple Music XML and YouTube Music exports.
 - [ ] Export through a sibling temporary file and atomic replacement.
 - [ ] Prefer an exact existing file path before metadata matching.
 - [ ] Enforce the documented duration tolerance and deterministic tie-breaking.
@@ -368,7 +373,7 @@ by P2.6. Packaging dry runs and the live manual release-workflow run remain outs
 
 Record scope or design decisions here so deferred work is explicit.
 
-- 2026-07-10 — Implemented P0.1, P0.3-P0.6, and P0.8 in the current worktree. P0.7's
+- 2026-07-10 — Implemented P0.1, P0.3-P0.6, and P0.8 in PR #68. P0.7's
   workflow contract is implemented, but its live manual-dispatch acceptance test requires a
   pushed ref and remains open.
 - 2026-07-10 — P0.2 now fails closed for incomplete traversal, unavailable/replaced roots,
@@ -391,6 +396,11 @@ Record scope or design decisions here so deferred work is explicit.
 - 2026-07-10 — The remaining `cargo audit` warnings are unmaintained transitive dependencies,
   not known vulnerabilities; their owners and 2026-10-10 review deadline are recorded under
   P0.8.
+- 2026-07-12 — Track deletion now preserves playlist-entry identity, order, and fingerprint by
+  nulling the real track foreign key. Scan and watcher-batch reconciliation relink only when
+  fingerprint plus optional duration identifies exactly one current track; ambiguous matches
+  remain orphaned. Stable track identity across filesystem renames remains P1.2; safely
+  refreshing an already-open playlist after background reconciliation remains P1.9.
 
 ## Completed work log
 
@@ -398,9 +408,10 @@ Add one line per completed task:
 
 | Date | Task | Commit/PR | Notes |
 |---|---|---|---|
-| 2026-07-10 | P0.1 | Current worktree | Transactional, deterministic, retry-safe migration with focused upgrade fixtures. |
-| 2026-07-10 | P0.3 | Current worktree | Owned DAAP registry, generation-safe sync, live URL resolution, and exactly-once shutdown. |
-| 2026-07-10 | P0.4 | Current worktree | Stable queue/session identity, generation-filtered events, and deterministic output reset. |
-| 2026-07-10 | P0.5 | Current worktree | One setup-time sidebar handler with current-item resolution and recycling tests. |
-| 2026-07-10 | P0.6 | Current worktree | Immutable release inputs and publication-only repository credentials. |
-| 2026-07-10 | P0.8 | Current worktree | Patched dependency graph and time-bounded informational advisory dispositions. |
+| 2026-07-10 | P0.1 | PR #68 | Transactional, deterministic, retry-safe migration with focused upgrade fixtures. |
+| 2026-07-10 | P0.3 | PR #68 | Owned DAAP registry, generation-safe sync, live URL resolution, and exactly-once shutdown. |
+| 2026-07-10 | P0.4 | PR #68 | Stable queue/session identity, generation-filtered events, and deterministic output reset. |
+| 2026-07-10 | P0.5 | PR #68 | One setup-time sidebar handler with current-item resolution and recycling tests. |
+| 2026-07-10 | P0.6 | PR #68 | Immutable release inputs and publication-only repository credentials. |
+| 2026-07-10 | P0.8 | PR #68 | Patched dependency graph and time-bounded informational advisory dispositions. |
+| 2026-07-12 | P1.1 | Current worktree | Transactional, retry-safe track-FK rebuild with dangling-link cleanup, index preservation, and scan/watcher reconciliation. |

--- a/docs/task.md
+++ b/docs/task.md
@@ -168,8 +168,9 @@ explicitly justified and time-bounded.
   indexed descendant in one transaction after a complete scoped traversal.
 - [x] Refresh already-captured local/playlist queue items by stable track ID after an
   ID-preserving committed rename, so Next/EOS uses the new URI.
-- [x] Record implementation: stacked P1.2 commits; 23 additional focused directory-rename,
-  batch-deferral, no-follow, scoped-scan, and queue-refresh tests, for 31 focused P1.2 tests total.
+- [x] Record implementation: stacked P1.2 commits; 24 additional focused directory-rename,
+  batch-deferral, no-follow, scoped-scan, playlist-projection, and queue-refresh tests, for 32
+  focused P1.2 tests total.
 
 ### P1.3 Close the scan/watcher handoff gap
 
@@ -229,8 +230,9 @@ explicitly justified and time-bounded.
 ### P1.9 Prevent stale async source rendering
 
 - [ ] Attach a source key/generation to playlist, radio, and remote loads.
-- [ ] Refresh an active playlist model after watcher reconciliation or an ID-preserving local
-  rename.
+- [x] Refresh already-open playlist URIs after an ID-preserving local rename and overlay committed
+  URIs onto an in-flight result before publication.
+- [ ] Reload an active playlist after watcher reconciliation remints or relinks track IDs.
 - [ ] Reject an in-flight playlist result when its source generation is stale, including when it
   would render pre-rename rows after the refreshed model or replace a newer source selection.
 - [ ] Cache completed results even when no longer active.
@@ -447,8 +449,9 @@ Record scope or design decisions here so deferred work is explicit.
   reparse points, unexpected path types, and metadata errors force authoritative reconciliation.
 - 2026-07-12 — A committed bulk rename publishes one library snapshot rather than a per-row
   event storm, and an already-captured playback queue re-resolves its items from it by stable
-  track ID, in place. An in-flight playlist load can still render a pre-rename model after that
-  event; source generations and active-model refresh remain P1.9. A rename that falls back to
+  track ID, in place. Already-open playlist rows are retargeted by the same stable ID, and an
+  in-flight playlist result overlays committed local URIs before it can render. Same-key request
+  generations and post-reconciliation reloads remain P1.9. A rename that falls back to
   reconciliation still mints new track IDs, so the ID-based refresh cannot repair a queue captured
   before it; recovery requires rebuilding it from a refreshed source model. Stable-ID resolution
   at playback, navigation, and receiver-load time remains P3.1 rather than changing queue semantics
@@ -467,4 +470,4 @@ Add one line per completed task:
 | 2026-07-10 | P0.6 | PR #68 | Immutable release inputs and publication-only repository credentials. |
 | 2026-07-10 | P0.8 | PR #68 | Patched dependency graph and time-bounded informational advisory dispositions. |
 | 2026-07-12 | P1.1 | `8ec84a5` | Transactional, retry-safe track-FK rebuild with dangling-link cleanup, index preservation, and scan/watcher reconciliation. |
-| 2026-07-12 | P1.2 | `93d03bf`, `b961b7c` | Identity preserved across authoritative paired file and directory renames; already-captured local/playlist queue snapshots re-resolve ID-preserving committed changes by stable track ID. |
+| 2026-07-12 | P1.2 | `93d03bf`, `b961b7c`, `17babaf`, `000d9c0` | Identity preserved across authoritative paired file and directory renames; queue and active-playlist snapshots re-resolve ID-preserving committed changes by stable track ID. |

--- a/docs/task.md
+++ b/docs/task.md
@@ -150,16 +150,26 @@ explicitly justified and time-bounded.
 - [x] Null existing dangling IDs before enabling the constraint.
 - [x] Reconcile newly orphaned entries after scans and watcher insertions.
 - [x] Test delete, rename, re-add, and full rebuild behavior.
-- [x] Record implementation: current worktree (commit pending); 12 focused migration,
+- [x] Record implementation: commit `8ec84a5`; 12 focused migration,
   reconciliation, and watcher-batch tests.
 
-### P1.2 Preserve identity across filesystem renames
+### P1.2 Preserve identity for authoritative filesystem renames
 
-- [ ] Treat paired file renames as transactional path updates.
-- [ ] Preserve UUID, `date_added`, play count, and playlist linkage.
-- [ ] Handle directory rename/removal by rescanning the affected subtree.
-- [ ] Define fallback behavior when rename pairing is unavailable.
-- [ ] Record implementation: _pending_
+- [x] Preserve event order and tracker metadata; normalize authoritative Linux and Windows
+  rename pairs without processing duplicate halves.
+- [x] Transactionally update same-root, same-format paired file paths while preserving UUID,
+  `date_added`, play count, playlist linkage, and mutable metadata.
+- [x] Reconcile directory changes, unpaired/unknown renames, cross-root moves, and format changes
+  with one hardened authoritative scan per watcher batch rather than guessing identity.
+- [x] Disable watcher symlink following so incremental indexing matches authoritative scans.
+- [x] Cover cross-platform event shapes, destination replacement, guard rejection, SQL rollback,
+  and playlist-FK preservation with eight focused tests.
+- [ ] Preserve descendant IDs for paired directory renames with a complete scoped path mapping;
+  the current full-scan fallback converges safely but replaces those track IDs.
+- [ ] Refresh queued local/playlist items by stable track ID so Next/EOS cannot retain the old
+  URI after a committed rename.
+- [ ] Record implementation: stacked P1.2 commit; paired-file core complete,
+  directory identity and playback-queue refresh remain.
 
 ### P1.3 Close the scan/watcher handoff gap
 
@@ -401,6 +411,11 @@ Record scope or design decisions here so deferred work is explicit.
   fingerprint plus optional duration identifies exactly one current track; ambiguous matches
   remain orphaned. Stable track identity across filesystem renames remains P1.2; safely
   refreshing an already-open playlist after background reconciliation remains P1.9.
+- 2026-07-12 — P1.2 preserves identity only for authoritative same-root, same-format pairs:
+  tracked Linux events and strictly adjacent Windows rename halves. Unpairable macOS/BSD events,
+  directory changes, cross-root moves, and format changes use a full hardened scan and never
+  infer identity from tags. Paired-directory descendant IDs and immutable playback-queue URI
+  refresh remain explicit P1.2 follow-ups.
 
 ## Completed work log
 
@@ -414,4 +429,4 @@ Add one line per completed task:
 | 2026-07-10 | P0.5 | PR #68 | One setup-time sidebar handler with current-item resolution and recycling tests. |
 | 2026-07-10 | P0.6 | PR #68 | Immutable release inputs and publication-only repository credentials. |
 | 2026-07-10 | P0.8 | PR #68 | Patched dependency graph and time-bounded informational advisory dispositions. |
-| 2026-07-12 | P1.1 | Current worktree | Transactional, retry-safe track-FK rebuild with dangling-link cleanup, index preservation, and scan/watcher reconciliation. |
+| 2026-07-12 | P1.1 | `8ec84a5` | Transactional, retry-safe track-FK rebuild with dangling-link cleanup, index preservation, and scan/watcher reconciliation. |

--- a/docs/task.md
+++ b/docs/task.md
@@ -164,12 +164,12 @@ explicitly justified and time-bounded.
 - [x] Disable watcher symlink following so incremental indexing matches authoritative scans.
 - [x] Cover cross-platform event shapes, destination replacement, guard rejection, SQL rollback,
   and playlist-FK preservation with eight focused tests.
-- [ ] Preserve descendant IDs for paired directory renames with a complete scoped path mapping;
-  the current full-scan fallback converges safely but replaces those track IDs.
-- [ ] Refresh queued local/playlist items by stable track ID so Next/EOS cannot retain the old
-  URI after a committed rename.
-- [ ] Record implementation: stacked P1.2 commit; paired-file core complete,
-  directory identity and playback-queue refresh remain.
+- [x] Preserve descendant IDs for paired directory renames by retargeting every safely mapped
+  indexed descendant in one transaction after a complete scoped traversal.
+- [x] Refresh already-captured local/playlist queue items by stable track ID after an
+  ID-preserving committed rename, so Next/EOS uses the new URI.
+- [x] Record implementation: stacked P1.2 commits; 23 additional focused directory-rename,
+  batch-deferral, no-follow, scoped-scan, and queue-refresh tests, for 31 focused P1.2 tests total.
 
 ### P1.3 Close the scan/watcher handoff gap
 
@@ -229,8 +229,10 @@ explicitly justified and time-bounded.
 ### P1.9 Prevent stale async source rendering
 
 - [ ] Attach a source key/generation to playlist, radio, and remote loads.
-- [ ] Refresh an active playlist after watcher reconciliation without allowing a stale load to
-  replace a newer source selection.
+- [ ] Refresh an active playlist model after watcher reconciliation or an ID-preserving local
+  rename.
+- [ ] Reject an in-flight playlist result when its source generation is stale, including when it
+  would render pre-rename rows after the refreshed model or replace a newer source selection.
 - [ ] Cache completed results even when no longer active.
 - [ ] Render only if the requested source remains selected.
 - [ ] Reuse the active-key guard pattern already present in USB loading.
@@ -318,6 +320,8 @@ explicitly justified and time-bounded.
 - [ ] Store `Arc<dyn MediaBackend>` or a deliberate session abstraction per source.
 - [ ] Remove long-lived authenticated URLs from the generic `Track` model.
 - [ ] Resolve playable URLs/tickets at playback time.
+- [ ] Resolve local/playlist media by stable track ID at playback, navigation, and receiver-load
+  time so fallback reconciliation and in-flight casts cannot retain dead file paths.
 - [ ] Centralize source refresh, cancellation, disconnect, and failure state.
 - [ ] Decide how local, radio, and external-file sources fit the same lifecycle.
 - [ ] Record architecture decision: _pending_
@@ -413,9 +417,42 @@ Record scope or design decisions here so deferred work is explicit.
   refreshing an already-open playlist after background reconciliation remains P1.9.
 - 2026-07-12 — P1.2 preserves identity only for authoritative same-root, same-format pairs:
   tracked Linux events and strictly adjacent Windows rename halves. Unpairable macOS/BSD events,
-  directory changes, cross-root moves, and format changes use a full hardened scan and never
-  infer identity from tags. Paired-directory descendant IDs and immutable playback-queue URI
-  refresh remain explicit P1.2 follow-ups.
+  cross-root moves, and format changes use a full hardened scan and never infer identity from
+  tags.
+- 2026-07-12 — A paired directory rename now moves every safely mapped indexed descendant in one
+  transaction. Each descendant is moved only when a completed scoped traversal of the destination
+  observed a real file at its mirrored path. This is a path-based observation, not an inferred
+  metadata match; live filesystem handles retained by the traversal are revalidated before the
+  database transaction commits. A descendant with no such file is left in place for reconciliation
+  rather than followed to a path that may not exist, and destination files no row claims are
+  upserted normally, so an album gaining a file while the app was closed does not defeat identity
+  preservation. Paths are matched component-wise in the database's existing lossy namespace, so
+  already-persisted non-UTF-8 paths remain matchable subject to that namespace's collision limits,
+  and `/music/Album` cannot capture `/music/Album2`. Pairs nested inside a renamed directory, and
+  subtrees owning another persisted root or mount, remain fail-closed: the watcher cannot order
+  them, so they reconcile.
+- 2026-07-12 — Directory-rename halves are deferred, not reconciled on sight. A vanished
+  directory and a deleted cover image are indistinguishable when the path is already gone, so
+  the batch decides only once every event in the debounce window has arrived; anything no
+  authoritative pair claimed still forces the guarded rescan.
+- 2026-07-12 — Directory scans retain cross-platform filesystem-object handles for the
+  destination and every mapped audio file, then reopen and compare them in the transaction's
+  final guard. A removal, replacement, symlink/reparse point, or directory swap therefore rolls
+  the identity update back. Files with their own event in the same watcher batch are excluded from
+  identity mapping and take the normal parse/reconciliation path. The same object comparison also
+  authorizes case-only directory renames on case-insensitive filesystems without accepting a
+  copied or recreated source.
+- 2026-07-12 — Watcher upserts classify paths with no-follow metadata before parsing and again
+  before persistence. Missing audio paths retain the guarded-delete behavior; symlinks, Windows
+  reparse points, unexpected path types, and metadata errors force authoritative reconciliation.
+- 2026-07-12 — A committed bulk rename publishes one library snapshot rather than a per-row
+  event storm, and an already-captured playback queue re-resolves its items from it by stable
+  track ID, in place. An in-flight playlist load can still render a pre-rename model after that
+  event; source generations and active-model refresh remain P1.9. A rename that falls back to
+  reconciliation still mints new track IDs, so the ID-based refresh cannot repair a queue captured
+  before it; recovery requires rebuilding it from a refreshed source model. Stable-ID resolution
+  at playback, navigation, and receiver-load time remains P3.1 rather than changing queue semantics
+  here.
 
 ## Completed work log
 
@@ -430,3 +467,4 @@ Add one line per completed task:
 | 2026-07-10 | P0.6 | PR #68 | Immutable release inputs and publication-only repository credentials. |
 | 2026-07-10 | P0.8 | PR #68 | Patched dependency graph and time-bounded informational advisory dispositions. |
 | 2026-07-12 | P1.1 | `8ec84a5` | Transactional, retry-safe track-FK rebuild with dangling-link cleanup, index preservation, and scan/watcher reconciliation. |
+| 2026-07-12 | P1.2 | `93d03bf`, `b961b7c` | Identity preserved across authoritative paired file and directory renames; already-captured local/playlist queue snapshots re-resolve ID-preserving committed changes by stable track ID. |

--- a/src/db/migration/m20250710_000005_create_library_roots.rs
+++ b/src/db/migration/m20250710_000005_create_library_roots.rs
@@ -82,7 +82,9 @@ mod tests {
         let db = Database::connect("sqlite::memory:")
             .await
             .expect("open in-memory database");
-        Migrator::up(&db, None).await.expect("apply all migrations");
+        Migrator::up(&db, Some(5))
+            .await
+            .expect("apply through the library-roots migration");
         db
     }
 

--- a/src/db/migration/m20260712_000006_playlist_track_fk.rs
+++ b/src/db/migration/m20260712_000006_playlist_track_fk.rs
@@ -1,0 +1,1069 @@
+//! Migration: enforce playlist-entry references to local tracks.
+//!
+//! The original playlist table declared `track_id` as a nullable string but
+//! omitted its database foreign key. Deleting a track could therefore leave a
+//! non-null dangling ID that reconciliation would never inspect. SQLite cannot
+//! add a foreign key in place, so this migration transactionally rebuilds the
+//! table, nulls existing dangling IDs, and restores every index.
+
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::{ConnectionTrait, DbBackend, Statement, TransactionTrait};
+
+const REBUILD_TABLE: &str = "tributary_playlist_entries_track_fk_rebuild";
+const PLAYLIST_INDEX: &str = "idx_playlist_entries_playlist_id";
+const TRACK_INDEX: &str = "idx_playlist_entries_track_id";
+const UNIQUE_POSITION_INDEX: &str = "idx_playlist_entries_playlist_position_unique";
+
+#[derive(Debug, Eq, PartialEq)]
+enum PlaylistEntriesSchema {
+    Legacy,
+    WithTrackForeignKey,
+}
+
+#[derive(Debug)]
+struct ExplicitIndex {
+    name: String,
+    sql: String,
+}
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        rebuild_playlist_entries(manager, true).await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        rebuild_playlist_entries(manager, false).await
+    }
+}
+
+/// Rebuild `playlist_entries` inside one explicit transaction.
+///
+/// SeaORM does not automatically wrap SQLite migrations in a transaction.
+/// Owning it here ensures a failed copy, constraint check, or index recreation
+/// restores the original table exactly and leaves the migration retryable.
+async fn rebuild_playlist_entries(
+    manager: &SchemaManager<'_>,
+    include_track_foreign_key: bool,
+) -> Result<(), DbErr> {
+    if !manager.has_table("playlist_entries").await? {
+        return Err(DbErr::Migration(
+            "playlist_entries must exist for the track foreign-key migration".to_string(),
+        ));
+    }
+
+    let transaction = manager.get_connection().begin().await?;
+    let result = {
+        let manager = SchemaManager::new(&transaction);
+        let schema = inspect_playlist_entries_schema(&manager).await?;
+        let indexes = capture_and_validate_indexes(&manager).await?;
+        let already_has_requested_schema = matches!(
+            (include_track_foreign_key, schema),
+            (true, PlaylistEntriesSchema::WithTrackForeignKey)
+                | (false, PlaylistEntriesSchema::Legacy)
+        );
+        if already_has_requested_schema {
+            if include_track_foreign_key {
+                null_dangling_track_ids(&manager).await?;
+            }
+            validate_playlist_entry_foreign_keys(&manager).await
+        } else {
+            rebuild_playlist_entries_in_transaction(&manager, include_track_foreign_key, &indexes)
+                .await
+        }
+    };
+
+    match result {
+        Ok(()) => transaction.commit().await,
+        Err(error) => {
+            transaction.rollback().await?;
+            Err(error)
+        }
+    }
+}
+
+async fn rebuild_playlist_entries_in_transaction(
+    manager: &SchemaManager<'_>,
+    include_track_foreign_key: bool,
+    indexes: &[ExplicitIndex],
+) -> Result<(), DbErr> {
+    let connection = manager.get_connection();
+    let track_foreign_key = if include_track_foreign_key {
+        ",
+         CONSTRAINT fk_entry_track
+             FOREIGN KEY (track_id)
+             REFERENCES tracks (id)
+             ON DELETE SET NULL"
+    } else {
+        ""
+    };
+
+    connection
+        .execute_unprepared(&format!(
+            "CREATE TABLE {REBUILD_TABLE} (
+                 id VARCHAR PRIMARY KEY NOT NULL,
+                 playlist_id VARCHAR NOT NULL,
+                 position INTEGER NOT NULL,
+                 track_id VARCHAR NULL,
+                 match_title VARCHAR NOT NULL DEFAULT '',
+                 match_artist VARCHAR NOT NULL DEFAULT '',
+                 match_album VARCHAR NOT NULL DEFAULT '',
+                 match_duration_secs INTEGER NULL,
+                 CONSTRAINT fk_entry_playlist
+                     FOREIGN KEY (playlist_id)
+                     REFERENCES playlists (id)
+                     ON DELETE CASCADE
+                 {track_foreign_key}
+             )"
+        ))
+        .await?;
+
+    if include_track_foreign_key {
+        null_dangling_track_ids(manager).await?;
+    }
+
+    connection
+        .execute_unprepared(&format!(
+            "INSERT INTO {REBUILD_TABLE} (
+                 id,
+                 playlist_id,
+                 position,
+                 track_id,
+                 match_title,
+                 match_artist,
+                 match_album,
+                 match_duration_secs
+             )
+             SELECT source.id,
+                    source.playlist_id,
+                    source.position,
+                    source.track_id,
+                    source.match_title,
+                    source.match_artist,
+                    source.match_album,
+                    source.match_duration_secs
+             FROM playlist_entries AS source"
+        ))
+        .await?;
+
+    connection
+        .execute_unprepared("DROP TABLE playlist_entries")
+        .await?;
+    connection
+        .execute_unprepared(&format!(
+            "ALTER TABLE {REBUILD_TABLE} RENAME TO playlist_entries"
+        ))
+        .await?;
+
+    for index in indexes {
+        connection
+            .execute_unprepared(&index.sql)
+            .await
+            .map_err(|error| {
+                DbErr::Migration(format!(
+                    "failed to restore playlist_entries index {}: {error}",
+                    index.name
+                ))
+            })?;
+    }
+
+    validate_playlist_entry_foreign_keys(manager).await
+}
+
+async fn null_dangling_track_ids(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .get_connection()
+        .execute_unprepared(
+            "UPDATE playlist_entries
+             SET track_id = NULL
+             WHERE track_id IS NOT NULL
+               AND NOT EXISTS (
+                   SELECT 1
+                   FROM tracks
+                   WHERE tracks.id = playlist_entries.track_id
+               )",
+        )
+        .await?;
+    Ok(())
+}
+
+async fn validate_playlist_entry_foreign_keys(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    let violations = manager
+        .get_connection()
+        .query_all(Statement::from_string(
+            manager.get_database_backend(),
+            "PRAGMA foreign_key_check('playlist_entries')".to_string(),
+        ))
+        .await?;
+    if !violations.is_empty() {
+        return Err(DbErr::Migration(format!(
+            "rebuilt playlist_entries has {} foreign-key violation(s)",
+            violations.len()
+        )));
+    }
+
+    Ok(())
+}
+
+async fn inspect_playlist_entries_schema(
+    manager: &SchemaManager<'_>,
+) -> Result<PlaylistEntriesSchema, DbErr> {
+    let connection = manager.get_connection();
+    let backend = manager.get_database_backend();
+    let columns = connection
+        .query_all(Statement::from_string(
+            backend,
+            "PRAGMA table_info('playlist_entries')".to_string(),
+        ))
+        .await?
+        .into_iter()
+        .map(|row| {
+            Ok::<_, DbErr>((
+                row.try_get::<String>("", "name")?,
+                row.try_get::<String>("", "type")?.to_ascii_lowercase(),
+                row.try_get::<i32>("", "notnull")?,
+                row.try_get::<Option<String>>("", "dflt_value")?,
+                row.try_get::<i32>("", "pk")?,
+            ))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let expected_columns = vec![
+        ("id".to_string(), "varchar".to_string(), 1, None, 1),
+        ("playlist_id".to_string(), "varchar".to_string(), 1, None, 0),
+        ("position".to_string(), "integer".to_string(), 1, None, 0),
+        ("track_id".to_string(), "varchar".to_string(), 0, None, 0),
+        (
+            "match_title".to_string(),
+            "varchar".to_string(),
+            1,
+            Some("''".to_string()),
+            0,
+        ),
+        (
+            "match_artist".to_string(),
+            "varchar".to_string(),
+            1,
+            Some("''".to_string()),
+            0,
+        ),
+        (
+            "match_album".to_string(),
+            "varchar".to_string(),
+            1,
+            Some("''".to_string()),
+            0,
+        ),
+        (
+            "match_duration_secs".to_string(),
+            "integer".to_string(),
+            0,
+            None,
+            0,
+        ),
+    ];
+    if columns != expected_columns {
+        return Err(DbErr::Migration(format!(
+            "playlist_entries has an unexpected column schema: {columns:?}"
+        )));
+    }
+
+    let foreign_keys = connection
+        .query_all(Statement::from_string(
+            backend,
+            "PRAGMA foreign_key_list('playlist_entries')".to_string(),
+        ))
+        .await?
+        .into_iter()
+        .map(|row| {
+            Ok::<_, DbErr>((
+                row.try_get::<String>("", "from")?,
+                row.try_get::<String>("", "table")?,
+                row.try_get::<String>("", "to")?,
+                row.try_get::<String>("", "on_update")?,
+                row.try_get::<String>("", "on_delete")?,
+            ))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let playlist_foreign_key = (
+        "playlist_id".to_string(),
+        "playlists".to_string(),
+        "id".to_string(),
+        "NO ACTION".to_string(),
+        "CASCADE".to_string(),
+    );
+    let track_foreign_key = (
+        "track_id".to_string(),
+        "tracks".to_string(),
+        "id".to_string(),
+        "NO ACTION".to_string(),
+        "SET NULL".to_string(),
+    );
+
+    if foreign_keys.len() == 1 && foreign_keys.contains(&playlist_foreign_key) {
+        Ok(PlaylistEntriesSchema::Legacy)
+    } else if foreign_keys.len() == 2
+        && foreign_keys.contains(&playlist_foreign_key)
+        && foreign_keys.contains(&track_foreign_key)
+    {
+        Ok(PlaylistEntriesSchema::WithTrackForeignKey)
+    } else {
+        Err(DbErr::Migration(format!(
+            "playlist_entries has unexpected foreign keys: {foreign_keys:?}"
+        )))
+    }
+}
+
+async fn capture_and_validate_indexes(
+    manager: &SchemaManager<'_>,
+) -> Result<Vec<ExplicitIndex>, DbErr> {
+    let connection = manager.get_connection();
+    let backend = manager.get_database_backend();
+    let indexes = connection
+        .query_all(Statement::from_string(
+            backend,
+            "SELECT name, sql
+             FROM sqlite_master
+             WHERE type = 'index'
+               AND tbl_name = 'playlist_entries'
+               AND sql IS NOT NULL
+             ORDER BY name"
+                .to_string(),
+        ))
+        .await?
+        .into_iter()
+        .map(|row| {
+            Ok::<_, DbErr>(ExplicitIndex {
+                name: row.try_get("", "name")?,
+                sql: row.try_get("", "sql")?,
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    validate_implicit_primary_key_index(connection, backend).await?;
+
+    validate_index(
+        connection,
+        backend,
+        &indexes,
+        PLAYLIST_INDEX,
+        false,
+        &["playlist_id"],
+    )
+    .await?;
+    validate_index(
+        connection,
+        backend,
+        &indexes,
+        TRACK_INDEX,
+        false,
+        &["track_id"],
+    )
+    .await?;
+    validate_index(
+        connection,
+        backend,
+        &indexes,
+        UNIQUE_POSITION_INDEX,
+        true,
+        &["playlist_id", "position"],
+    )
+    .await?;
+
+    Ok(indexes)
+}
+
+async fn validate_implicit_primary_key_index<C>(
+    connection: &C,
+    backend: DbBackend,
+) -> Result<(), DbErr>
+where
+    C: ConnectionTrait,
+{
+    let implicit_indexes = connection
+        .query_all(Statement::from_string(
+            backend,
+            "PRAGMA index_list('playlist_entries')".to_string(),
+        ))
+        .await?
+        .into_iter()
+        .map(|row| {
+            Ok::<_, DbErr>((
+                row.try_get::<String>("", "name")?,
+                row.try_get::<i32>("", "unique")? == 1,
+                row.try_get::<String>("", "origin")?,
+                row.try_get::<i32>("", "partial").unwrap_or_default() == 1,
+            ))
+        })
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .filter(|(_, _, origin, _)| origin != "c")
+        .collect::<Vec<_>>();
+
+    let [(name, true, origin, false)] = implicit_indexes.as_slice() else {
+        return Err(DbErr::Migration(format!(
+            "playlist_entries has unexpected implicit indexes: {implicit_indexes:?}"
+        )));
+    };
+    if origin != "pk" {
+        return Err(DbErr::Migration(format!(
+            "playlist_entries has unexpected implicit index origin {origin}"
+        )));
+    }
+
+    let columns = connection
+        .query_all(Statement::from_string(
+            backend,
+            format!("PRAGMA index_info('{name}')"),
+        ))
+        .await?
+        .into_iter()
+        .map(|row| {
+            Ok::<_, DbErr>((
+                row.try_get::<i32>("", "seqno")?,
+                row.try_get::<Option<String>>("", "name")?,
+            ))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if columns != vec![(0, Some("id".to_string()))] {
+        return Err(DbErr::Migration(format!(
+            "playlist_entries primary-key index has unexpected columns: {columns:?}"
+        )));
+    }
+
+    Ok(())
+}
+
+async fn validate_index<C>(
+    connection: &C,
+    backend: DbBackend,
+    captured: &[ExplicitIndex],
+    name: &str,
+    expected_unique: bool,
+    expected_columns: &[&str],
+) -> Result<(), DbErr>
+where
+    C: ConnectionTrait,
+{
+    if !captured.iter().any(|index| index.name == name) {
+        return Err(DbErr::Migration(format!(
+            "playlist_entries is missing required index {name}"
+        )));
+    }
+
+    let index_row = connection
+        .query_all(Statement::from_string(
+            backend,
+            "PRAGMA index_list('playlist_entries')".to_string(),
+        ))
+        .await?
+        .into_iter()
+        .find(|row| {
+            row.try_get::<String>("", "name")
+                .is_ok_and(|value| value == name)
+        })
+        .ok_or_else(|| DbErr::Migration(format!("SQLite did not expose index {name}")))?;
+    let unique = index_row.try_get::<i32>("", "unique")? == 1;
+    let partial = index_row.try_get::<i32>("", "partial").unwrap_or_default() == 1;
+    let mut columns = connection
+        .query_all(Statement::from_string(
+            backend,
+            format!("PRAGMA index_info('{name}')"),
+        ))
+        .await?
+        .into_iter()
+        .map(|row| {
+            Ok::<_, DbErr>((
+                row.try_get::<i32>("", "seqno")?,
+                row.try_get::<Option<String>>("", "name")?,
+            ))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    columns.sort_by_key(|(sequence, _)| *sequence);
+    let columns = columns
+        .into_iter()
+        .map(|(_, column)| column)
+        .collect::<Vec<_>>();
+    let expected_columns = expected_columns
+        .iter()
+        .map(|column| Some((*column).to_string()))
+        .collect::<Vec<_>>();
+
+    if unique != expected_unique || partial || columns != expected_columns {
+        return Err(DbErr::Migration(format!(
+            "required index {name} has unexpected shape: unique={unique}, partial={partial}, columns={columns:?}"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm_migration::sea_orm::{
+        ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement,
+    };
+
+    use super::*;
+    use crate::db::migration::Migrator;
+
+    async fn database_before_track_fk_migration() -> DatabaseConnection {
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("open in-memory database");
+        Migrator::up(&db, Some(5))
+            .await
+            .expect("apply migrations preceding playlist track foreign key");
+        db
+    }
+
+    async fn insert_playlist(db: &DatabaseConnection, id: &str) {
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO playlists (id, name, created_at, updated_at)
+             VALUES (?, ?, '2026-07-12T00:00:00Z', '2026-07-12T00:00:00Z')",
+            [id.into(), format!("Playlist {id}").into()],
+        ))
+        .await
+        .expect("insert playlist");
+    }
+
+    async fn insert_track(db: &DatabaseConnection, id: &str) {
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO tracks (
+                 id, file_path, title, artist_name, album_title,
+                 date_added, date_modified
+             )
+             VALUES (?, ?, ?, 'Artist', 'Album',
+                     '2026-07-12T00:00:00Z', '2026-07-12T00:00:00Z')",
+            [
+                id.into(),
+                format!("/music/{id}.flac").into(),
+                format!("Track {id}").into(),
+            ],
+        ))
+        .await
+        .expect("insert track");
+    }
+
+    async fn insert_entry(
+        db: &DatabaseConnection,
+        id: &str,
+        playlist_id: &str,
+        position: i32,
+        track_id: Option<&str>,
+    ) {
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO playlist_entries (
+                 id, playlist_id, position, track_id,
+                 match_title, match_artist, match_album, match_duration_secs
+             )
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                id.into(),
+                playlist_id.into(),
+                position.into(),
+                track_id.into(),
+                format!("title-{id}").into(),
+                format!("artist-{id}").into(),
+                format!("album-{id}").into(),
+                (position + 180).into(),
+            ],
+        ))
+        .await
+        .expect("insert playlist entry");
+    }
+
+    async fn apply_track_fk_migration(db: &DatabaseConnection) -> Result<(), DbErr> {
+        Migrator::up(db, Some(1)).await
+    }
+
+    async fn track_fk_migration_is_applied(db: &DatabaseConnection) -> bool {
+        let migration_name = Migration.name().to_string();
+        Migrator::get_migration_models(db)
+            .await
+            .expect("query migration ledger")
+            .iter()
+            .any(|migration| migration.version == migration_name)
+    }
+
+    async fn entry_rows(
+        db: &DatabaseConnection,
+    ) -> Vec<(
+        String,
+        i32,
+        Option<String>,
+        String,
+        String,
+        String,
+        Option<i32>,
+    )> {
+        db.query_all(Statement::from_string(
+            DbBackend::Sqlite,
+            "SELECT id, position, track_id, match_title, match_artist,
+                    match_album, match_duration_secs
+             FROM playlist_entries
+             ORDER BY position"
+                .to_string(),
+        ))
+        .await
+        .expect("query playlist entries")
+        .into_iter()
+        .map(|row| {
+            (
+                row.try_get("", "id").expect("entry id"),
+                row.try_get("", "position").expect("entry position"),
+                row.try_get("", "track_id").expect("entry track id"),
+                row.try_get("", "match_title").expect("match title"),
+                row.try_get("", "match_artist").expect("match artist"),
+                row.try_get("", "match_album").expect("match album"),
+                row.try_get("", "match_duration_secs")
+                    .expect("match duration"),
+            )
+        })
+        .collect()
+    }
+
+    async fn track_foreign_key(db: &DatabaseConnection) -> Option<(String, String, String)> {
+        db.query_all(Statement::from_string(
+            DbBackend::Sqlite,
+            "PRAGMA foreign_key_list('playlist_entries')".to_string(),
+        ))
+        .await
+        .expect("query playlist entry foreign keys")
+        .into_iter()
+        .find_map(|row| {
+            let from: String = row.try_get("", "from").ok()?;
+            (from == "track_id").then(|| {
+                (
+                    row.try_get("", "table").expect("foreign table"),
+                    row.try_get("", "to").expect("foreign column"),
+                    row.try_get("", "on_delete").expect("delete action"),
+                )
+            })
+        })
+    }
+
+    async fn playlist_foreign_key(db: &DatabaseConnection) -> Option<(String, String, String)> {
+        db.query_all(Statement::from_string(
+            DbBackend::Sqlite,
+            "PRAGMA foreign_key_list('playlist_entries')".to_string(),
+        ))
+        .await
+        .expect("query playlist entry foreign keys")
+        .into_iter()
+        .find_map(|row| {
+            let from: String = row.try_get("", "from").ok()?;
+            (from == "playlist_id").then(|| {
+                (
+                    row.try_get("", "table").expect("foreign table"),
+                    row.try_get("", "to").expect("foreign column"),
+                    row.try_get("", "on_delete").expect("delete action"),
+                )
+            })
+        })
+    }
+
+    async fn index_definition(db: &DatabaseConnection, name: &str) -> Option<(bool, Vec<String>)> {
+        let index_row = db
+            .query_all(Statement::from_string(
+                DbBackend::Sqlite,
+                "PRAGMA index_list('playlist_entries')".to_string(),
+            ))
+            .await
+            .expect("query playlist entry indexes")
+            .into_iter()
+            .find(|row| {
+                row.try_get::<String>("", "name")
+                    .is_ok_and(|value| value == name)
+            })?;
+        let unique = index_row
+            .try_get::<i32>("", "unique")
+            .expect("index uniqueness")
+            == 1;
+        let mut columns = db
+            .query_all(Statement::from_string(
+                DbBackend::Sqlite,
+                format!("PRAGMA index_info('{name}')"),
+            ))
+            .await
+            .expect("query index columns")
+            .into_iter()
+            .map(|row| {
+                (
+                    row.try_get::<i32>("", "seqno").expect("column sequence"),
+                    row.try_get::<String>("", "name").expect("column name"),
+                )
+            })
+            .collect::<Vec<_>>();
+        columns.sort_by_key(|(sequence, _)| *sequence);
+        Some((
+            unique,
+            columns.into_iter().map(|(_, column)| column).collect(),
+        ))
+    }
+
+    async fn index_sql(db: &DatabaseConnection, name: &str) -> Option<String> {
+        db.query_one(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?",
+            [name.into()],
+        ))
+        .await
+        .expect("query index SQL")
+        .map(|row| row.try_get("", "sql").expect("index SQL"))
+    }
+
+    #[tokio::test]
+    async fn upgrade_preserves_entries_and_nulls_only_dangling_track_ids() {
+        let db = database_before_track_fk_migration().await;
+        insert_playlist(&db, "playlist-a").await;
+        insert_track(&db, "track-valid").await;
+        insert_entry(&db, "entry-valid", "playlist-a", 0, Some("track-valid")).await;
+        insert_entry(
+            &db,
+            "entry-dangling",
+            "playlist-a",
+            1,
+            Some("track-missing"),
+        )
+        .await;
+        insert_entry(&db, "entry-null", "playlist-a", 2, None).await;
+        let before = entry_rows(&db).await;
+
+        apply_track_fk_migration(&db)
+            .await
+            .expect("apply playlist track foreign key migration");
+
+        let after = entry_rows(&db).await;
+        assert_eq!(after.len(), before.len());
+        assert_eq!(after[0], before[0]);
+        assert_eq!(after[1].0, before[1].0);
+        assert_eq!(after[1].1, before[1].1);
+        assert_eq!(after[1].2, None);
+        assert_eq!(after[1].3, before[1].3);
+        assert_eq!(after[1].4, before[1].4);
+        assert_eq!(after[1].5, before[1].5);
+        assert_eq!(after[1].6, before[1].6);
+        assert_eq!(after[2], before[2]);
+    }
+
+    #[tokio::test]
+    async fn rebuilt_schema_enforces_both_foreign_keys_and_restores_indexes() {
+        let db = database_before_track_fk_migration().await;
+        insert_playlist(&db, "playlist-a").await;
+        insert_track(&db, "track-a").await;
+        insert_entry(&db, "entry-a", "playlist-a", 0, Some("track-a")).await;
+        db.execute_unprepared(
+            "CREATE INDEX idx_playlist_entries_match_title_custom
+             ON playlist_entries (match_title)
+             WHERE match_title <> ''",
+        )
+        .await
+        .expect("create custom playlist-entry index");
+
+        apply_track_fk_migration(&db)
+            .await
+            .expect("apply playlist track foreign key migration");
+
+        assert_eq!(
+            playlist_foreign_key(&db).await,
+            Some((
+                "playlists".to_string(),
+                "id".to_string(),
+                "CASCADE".to_string(),
+            ))
+        );
+        assert_eq!(
+            track_foreign_key(&db).await,
+            Some((
+                "tracks".to_string(),
+                "id".to_string(),
+                "SET NULL".to_string(),
+            ))
+        );
+        assert_eq!(
+            index_definition(&db, PLAYLIST_INDEX).await,
+            Some((false, vec!["playlist_id".to_string()]))
+        );
+        assert_eq!(
+            index_definition(&db, TRACK_INDEX).await,
+            Some((false, vec!["track_id".to_string()]))
+        );
+        assert_eq!(
+            index_definition(&db, UNIQUE_POSITION_INDEX).await,
+            Some((
+                true,
+                vec!["playlist_id".to_string(), "position".to_string()],
+            ))
+        );
+        assert_eq!(
+            index_definition(&db, "idx_playlist_entries_match_title_custom").await,
+            Some((false, vec!["match_title".to_string()]))
+        );
+        assert_eq!(
+            index_sql(&db, "idx_playlist_entries_match_title_custom").await,
+            Some(
+                "CREATE INDEX idx_playlist_entries_match_title_custom\n             ON playlist_entries (match_title)\n             WHERE match_title <> ''"
+                    .to_string()
+            )
+        );
+
+        let missing_track_insert = db
+            .execute_unprepared(
+                "INSERT INTO playlist_entries (id, playlist_id, position, track_id)
+                 VALUES ('entry-missing', 'playlist-a', 1, 'track-missing')",
+            )
+            .await;
+        assert!(
+            missing_track_insert.is_err(),
+            "a non-null missing track ID must violate the new foreign key"
+        );
+        let duplicate_position_insert = db
+            .execute_unprepared(
+                "INSERT INTO playlist_entries (id, playlist_id, position, track_id)
+                 VALUES ('entry-duplicate-position', 'playlist-a', 0, NULL)",
+            )
+            .await;
+        assert!(
+            duplicate_position_insert.is_err(),
+            "the restored unique position index must reject duplicates"
+        );
+
+        db.execute_unprepared("DELETE FROM tracks WHERE id = 'track-a'")
+            .await
+            .expect("delete referenced track");
+        let track_id: Option<String> = db
+            .query_one(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT track_id FROM playlist_entries WHERE id = 'entry-a'".to_string(),
+            ))
+            .await
+            .expect("query entry after track deletion")
+            .expect("entry remains")
+            .try_get("", "track_id")
+            .expect("track id is nullable");
+        assert_eq!(track_id, None);
+
+        db.execute_unprepared("DELETE FROM playlists WHERE id = 'playlist-a'")
+            .await
+            .expect("delete referenced playlist");
+        let remaining: i64 = db
+            .query_one(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT COUNT(*) AS count FROM playlist_entries".to_string(),
+            ))
+            .await
+            .expect("count playlist entries")
+            .expect("count row")
+            .try_get("", "count")
+            .expect("entry count");
+        assert_eq!(remaining, 0);
+    }
+
+    #[tokio::test]
+    async fn failed_copy_rolls_back_dangling_id_cleanup_and_migration_can_retry() {
+        let db = database_before_track_fk_migration().await;
+        insert_playlist(&db, "playlist-a").await;
+        insert_track(&db, "track-a").await;
+        insert_entry(&db, "entry-a", "playlist-a", 0, Some("track-a")).await;
+
+        // Force a legacy-only playlist violation so the table copy fails after
+        // the migration has already nulled dangling track IDs.
+        db.execute_unprepared("PRAGMA foreign_keys = OFF")
+            .await
+            .expect("disable foreign keys for fault injection");
+        insert_entry(
+            &db,
+            "entry-invalid-playlist",
+            "playlist-missing",
+            1,
+            Some("track-missing"),
+        )
+        .await;
+        db.execute_unprepared("PRAGMA foreign_keys = ON")
+            .await
+            .expect("restore foreign-key enforcement");
+        let before = entry_rows(&db).await;
+
+        assert!(
+            apply_track_fk_migration(&db).await.is_err(),
+            "invalid playlist reference must fail the rebuilt-table copy"
+        );
+        assert_eq!(entry_rows(&db).await, before);
+        assert_eq!(track_foreign_key(&db).await, None);
+        assert!(
+            !SchemaManager::new(&db)
+                .has_table(REBUILD_TABLE)
+                .await
+                .expect("inspect rebuild table"),
+            "transaction rollback must remove the temporary rebuild table"
+        );
+
+        db.execute_unprepared("DELETE FROM playlist_entries WHERE id = 'entry-invalid-playlist'")
+            .await
+            .expect("remove injected invalid entry");
+        apply_track_fk_migration(&db)
+            .await
+            .expect("retry playlist track foreign key migration");
+        assert_eq!(
+            track_foreign_key(&db).await,
+            Some((
+                "tracks".to_string(),
+                "id".to_string(),
+                "SET NULL".to_string(),
+            ))
+        );
+        assert_eq!(entry_rows(&db).await, before[..1]);
+    }
+
+    #[tokio::test]
+    async fn migration_can_be_reapplied_after_schema_commit_before_ledger_update() {
+        let db = database_before_track_fk_migration().await;
+        insert_playlist(&db, "playlist-a").await;
+        insert_track(&db, "track-a").await;
+        insert_entry(&db, "entry-a", "playlist-a", 0, Some("track-a")).await;
+        let before = entry_rows(&db).await;
+
+        Migration
+            .up(&SchemaManager::new(&db))
+            .await
+            .expect("apply schema change directly");
+        db.execute_unprepared("PRAGMA foreign_keys = OFF")
+            .await
+            .expect("disable foreign keys for retry fixture");
+        insert_entry(
+            &db,
+            "entry-dangling-after-schema-commit",
+            "playlist-a",
+            1,
+            Some("track-missing"),
+        )
+        .await;
+        db.execute_unprepared("PRAGMA foreign_keys = ON")
+            .await
+            .expect("restore foreign-key enforcement");
+        apply_track_fk_migration(&db)
+            .await
+            .expect("retry already-committed schema change");
+        assert!(track_fk_migration_is_applied(&db).await);
+
+        let after = entry_rows(&db).await;
+        assert_eq!(after.len(), 2);
+        assert_eq!(after[0], before[0]);
+        assert_eq!(after[1].2, None);
+        assert_eq!(
+            track_foreign_key(&db).await,
+            Some((
+                "tracks".to_string(),
+                "id".to_string(),
+                "SET NULL".to_string(),
+            ))
+        );
+    }
+
+    #[tokio::test]
+    async fn down_removes_only_the_track_foreign_key_and_is_repeatable() {
+        let db = database_before_track_fk_migration().await;
+        insert_playlist(&db, "playlist-a").await;
+        insert_track(&db, "track-a").await;
+        insert_entry(&db, "entry-a", "playlist-a", 0, Some("track-a")).await;
+        let before = entry_rows(&db).await;
+        apply_track_fk_migration(&db)
+            .await
+            .expect("apply playlist track foreign key migration");
+
+        // Simulate the schema rebuild committing before SeaORM removes the
+        // migration-ledger row, then finish through the normal migrator.
+        Migration
+            .down(&SchemaManager::new(&db))
+            .await
+            .expect("apply down schema change directly");
+        assert_eq!(track_foreign_key(&db).await, None);
+        assert_eq!(
+            playlist_foreign_key(&db).await,
+            Some((
+                "playlists".to_string(),
+                "id".to_string(),
+                "CASCADE".to_string(),
+            ))
+        );
+        assert_eq!(entry_rows(&db).await, before);
+        assert_eq!(
+            index_definition(&db, UNIQUE_POSITION_INDEX).await,
+            Some((
+                true,
+                vec!["playlist_id".to_string(), "position".to_string()],
+            ))
+        );
+
+        Migrator::down(&db, Some(1))
+            .await
+            .expect("finish partially applied down migration");
+        assert!(!track_fk_migration_is_applied(&db).await);
+        Migration
+            .down(&SchemaManager::new(&db))
+            .await
+            .expect("repeat direct down migration");
+        assert_eq!(track_foreign_key(&db).await, None);
+    }
+
+    #[tokio::test]
+    async fn down_rejects_a_missing_playlist_entries_table() {
+        let db = database_before_track_fk_migration().await;
+        apply_track_fk_migration(&db)
+            .await
+            .expect("apply playlist track foreign key migration");
+        db.execute_unprepared("DROP TABLE playlist_entries")
+            .await
+            .expect("simulate catastrophic table loss");
+
+        assert!(
+            Migration.down(&SchemaManager::new(&db)).await.is_err(),
+            "down must not treat a missing target table as its valid legacy state"
+        );
+    }
+
+    #[tokio::test]
+    async fn wrong_required_index_shape_fails_without_mutation_and_can_be_retried() {
+        let db = database_before_track_fk_migration().await;
+        insert_playlist(&db, "playlist-a").await;
+        insert_track(&db, "track-a").await;
+        insert_entry(&db, "entry-a", "playlist-a", 0, Some("track-a")).await;
+        let before = entry_rows(&db).await;
+
+        db.execute_unprepared(&format!("DROP INDEX {TRACK_INDEX}"))
+            .await
+            .expect("drop required track index");
+        db.execute_unprepared(&format!(
+            "CREATE INDEX {TRACK_INDEX} ON playlist_entries (match_title)"
+        ))
+        .await
+        .expect("replace track index with wrong shape");
+
+        assert!(
+            apply_track_fk_migration(&db).await.is_err(),
+            "preflight must reject a malformed required index"
+        );
+        assert_eq!(entry_rows(&db).await, before);
+        assert_eq!(track_foreign_key(&db).await, None);
+        assert!(!track_fk_migration_is_applied(&db).await);
+
+        db.execute_unprepared(&format!("DROP INDEX {TRACK_INDEX}"))
+            .await
+            .expect("drop malformed track index");
+        db.execute_unprepared(&format!(
+            "CREATE INDEX {TRACK_INDEX} ON playlist_entries (track_id)"
+        ))
+        .await
+        .expect("restore required track index");
+        apply_track_fk_migration(&db)
+            .await
+            .expect("retry after restoring index shape");
+        assert_eq!(entry_rows(&db).await, before);
+        assert!(track_fk_migration_is_applied(&db).await);
+    }
+}

--- a/src/db/migration/mod.rs
+++ b/src/db/migration/mod.rs
@@ -7,6 +7,7 @@ mod m20250102_000002_create_playlists;
 mod m20250103_000003_add_album_artist;
 mod m20250104_000004_unique_entry_position;
 mod m20250710_000005_create_library_roots;
+mod m20260712_000006_playlist_track_fk;
 
 pub struct Migrator;
 
@@ -19,6 +20,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20250103_000003_add_album_artist::Migration),
             Box::new(m20250104_000004_unique_entry_position::Migration),
             Box::new(m20250710_000005_create_library_roots::Migration),
+            Box::new(m20260712_000006_playlist_track_fk::Migration),
         ]
     }
 }

--- a/src/local/engine.rs
+++ b/src/local/engine.rs
@@ -1643,6 +1643,19 @@ fn marker_event_invalidates_root(kind: notify::EventKind) -> bool {
     )
 }
 
+async fn reconcile_playlists_after_watcher_batch(
+    db: &DatabaseConnection,
+    upsert_committed: bool,
+) -> Result<u32, sea_orm::DbErr> {
+    if !upsert_committed {
+        return Ok(0);
+    }
+
+    super::playlist_manager::PlaylistManager::new(db.clone())
+        .reconcile_all()
+        .await
+}
+
 async fn watch_directories(
     db: &Arc<DatabaseConnection>,
     music_dirs: &[PathBuf],
@@ -1826,6 +1839,7 @@ async fn watch_directories(
         }
 
         // Process upserts from the shared, batch-scoped root snapshot.
+        let mut upsert_committed = false;
         if !upsert_paths.is_empty() {
             debug!(count = upsert_paths.len(), "Processing debounced upserts");
             let paths: Vec<PathBuf> = upsert_paths.into_iter().collect();
@@ -1895,6 +1909,7 @@ async fn watch_directories(
 
                         match upsert_track(db.as_ref(), &parsed, existing.as_ref()).await {
                             Ok(model) => {
+                                upsert_committed = true;
                                 let t = db_model_to_track(&model);
                                 let _ = tx.send(LibraryEvent::TrackUpserted(Box::new(t))).await;
                             }
@@ -1910,6 +1925,20 @@ async fn watch_directories(
                         warn!(error = %e, "spawn_blocking failed");
                     }
                 }
+            }
+        }
+
+        // Deletions null playlist links through the database foreign key.
+        // Reconcile once after all successful upserts in this debounced batch
+        // so a replacement file can restore those links immediately. A
+        // reconciliation error is retryable and must not terminate watching.
+        match reconcile_playlists_after_watcher_batch(db.as_ref(), upsert_committed).await {
+            Ok(relinked) if relinked > 0 => {
+                info!(relinked, "Playlist entries reconciled after watcher batch");
+            }
+            Ok(_) => debug!("No orphaned playlist entries matched watcher upserts"),
+            Err(error) => {
+                warn!(%error, "Failed to reconcile playlists after watcher batch");
             }
         }
     }
@@ -2048,6 +2077,78 @@ mod tests {
         fn drop(&mut self) {
             let _ = std::fs::remove_dir_all(&self.path);
         }
+    }
+
+    #[tokio::test]
+    async fn watcher_batch_reconciles_only_after_a_committed_upsert() {
+        use sea_orm::{ConnectionTrait, Database};
+        use sea_orm_migration::MigratorTrait;
+
+        use crate::db::entities::playlist_entry;
+        use crate::db::migration::Migrator;
+
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("open in-memory database");
+        Migrator::up(&db, None).await.expect("run migrations");
+        db.execute_unprepared(
+            "INSERT INTO playlists (id, name, created_at, updated_at)
+             VALUES ('watcher-playlist', 'Watcher',
+                     '2026-07-12T00:00:00Z', '2026-07-12T00:00:00Z')",
+        )
+        .await
+        .expect("insert playlist");
+        db.execute_unprepared(
+            "INSERT INTO tracks (
+                 id, file_path, title, artist_name, album_title,
+                 duration_secs, date_added, date_modified
+             )
+             VALUES (
+                 'watcher-track', '/music/watcher.flac', 'Watcher Song',
+                 'Watcher Artist', 'Watcher Album', 180,
+                 '2026-07-12T00:00:00Z', '2026-07-12T00:00:00Z'
+             )",
+        )
+        .await
+        .expect("insert watcher track");
+        db.execute_unprepared(
+            "INSERT INTO playlist_entries (
+                 id, playlist_id, position, track_id,
+                 match_title, match_artist, match_album, match_duration_secs
+             )
+             VALUES (
+                 'watcher-entry', 'watcher-playlist', 0, NULL,
+                 'watcher song', 'watcher artist', 'watcher album', 180
+             )",
+        )
+        .await
+        .expect("insert orphaned playlist entry");
+
+        assert_eq!(
+            reconcile_playlists_after_watcher_batch(&db, false)
+                .await
+                .expect("skip watcher reconciliation"),
+            0
+        );
+        let still_orphaned = playlist_entry::Entity::find_by_id("watcher-entry")
+            .one(&db)
+            .await
+            .expect("query skipped reconciliation")
+            .expect("playlist entry remains");
+        assert_eq!(still_orphaned.track_id, None);
+
+        assert_eq!(
+            reconcile_playlists_after_watcher_batch(&db, true)
+                .await
+                .expect("run watcher reconciliation"),
+            1
+        );
+        let relinked = playlist_entry::Entity::find_by_id("watcher-entry")
+            .one(&db)
+            .await
+            .expect("query watcher reconciliation")
+            .expect("playlist entry remains");
+        assert_eq!(relinked.track_id.as_deref(), Some("watcher-track"));
     }
 
     #[test]

--- a/src/local/engine.rs
+++ b/src/local/engine.rs
@@ -3874,33 +3874,67 @@ mod tests {
 
     // ── Paired directory renames ────────────────────────────────────────
 
+    /// Build an absolute fixture path with the target platform's separator.
+    /// Production rows come from `Path::to_string_lossy`; keeping synthetic DB
+    /// paths in the same namespace prevents Windows-only slash mismatches.
+    fn directory_fixture_path(path: &str) -> PathBuf {
+        path.split('/')
+            .filter(|component| !component.is_empty())
+            .fold(
+                PathBuf::from(std::path::MAIN_SEPARATOR.to_string()),
+                |mut result, component| {
+                    result.push(component);
+                    result
+                },
+            )
+    }
+
+    fn directory_fixture_key(path: &str) -> String {
+        directory_fixture_path(path).to_string_lossy().into_owned()
+    }
+
+    async fn insert_directory_rename_test_track(
+        db: &DatabaseConnection,
+        id: &str,
+        path: &str,
+        title: &str,
+        play_count: i32,
+    ) -> track::Model {
+        insert_rename_test_track(db, id, &directory_fixture_key(path), title, play_count).await
+    }
+
     fn destination_files(paths: &[&str]) -> HashSet<String> {
-        paths.iter().map(|path| (*path).to_string()).collect()
+        paths
+            .iter()
+            .map(|path| directory_fixture_key(path))
+            .collect()
     }
 
     #[test]
     fn directory_identity_mapping_excludes_dirty_destination_descendants() {
+        let source = directory_fixture_path("/music/Album");
+        let destination = directory_fixture_path("/music/Renamed");
         let audio_files = vec![
-            PathBuf::from("/music/Renamed/clean.flac"),
-            PathBuf::from("/music/Renamed/modified.flac"),
-            PathBuf::from("/music/Renamed/removed.flac"),
-            PathBuf::from("/music/Renamed/Disc 2/changed.flac"),
+            directory_fixture_path("/music/Renamed/clean.flac"),
+            directory_fixture_path("/music/Renamed/modified.flac"),
+            directory_fixture_path("/music/Renamed/removed.flac"),
+            directory_fixture_path("/music/Renamed/Disc 2/changed.flac"),
         ];
         let upserts = HashSet::from([
             // The old spelling is common when a child event was delivered
             // immediately before the parent rename pair.
-            PathBuf::from("/music/Album/modified.flac"),
-            PathBuf::from("/music/Other/unrelated.flac"),
+            directory_fixture_path("/music/Album/modified.flac"),
+            directory_fixture_path("/music/Other/unrelated.flac"),
         ]);
-        let removals = HashSet::from([PathBuf::from("/music/Renamed/removed.flac")]);
-        let deferred = HashSet::from([PathBuf::from("/music/Renamed/Disc 2")]);
+        let removals = HashSet::from([directory_fixture_path("/music/Renamed/removed.flac")]);
+        let deferred = HashSet::from([directory_fixture_path("/music/Renamed/Disc 2")]);
         let dirty_directories = HashSet::new();
 
         assert_eq!(
             directory_identity_destinations(
                 &audio_files,
-                Path::new("/music/Album"),
-                Path::new("/music/Renamed"),
+                &source,
+                &destination,
                 &upserts,
                 &removals,
                 &deferred,
@@ -3913,8 +3947,8 @@ mod tests {
 
     #[test]
     fn directory_identity_mapping_rejects_an_exact_destination_folder_replacement() {
-        let source = PathBuf::from("/music/Album");
-        let destination = PathBuf::from("/music/Renamed");
+        let source = directory_fixture_path("/music/Album");
+        let destination = directory_fixture_path("/music/Renamed");
         let mut batch = WatcherBatch::default();
         batch.record_rename_pair(source.clone(), destination.clone());
         batch.collect(
@@ -4122,11 +4156,20 @@ mod tests {
             .expect("create playlist");
 
         let first =
-            insert_rename_test_track(&db, "track-one", "/music/Album/01.flac", "One", 11).await;
-        insert_rename_test_track(&db, "track-two", "/music/Album/Disc 2/02.flac", "Two", 4).await;
+            insert_directory_rename_test_track(&db, "track-one", "/music/Album/01.flac", "One", 11)
+                .await;
+        insert_directory_rename_test_track(
+            &db,
+            "track-two",
+            "/music/Album/Disc 2/02.flac",
+            "Two",
+            4,
+        )
+        .await;
         // A sibling whose path shares a textual prefix with the renamed
         // directory must not be dragged along with it.
-        insert_rename_test_track(&db, "track-other", "/music/Album2/03.flac", "Three", 2).await;
+        insert_directory_rename_test_track(&db, "track-other", "/music/Album2/03.flac", "Three", 2)
+            .await;
 
         manager
             .add_track(&playlist.id, &first)
@@ -4139,10 +4182,13 @@ mod tests {
             .expect("load playlist entry")
             .expect("playlist entry exists");
 
+        let source_directory = directory_fixture_path("/music/Album");
+        let destination_directory = directory_fixture_path("/music/Renamed");
+
         let outcome = rename_directory_rows(
             &db,
-            Path::new("/music/Album"),
-            Path::new("/music/Renamed"),
+            &source_directory,
+            &destination_directory,
             &destination_files(&["/music/Renamed/01.flac", "/music/Renamed/Disc 2/02.flac"]),
             || true,
         )
@@ -4166,7 +4212,10 @@ mod tests {
             .await
             .expect("load renamed track")
             .expect("renamed track exists");
-        assert_eq!(renamed.file_path, "/music/Renamed/01.flac");
+        assert_eq!(
+            renamed.file_path,
+            directory_fixture_key("/music/Renamed/01.flac")
+        );
         assert_eq!(renamed.play_count, 11, "history survives the move");
         assert_eq!(renamed.date_added, "2025-01-02T03:04:05Z");
         assert_eq!(
@@ -4179,7 +4228,10 @@ mod tests {
             .await
             .expect("load nested track")
             .expect("nested track exists");
-        assert_eq!(nested.file_path, "/music/Renamed/Disc 2/02.flac");
+        assert_eq!(
+            nested.file_path,
+            directory_fixture_key("/music/Renamed/Disc 2/02.flac")
+        );
 
         let sibling = track::Entity::find_by_id("track-other")
             .one(&db)
@@ -4187,7 +4239,8 @@ mod tests {
             .expect("load sibling track")
             .expect("sibling track exists");
         assert_eq!(
-            sibling.file_path, "/music/Album2/03.flac",
+            sibling.file_path,
+            directory_fixture_key("/music/Album2/03.flac"),
             "the prefix must match whole path components"
         );
 
@@ -4205,13 +4258,16 @@ mod tests {
     #[tokio::test]
     async fn directory_rename_reports_descendants_without_a_destination_file() {
         let db = rename_test_database().await;
-        insert_rename_test_track(&db, "moved", "/music/Album/01.flac", "One", 0).await;
-        insert_rename_test_track(&db, "vanished", "/music/Album/02.flac", "Two", 0).await;
+        insert_directory_rename_test_track(&db, "moved", "/music/Album/01.flac", "One", 0).await;
+        insert_directory_rename_test_track(&db, "vanished", "/music/Album/02.flac", "Two", 0).await;
+
+        let source_directory = directory_fixture_path("/music/Album");
+        let destination_directory = directory_fixture_path("/music/Renamed");
 
         let outcome = rename_directory_rows(
             &db,
-            Path::new("/music/Album"),
-            Path::new("/music/Renamed"),
+            &source_directory,
+            &destination_directory,
             // The second file was deleted during the rename window, so nothing
             // observed it at the destination.
             &destination_files(&["/music/Renamed/01.flac"]),
@@ -4238,7 +4294,8 @@ mod tests {
             .expect("load unmapped track")
             .expect("unmapped track exists");
         assert_eq!(
-            vanished.file_path, "/music/Album/02.flac",
+            vanished.file_path,
+            directory_fixture_key("/music/Album/02.flac"),
             "an unproven row keeps its path until a guarded scan can resolve it"
         );
     }
@@ -4246,15 +4303,19 @@ mod tests {
     #[tokio::test]
     async fn directory_rename_displaces_a_stale_row_parked_at_a_destination_path() {
         let db = rename_test_database().await;
-        insert_rename_test_track(&db, "moved", "/music/Album/01.flac", "One", 5).await;
+        insert_directory_rename_test_track(&db, "moved", "/music/Album/01.flac", "One", 5).await;
         // A row a previous scan was never authoritative enough to delete. The
         // unique path index would otherwise abort the move.
-        insert_rename_test_track(&db, "stale", "/music/Renamed/01.flac", "Stale", 0).await;
+        insert_directory_rename_test_track(&db, "stale", "/music/Renamed/01.flac", "Stale", 0)
+            .await;
+
+        let source_directory = directory_fixture_path("/music/Album");
+        let destination_directory = directory_fixture_path("/music/Renamed");
 
         let outcome = rename_directory_rows(
             &db,
-            Path::new("/music/Album"),
-            Path::new("/music/Renamed"),
+            &source_directory,
+            &destination_directory,
             &destination_files(&["/music/Renamed/01.flac"]),
             || true,
         )
@@ -4280,20 +4341,27 @@ mod tests {
             .await
             .expect("load moved track")
             .expect("moved track exists");
-        assert_eq!(survivor.file_path, "/music/Renamed/01.flac");
+        assert_eq!(
+            survivor.file_path,
+            directory_fixture_key("/music/Renamed/01.flac")
+        );
         assert_eq!(survivor.play_count, 5);
     }
 
     #[tokio::test]
     async fn directory_rename_guard_rejection_rolls_back_every_change() {
         let db = rename_test_database().await;
-        insert_rename_test_track(&db, "moved", "/music/Album/01.flac", "One", 5).await;
-        insert_rename_test_track(&db, "stale", "/music/Renamed/01.flac", "Stale", 0).await;
+        insert_directory_rename_test_track(&db, "moved", "/music/Album/01.flac", "One", 5).await;
+        insert_directory_rename_test_track(&db, "stale", "/music/Renamed/01.flac", "Stale", 0)
+            .await;
+
+        let source_directory = directory_fixture_path("/music/Album");
+        let destination_directory = directory_fixture_path("/music/Renamed");
 
         let outcome = rename_directory_rows(
             &db,
-            Path::new("/music/Album"),
-            Path::new("/music/Renamed"),
+            &source_directory,
+            &destination_directory,
             &destination_files(&["/music/Renamed/01.flac"]),
             || false,
         )
@@ -4306,7 +4374,10 @@ mod tests {
             .await
             .expect("load source track")
             .expect("source track exists");
-        assert_eq!(source.file_path, "/music/Album/01.flac");
+        assert_eq!(
+            source.file_path,
+            directory_fixture_key("/music/Album/01.flac")
+        );
         assert!(
             track::Entity::find_by_id("stale")
                 .one(&db)
@@ -4320,12 +4391,15 @@ mod tests {
     #[tokio::test]
     async fn directory_rename_refuses_a_destination_inside_its_own_source() {
         let db = rename_test_database().await;
-        insert_rename_test_track(&db, "moved", "/music/Album/01.flac", "One", 0).await;
+        insert_directory_rename_test_track(&db, "moved", "/music/Album/01.flac", "One", 0).await;
+
+        let source_directory = directory_fixture_path("/music/Album");
+        let nested_destination = directory_fixture_path("/music/Album/Nested");
 
         let error = rename_directory_rows(
             &db,
-            Path::new("/music/Album"),
-            Path::new("/music/Album/Nested"),
+            &source_directory,
+            &nested_destination,
             &destination_files(&["/music/Album/Nested/01.flac"]),
             || true,
         )
@@ -4337,7 +4411,10 @@ mod tests {
             .await
             .expect("load track")
             .expect("track exists");
-        assert_eq!(unchanged.file_path, "/music/Album/01.flac");
+        assert_eq!(
+            unchanged.file_path,
+            directory_fixture_key("/music/Album/01.flac")
+        );
     }
 
     #[test]
@@ -4398,7 +4475,17 @@ mod tests {
         let directory_scan = scan_renamed_directory(library.path(), &album);
         assert!(directory_scan.is_complete());
         let parked_album = library.path().join("Parked");
-        std::fs::rename(&album, &parked_album).expect("park original directory");
+        if let Err(error) = std::fs::rename(&album, &parked_album) {
+            #[cfg(windows)]
+            if error.kind() == std::io::ErrorKind::PermissionDenied {
+                assert!(
+                    directory_scan.observations_still_current(&album),
+                    "Windows retained handles prevent the directory swap outright"
+                );
+                return;
+            }
+            panic!("park original directory: {error}");
+        }
         std::fs::create_dir_all(&album).expect("create replacement directory");
         std::fs::write(album.join("01.flac"), b"replacement").expect("mirror old file name");
         std::fs::write(album.join("original.flac"), b"replacement")

--- a/src/local/engine.rs
+++ b/src/local/engine.rs
@@ -659,7 +659,6 @@ where
         }
     };
 
-    let mut audio_files = Vec::new();
     let mut errors = Vec::new();
     let root_boundary = match filesystem_boundary_id(&root) {
         Ok(boundary) => Some(boundary),
@@ -672,58 +671,8 @@ where
         }
     };
 
-    let mut entries = WalkDir::new(&root)
-        // Do NOT follow symlinks: the notify watcher does not follow them
-        // either, so following here would index files (via symlinked
-        // subtrees) that are never watched for changes, and could index one
-        // physical file under multiple paths as duplicate rows.
-        .follow_links(false)
-        .into_iter();
-    while let Some(entry) = entries.next() {
-        match entry {
-            Ok(entry) if entry.depth() > 0 && entry.file_type().is_dir() => {
-                if exclusions.iter().any(|path| path == entry.path()) {
-                    entries.skip_current_dir();
-                    continue;
-                }
-                if let Some(root_id) = root_boundary {
-                    match filesystem_boundary_id(entry.path()) {
-                        Ok(entry_id) if root_id != entry_id => {
-                            errors.push(format!(
-                                "nested filesystem requires its own configured root: {}",
-                                entry.path().display()
-                            ));
-                            entries.skip_current_dir();
-                        }
-                        Ok(_) => {}
-                        Err(error) => {
-                            errors.push(format!(
-                                "failed to identify filesystem boundary {}: {error}",
-                                entry.path().display()
-                            ));
-                            entries.skip_current_dir();
-                        }
-                    }
-                } else {
-                    // A root whose boundary could not be established is never
-                    // authoritative, but avoid crossing any child scope while
-                    // collecting diagnostics from the rest of the traversal.
-                    if entry.depth() > 0 {
-                        errors.push(format!(
-                            "skipping directory without a trusted root boundary: {}",
-                            entry.path().display()
-                        ));
-                        entries.skip_current_dir();
-                    }
-                }
-            }
-            Ok(entry) if entry.file_type().is_file() && tag_parser::is_audio_file(entry.path()) => {
-                audio_files.push(entry.into_path());
-            }
-            Ok(_) => {}
-            Err(error) => errors.push(error.to_string()),
-        }
-    }
+    let (audio_files, traversal_errors) = enumerate_audio_files(&root, root_boundary, exclusions);
+    errors.extend(traversal_errors);
 
     match mount_generation_probe(&root) {
         Ok(generation) if generation == mount_generation => {}
@@ -756,6 +705,298 @@ where
         reconciliation_authoritative: false,
         content_authorized: false,
     }
+}
+
+/// Enumerate the audio files under `directory` using the one indexing policy
+/// every scope shares.
+///
+/// Symlinks are never followed: the notify watcher does not follow them either,
+/// so following here would index files that are never watched for changes, and
+/// could index one physical file under several paths as duplicate rows. A
+/// subdirectory on another filesystem, or one that owns its own scan scope, is
+/// skipped rather than absorbed. Every error is returned: a caller that cannot
+/// see the whole subtree must fail closed instead of treating a partial view as
+/// authoritative.
+///
+/// `boundary` is the filesystem the enclosing library root lives on, not the
+/// one `directory` itself lives on — a scoped traversal must not accept a
+/// nested filesystem simply because it is self-consistent below its own mount.
+fn enumerate_audio_files(
+    directory: &Path,
+    boundary: Option<u64>,
+    exclusions: &[PathBuf],
+) -> (Vec<PathBuf>, Vec<String>) {
+    enumerate_audio_files_with_observer(directory, boundary, exclusions, |_| Ok(()))
+}
+
+/// Shared traversal with an optional per-file observation performed at the
+/// instant the entry is discovered. Directory-rename scans use this to retain
+/// the exact filesystem object that justified a path mapping; ordinary root
+/// scans use the zero-cost no-op wrapper above.
+fn enumerate_audio_files_with_observer<F>(
+    directory: &Path,
+    boundary: Option<u64>,
+    exclusions: &[PathBuf],
+    mut observe: F,
+) -> (Vec<PathBuf>, Vec<String>)
+where
+    F: FnMut(&Path) -> Result<(), String>,
+{
+    let mut audio_files = Vec::new();
+    let mut errors = Vec::new();
+
+    let mut entries = WalkDir::new(directory).follow_links(false).into_iter();
+    while let Some(entry) = entries.next() {
+        match entry {
+            Ok(entry) if entry.depth() > 0 && entry.file_type().is_dir() => {
+                if exclusions.iter().any(|path| path == entry.path()) {
+                    entries.skip_current_dir();
+                    continue;
+                }
+                if let Some(boundary) = boundary {
+                    match filesystem_boundary_id(entry.path()) {
+                        Ok(entry_id) if boundary != entry_id => {
+                            errors.push(format!(
+                                "nested filesystem requires its own configured root: {}",
+                                entry.path().display()
+                            ));
+                            entries.skip_current_dir();
+                        }
+                        Ok(_) => {}
+                        Err(error) => {
+                            errors.push(format!(
+                                "failed to identify filesystem boundary {}: {error}",
+                                entry.path().display()
+                            ));
+                            entries.skip_current_dir();
+                        }
+                    }
+                } else {
+                    // A scope whose boundary could not be established is never
+                    // authoritative, but avoid crossing any child scope while
+                    // collecting diagnostics from the rest of the traversal.
+                    errors.push(format!(
+                        "skipping directory without a trusted root boundary: {}",
+                        entry.path().display()
+                    ));
+                    entries.skip_current_dir();
+                }
+            }
+            Ok(entry) if entry.file_type().is_file() && tag_parser::is_audio_file(entry.path()) => {
+                let path = entry.into_path();
+                if let Err(error) = observe(&path) {
+                    errors.push(error);
+                }
+                audio_files.push(path);
+            }
+            Ok(_) => {}
+            Err(error) => errors.push(error.to_string()),
+        }
+    }
+
+    (audio_files, errors)
+}
+
+/// Traversal of the destination of a paired directory rename.
+#[derive(Debug, Default)]
+struct DirectoryRenameScan {
+    audio_files: Vec<PathBuf>,
+    observed_files: HashMap<String, same_file::Handle>,
+    directory_handle: Option<same_file::Handle>,
+    errors: Vec<String>,
+}
+
+impl DirectoryRenameScan {
+    fn failed(error: String) -> Self {
+        Self {
+            audio_files: Vec::new(),
+            observed_files: HashMap::new(),
+            directory_handle: None,
+            errors: vec![error],
+        }
+    }
+
+    fn is_complete(&self) -> bool {
+        self.errors.is_empty()
+    }
+
+    /// Reopen every observed path and compare it with the live handle retained
+    /// by the scan. This closes the traversal-to-commit window for removals,
+    /// replacements, symlinks, and directory swaps without holding a SQLite
+    /// write transaction open for a second recursive traversal.
+    fn observations_still_current(&self, directory: &Path) -> bool {
+        if !self.is_complete() || self.audio_files.len() != self.observed_files.len() {
+            return false;
+        }
+        let Some(expected_directory) = &self.directory_handle else {
+            return false;
+        };
+        if !open_real_path_handle(directory, true)
+            .is_ok_and(|current| current == *expected_directory)
+        {
+            return false;
+        }
+
+        for path in &self.audio_files {
+            let key = path.to_string_lossy();
+            let Some(expected) = self.observed_files.get(key.as_ref()) else {
+                return false;
+            };
+            if !open_real_path_handle(path, false).is_ok_and(|current| current == *expected) {
+                return false;
+            }
+        }
+
+        // The destination itself must also remain the same object across all
+        // of the per-file probes.
+        open_real_path_handle(directory, true).is_ok_and(|current| current == *expected_directory)
+    }
+}
+
+/// Open a real file or directory and retain its filesystem object identity.
+/// The metadata checks before and after opening reject symlinks/reparse points
+/// even when they race with the handle acquisition.
+fn open_real_path_handle(
+    path: &Path,
+    expect_directory: bool,
+) -> std::io::Result<same_file::Handle> {
+    let has_expected_shape = |metadata: &std::fs::Metadata| {
+        if metadata_is_reparse_point(metadata) {
+            false
+        } else if expect_directory {
+            metadata.file_type().is_dir()
+        } else {
+            metadata.file_type().is_file()
+        }
+    };
+    let before = std::fs::symlink_metadata(path)?;
+    if !has_expected_shape(&before) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("path is not a real filesystem entry: {}", path.display()),
+        ));
+    }
+    let handle = same_file::Handle::from_path(path)?;
+    let after = std::fs::symlink_metadata(path)?;
+    if !has_expected_shape(&after) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("filesystem entry changed while opening: {}", path.display()),
+        ));
+    }
+    Ok(handle)
+}
+
+/// Enumerate the destination of a paired directory rename under its library
+/// root's filesystem.
+///
+/// The destination itself is checked against the root's boundary, which the
+/// shared per-entry traversal cannot do: it only compares descendants, so a
+/// whole filesystem mounted exactly at `directory` would otherwise look
+/// self-consistent. An incomplete traversal is never used to derive identity.
+fn scan_renamed_directory(root: &Path, directory: &Path) -> DirectoryRenameScan {
+    let boundary = match filesystem_boundary_id(root) {
+        Ok(boundary) => boundary,
+        Err(error) => {
+            return DirectoryRenameScan::failed(format!(
+                "failed to identify library root boundary {}: {error}",
+                root.display()
+            ))
+        }
+    };
+    match filesystem_boundary_id(directory) {
+        Ok(destination) if destination == boundary => {}
+        Ok(_) => {
+            return DirectoryRenameScan::failed(format!(
+                "renamed directory does not share the library root filesystem: {}",
+                directory.display()
+            ))
+        }
+        Err(error) => {
+            return DirectoryRenameScan::failed(format!(
+                "failed to identify renamed directory boundary {}: {error}",
+                directory.display()
+            ))
+        }
+    }
+
+    let directory_handle = match open_real_path_handle(directory, true) {
+        Ok(handle) => handle,
+        Err(error) => {
+            return DirectoryRenameScan::failed(format!(
+                "failed to retain renamed directory identity {}: {error}",
+                directory.display()
+            ))
+        }
+    };
+
+    // No exclusions: a pair whose subtree owns another scan scope is rejected
+    // before it reaches this traversal (`subtree_owns_another_scope`).
+    let mut observed_files = HashMap::new();
+    let (audio_files, mut errors) =
+        enumerate_audio_files_with_observer(directory, Some(boundary), &[], |path| {
+            let handle = open_real_path_handle(path, false).map_err(|error| {
+                format!(
+                    "failed to retain renamed file identity {}: {error}",
+                    path.display()
+                )
+            })?;
+            let key = path.to_string_lossy().into_owned();
+            if observed_files.insert(key.clone(), handle).is_some() {
+                return Err(format!(
+                    "multiple renamed files collapse to the persisted path key: {key}"
+                ));
+            }
+            Ok(())
+        });
+    if !open_real_path_handle(directory, true).is_ok_and(|after| after == directory_handle) {
+        errors.push(format!(
+            "renamed directory changed during traversal: {}",
+            directory.display()
+        ));
+    }
+    DirectoryRenameScan {
+        audio_files,
+        observed_files,
+        directory_handle: Some(directory_handle),
+        errors,
+    }
+}
+
+/// Select traversal observations that may inherit indexed identities.
+/// Descendant paths with their own event in the same batch are deliberately
+/// excluded because that event may describe a replacement independent of the
+/// directory move.
+fn directory_identity_destinations(
+    audio_files: &[PathBuf],
+    source: &Path,
+    destination: &Path,
+    upsert_paths: &HashSet<PathBuf>,
+    remove_paths: &HashSet<PathBuf>,
+    deferred_paths: &HashSet<PathBuf>,
+    dirty_directory_scopes: &HashSet<PathBuf>,
+) -> HashSet<String> {
+    let dirty_scopes: Vec<&Path> = upsert_paths
+        .iter()
+        .chain(remove_paths.iter())
+        .chain(deferred_paths.iter())
+        .chain(dirty_directory_scopes.iter())
+        .map(PathBuf::as_path)
+        .collect();
+
+    audio_files
+        .iter()
+        .filter(|path| {
+            let Ok(relative) = path.strip_prefix(destination) else {
+                return false;
+            };
+            let source_path = source.join(relative);
+            !dirty_scopes
+                .iter()
+                .any(|dirty| path.starts_with(dirty) || source_path.starts_with(dirty))
+        })
+        .map(|path| path.to_string_lossy().into_owned())
+        .collect()
 }
 
 fn collect_audio_files(root_scans: &[RootScan]) -> Vec<PathBuf> {
@@ -1363,13 +1604,7 @@ async fn initial_scan(
     // Send full sync. A transient failure here is logged but still lets the
     // scan finish (reconcile + ScanComplete) so the UI settles into a synced
     // state instead of hanging on the spinner with no completion signal.
-    match track::Entity::find().all(db).await {
-        Ok(rows) => {
-            let all_tracks: Vec<Track> = rows.iter().map(db_model_to_track).collect();
-            let _ = tx.send(LibraryEvent::FullSync(all_tracks)).await;
-        }
-        Err(e) => warn!(error = %e, "Failed to load tracks for full sync"),
-    }
+    send_library_snapshot(db, tx).await;
 
     // Reconcile orphaned playlist entries with newly-discovered tracks.
     let playlist_mgr = super::playlist_manager::PlaylistManager::new(db.clone());
@@ -1552,6 +1787,32 @@ async fn root_identity_allows_content(
     Ok(matches)
 }
 
+/// The shape an authoritative rename pair was observed to have.
+///
+/// The watcher never reports whether a renamed path was a file or a directory,
+/// and the source side no longer exists by the time the batch is processed, so
+/// the shape is established from the destination alone — without following
+/// symlinks, because neither the traversal nor the watcher follows them.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WatcherRenameKind {
+    File,
+    Directory,
+}
+
+fn classify_rename_pair(pair: &WatcherRenamePair) -> Option<WatcherRenameKind> {
+    if same_audio_extension(&pair.from, &pair.to)
+        && is_regular_file_without_following_symlinks(&pair.to)
+    {
+        return Some(WatcherRenameKind::File);
+    }
+    if is_directory_without_following_symlinks(&pair.to)
+        && directory_rename_source_is_authoritative(&pair.from, &pair.to)
+    {
+        return Some(WatcherRenameKind::Directory);
+    }
+    None
+}
+
 #[derive(Clone, Debug)]
 struct WatcherRenameGuard {
     root_index: usize,
@@ -1567,8 +1828,25 @@ impl WatcherRenameGuard {
                 .is_ok_and(|generation| generation == self.mount_generation)
     }
 
-    fn commit_allowed(&self, music_dirs: &[PathBuf], from: &Path, to: &Path) -> bool {
-        is_regular_file_without_following_symlinks(to)
+    fn commit_allowed(
+        &self,
+        music_dirs: &[PathBuf],
+        from: &Path,
+        to: &Path,
+        kind: WatcherRenameKind,
+    ) -> bool {
+        let destination_shape_holds = match kind {
+            WatcherRenameKind::File => is_regular_file_without_following_symlinks(to),
+            // A directory whose source reappeared as a different object was
+            // copied, not renamed, and its descendants then exist under both
+            // paths. Case-only aliases of the destination are still valid.
+            WatcherRenameKind::Directory => {
+                is_directory_without_following_symlinks(to)
+                    && directory_rename_source_is_authoritative(from, to)
+            }
+        };
+
+        destination_shape_holds
             && !crosses_untracked_nested_mount(&self.root, from, music_dirs)
             && !crosses_untracked_nested_mount(&self.root, to, music_dirs)
             && self.root_is_stable()
@@ -1576,7 +1854,63 @@ impl WatcherRenameGuard {
 }
 
 fn is_regular_file_without_following_symlinks(path: &Path) -> bool {
-    std::fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_file())
+    std::fs::symlink_metadata(path).is_ok_and(|metadata| {
+        !metadata_is_reparse_point(&metadata) && metadata.file_type().is_file()
+    })
+}
+
+fn is_directory_without_following_symlinks(path: &Path) -> bool {
+    std::fs::symlink_metadata(path).is_ok_and(|metadata| {
+        !metadata_is_reparse_point(&metadata) && metadata.file_type().is_dir()
+    })
+}
+
+/// A rename source must be provably absent. An existence probe that fails is
+/// not proof, so it is treated as still present.
+fn source_path_is_gone(path: &Path) -> bool {
+    matches!(path.try_exists(), Ok(false))
+}
+
+/// A case-only rename can leave the old spelling resolvable on a
+/// case-insensitive filesystem. Treat it as authoritative only when both
+/// no-follow directory paths open the exact same filesystem object; a copied
+/// or recreated source remains a reconciliation case.
+fn directory_rename_source_is_authoritative(from: &Path, to: &Path) -> bool {
+    source_path_is_gone(from)
+        || open_real_path_handle(from, true)
+            .ok()
+            .zip(open_real_path_handle(to, true).ok())
+            .is_some_and(|(from_handle, to_handle)| from_handle == to_handle)
+}
+
+/// Reject a directory pair whose subtree owns another scan scope.
+///
+/// Nothing rewrites `library_root.path` on rename, so moving a persisted root
+/// would leave a row pointing at a path that no longer exists — and a nested
+/// mount must never be traversed through its parent. Both cases fall back to a
+/// full reconciliation, which reasons about every scope at once.
+fn subtree_owns_another_scope(
+    subtree: &Path,
+    roots: &WatcherRootCache,
+    music_dirs: &[PathBuf],
+) -> bool {
+    let is_nested = |candidate: &Path| candidate != subtree && candidate.starts_with(subtree);
+
+    if music_dirs.iter().any(|dir| is_nested(dir))
+        || roots.entries.iter().any(|entry| is_nested(&entry.root))
+    {
+        return true;
+    }
+
+    match mounted_subroots(music_dirs) {
+        Ok(mountpoints) => mountpoints
+            .iter()
+            .any(|mountpoint| is_nested(mountpoint.as_path())),
+        Err(error) => {
+            warn!(%error, "Could not inspect mounted library scopes; directory rename rejected");
+            true
+        }
+    }
 }
 
 fn same_audio_extension(from: &Path, to: &Path) -> bool {
@@ -1728,12 +2062,63 @@ struct WatcherRenamePair {
     to: PathBuf,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WatcherUpsertPathKind {
+    RegularFile,
+    Directory,
+    Missing,
+    Unsafe,
+}
+
+#[cfg(windows)]
+fn metadata_is_reparse_point(metadata: &std::fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt;
+
+    // Reject every reparse-point flavor, not only the name-surrogate tags that
+    // `FileType::is_symlink` recognizes.
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+    metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+}
+
+#[cfg(not(windows))]
+fn metadata_is_reparse_point(_metadata: &std::fs::Metadata) -> bool {
+    false
+}
+
+/// Classify a watcher path without following symlinks or reparse points.
+///
+/// A missing audio path remains useful: the upsert loop treats it as a
+/// debounced removal. Every other non-regular object is unsafe to parse and
+/// forces an authoritative reconciliation instead.
+fn watcher_upsert_path_kind(path: &Path) -> std::io::Result<WatcherUpsertPathKind> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata_is_reparse_point(&metadata) => Ok(WatcherUpsertPathKind::Unsafe),
+        Ok(metadata) if metadata.file_type().is_file() => Ok(WatcherUpsertPathKind::RegularFile),
+        Ok(metadata) if metadata.file_type().is_dir() => Ok(WatcherUpsertPathKind::Directory),
+        Ok(_) => Ok(WatcherUpsertPathKind::Unsafe),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            Ok(WatcherUpsertPathKind::Missing)
+        }
+        Err(error) => Err(error),
+    }
+}
+
 #[derive(Debug, Default)]
 struct WatcherBatch {
     upsert_paths: HashSet<PathBuf>,
     remove_paths: HashSet<PathBuf>,
     rename_pairs: HashSet<WatcherRenamePair>,
     paired_paths: HashSet<PathBuf>,
+    /// Directory and other non-audio observations whose meaning is not yet
+    /// known. A rename half arrives before the pair that explains it, so
+    /// deciding to reconcile on sight would make every directory rename fall
+    /// back to a full rescan. [`WatcherBatch::finish`] promotes whatever no
+    /// authoritative pair claimed.
+    deferred_paths: HashSet<PathBuf>,
+    /// Explicit folder create/remove observations are independent changes, not
+    /// ambiguous rename halves. Pair normalization must never erase them: an
+    /// exact destination replacement invalidates every descendant mapping.
+    dirty_directory_scopes: HashSet<PathBuf>,
     identity_changed_roots: HashSet<PathBuf>,
     tracked_rename_from: HashMap<usize, PathBuf>,
     adjacent_untracked_rename_from: Option<PathBuf>,
@@ -1782,7 +2167,11 @@ impl WatcherBatch {
                 let folder = matches!(kind, RemoveKind::Folder);
                 for path in event.paths {
                     if folder {
-                        self.reconciliation_required = true;
+                        // Retain the scope as well as requesting reconciliation
+                        // so a paired parent-directory rename cannot assign old
+                        // identities beneath a separately changed subtree.
+                        self.dirty_directory_scopes.insert(path.clone());
+                        self.deferred_paths.insert(path);
                     } else {
                         self.record_remove(path);
                     }
@@ -1846,7 +2235,8 @@ impl WatcherBatch {
                 let folder = matches!(kind, CreateKind::Folder);
                 for path in event.paths {
                     if folder {
-                        self.reconciliation_required = true;
+                        self.dirty_directory_scopes.insert(path.clone());
+                        self.deferred_paths.insert(path);
                     } else {
                         self.record_upsert(path);
                     }
@@ -1869,19 +2259,39 @@ impl WatcherBatch {
             self.upsert_paths.remove(&path);
             self.remove_paths.insert(path);
         } else {
-            self.reconciliation_required = true;
+            // The vanished path cannot be stat'd, so a renamed directory and a
+            // deleted cover image look identical here. Defer both.
+            self.deferred_paths.insert(path);
         }
     }
 
     fn record_upsert(&mut self, path: PathBuf) {
-        if self.paired_paths.contains(&path) {
-            return;
-        }
-        if path.is_dir() {
-            self.reconciliation_required = true;
-        } else if tag_parser::is_audio_file(&path) {
-            self.remove_paths.remove(&path);
-            self.upsert_paths.insert(path);
+        let paired = self.paired_paths.contains(&path);
+        match watcher_upsert_path_kind(&path) {
+            Ok(WatcherUpsertPathKind::Unsafe) | Err(_) => {
+                self.upsert_paths.remove(&path);
+                self.reconciliation_required = true;
+            }
+            Ok(_) if paired => {}
+            Ok(WatcherUpsertPathKind::Directory) => {
+                self.deferred_paths.insert(path);
+            }
+            Ok(WatcherUpsertPathKind::RegularFile) if tag_parser::is_audio_file(&path) => {
+                self.remove_paths.remove(&path);
+                self.upsert_paths.insert(path);
+            }
+            Ok(WatcherUpsertPathKind::Missing) if tag_parser::is_audio_file(&path) => {
+                // Keep a vanished debounced upsert in the work set. The
+                // guarded removal path below can safely remove its stale row.
+                self.remove_paths.remove(&path);
+                self.upsert_paths.insert(path);
+            }
+            Ok(WatcherUpsertPathKind::Missing) => {
+                // A vanished non-audio path may have been a directory whose
+                // descendants need reconciliation.
+                self.deferred_paths.insert(path);
+            }
+            Ok(WatcherUpsertPathKind::RegularFile) => {}
         }
     }
 
@@ -1899,8 +2309,9 @@ impl WatcherBatch {
             .iter()
             .any(|existing| rename_pairs_overlap(existing, &pair))
         {
-            // Overlapping/chained pairs cannot be applied independently
-            // without ordering and inode guarantees. Reconcile instead.
+            // Overlapping, chained, and nested pairs cannot be applied
+            // independently without ordering and inode guarantees. Reconcile
+            // instead.
             self.reconciliation_required = true;
             self.rename_pairs
                 .retain(|existing| !rename_pairs_overlap(existing, &pair));
@@ -1911,24 +2322,51 @@ impl WatcherBatch {
         self.upsert_paths.remove(&pair.to);
         self.remove_paths.remove(&pair.from);
         self.remove_paths.remove(&pair.to);
+        self.deferred_paths.remove(&pair.from);
+        self.deferred_paths.remove(&pair.to);
         self.paired_paths.insert(pair.from.clone());
         self.paired_paths.insert(pair.to.clone());
         self.rename_pairs.insert(pair);
+    }
+
+    /// Settle the batch once every event in the debounce window has been seen.
+    ///
+    /// Only now is it known whether a deferred path was one half of an
+    /// authoritative rename. Anything unclaimed keeps the conservative
+    /// fallback: a guarded reconciliation that never infers identity.
+    fn finish(&mut self) {
+        self.deferred_paths
+            .retain(|path| !self.paired_paths.contains(path));
+        if !self.deferred_paths.is_empty() {
+            self.reconciliation_required = true;
+        }
+        if !self.dirty_directory_scopes.is_empty() {
+            self.reconciliation_required = true;
+        }
     }
 
     fn is_empty(&self) -> bool {
         self.upsert_paths.is_empty()
             && self.remove_paths.is_empty()
             && self.rename_pairs.is_empty()
+            && self.deferred_paths.is_empty()
+            && self.dirty_directory_scopes.is_empty()
             && self.identity_changed_roots.is_empty()
             && !self.reconciliation_required
     }
 }
 
+/// Two pairs overlap when either shares a path with the other, or when one
+/// renames a directory that contains the other's source or destination.
+///
+/// A directory pair moves a whole subtree, so a pair nested inside it can only
+/// be interpreted with the event ordering the watcher does not provide.
 fn rename_pairs_overlap(left: &WatcherRenamePair, right: &WatcherRenamePair) -> bool {
-    [&left.from, &left.to]
-        .into_iter()
-        .any(|path| path == &right.from || path == &right.to)
+    [&left.from, &left.to].into_iter().any(|path| {
+        [&right.from, &right.to]
+            .into_iter()
+            .any(|other| path.starts_with(other) || other.starts_with(path))
+    })
 }
 
 async fn reconcile_playlists_after_watcher_batch(
@@ -2014,6 +2452,10 @@ async fn watch_directories(
             }
         }
 
+        // Deferred directory observations can only be interpreted once every
+        // half of every rename in this window has arrived.
+        batch.finish();
+
         if batch.is_empty() {
             continue;
         }
@@ -2038,17 +2480,23 @@ async fn watch_directories(
 
         let mut reconciliation_required = batch.reconciliation_required;
         let mut upsert_committed = false;
+        let mut library_snapshot_dirty = false;
 
-        // Apply authoritative same-root file rename pairs before standalone
-        // removals and upserts. This keeps the source row alive, preserving
-        // its stable ID, historical fields, and direct playlist references.
-        for pair in &batch.rename_pairs {
-            if !same_audio_extension(&pair.from, &pair.to)
-                || !is_regular_file_without_following_symlinks(&pair.to)
-            {
+        // Apply authoritative same-root rename pairs before standalone removals
+        // and upserts. This keeps the source rows alive, preserving their stable
+        // IDs, historical fields, and direct playlist references.
+        //
+        // The removal and upsert loops below are keyed by the paths the watcher
+        // reported, which a committed rename has already vacated. They stay
+        // correct only because they resolve rows by exact path: a leftover event
+        // for a moved-away path matches nothing. Do not reorder them ahead of
+        // the renames, and do not make them match by prefix.
+        let rename_pairs: Vec<WatcherRenamePair> = batch.rename_pairs.iter().cloned().collect();
+        for pair in rename_pairs {
+            let Some(kind) = classify_rename_pair(&pair) else {
                 reconciliation_required = true;
                 continue;
-            }
+            };
 
             let guard = match prepare_watcher_rename_guard(
                 db.as_ref(),
@@ -2071,78 +2519,217 @@ async fn watch_directories(
                 }
             };
 
-            let to_parse = pair.to.clone();
-            let parsed = match tokio::task::spawn_blocking(move || {
-                tag_parser::parse_audio_file(&to_parse)
-            })
-            .await
-            {
-                Ok(Ok(parsed)) => Some(parsed),
-                Ok(Err(error)) => {
-                    warn!(to = %pair.to.display(), %error, "Renamed file could not be reparsed; preserving identity and scheduling reconciliation");
-                    reconciliation_required = true;
-                    None
-                }
-                Err(error) => {
-                    warn!(to = %pair.to.display(), %error, "Rename parser task failed; preserving identity and scheduling reconciliation");
-                    reconciliation_required = true;
-                    None
-                }
-            };
+            match kind {
+                WatcherRenameKind::File => {
+                    let to_parse = pair.to.clone();
+                    let parsed = match tokio::task::spawn_blocking(move || {
+                        tag_parser::parse_audio_file(&to_parse)
+                    })
+                    .await
+                    {
+                        Ok(Ok(parsed)) => Some(parsed),
+                        Ok(Err(error)) => {
+                            warn!(to = %pair.to.display(), %error, "Renamed file could not be reparsed; preserving identity and scheduling reconciliation");
+                            reconciliation_required = true;
+                            None
+                        }
+                        Err(error) => {
+                            warn!(to = %pair.to.display(), %error, "Rename parser task failed; preserving identity and scheduling reconciliation");
+                            reconciliation_required = true;
+                            None
+                        }
+                    };
 
-            if !guard.commit_allowed(music_dirs, &pair.from, &pair.to) {
-                if !guard.root_is_stable() {
-                    mark_cached_root_unavailable(db.as_ref(), &mut root_cache, guard.root_index)
-                        .await;
-                }
-                reconciliation_required = true;
-                continue;
-            }
-
-            match rename_track_row(db.as_ref(), &pair.from, &pair.to, parsed.as_ref(), || {
-                guard.commit_allowed(music_dirs, &pair.from, &pair.to)
-            })
-            .await
-            {
-                Ok(RenameTrackOutcome::Renamed { model, displaced }) => {
-                    let _ = tx
-                        .send(LibraryEvent::TrackRemoved(
-                            pair.from.to_string_lossy().into_owned(),
-                        ))
-                        .await;
-                    if let Some(displaced) = displaced {
-                        let displaced = *displaced;
-                        let _ = tx
-                            .send(LibraryEvent::TrackRemoved(displaced.file_path))
+                    if !guard.commit_allowed(music_dirs, &pair.from, &pair.to, kind) {
+                        if !guard.root_is_stable() {
+                            mark_cached_root_unavailable(
+                                db.as_ref(),
+                                &mut root_cache,
+                                guard.root_index,
+                            )
                             .await;
+                        }
+                        reconciliation_required = true;
+                        continue;
                     }
-                    let _ = tx
-                        .send(LibraryEvent::TrackUpserted(Box::new(db_model_to_track(
-                            &model,
-                        ))))
-                        .await;
-                    upsert_committed = true;
-                    info!(from = %pair.from.display(), to = %pair.to.display(), id = %model.id, "Preserved track identity across filesystem rename");
-                }
-                Ok(RenameTrackOutcome::SourceMissing) => {
-                    debug!(from = %pair.from.display(), to = %pair.to.display(), "Rename source was not indexed; falling back to reconciliation");
-                    reconciliation_required = true;
-                }
-                Ok(RenameTrackOutcome::GuardRejected) => {
-                    if !guard.root_is_stable() {
-                        mark_cached_root_unavailable(
-                            db.as_ref(),
-                            &mut root_cache,
-                            guard.root_index,
-                        )
-                        .await;
+
+                    match rename_track_row(
+                        db.as_ref(),
+                        &pair.from,
+                        &pair.to,
+                        parsed.as_ref(),
+                        || guard.commit_allowed(music_dirs, &pair.from, &pair.to, kind),
+                    )
+                    .await
+                    {
+                        Ok(RenameTrackOutcome::Renamed { model, displaced }) => {
+                            let _ = tx
+                                .send(LibraryEvent::TrackRemoved(
+                                    pair.from.to_string_lossy().into_owned(),
+                                ))
+                                .await;
+                            if let Some(displaced) = displaced {
+                                let displaced = *displaced;
+                                let _ = tx
+                                    .send(LibraryEvent::TrackRemoved(displaced.file_path))
+                                    .await;
+                            }
+                            let _ = tx
+                                .send(LibraryEvent::TrackUpserted(Box::new(db_model_to_track(
+                                    &model,
+                                ))))
+                                .await;
+                            upsert_committed = true;
+                            info!(from = %pair.from.display(), to = %pair.to.display(), id = %model.id, "Preserved track identity across filesystem rename");
+                        }
+                        Ok(RenameTrackOutcome::SourceMissing) => {
+                            debug!(from = %pair.from.display(), to = %pair.to.display(), "Rename source was not indexed; falling back to reconciliation");
+                            reconciliation_required = true;
+                        }
+                        Ok(RenameTrackOutcome::GuardRejected) => {
+                            if !guard.root_is_stable() {
+                                mark_cached_root_unavailable(
+                                    db.as_ref(),
+                                    &mut root_cache,
+                                    guard.root_index,
+                                )
+                                .await;
+                            }
+                            warn!(from = %pair.from.display(), to = %pair.to.display(), "Filesystem changed before paired rename commit; transaction rolled back");
+                            reconciliation_required = true;
+                        }
+                        Err(error) => {
+                            warn!(from = %pair.from.display(), to = %pair.to.display(), %error, "Failed to update paired rename transactionally");
+                            reconciliation_required = true;
+                        }
                     }
-                    warn!(from = %pair.from.display(), to = %pair.to.display(), "Filesystem changed before paired rename commit; transaction rolled back");
-                    reconciliation_required = true;
                 }
-                Err(error) => {
-                    warn!(from = %pair.from.display(), to = %pair.to.display(), %error, "Failed to update paired rename transactionally");
-                    reconciliation_required = true;
+
+                WatcherRenameKind::Directory => {
+                    if subtree_owns_another_scope(&pair.from, &root_cache, music_dirs)
+                        || subtree_owns_another_scope(&pair.to, &root_cache, music_dirs)
+                    {
+                        warn!(from = %pair.from.display(), to = %pair.to.display(), "Renamed directory owns another library scope; falling back to reconciliation");
+                        reconciliation_required = true;
+                        continue;
+                    }
+
+                    // Enumerate the destination before opening a transaction: a
+                    // whole subtree of blocking filesystem probes must not run
+                    // with a SQLite write lock held.
+                    let root = guard.root.clone();
+                    let destination = pair.to.clone();
+                    let scan = match tokio::task::spawn_blocking(move || {
+                        scan_renamed_directory(&root, &destination)
+                    })
+                    .await
+                    {
+                        Ok(scan) => scan,
+                        Err(error) => {
+                            warn!(to = %pair.to.display(), %error, "Renamed directory scan task failed");
+                            reconciliation_required = true;
+                            continue;
+                        }
+                    };
+                    if !scan.is_complete() {
+                        for error in &scan.errors {
+                            warn!(to = %pair.to.display(), %error, "Renamed directory could not be fully enumerated");
+                        }
+                        reconciliation_required = true;
+                        continue;
+                    }
+
+                    // A child event in the same batch means the file may have
+                    // been modified or replaced independently of the directory
+                    // move. Do not give that path the old row's identity even
+                    // though the scoped traversal observed it; the normal
+                    // upsert/reconciliation path will assign it deliberately.
+                    let destination_files = directory_identity_destinations(
+                        &scan.audio_files,
+                        &pair.from,
+                        &pair.to,
+                        &batch.upsert_paths,
+                        &batch.remove_paths,
+                        &batch.deferred_paths,
+                        &batch.dirty_directory_scopes,
+                    );
+
+                    if !guard.commit_allowed(music_dirs, &pair.from, &pair.to, kind) {
+                        if !guard.root_is_stable() {
+                            mark_cached_root_unavailable(
+                                db.as_ref(),
+                                &mut root_cache,
+                                guard.root_index,
+                            )
+                            .await;
+                        }
+                        reconciliation_required = true;
+                        continue;
+                    }
+
+                    match rename_directory_rows(
+                        db.as_ref(),
+                        &pair.from,
+                        &pair.to,
+                        &destination_files,
+                        || {
+                            guard.commit_allowed(music_dirs, &pair.from, &pair.to, kind)
+                                && scan.observations_still_current(&pair.to)
+                        },
+                    )
+                    .await
+                    {
+                        Ok(RenameDirectoryOutcome::Renamed {
+                            moved,
+                            displaced,
+                            unmapped,
+                        }) => {
+                            if !moved.is_empty() || displaced > 0 {
+                                library_snapshot_dirty = true;
+                            }
+                            // Displacing a row nulls its playlist links through
+                            // the foreign key; the surviving row can reclaim them.
+                            if displaced > 0 {
+                                upsert_committed = true;
+                            }
+
+                            // Files the rename carried along that were never
+                            // indexed — added while the app was closed, or created
+                            // inside the destination during the debounce window —
+                            // still need their own parse and insert.
+                            let claimed: HashSet<&str> = moved
+                                .iter()
+                                .map(|(_, model)| model.file_path.as_str())
+                                .collect();
+                            for file in &scan.audio_files {
+                                if !claimed.contains(file.to_string_lossy().as_ref()) {
+                                    batch.upsert_paths.insert(file.clone());
+                                }
+                            }
+
+                            if unmapped > 0 {
+                                warn!(from = %pair.from.display(), to = %pair.to.display(), unmapped, "Renamed directory is missing indexed files; scheduling reconciliation");
+                                reconciliation_required = true;
+                            }
+                            info!(from = %pair.from.display(), to = %pair.to.display(), moved = moved.len(), displaced, "Preserved track identity across directory rename");
+                        }
+                        Ok(RenameDirectoryOutcome::GuardRejected) => {
+                            if !guard.root_is_stable() {
+                                mark_cached_root_unavailable(
+                                    db.as_ref(),
+                                    &mut root_cache,
+                                    guard.root_index,
+                                )
+                                .await;
+                            }
+                            warn!(from = %pair.from.display(), to = %pair.to.display(), "Filesystem changed before directory rename commit; transaction rolled back");
+                            reconciliation_required = true;
+                        }
+                        Err(error) => {
+                            warn!(from = %pair.from.display(), to = %pair.to.display(), %error, "Failed to update directory rename transactionally");
+                            reconciliation_required = true;
+                        }
+                    }
                 }
             }
         }
@@ -2187,28 +2774,41 @@ async fn watch_directories(
                         continue;
                     }
                 }
-                if !path.exists() {
-                    // Backstop: a debounced "upsert" whose file no longer
-                    // exists is really a move/rename away (or a delete the
-                    // watcher reported as an ambiguous Modify). Remove the
-                    // stale DB row instead of leaving an orphan that fails to
-                    // play.
-                    let path_str = path.to_string_lossy().to_string();
-                    if delete_track_if_root_stable(
-                        db.as_ref(),
-                        &mut root_cache,
-                        music_dirs,
-                        &path,
-                    )
-                    .await
-                    .unwrap_or_else(|error| {
-                            warn!(path = %path.display(), %error, "Failed to process missing watched path safely");
-                            false
-                        })
-                    {
-                        let _ = tx.send(LibraryEvent::TrackRemoved(path_str)).await;
+                match watcher_upsert_path_kind(&path) {
+                    Ok(WatcherUpsertPathKind::RegularFile) => {}
+                    Ok(WatcherUpsertPathKind::Missing) => {
+                        // Backstop: a debounced "upsert" whose file no longer
+                        // exists is really a move/rename away (or a delete the
+                        // watcher reported as an ambiguous Modify). Remove the
+                        // stale DB row instead of leaving an orphan that fails
+                        // to play.
+                        let path_str = path.to_string_lossy().to_string();
+                        if delete_track_if_root_stable(
+                            db.as_ref(),
+                            &mut root_cache,
+                            music_dirs,
+                            &path,
+                        )
+                        .await
+                        .unwrap_or_else(|error| {
+                                warn!(path = %path.display(), %error, "Failed to process missing watched path safely");
+                                false
+                            })
+                        {
+                            let _ = tx.send(LibraryEvent::TrackRemoved(path_str)).await;
+                        }
+                        continue;
                     }
-                    continue;
+                    Ok(kind) => {
+                        warn!(path = %path.display(), ?kind, "Watched audio path is not a regular file; scheduling reconciliation");
+                        reconciliation_required = true;
+                        continue;
+                    }
+                    Err(error) => {
+                        warn!(path = %path.display(), %error, "Could not inspect watched audio path safely; scheduling reconciliation");
+                        reconciliation_required = true;
+                        continue;
+                    }
                 }
                 let p = path.clone();
                 match tokio::task::spawn_blocking(move || tag_parser::parse_audio_file(&p)).await {
@@ -2236,6 +2836,20 @@ async fn watch_directories(
                             .ok()
                             .flatten();
 
+                        match watcher_upsert_path_kind(&path) {
+                            Ok(WatcherUpsertPathKind::RegularFile) => {}
+                            Ok(kind) => {
+                                warn!(path = %path.display(), ?kind, "Watched audio path changed after parsing; scheduling reconciliation");
+                                reconciliation_required = true;
+                                continue;
+                            }
+                            Err(error) => {
+                                warn!(path = %path.display(), %error, "Could not re-inspect watched audio path after parsing; scheduling reconciliation");
+                                reconciliation_required = true;
+                                continue;
+                            }
+                        }
+
                         match upsert_track(db.as_ref(), &parsed, existing.as_ref()).await {
                             Ok(model) => {
                                 upsert_committed = true;
@@ -2257,15 +2871,23 @@ async fn watch_directories(
             }
         }
 
-        // Directory changes and unpairable rename shapes deliberately avoid
-        // guessing identity. Reuse the hardened authoritative scan once per
-        // batch as the conservative reconciliation fallback.
+        // Unpairable rename shapes and unclaimed directory changes deliberately
+        // avoid guessing identity. Reuse the hardened authoritative scan once
+        // per batch as the conservative reconciliation fallback. It publishes
+        // its own snapshot, so no separate one is needed here.
         if reconciliation_required {
-            info!("Reconciling library after unpaired or directory watcher changes");
+            info!("Reconciling library after unpaired or unclaimed watcher changes");
             if let Err(error) = initial_scan(db.as_ref(), music_dirs, tx).await {
                 warn!(%error, "Watcher-triggered library reconciliation failed");
             }
             continue;
+        }
+
+        // A directory rename retargets an unbounded number of rows at once.
+        // Publish one snapshot rather than a per-row event storm, which the GTK
+        // receiver would resolve against the whole library once per row.
+        if library_snapshot_dirty {
+            send_library_snapshot(db.as_ref(), tx).await;
         }
 
         // Deletions null playlist links through the database foreign key.
@@ -2448,6 +3070,150 @@ where
             transaction.rollback().await?;
             Err(error)
         }
+    }
+}
+
+#[derive(Debug)]
+enum RenameDirectoryOutcome {
+    Renamed {
+        /// `(previous path, retargeted row)` for every descendant that kept its
+        /// identity.
+        moved: Vec<(String, track::Model)>,
+        /// Stale rows evicted from a destination path before it was claimed.
+        displaced: usize,
+        /// Indexed descendants with no file at the mirrored destination. Their
+        /// rows are left untouched for reconciliation to resolve.
+        unmapped: usize,
+    },
+    GuardRejected,
+}
+
+/// Retarget every indexed descendant of an authoritative paired directory
+/// rename in one transaction.
+///
+/// Row IDs, `date_added`, play counts, and playlist references survive; only
+/// `file_path` moves. A directory rename changes no file content, so tags are
+/// not reparsed and `date_modified` is left alone.
+///
+/// `destination_files` is the completed scoped traversal of `to`. A descendant
+/// is moved only when a real file was observed at its mirrored destination, and
+/// the caller's commit guard revalidates the retained filesystem handles before
+/// the transaction commits. A descendant without an observed destination is
+/// reported as `unmapped` rather than followed to a path that does not exist.
+/// Files under `to` that no row claims are surplus: they were never indexed,
+/// and the caller upserts them normally.
+async fn rename_directory_rows<F>(
+    db: &DatabaseConnection,
+    from: &Path,
+    to: &Path,
+    destination_files: &HashSet<String>,
+    commit_guard: F,
+) -> anyhow::Result<RenameDirectoryOutcome>
+where
+    F: FnOnce() -> bool,
+{
+    // Rows are persisted through `to_string_lossy`, so a non-UTF-8 name never
+    // round-trips back to its original bytes. Matching in the database's own
+    // lossy namespace keeps those rows reachable; matching through `Path` keeps
+    // the prefix component-wise, so `/music/Album` cannot capture the sibling
+    // `/music/Album2`.
+    let from_prefix = PathBuf::from(from.to_string_lossy().into_owned());
+    let to_prefix = PathBuf::from(to.to_string_lossy().into_owned());
+    if from_prefix.starts_with(&to_prefix) || to_prefix.starts_with(&from_prefix) {
+        return Err(anyhow::anyhow!(
+            "paired directory rename source and destination overlap"
+        ));
+    }
+
+    let transaction = db.begin().await?;
+
+    let result: anyhow::Result<RenameDirectoryOutcome> = async {
+        let rows = track::Entity::find().all(&transaction).await?;
+
+        let mut moves: Vec<(track::Model, String)> = Vec::new();
+        let mut unmapped = 0usize;
+        for row in &rows {
+            let Ok(relative) = Path::new(&row.file_path).strip_prefix(&from_prefix) else {
+                continue;
+            };
+            if relative.as_os_str().is_empty() {
+                continue;
+            }
+            let destination = to_prefix.join(relative).to_string_lossy().into_owned();
+            if destination_files.contains(&destination) {
+                moves.push((row.clone(), destination));
+            } else {
+                unmapped += 1;
+            }
+        }
+
+        // `tracks.file_path` is unique. The filesystem cannot leave a file
+        // parked at a destination path — a directory rename only succeeds onto
+        // an empty destination — but a stale row can still sit there, left by a
+        // scan that was never authoritative enough to delete it. Evict it before
+        // its path is claimed, or the update aborts on the unique index.
+        let claimed: HashSet<&str> = moves
+            .iter()
+            .map(|(_, destination)| destination.as_str())
+            .collect();
+        let mut displaced = 0usize;
+        for row in &rows {
+            if claimed.contains(row.file_path.as_str()) {
+                track::Entity::delete_by_id(&row.id)
+                    .exec(&transaction)
+                    .await?;
+                displaced += 1;
+            }
+        }
+
+        let mut moved = Vec::with_capacity(moves.len());
+        for (row, destination) in moves {
+            let previous = row.file_path.clone();
+            let mut active: track::ActiveModel = row.into();
+            active.file_path = Set(destination);
+            moved.push((previous, active.update(&transaction).await?));
+        }
+
+        if !commit_guard() {
+            return Ok(RenameDirectoryOutcome::GuardRejected);
+        }
+
+        Ok(RenameDirectoryOutcome::Renamed {
+            moved,
+            displaced,
+            unmapped,
+        })
+    }
+    .await;
+
+    match result {
+        Ok(outcome @ RenameDirectoryOutcome::Renamed { .. }) => {
+            transaction.commit().await?;
+            Ok(outcome)
+        }
+        Ok(outcome) => {
+            transaction.rollback().await?;
+            Ok(outcome)
+        }
+        Err(error) => {
+            transaction.rollback().await?;
+            Err(error)
+        }
+    }
+}
+
+/// Publish the committed library as one authoritative snapshot.
+///
+/// Bulk changes emit this instead of a per-row event storm: the receiving GTK
+/// thread rebuilds from a snapshot in one pass, and the playback queue
+/// re-resolves its items by their stable track IDs.
+async fn send_library_snapshot(db: &DatabaseConnection, tx: &async_channel::Sender<LibraryEvent>) {
+    match track::Entity::find().all(db).await {
+        Ok(rows) => {
+            let all_tracks: Vec<Track> = rows.iter().map(db_model_to_track).collect();
+            let _ = tx.send(LibraryEvent::FullSync(all_tracks)).await;
+        }
+        Err(error) => warn!(%error, "Failed to load tracks for full sync"),
     }
 }
 
@@ -2640,6 +3406,60 @@ mod tests {
 
         assert!(batch.reconciliation_required);
         assert!(batch.rename_pairs.is_empty());
+        assert!(
+            batch.deferred_paths.contains(Path::new("/music/album")),
+            "folder changes remain available as dirty scopes for a paired parent rename"
+        );
+    }
+
+    #[test]
+    fn watcher_batch_queues_regular_and_missing_audio_paths_only() {
+        let library = TestDirectory::new("watcher-upsert-paths");
+        let regular = library.path().join("regular.flac");
+        let missing = library.path().join("missing.flac");
+        std::fs::write(&regular, b"audio").expect("create regular audio path");
+
+        let mut batch = WatcherBatch::default();
+        batch.record_upsert(regular.clone());
+        batch.record_upsert(missing.clone());
+
+        assert_eq!(
+            watcher_upsert_path_kind(&regular).expect("classify regular path"),
+            WatcherUpsertPathKind::RegularFile
+        );
+        assert_eq!(
+            watcher_upsert_path_kind(&missing).expect("classify missing path"),
+            WatcherUpsertPathKind::Missing
+        );
+        assert!(batch.upsert_paths.contains(&regular));
+        assert!(
+            batch.upsert_paths.contains(&missing),
+            "a vanished upsert must reach the guarded removal backstop"
+        );
+        assert!(!batch.reconciliation_required);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn watcher_batch_rejects_symlinked_audio_upserts() {
+        let library = TestDirectory::new("watcher-symlink-upsert");
+        let target = library.path().join("target.flac");
+        let linked = library.path().join("linked.flac");
+        std::fs::write(&target, b"audio").expect("create symlink target");
+        std::os::unix::fs::symlink(&target, &linked).expect("create audio symlink");
+
+        let mut batch = WatcherBatch::default();
+        batch.record_upsert(linked.clone());
+
+        assert_eq!(
+            watcher_upsert_path_kind(&linked).expect("classify symlink"),
+            WatcherUpsertPathKind::Unsafe
+        );
+        assert!(!batch.upsert_paths.contains(&linked));
+        assert!(
+            batch.reconciliation_required,
+            "a symlink must use the authoritative no-follow scan"
+        );
     }
 
     async fn rename_test_database() -> DatabaseConnection {
@@ -3050,6 +3870,599 @@ mod tests {
             .expect("query watcher reconciliation")
             .expect("playlist entry remains");
         assert_eq!(relinked.track_id.as_deref(), Some("watcher-track"));
+    }
+
+    // ── Paired directory renames ────────────────────────────────────────
+
+    fn destination_files(paths: &[&str]) -> HashSet<String> {
+        paths.iter().map(|path| (*path).to_string()).collect()
+    }
+
+    #[test]
+    fn directory_identity_mapping_excludes_dirty_destination_descendants() {
+        let audio_files = vec![
+            PathBuf::from("/music/Renamed/clean.flac"),
+            PathBuf::from("/music/Renamed/modified.flac"),
+            PathBuf::from("/music/Renamed/removed.flac"),
+            PathBuf::from("/music/Renamed/Disc 2/changed.flac"),
+        ];
+        let upserts = HashSet::from([
+            // The old spelling is common when a child event was delivered
+            // immediately before the parent rename pair.
+            PathBuf::from("/music/Album/modified.flac"),
+            PathBuf::from("/music/Other/unrelated.flac"),
+        ]);
+        let removals = HashSet::from([PathBuf::from("/music/Renamed/removed.flac")]);
+        let deferred = HashSet::from([PathBuf::from("/music/Renamed/Disc 2")]);
+        let dirty_directories = HashSet::new();
+
+        assert_eq!(
+            directory_identity_destinations(
+                &audio_files,
+                Path::new("/music/Album"),
+                Path::new("/music/Renamed"),
+                &upserts,
+                &removals,
+                &deferred,
+                &dirty_directories,
+            ),
+            destination_files(&["/music/Renamed/clean.flac"]),
+            "a child with its own event must take the parse/reconciliation path instead"
+        );
+    }
+
+    #[test]
+    fn directory_identity_mapping_rejects_an_exact_destination_folder_replacement() {
+        let source = PathBuf::from("/music/Album");
+        let destination = PathBuf::from("/music/Renamed");
+        let mut batch = WatcherBatch::default();
+        batch.record_rename_pair(source.clone(), destination.clone());
+        batch.collect(
+            notify::Event::new(notify::EventKind::Remove(notify::event::RemoveKind::Folder))
+                .add_path(destination.clone()),
+        );
+        batch.collect(
+            notify::Event::new(notify::EventKind::Create(notify::event::CreateKind::Folder))
+                .add_path(destination.clone()),
+        );
+        batch.finish();
+
+        assert!(batch.rename_pairs.contains(&WatcherRenamePair {
+            from: source.clone(),
+            to: destination.clone(),
+        }));
+        assert!(batch.dirty_directory_scopes.contains(&destination));
+        assert!(batch.reconciliation_required);
+        assert!(
+            directory_identity_destinations(
+                &[destination.join("01.flac")],
+                &source,
+                &destination,
+                &batch.upsert_paths,
+                &batch.remove_paths,
+                &batch.deferred_paths,
+                &batch.dirty_directory_scopes,
+            )
+            .is_empty(),
+            "a recreated destination directory cannot inherit any old descendant identity"
+        );
+    }
+
+    #[test]
+    fn watcher_batch_defers_directory_rename_halves_until_the_pair_is_known() {
+        let library = TestDirectory::new("directory-rename-batch");
+        let destination = library.path().join("Renamed Album");
+        std::fs::create_dir_all(&destination).expect("create renamed album");
+        let source = library.path().join("Album");
+
+        let mut batch = WatcherBatch::default();
+        batch.collect(rename_event(
+            notify::event::RenameMode::From,
+            &[source.to_str().expect("utf-8 fixture path")],
+            Some(9),
+        ));
+        // The source half alone is indistinguishable from a deleted directory.
+        assert!(!batch.reconciliation_required);
+        batch.collect(rename_event(
+            notify::event::RenameMode::To,
+            &[destination.to_str().expect("utf-8 fixture path")],
+            Some(9),
+        ));
+        batch.finish();
+
+        assert_eq!(
+            batch.rename_pairs,
+            HashSet::from([WatcherRenamePair {
+                from: source,
+                to: destination,
+            }])
+        );
+        assert!(
+            !batch.reconciliation_required,
+            "an authoritative directory pair must not force a full rescan"
+        );
+        assert!(batch.remove_paths.is_empty());
+        assert!(batch.upsert_paths.is_empty());
+    }
+
+    #[test]
+    fn watcher_batch_promotes_an_unclaimed_directory_removal_to_reconciliation() {
+        let mut batch = WatcherBatch::default();
+        batch.collect(rename_event(
+            notify::event::RenameMode::From,
+            &["/music/Album"],
+            Some(3),
+        ));
+
+        batch.finish();
+
+        assert!(batch.rename_pairs.is_empty());
+        assert!(
+            batch.reconciliation_required,
+            "a directory that left the library without a destination must reconcile"
+        );
+    }
+
+    #[test]
+    fn watcher_batch_rejects_rename_pairs_nested_in_a_renamed_directory() {
+        let mut batch = WatcherBatch::default();
+        batch.collect(rename_event(
+            notify::event::RenameMode::Both,
+            &["/music/Album", "/music/Renamed"],
+            Some(1),
+        ));
+        batch.collect(rename_event(
+            notify::event::RenameMode::Both,
+            &["/music/Renamed/01.flac", "/music/Renamed/02.flac"],
+            Some(2),
+        ));
+        batch.finish();
+
+        assert!(
+            batch.rename_pairs.is_empty(),
+            "a pair nested inside a renamed directory cannot be ordered from watcher events"
+        );
+        assert!(batch.reconciliation_required);
+    }
+
+    #[test]
+    fn rename_destination_shape_is_established_without_following_symlinks() {
+        let library = TestDirectory::new("rename-classification");
+        let album = library.path().join("Album");
+        std::fs::create_dir_all(&album).expect("create album");
+        let track = library.path().join("01.flac");
+        std::fs::write(&track, b"audio").expect("create track");
+
+        assert_eq!(
+            classify_rename_pair(&WatcherRenamePair {
+                from: library.path().join("00.flac"),
+                to: track,
+            }),
+            Some(WatcherRenameKind::File)
+        );
+        assert_eq!(
+            classify_rename_pair(&WatcherRenamePair {
+                from: library.path().join("Old Album"),
+                to: album.clone(),
+            }),
+            Some(WatcherRenameKind::Directory)
+        );
+        // A source that still exists was copied, not renamed.
+        assert_eq!(
+            classify_rename_pair(&WatcherRenamePair {
+                from: library.path().to_path_buf(),
+                to: album,
+            }),
+            None
+        );
+
+        #[cfg(unix)]
+        {
+            let linked = library.path().join("Linked Album");
+            std::os::unix::fs::symlink(library.path().join("Album"), &linked)
+                .expect("create symlinked album");
+            assert_eq!(
+                classify_rename_pair(&WatcherRenamePair {
+                    from: library.path().join("Old Album"),
+                    to: linked,
+                }),
+                None,
+                "neither the traversal nor the watcher follows symlinks"
+            );
+        }
+    }
+
+    #[test]
+    fn directory_rename_source_accepts_a_case_alias_only_for_the_same_object() {
+        let library = TestDirectory::new("directory-case-alias");
+        let source = library.path().join("Album");
+        let destination = library.path().join("album");
+        std::fs::create_dir_all(&source).expect("create source album");
+        std::fs::rename(&source, &destination).expect("apply case-only rename");
+
+        assert!(directory_rename_source_is_authoritative(
+            &source,
+            &destination
+        ));
+        assert_eq!(
+            classify_rename_pair(&WatcherRenamePair {
+                from: source.clone(),
+                to: destination.clone(),
+            }),
+            Some(WatcherRenameKind::Directory)
+        );
+
+        // On a case-insensitive filesystem the old spelling still resolves;
+        // the same-object handle comparison, rather than absence, is what
+        // authorizes the pair.
+        if source.try_exists().expect("probe old spelling") {
+            let source_handle = open_real_path_handle(&source, true).expect("open old alias");
+            let destination_handle =
+                open_real_path_handle(&destination, true).expect("open new alias");
+            assert_eq!(source_handle, destination_handle);
+        }
+
+        let recreated_source = library.path().join("Other");
+        std::fs::create_dir_all(&recreated_source).expect("create distinct source");
+        assert!(!directory_rename_source_is_authoritative(
+            &recreated_source,
+            &destination
+        ));
+    }
+
+    #[tokio::test]
+    async fn directory_rename_preserves_descendant_identity_and_playlist_links() {
+        use crate::db::entities::playlist_entry;
+
+        let db = rename_test_database().await;
+        let manager = super::super::playlist_manager::PlaylistManager::new(db.clone());
+        let playlist = manager
+            .create_playlist("Album", false)
+            .await
+            .expect("create playlist");
+
+        let first =
+            insert_rename_test_track(&db, "track-one", "/music/Album/01.flac", "One", 11).await;
+        insert_rename_test_track(&db, "track-two", "/music/Album/Disc 2/02.flac", "Two", 4).await;
+        // A sibling whose path shares a textual prefix with the renamed
+        // directory must not be dragged along with it.
+        insert_rename_test_track(&db, "track-other", "/music/Album2/03.flac", "Three", 2).await;
+
+        manager
+            .add_track(&playlist.id, &first)
+            .await
+            .expect("add track to playlist");
+        let entry_before = playlist_entry::Entity::find()
+            .filter(playlist_entry::Column::PlaylistId.eq(&playlist.id))
+            .one(&db)
+            .await
+            .expect("load playlist entry")
+            .expect("playlist entry exists");
+
+        let outcome = rename_directory_rows(
+            &db,
+            Path::new("/music/Album"),
+            Path::new("/music/Renamed"),
+            &destination_files(&["/music/Renamed/01.flac", "/music/Renamed/Disc 2/02.flac"]),
+            || true,
+        )
+        .await
+        .expect("rename directory rows");
+
+        let RenameDirectoryOutcome::Renamed {
+            moved,
+            displaced,
+            unmapped,
+        } = outcome
+        else {
+            panic!("expected the directory rename to commit");
+        };
+        assert_eq!(moved.len(), 2);
+        assert_eq!(displaced, 0);
+        assert_eq!(unmapped, 0);
+
+        let renamed = track::Entity::find_by_id("track-one")
+            .one(&db)
+            .await
+            .expect("load renamed track")
+            .expect("renamed track exists");
+        assert_eq!(renamed.file_path, "/music/Renamed/01.flac");
+        assert_eq!(renamed.play_count, 11, "history survives the move");
+        assert_eq!(renamed.date_added, "2025-01-02T03:04:05Z");
+        assert_eq!(
+            renamed.date_modified, "2025-01-02T03:04:05Z",
+            "a directory rename changes no file content"
+        );
+
+        let nested = track::Entity::find_by_id("track-two")
+            .one(&db)
+            .await
+            .expect("load nested track")
+            .expect("nested track exists");
+        assert_eq!(nested.file_path, "/music/Renamed/Disc 2/02.flac");
+
+        let sibling = track::Entity::find_by_id("track-other")
+            .one(&db)
+            .await
+            .expect("load sibling track")
+            .expect("sibling track exists");
+        assert_eq!(
+            sibling.file_path, "/music/Album2/03.flac",
+            "the prefix must match whole path components"
+        );
+
+        let entry_after = playlist_entry::Entity::find_by_id(&entry_before.id)
+            .one(&db)
+            .await
+            .expect("reload playlist entry")
+            .expect("playlist entry remains");
+        assert_eq!(
+            entry_after, entry_before,
+            "the playlist keeps its direct reference to the moved track"
+        );
+    }
+
+    #[tokio::test]
+    async fn directory_rename_reports_descendants_without_a_destination_file() {
+        let db = rename_test_database().await;
+        insert_rename_test_track(&db, "moved", "/music/Album/01.flac", "One", 0).await;
+        insert_rename_test_track(&db, "vanished", "/music/Album/02.flac", "Two", 0).await;
+
+        let outcome = rename_directory_rows(
+            &db,
+            Path::new("/music/Album"),
+            Path::new("/music/Renamed"),
+            // The second file was deleted during the rename window, so nothing
+            // observed it at the destination.
+            &destination_files(&["/music/Renamed/01.flac"]),
+            || true,
+        )
+        .await
+        .expect("rename directory rows");
+
+        let RenameDirectoryOutcome::Renamed {
+            moved, unmapped, ..
+        } = outcome
+        else {
+            panic!("expected the directory rename to commit");
+        };
+        assert_eq!(moved.len(), 1);
+        assert_eq!(
+            unmapped, 1,
+            "an unproven descendant is left for reconciliation, not followed to a guess"
+        );
+
+        let vanished = track::Entity::find_by_id("vanished")
+            .one(&db)
+            .await
+            .expect("load unmapped track")
+            .expect("unmapped track exists");
+        assert_eq!(
+            vanished.file_path, "/music/Album/02.flac",
+            "an unproven row keeps its path until a guarded scan can resolve it"
+        );
+    }
+
+    #[tokio::test]
+    async fn directory_rename_displaces_a_stale_row_parked_at_a_destination_path() {
+        let db = rename_test_database().await;
+        insert_rename_test_track(&db, "moved", "/music/Album/01.flac", "One", 5).await;
+        // A row a previous scan was never authoritative enough to delete. The
+        // unique path index would otherwise abort the move.
+        insert_rename_test_track(&db, "stale", "/music/Renamed/01.flac", "Stale", 0).await;
+
+        let outcome = rename_directory_rows(
+            &db,
+            Path::new("/music/Album"),
+            Path::new("/music/Renamed"),
+            &destination_files(&["/music/Renamed/01.flac"]),
+            || true,
+        )
+        .await
+        .expect("rename directory rows");
+
+        let RenameDirectoryOutcome::Renamed {
+            moved, displaced, ..
+        } = outcome
+        else {
+            panic!("expected the directory rename to commit");
+        };
+        assert_eq!(moved.len(), 1);
+        assert_eq!(displaced, 1);
+
+        assert!(track::Entity::find_by_id("stale")
+            .one(&db)
+            .await
+            .expect("query displaced track")
+            .is_none());
+        let survivor = track::Entity::find_by_id("moved")
+            .one(&db)
+            .await
+            .expect("load moved track")
+            .expect("moved track exists");
+        assert_eq!(survivor.file_path, "/music/Renamed/01.flac");
+        assert_eq!(survivor.play_count, 5);
+    }
+
+    #[tokio::test]
+    async fn directory_rename_guard_rejection_rolls_back_every_change() {
+        let db = rename_test_database().await;
+        insert_rename_test_track(&db, "moved", "/music/Album/01.flac", "One", 5).await;
+        insert_rename_test_track(&db, "stale", "/music/Renamed/01.flac", "Stale", 0).await;
+
+        let outcome = rename_directory_rows(
+            &db,
+            Path::new("/music/Album"),
+            Path::new("/music/Renamed"),
+            &destination_files(&["/music/Renamed/01.flac"]),
+            || false,
+        )
+        .await
+        .expect("rename directory rows");
+        assert!(matches!(outcome, RenameDirectoryOutcome::GuardRejected));
+
+        let source = track::Entity::find_by_id("moved")
+            .one(&db)
+            .await
+            .expect("load source track")
+            .expect("source track exists");
+        assert_eq!(source.file_path, "/music/Album/01.flac");
+        assert!(
+            track::Entity::find_by_id("stale")
+                .one(&db)
+                .await
+                .expect("query displaced track")
+                .is_some(),
+            "a rejected commit must not leave the destination row deleted"
+        );
+    }
+
+    #[tokio::test]
+    async fn directory_rename_refuses_a_destination_inside_its_own_source() {
+        let db = rename_test_database().await;
+        insert_rename_test_track(&db, "moved", "/music/Album/01.flac", "One", 0).await;
+
+        let error = rename_directory_rows(
+            &db,
+            Path::new("/music/Album"),
+            Path::new("/music/Album/Nested"),
+            &destination_files(&["/music/Album/Nested/01.flac"]),
+            || true,
+        )
+        .await;
+        assert!(error.is_err());
+
+        let unchanged = track::Entity::find_by_id("moved")
+            .one(&db)
+            .await
+            .expect("load track")
+            .expect("track exists");
+        assert_eq!(unchanged.file_path, "/music/Album/01.flac");
+    }
+
+    #[test]
+    fn renamed_directory_scan_enumerates_descendants_without_following_symlinks() {
+        let library = TestDirectory::new("renamed-directory-scan");
+        let album = library.path().join("Renamed");
+        std::fs::create_dir_all(album.join("Disc 2")).expect("create nested directory");
+        std::fs::write(album.join("01.flac"), b"audio").expect("write track");
+        std::fs::write(album.join("Disc 2").join("02.flac"), b"audio").expect("write nested track");
+        std::fs::write(album.join("cover.jpg"), b"art").expect("write cover");
+
+        let scan = scan_renamed_directory(library.path(), &album);
+        assert!(scan.is_complete());
+        let mut found = scan.audio_files.clone();
+        found.sort_unstable();
+        assert_eq!(
+            found,
+            vec![album.join("01.flac"), album.join("Disc 2").join("02.flac")]
+        );
+
+        #[cfg(unix)]
+        {
+            let outside = library.path().join("outside.flac");
+            std::fs::write(&outside, b"audio").expect("write outside track");
+            std::os::unix::fs::symlink(&outside, album.join("linked.flac"))
+                .expect("create symlinked track");
+
+            let scan = scan_renamed_directory(library.path(), &album);
+            assert!(scan.is_complete());
+            assert_eq!(
+                scan.audio_files.len(),
+                2,
+                "a symlinked file is never indexed, so it can never be mapped"
+            );
+        }
+    }
+
+    #[test]
+    fn renamed_directory_scan_rejects_file_or_directory_replacement_before_commit() {
+        let library = TestDirectory::new("renamed-directory-revalidation");
+        let album = library.path().join("Renamed");
+        std::fs::create_dir_all(&album).expect("create album");
+        let track = album.join("01.flac");
+        std::fs::write(&track, b"first object").expect("write original track");
+
+        let file_scan = scan_renamed_directory(library.path(), &album);
+        assert!(file_scan.is_complete());
+        assert!(file_scan.observations_still_current(&album));
+
+        let original_track = album.join("original.flac");
+        std::fs::rename(&track, &original_track).expect("park original track");
+        std::fs::write(&track, b"replacement").expect("write replacement track");
+        assert!(
+            !file_scan.observations_still_current(&album),
+            "a different file at the same path must not inherit the indexed row"
+        );
+
+        let directory_scan = scan_renamed_directory(library.path(), &album);
+        assert!(directory_scan.is_complete());
+        let parked_album = library.path().join("Parked");
+        std::fs::rename(&album, &parked_album).expect("park original directory");
+        std::fs::create_dir_all(&album).expect("create replacement directory");
+        std::fs::write(album.join("01.flac"), b"replacement").expect("mirror old file name");
+        std::fs::write(album.join("original.flac"), b"replacement")
+            .expect("mirror second file name");
+        assert!(
+            !directory_scan.observations_still_current(&album),
+            "an identical-looking replacement directory must fail the handle guard"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn renamed_directory_scan_fails_closed_on_an_unreadable_descendant() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let library = TestDirectory::new("renamed-directory-unreadable");
+        let album = library.path().join("Renamed");
+        let locked = album.join("Disc 2");
+        std::fs::create_dir_all(&locked).expect("create nested directory");
+        std::fs::write(album.join("01.flac"), b"audio").expect("write track");
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000))
+            .expect("remove directory permissions");
+
+        // Privileged containers can retain directory access despite mode 000.
+        if std::fs::read_dir(&locked).is_ok() {
+            std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o700))
+                .expect("restore directory permissions");
+            return;
+        }
+
+        let scan = scan_renamed_directory(library.path(), &album);
+
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o700))
+            .expect("restore directory permissions");
+        assert!(
+            !scan.is_complete(),
+            "a partial view of the destination can never prove where a track moved"
+        );
+    }
+
+    #[test]
+    fn renamed_subtree_owning_another_scope_is_rejected() {
+        let library = PathBuf::from("/music");
+        let nested = library_root::Model {
+            path: "/music/Album/Nested".to_string(),
+            device_id: Some("marker:v1:nested".to_string()),
+            identity_confirmed: true,
+            is_available: true,
+            last_scan_complete: true,
+            last_checked_at: "2026-07-12T00:00:00Z".to_string(),
+        };
+        let roots =
+            WatcherRootCache::from_models(vec![nested], std::slice::from_ref(&library.clone()));
+        let music_dirs = [library];
+
+        assert!(
+            subtree_owns_another_scope(Path::new("/music/Album"), &roots, &music_dirs),
+            "moving a persisted root would leave its row pointing at a path that no longer exists"
+        );
+        assert!(!subtree_owns_another_scope(
+            Path::new("/music/Other"),
+            &roots,
+            &music_dirs
+        ));
     }
 
     #[test]

--- a/src/local/engine.rs
+++ b/src/local/engine.rs
@@ -13,8 +13,8 @@ use std::time::Duration;
 use chrono::{DateTime, Utc};
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, Set,
-    TransactionTrait,
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, DatabaseConnection, EntityTrait, QueryFilter,
+    Set, TransactionTrait,
 };
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
@@ -1552,6 +1552,85 @@ async fn root_identity_allows_content(
     Ok(matches)
 }
 
+#[derive(Clone, Debug)]
+struct WatcherRenameGuard {
+    root_index: usize,
+    root: PathBuf,
+    expected_identity: String,
+    mount_generation: u64,
+}
+
+impl WatcherRenameGuard {
+    fn root_is_stable(&self) -> bool {
+        filesystem_identity(&self.root).is_ok_and(|identity| identity == self.expected_identity)
+            && root_mount_generation(&self.root)
+                .is_ok_and(|generation| generation == self.mount_generation)
+    }
+
+    fn commit_allowed(&self, music_dirs: &[PathBuf], from: &Path, to: &Path) -> bool {
+        is_regular_file_without_following_symlinks(to)
+            && !crosses_untracked_nested_mount(&self.root, from, music_dirs)
+            && !crosses_untracked_nested_mount(&self.root, to, music_dirs)
+            && self.root_is_stable()
+    }
+}
+
+fn is_regular_file_without_following_symlinks(path: &Path) -> bool {
+    std::fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_file())
+}
+
+fn same_audio_extension(from: &Path, to: &Path) -> bool {
+    tag_parser::is_audio_file(from)
+        && tag_parser::is_audio_file(to)
+        && from
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .zip(to.extension().and_then(|extension| extension.to_str()))
+            .is_some_and(|(from, to)| from.eq_ignore_ascii_case(to))
+}
+
+async fn prepare_watcher_rename_guard(
+    db: &DatabaseConnection,
+    roots: &mut WatcherRootCache,
+    music_dirs: &[PathBuf],
+    from: &Path,
+    to: &Path,
+) -> anyhow::Result<Option<WatcherRenameGuard>> {
+    if !root_identity_allows_content(db, roots, music_dirs, from).await?
+        || !root_identity_allows_content(db, roots, music_dirs, to).await?
+    {
+        return Ok(None);
+    }
+
+    let Some((from_index, from_root, from_state)) = roots.root_for_path(from) else {
+        return Ok(None);
+    };
+    let Some((to_index, to_root, _)) = roots.root_for_path(to) else {
+        return Ok(None);
+    };
+    if from_index != to_index || from_root != to_root {
+        return Ok(None);
+    }
+    let Some(expected_identity) = from_state.device_id else {
+        return Ok(None);
+    };
+    let mount_generation = match root_mount_generation(&from_root) {
+        Ok(generation) => generation,
+        Err(error) => {
+            mark_cached_root_unavailable(db, roots, from_index).await;
+            warn!(root = %from_root.display(), %error, "Could not capture rename mount generation");
+            return Ok(None);
+        }
+    };
+
+    Ok(Some(WatcherRenameGuard {
+        root_index: from_index,
+        root: from_root,
+        expected_identity,
+        mount_generation,
+    }))
+}
+
 /// Delete a watcher-reported missing path only while its confirmed root
 /// identity remains stable across the database transaction.
 async fn delete_track_if_root_stable(
@@ -1643,6 +1722,215 @@ fn marker_event_invalidates_root(kind: notify::EventKind) -> bool {
     )
 }
 
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct WatcherRenamePair {
+    from: PathBuf,
+    to: PathBuf,
+}
+
+#[derive(Debug, Default)]
+struct WatcherBatch {
+    upsert_paths: HashSet<PathBuf>,
+    remove_paths: HashSet<PathBuf>,
+    rename_pairs: HashSet<WatcherRenamePair>,
+    paired_paths: HashSet<PathBuf>,
+    identity_changed_roots: HashSet<PathBuf>,
+    tracked_rename_from: HashMap<usize, PathBuf>,
+    adjacent_untracked_rename_from: Option<PathBuf>,
+    reconciliation_required: bool,
+}
+
+impl WatcherBatch {
+    fn collect(&mut self, mut event: notify::Event) {
+        use notify::event::{CreateKind, ModifyKind, RemoveKind, RenameMode};
+        use notify::EventKind;
+
+        let marker_invalidates_root = marker_event_invalidates_root(event.kind);
+        event.paths.retain(|path| {
+            if path
+                .file_name()
+                .is_some_and(|name| name == ROOT_IDENTITY_FILE)
+            {
+                if marker_invalidates_root {
+                    if let Some(root) = path.parent() {
+                        self.identity_changed_roots.insert(root.to_path_buf());
+                    }
+                }
+                false
+            } else {
+                true
+            }
+        });
+        if event.paths.is_empty() {
+            self.adjacent_untracked_rename_from = None;
+            return;
+        }
+
+        let tracker = event.tracker();
+        let is_adjacent_untracked_to = tracker.is_none()
+            && matches!(
+                event.kind,
+                EventKind::Modify(ModifyKind::Name(RenameMode::To))
+            )
+            && event.paths.len() == 1;
+        if !is_adjacent_untracked_to {
+            self.adjacent_untracked_rename_from = None;
+        }
+
+        match event.kind {
+            EventKind::Remove(kind) => {
+                let folder = matches!(kind, RemoveKind::Folder);
+                for path in event.paths {
+                    if folder {
+                        self.reconciliation_required = true;
+                    } else {
+                        self.record_remove(path);
+                    }
+                }
+            }
+            EventKind::Modify(ModifyKind::Name(RenameMode::From)) => {
+                let candidate = (event.paths.len() == 1).then(|| event.paths[0].clone());
+                for path in event.paths {
+                    self.record_remove(path);
+                }
+                if let Some(path) = candidate {
+                    if let Some(tracker) = tracker {
+                        self.tracked_rename_from.insert(tracker, path);
+                    } else {
+                        self.adjacent_untracked_rename_from = Some(path);
+                    }
+                } else {
+                    self.reconciliation_required = true;
+                }
+            }
+            EventKind::Modify(ModifyKind::Name(RenameMode::To)) => {
+                let candidate = (event.paths.len() == 1).then(|| event.paths[0].clone());
+                for path in event.paths {
+                    self.record_upsert(path);
+                }
+                if let Some(to) = candidate {
+                    let from = tracker
+                        .and_then(|tracker| self.tracked_rename_from.remove(&tracker))
+                        .or_else(|| {
+                            tracker
+                                .is_none()
+                                .then(|| self.adjacent_untracked_rename_from.take())
+                                .flatten()
+                        });
+                    if let Some(from) = from {
+                        self.record_rename_pair(from, to);
+                    }
+                } else {
+                    self.reconciliation_required = true;
+                }
+            }
+            EventKind::Modify(ModifyKind::Name(RenameMode::Both)) => {
+                if event.paths.len() == 2 {
+                    let from = event.paths[0].clone();
+                    let to = event.paths[1].clone();
+                    if let Some(tracker) = tracker {
+                        self.tracked_rename_from.remove(&tracker);
+                    }
+                    self.record_rename_pair(from, to);
+                } else {
+                    self.reconciliation_required = true;
+                }
+            }
+            EventKind::Modify(ModifyKind::Name(_)) => {
+                // FSEvents and kqueue cannot associate the old and new sides.
+                // Never infer identity from metadata; a guarded scan performs
+                // the conservative delete/upsert fallback.
+                self.reconciliation_required = true;
+            }
+            EventKind::Create(kind) => {
+                let folder = matches!(kind, CreateKind::Folder);
+                for path in event.paths {
+                    if folder {
+                        self.reconciliation_required = true;
+                    } else {
+                        self.record_upsert(path);
+                    }
+                }
+            }
+            EventKind::Modify(_) => {
+                for path in event.paths {
+                    self.record_upsert(path);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn record_remove(&mut self, path: PathBuf) {
+        if self.paired_paths.contains(&path) {
+            return;
+        }
+        if tag_parser::is_audio_file(&path) {
+            self.upsert_paths.remove(&path);
+            self.remove_paths.insert(path);
+        } else {
+            self.reconciliation_required = true;
+        }
+    }
+
+    fn record_upsert(&mut self, path: PathBuf) {
+        if self.paired_paths.contains(&path) {
+            return;
+        }
+        if path.is_dir() {
+            self.reconciliation_required = true;
+        } else if tag_parser::is_audio_file(&path) {
+            self.remove_paths.remove(&path);
+            self.upsert_paths.insert(path);
+        }
+    }
+
+    fn record_rename_pair(&mut self, from: PathBuf, to: PathBuf) {
+        let pair = WatcherRenamePair { from, to };
+        if pair.from == pair.to {
+            self.record_upsert(pair.to);
+            return;
+        }
+        if self.rename_pairs.contains(&pair) {
+            return;
+        }
+        if self
+            .rename_pairs
+            .iter()
+            .any(|existing| rename_pairs_overlap(existing, &pair))
+        {
+            // Overlapping/chained pairs cannot be applied independently
+            // without ordering and inode guarantees. Reconcile instead.
+            self.reconciliation_required = true;
+            self.rename_pairs
+                .retain(|existing| !rename_pairs_overlap(existing, &pair));
+            return;
+        }
+
+        self.upsert_paths.remove(&pair.from);
+        self.upsert_paths.remove(&pair.to);
+        self.remove_paths.remove(&pair.from);
+        self.remove_paths.remove(&pair.to);
+        self.paired_paths.insert(pair.from.clone());
+        self.paired_paths.insert(pair.to.clone());
+        self.rename_pairs.insert(pair);
+    }
+
+    fn is_empty(&self) -> bool {
+        self.upsert_paths.is_empty()
+            && self.remove_paths.is_empty()
+            && self.rename_pairs.is_empty()
+            && self.identity_changed_roots.is_empty()
+            && !self.reconciliation_required
+    }
+}
+
+fn rename_pairs_overlap(left: &WatcherRenamePair, right: &WatcherRenamePair) -> bool {
+    [&left.from, &left.to]
+        .into_iter()
+        .any(|path| path == &right.from || path == &right.to)
+}
+
 async fn reconcile_playlists_after_watcher_batch(
     db: &DatabaseConnection,
     upsert_committed: bool,
@@ -1667,7 +1955,9 @@ async fn watch_directories(
         move |res| {
             let _ = notify_tx.blocking_send(res);
         },
-        notify::Config::default().with_poll_interval(Duration::from_secs(2)),
+        notify::Config::default()
+            .with_poll_interval(Duration::from_secs(2))
+            .with_follow_symlinks(false),
     )?;
 
     // Watch each directory independently. A missing or unwatchable directory
@@ -1703,94 +1993,20 @@ async fn watch_directories(
         let first = notify_rx.recv().await;
         let Some(first) = first else { break };
 
-        // Collect the first event + any more that arrive within the
-        // debounce window into path sets.
-        let mut upsert_paths: HashSet<PathBuf> = HashSet::new();
-        let mut remove_paths: HashSet<PathBuf> = HashSet::new();
-        let mut identity_changed_roots: HashSet<PathBuf> = HashSet::new();
-
-        let mut collect_event = |mut event: notify::Event| {
-            use notify::event::{ModifyKind, RenameMode};
-            use notify::EventKind;
-
-            let marker_invalidates_root = marker_event_invalidates_root(event.kind);
-
-            // The root marker is a control file, not media. Any create,
-            // content/identity change, rename, removal, or unknown event
-            // invalidates cached authorization and requires a future complete
-            // scan before watcher writes resume. Read/access events are
-            // expected from identity probes and are ignored.
-            event.paths.retain(|path| {
-                if path
-                    .file_name()
-                    .is_some_and(|name| name == ROOT_IDENTITY_FILE)
-                {
-                    if marker_invalidates_root {
-                        if let Some(root) = path.parent() {
-                            identity_changed_roots.insert(root.to_path_buf());
-                        }
-                    }
-                    false
-                } else {
-                    true
-                }
-            });
-
-            // Classify each path as a removal or an upsert. A rename is
-            // delivered as Modify(Name(...)) rather than Remove: the "from"
-            // side must be treated as a removal (the file is gone at the old
-            // path) and the "to" side as an upsert. Routing a rename through
-            // the generic Modify upsert arm would re-add the new path while
-            // leaving the old path orphaned as a stale DB row.
-            match event.kind {
-                EventKind::Remove(_) | EventKind::Modify(ModifyKind::Name(RenameMode::From)) => {
-                    for path in event.paths {
-                        if !tag_parser::is_audio_file(&path) {
-                            continue;
-                        }
-                        upsert_paths.remove(&path);
-                        remove_paths.insert(path);
-                    }
-                }
-                EventKind::Modify(ModifyKind::Name(RenameMode::Both)) => {
-                    // RenameMode::Both packs [from, to] into event.paths.
-                    let mut iter = event.paths.into_iter();
-                    if let Some(from) = iter.next() {
-                        if tag_parser::is_audio_file(&from) {
-                            upsert_paths.remove(&from);
-                            remove_paths.insert(from);
-                        }
-                    }
-                    for to in iter {
-                        if !tag_parser::is_audio_file(&to) {
-                            continue;
-                        }
-                        remove_paths.remove(&to);
-                        upsert_paths.insert(to);
-                    }
-                }
-                EventKind::Create(_) | EventKind::Modify(_) => {
-                    for path in event.paths {
-                        if !tag_parser::is_audio_file(&path) {
-                            continue;
-                        }
-                        remove_paths.remove(&path);
-                        upsert_paths.insert(path);
-                    }
-                }
-                _ => {}
-            }
-        };
+        // Preserve event order and tracker metadata until rename halves have
+        // been normalized. Flattening immediately into unordered path sets
+        // would discard the only authoritative identity association.
+        let mut batch = WatcherBatch::default();
 
         if let Ok(event) = first {
-            collect_event(event);
+            batch.collect(event);
         }
 
         // Drain any additional events that arrive within the debounce window.
         let deadline = tokio::time::Instant::now() + Duration::from_millis(DEBOUNCE_MS);
         loop {
             match tokio::time::timeout_at(deadline, notify_rx.recv()).await {
-                Ok(Some(Ok(event))) => collect_event(event),
+                Ok(Some(Ok(event))) => batch.collect(event),
                 Ok(Some(Err(e))) => {
                     warn!(error = %e, "Filesystem watcher error");
                 }
@@ -1798,7 +2014,7 @@ async fn watch_directories(
             }
         }
 
-        if remove_paths.is_empty() && upsert_paths.is_empty() && identity_changed_roots.is_empty() {
+        if batch.is_empty() {
             continue;
         }
 
@@ -1813,15 +2029,126 @@ async fn watch_directories(
             }
         };
 
-        for root in identity_changed_roots {
-            if let Some(index) = root_cache.exact_root(&root) {
+        for root in &batch.identity_changed_roots {
+            if let Some(index) = root_cache.exact_root(root) {
                 mark_cached_root_unavailable(db.as_ref(), &mut root_cache, index).await;
                 warn!(root = %root.display(), "Library root marker changed — watcher writes disabled until rescan");
             }
         }
 
+        let mut reconciliation_required = batch.reconciliation_required;
+        let mut upsert_committed = false;
+
+        // Apply authoritative same-root file rename pairs before standalone
+        // removals and upserts. This keeps the source row alive, preserving
+        // its stable ID, historical fields, and direct playlist references.
+        for pair in &batch.rename_pairs {
+            if !same_audio_extension(&pair.from, &pair.to)
+                || !is_regular_file_without_following_symlinks(&pair.to)
+            {
+                reconciliation_required = true;
+                continue;
+            }
+
+            let guard = match prepare_watcher_rename_guard(
+                db.as_ref(),
+                &mut root_cache,
+                music_dirs,
+                &pair.from,
+                &pair.to,
+            )
+            .await
+            {
+                Ok(Some(guard)) => guard,
+                Ok(None) => {
+                    reconciliation_required = true;
+                    continue;
+                }
+                Err(error) => {
+                    warn!(from = %pair.from.display(), to = %pair.to.display(), %error, "Failed to authorize paired rename");
+                    reconciliation_required = true;
+                    continue;
+                }
+            };
+
+            let to_parse = pair.to.clone();
+            let parsed = match tokio::task::spawn_blocking(move || {
+                tag_parser::parse_audio_file(&to_parse)
+            })
+            .await
+            {
+                Ok(Ok(parsed)) => Some(parsed),
+                Ok(Err(error)) => {
+                    warn!(to = %pair.to.display(), %error, "Renamed file could not be reparsed; preserving identity and scheduling reconciliation");
+                    reconciliation_required = true;
+                    None
+                }
+                Err(error) => {
+                    warn!(to = %pair.to.display(), %error, "Rename parser task failed; preserving identity and scheduling reconciliation");
+                    reconciliation_required = true;
+                    None
+                }
+            };
+
+            if !guard.commit_allowed(music_dirs, &pair.from, &pair.to) {
+                if !guard.root_is_stable() {
+                    mark_cached_root_unavailable(db.as_ref(), &mut root_cache, guard.root_index)
+                        .await;
+                }
+                reconciliation_required = true;
+                continue;
+            }
+
+            match rename_track_row(db.as_ref(), &pair.from, &pair.to, parsed.as_ref(), || {
+                guard.commit_allowed(music_dirs, &pair.from, &pair.to)
+            })
+            .await
+            {
+                Ok(RenameTrackOutcome::Renamed { model, displaced }) => {
+                    let _ = tx
+                        .send(LibraryEvent::TrackRemoved(
+                            pair.from.to_string_lossy().into_owned(),
+                        ))
+                        .await;
+                    if let Some(displaced) = displaced {
+                        let displaced = *displaced;
+                        let _ = tx
+                            .send(LibraryEvent::TrackRemoved(displaced.file_path))
+                            .await;
+                    }
+                    let _ = tx
+                        .send(LibraryEvent::TrackUpserted(Box::new(db_model_to_track(
+                            &model,
+                        ))))
+                        .await;
+                    upsert_committed = true;
+                    info!(from = %pair.from.display(), to = %pair.to.display(), id = %model.id, "Preserved track identity across filesystem rename");
+                }
+                Ok(RenameTrackOutcome::SourceMissing) => {
+                    debug!(from = %pair.from.display(), to = %pair.to.display(), "Rename source was not indexed; falling back to reconciliation");
+                    reconciliation_required = true;
+                }
+                Ok(RenameTrackOutcome::GuardRejected) => {
+                    if !guard.root_is_stable() {
+                        mark_cached_root_unavailable(
+                            db.as_ref(),
+                            &mut root_cache,
+                            guard.root_index,
+                        )
+                        .await;
+                    }
+                    warn!(from = %pair.from.display(), to = %pair.to.display(), "Filesystem changed before paired rename commit; transaction rolled back");
+                    reconciliation_required = true;
+                }
+                Err(error) => {
+                    warn!(from = %pair.from.display(), to = %pair.to.display(), %error, "Failed to update paired rename transactionally");
+                    reconciliation_required = true;
+                }
+            }
+        }
+
         // Process removals.
-        for path in &remove_paths {
+        for path in &batch.remove_paths {
             let path_str = path.to_string_lossy().to_string();
             debug!(path = %path_str, "File removed (debounced)");
             match delete_track_if_root_stable(db.as_ref(), &mut root_cache, music_dirs, path).await
@@ -1839,10 +2166,12 @@ async fn watch_directories(
         }
 
         // Process upserts from the shared, batch-scoped root snapshot.
-        let mut upsert_committed = false;
-        if !upsert_paths.is_empty() {
-            debug!(count = upsert_paths.len(), "Processing debounced upserts");
-            let paths: Vec<PathBuf> = upsert_paths.into_iter().collect();
+        if !batch.upsert_paths.is_empty() {
+            debug!(
+                count = batch.upsert_paths.len(),
+                "Processing debounced upserts"
+            );
+            let paths: Vec<PathBuf> = batch.upsert_paths.drain().collect();
 
             for path in paths {
                 match root_identity_allows_content(db.as_ref(), &mut root_cache, music_dirs, &path)
@@ -1928,6 +2257,17 @@ async fn watch_directories(
             }
         }
 
+        // Directory changes and unpairable rename shapes deliberately avoid
+        // guessing identity. Reuse the hardened authoritative scan once per
+        // batch as the conservative reconciliation fallback.
+        if reconciliation_required {
+            info!("Reconciling library after unpaired or directory watcher changes");
+            if let Err(error) = initial_scan(db.as_ref(), music_dirs, tx).await {
+                warn!(%error, "Watcher-triggered library reconciliation failed");
+            }
+            continue;
+        }
+
         // Deletions null playlist links through the database foreign key.
         // Reconcile once after all successful upserts in this debounced batch
         // so a replacement file can restore those links immediately. A
@@ -1951,31 +2291,21 @@ async fn watch_directories(
 // ---------------------------------------------------------------------------
 
 /// Insert or update a track in the database, returning the final Model.
-async fn upsert_track(
-    db: &DatabaseConnection,
+async fn upsert_track<C>(
+    db: &C,
     parsed: &ParsedTrack,
     existing: Option<&track::Model>,
-) -> anyhow::Result<track::Model> {
+) -> anyhow::Result<track::Model>
+where
+    C: ConnectionTrait,
+{
     let now = Utc::now().to_rfc3339();
     let mtime = parsed.date_modified.to_rfc3339();
 
     if let Some(row) = existing {
         // Update existing
         let mut active: track::ActiveModel = row.clone().into();
-        active.title = Set(parsed.title.clone());
-        active.artist_name = Set(parsed.artist_name.clone());
-        active.album_artist_name = Set(parsed.album_artist_name.clone());
-        active.album_title = Set(parsed.album_title.clone());
-        active.genre = Set(parsed.genre.clone());
-        active.year = Set(parsed.year);
-        active.track_number = Set(parsed.track_number.map(|n| n as i32));
-        active.disc_number = Set(parsed.disc_number.map(|n| n as i32));
-        active.duration_secs = Set(parsed.duration_secs.map(|d| d as i64));
-        active.bitrate_kbps = Set(parsed.bitrate_kbps.map(|b| b as i32));
-        active.sample_rate_hz = Set(parsed.sample_rate_hz.map(|s| s as i32));
-        active.format = Set(Some(parsed.format.clone()));
-        active.date_modified = Set(mtime);
-        active.file_size_bytes = Set(parsed.file_size_bytes.map(|s| s as i64));
+        apply_parsed_track_fields(&mut active, parsed, mtime);
 
         let model = active.update(db).await?;
         debug!(path = %parsed.file_path, "Updated track in database");
@@ -2007,6 +2337,117 @@ async fn upsert_track(
         let model = active.insert(db).await?;
         debug!(path = %parsed.file_path, "Inserted new track into database");
         Ok(model)
+    }
+}
+
+fn apply_parsed_track_fields(
+    active: &mut track::ActiveModel,
+    parsed: &ParsedTrack,
+    date_modified: String,
+) {
+    active.file_path = Set(parsed.file_path.clone());
+    active.title = Set(parsed.title.clone());
+    active.artist_name = Set(parsed.artist_name.clone());
+    active.album_artist_name = Set(parsed.album_artist_name.clone());
+    active.album_title = Set(parsed.album_title.clone());
+    active.genre = Set(parsed.genre.clone());
+    active.year = Set(parsed.year);
+    active.track_number = Set(parsed.track_number.map(|n| n as i32));
+    active.disc_number = Set(parsed.disc_number.map(|n| n as i32));
+    active.duration_secs = Set(parsed.duration_secs.map(|d| d as i64));
+    active.bitrate_kbps = Set(parsed.bitrate_kbps.map(|b| b as i32));
+    active.sample_rate_hz = Set(parsed.sample_rate_hz.map(|s| s as i32));
+    active.format = Set(Some(parsed.format.clone()));
+    active.date_modified = Set(date_modified);
+    active.file_size_bytes = Set(parsed.file_size_bytes.map(|s| s as i64));
+}
+
+#[derive(Debug)]
+enum RenameTrackOutcome {
+    Renamed {
+        model: Box<track::Model>,
+        displaced: Option<Box<track::Model>>,
+    },
+    SourceMissing,
+    GuardRejected,
+}
+
+/// Atomically retarget one existing track row to an authoritative paired
+/// rename destination. The row ID, date-added timestamp, play count, and
+/// playlist references remain untouched. If the filesystem rename replaced
+/// an already-indexed destination, that displaced row is removed in the same
+/// transaction before the source claims its unique path.
+async fn rename_track_row<F>(
+    db: &DatabaseConnection,
+    from: &Path,
+    to: &Path,
+    parsed: Option<&ParsedTrack>,
+    commit_guard: F,
+) -> anyhow::Result<RenameTrackOutcome>
+where
+    F: FnOnce() -> bool,
+{
+    let from_path = from.to_string_lossy().into_owned();
+    let to_path = to.to_string_lossy().into_owned();
+    if parsed.is_some_and(|parsed| parsed.file_path != to_path) {
+        return Err(anyhow::anyhow!(
+            "parsed rename destination does not match the paired target path"
+        ));
+    }
+    let transaction = db.begin().await?;
+
+    let result: anyhow::Result<RenameTrackOutcome> = async {
+        let Some(source) = track::Entity::find()
+            .filter(track::Column::FilePath.eq(&from_path))
+            .one(&transaction)
+            .await?
+        else {
+            return Ok(RenameTrackOutcome::SourceMissing);
+        };
+
+        let displaced = track::Entity::find()
+            .filter(track::Column::FilePath.eq(&to_path))
+            .one(&transaction)
+            .await?
+            .filter(|destination| destination.id != source.id);
+        if let Some(destination) = &displaced {
+            track::Entity::delete_by_id(&destination.id)
+                .exec(&transaction)
+                .await?;
+        }
+
+        let model = if let Some(parsed) = parsed {
+            upsert_track(&transaction, parsed, Some(&source)).await?
+        } else {
+            let mut active: track::ActiveModel = source.into();
+            active.file_path = Set(to_path);
+            active.update(&transaction).await?
+        };
+
+        if !commit_guard() {
+            return Ok(RenameTrackOutcome::GuardRejected);
+        }
+
+        Ok(RenameTrackOutcome::Renamed {
+            model: Box::new(model),
+            displaced: displaced.map(Box::new),
+        })
+    }
+    .await;
+
+    match result {
+        Ok(outcome @ RenameTrackOutcome::Renamed { .. }) => {
+            transaction.commit().await?;
+            Ok(outcome)
+        }
+        Ok(outcome) => {
+            transaction.rollback().await?;
+            Ok(outcome)
+        }
+        Err(error) => {
+            transaction.rollback().await?;
+            Err(error)
+        }
     }
 }
 
@@ -2054,6 +2495,8 @@ pub fn db_model_to_track(model: &track::Model) -> Track {
 
 #[cfg(test)]
 mod tests {
+    use sea_orm::QueryOrder;
+
     use super::*;
 
     struct TestDirectory {
@@ -2077,6 +2520,464 @@ mod tests {
         fn drop(&mut self) {
             let _ = std::fs::remove_dir_all(&self.path);
         }
+    }
+
+    fn rename_event(
+        mode: notify::event::RenameMode,
+        paths: &[&str],
+        tracker: Option<usize>,
+    ) -> notify::Event {
+        let mut event = notify::Event::new(notify::EventKind::Modify(
+            notify::event::ModifyKind::Name(mode),
+        ));
+        for path in paths {
+            event = event.add_path(PathBuf::from(path));
+        }
+        if let Some(tracker) = tracker {
+            event = event.set_tracker(tracker);
+        }
+        event
+    }
+
+    #[test]
+    fn watcher_batch_normalizes_both_rename_without_fallback_paths() {
+        let mut batch = WatcherBatch::default();
+        batch.collect(rename_event(
+            notify::event::RenameMode::Both,
+            &["/music/old.flac", "/music/new.flac"],
+            Some(7),
+        ));
+
+        assert_eq!(
+            batch.rename_pairs,
+            HashSet::from([WatcherRenamePair {
+                from: PathBuf::from("/music/old.flac"),
+                to: PathBuf::from("/music/new.flac"),
+            }])
+        );
+        assert!(batch.remove_paths.is_empty());
+        assert!(batch.upsert_paths.is_empty());
+        assert!(!batch.reconciliation_required);
+    }
+
+    #[test]
+    fn watcher_batch_deduplicates_linux_from_to_and_both_events() {
+        let mut batch = WatcherBatch::default();
+        batch.collect(rename_event(
+            notify::event::RenameMode::From,
+            &["/music/old.flac"],
+            Some(41),
+        ));
+        batch.collect(rename_event(
+            notify::event::RenameMode::To,
+            &["/music/new.flac"],
+            Some(41),
+        ));
+        batch.collect(rename_event(
+            notify::event::RenameMode::Both,
+            &["/music/old.flac", "/music/new.flac"],
+            Some(41),
+        ));
+
+        assert_eq!(batch.rename_pairs.len(), 1);
+        assert!(batch.remove_paths.is_empty());
+        assert!(batch.upsert_paths.is_empty());
+    }
+
+    #[test]
+    fn watcher_batch_pairs_only_adjacent_untracked_windows_halves() {
+        let mut paired = WatcherBatch::default();
+        paired.collect(rename_event(
+            notify::event::RenameMode::From,
+            &["C:/Music/old.flac"],
+            None,
+        ));
+        paired.collect(rename_event(
+            notify::event::RenameMode::To,
+            &["C:/Music/new.flac"],
+            None,
+        ));
+        assert_eq!(paired.rename_pairs.len(), 1);
+        assert!(paired.remove_paths.is_empty());
+        assert!(paired.upsert_paths.is_empty());
+
+        let mut interleaved = WatcherBatch::default();
+        interleaved.collect(rename_event(
+            notify::event::RenameMode::From,
+            &["C:/Music/old.flac"],
+            None,
+        ));
+        interleaved.collect(
+            notify::Event::new(notify::EventKind::Create(notify::event::CreateKind::File))
+                .add_path(PathBuf::from("C:/Music/unrelated.flac")),
+        );
+        interleaved.collect(rename_event(
+            notify::event::RenameMode::To,
+            &["C:/Music/new.flac"],
+            None,
+        ));
+        assert!(interleaved.rename_pairs.is_empty());
+        assert!(interleaved
+            .remove_paths
+            .contains(Path::new("C:/Music/old.flac")));
+        assert!(interleaved
+            .upsert_paths
+            .contains(Path::new("C:/Music/new.flac")));
+    }
+
+    #[test]
+    fn watcher_batch_routes_unpairable_and_directory_events_to_reconciliation() {
+        let mut batch = WatcherBatch::default();
+        batch.collect(rename_event(
+            notify::event::RenameMode::Any,
+            &["/music/unknown"],
+            None,
+        ));
+        batch.collect(
+            notify::Event::new(notify::EventKind::Remove(notify::event::RemoveKind::Folder))
+                .add_path(PathBuf::from("/music/album")),
+        );
+
+        assert!(batch.reconciliation_required);
+        assert!(batch.rename_pairs.is_empty());
+    }
+
+    async fn rename_test_database() -> DatabaseConnection {
+        use sea_orm::Database;
+        use sea_orm_migration::MigratorTrait;
+
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("open in-memory database");
+        crate::db::migration::Migrator::up(&db, None)
+            .await
+            .expect("run migrations");
+        db
+    }
+
+    async fn insert_rename_test_track(
+        db: &DatabaseConnection,
+        id: &str,
+        path: &str,
+        title: &str,
+        play_count: i32,
+    ) -> track::Model {
+        let model = track::Model {
+            id: id.to_string(),
+            file_path: path.to_string(),
+            title: title.to_string(),
+            artist_name: "Original Artist".to_string(),
+            album_artist_name: Some("Original Album Artist".to_string()),
+            album_title: "Original Album".to_string(),
+            genre: Some("Original Genre".to_string()),
+            year: Some(2001),
+            track_number: Some(1),
+            disc_number: Some(1),
+            duration_secs: Some(180),
+            bitrate_kbps: Some(192),
+            sample_rate_hz: Some(44_100),
+            format: Some("FLAC".to_string()),
+            play_count,
+            date_added: "2025-01-02T03:04:05Z".to_string(),
+            date_modified: "2025-01-02T03:04:05Z".to_string(),
+            file_size_bytes: Some(1_000),
+        };
+        let active: track::ActiveModel = model.into();
+        active.insert(db).await.expect("insert rename test track")
+    }
+
+    fn parsed_rename_track(path: &str, title: &str) -> ParsedTrack {
+        ParsedTrack {
+            file_path: path.to_string(),
+            title: title.to_string(),
+            artist_name: "Updated Artist".to_string(),
+            album_artist_name: Some("Updated Album Artist".to_string()),
+            album_title: "Updated Album".to_string(),
+            genre: Some("Updated Genre".to_string()),
+            year: Some(2026),
+            track_number: Some(2),
+            disc_number: Some(2),
+            duration_secs: Some(240),
+            bitrate_kbps: Some(320),
+            sample_rate_hz: Some(48_000),
+            format: "FLAC".to_string(),
+            date_modified: chrono::DateTime::parse_from_rfc3339("2026-07-12T12:34:56Z")
+                .expect("parse fixture timestamp")
+                .with_timezone(&Utc),
+            file_size_bytes: Some(2_000),
+        }
+    }
+
+    #[tokio::test]
+    async fn paired_rename_preserves_track_history_and_playlist_linkage() {
+        use crate::db::entities::playlist_entry;
+
+        let db = rename_test_database().await;
+        let manager = super::super::playlist_manager::PlaylistManager::new(db.clone());
+        let playlist = manager
+            .create_playlist("Rename", false)
+            .await
+            .expect("create playlist");
+        let source = insert_rename_test_track(
+            &db,
+            "stable-track-id",
+            "/music/old.flac",
+            "Original Title",
+            17,
+        )
+        .await;
+        manager
+            .add_track(&playlist.id, &source)
+            .await
+            .expect("add source to playlist");
+        let entry_before = playlist_entry::Entity::find()
+            .filter(playlist_entry::Column::PlaylistId.eq(&playlist.id))
+            .one(&db)
+            .await
+            .expect("load playlist entry")
+            .expect("playlist entry exists");
+        let parsed = parsed_rename_track("/music/new.flac", "Updated Title");
+
+        let outcome = rename_track_row(
+            &db,
+            Path::new("/music/old.flac"),
+            Path::new("/music/new.flac"),
+            Some(&parsed),
+            || true,
+        )
+        .await
+        .expect("rename track row");
+        assert!(matches!(
+            outcome,
+            RenameTrackOutcome::Renamed {
+                displaced: None,
+                ..
+            }
+        ));
+
+        let renamed = track::Entity::find_by_id("stable-track-id")
+            .one(&db)
+            .await
+            .expect("load renamed track")
+            .expect("renamed track exists");
+        assert_eq!(renamed.file_path, "/music/new.flac");
+        assert_eq!(renamed.title, "Updated Title");
+        assert_eq!(renamed.artist_name, "Updated Artist");
+        assert_eq!(renamed.play_count, 17);
+        assert_eq!(renamed.date_added, "2025-01-02T03:04:05Z");
+
+        let entry_after = playlist_entry::Entity::find_by_id(&entry_before.id)
+            .one(&db)
+            .await
+            .expect("reload playlist entry")
+            .expect("playlist entry remains");
+        assert_eq!(entry_after, entry_before);
+        assert_eq!(entry_after.track_id.as_deref(), Some("stable-track-id"));
+    }
+
+    #[tokio::test]
+    async fn paired_rename_atomically_replaces_an_occupied_destination() {
+        use crate::db::entities::playlist_entry;
+
+        let db = rename_test_database().await;
+        let manager = super::super::playlist_manager::PlaylistManager::new(db.clone());
+        let playlist = manager
+            .create_playlist("Overwrite", false)
+            .await
+            .expect("create playlist");
+        let source =
+            insert_rename_test_track(&db, "source-track", "/music/source.flac", "Source", 9).await;
+        let destination = insert_rename_test_track(
+            &db,
+            "destination-track",
+            "/music/destination.flac",
+            "Destination",
+            3,
+        )
+        .await;
+        manager
+            .add_track(&playlist.id, &source)
+            .await
+            .expect("add source to playlist");
+        manager
+            .add_track(&playlist.id, &destination)
+            .await
+            .expect("add destination to playlist");
+        let parsed = parsed_rename_track("/music/destination.flac", "Source Renamed");
+
+        let outcome = rename_track_row(
+            &db,
+            Path::new("/music/source.flac"),
+            Path::new("/music/destination.flac"),
+            Some(&parsed),
+            || true,
+        )
+        .await
+        .expect("overwrite destination transactionally");
+        assert!(matches!(
+            outcome,
+            RenameTrackOutcome::Renamed {
+                displaced: Some(ref displaced),
+                ..
+            } if displaced.id == "destination-track"
+        ));
+        assert!(track::Entity::find_by_id("destination-track")
+            .one(&db)
+            .await
+            .expect("query displaced track")
+            .is_none());
+        assert_eq!(
+            track::Entity::find_by_id("source-track")
+                .one(&db)
+                .await
+                .expect("query source track")
+                .expect("source survives")
+                .file_path,
+            "/music/destination.flac"
+        );
+
+        let entries = playlist_entry::Entity::find()
+            .filter(playlist_entry::Column::PlaylistId.eq(&playlist.id))
+            .order_by_asc(playlist_entry::Column::Position)
+            .all(&db)
+            .await
+            .expect("load overwrite playlist entries");
+        assert_eq!(entries[0].track_id.as_deref(), Some("source-track"));
+        assert_eq!(entries[1].track_id, None);
+    }
+
+    #[tokio::test]
+    async fn paired_rename_guard_rejection_rolls_back_every_database_change() {
+        let db = rename_test_database().await;
+        let source =
+            insert_rename_test_track(&db, "guard-source", "/music/guard-source.flac", "Source", 4)
+                .await;
+        let destination = insert_rename_test_track(
+            &db,
+            "guard-destination",
+            "/music/guard-destination.flac",
+            "Destination",
+            5,
+        )
+        .await;
+        let parsed = parsed_rename_track("/music/guard-destination.flac", "Changed");
+
+        assert!(matches!(
+            rename_track_row(
+                &db,
+                Path::new("/music/guard-source.flac"),
+                Path::new("/music/guard-destination.flac"),
+                Some(&parsed),
+                || false,
+            )
+            .await
+            .expect("reject commit guard"),
+            RenameTrackOutcome::GuardRejected
+        ));
+        assert_eq!(
+            track::Entity::find_by_id(&source.id)
+                .one(&db)
+                .await
+                .expect("reload guard source")
+                .expect("guard source remains"),
+            source
+        );
+        assert_eq!(
+            track::Entity::find_by_id(&destination.id)
+                .one(&db)
+                .await
+                .expect("reload guard destination")
+                .expect("guard destination remains"),
+            destination
+        );
+    }
+
+    #[tokio::test]
+    async fn paired_rename_sql_failure_rolls_back_displacement_and_fk_updates() {
+        use crate::db::entities::playlist_entry;
+
+        let db = rename_test_database().await;
+        let manager = super::super::playlist_manager::PlaylistManager::new(db.clone());
+        let playlist = manager
+            .create_playlist("Rollback", false)
+            .await
+            .expect("create playlist");
+        let source = insert_rename_test_track(
+            &db,
+            "rollback-source",
+            "/music/rollback-source.flac",
+            "Source",
+            4,
+        )
+        .await;
+        let destination = insert_rename_test_track(
+            &db,
+            "rollback-destination",
+            "/music/rollback-destination.flac",
+            "Destination",
+            5,
+        )
+        .await;
+        manager
+            .add_track(&playlist.id, &source)
+            .await
+            .expect("add rollback source");
+        manager
+            .add_track(&playlist.id, &destination)
+            .await
+            .expect("add rollback destination");
+        let entries_before = playlist_entry::Entity::find()
+            .filter(playlist_entry::Column::PlaylistId.eq(&playlist.id))
+            .order_by_asc(playlist_entry::Column::Position)
+            .all(&db)
+            .await
+            .expect("load entries before rollback");
+        db.execute_unprepared(
+            "CREATE TRIGGER fail_track_rename
+             BEFORE UPDATE OF file_path ON tracks
+             WHEN OLD.id = 'rollback-source'
+             BEGIN
+                 SELECT RAISE(ABORT, 'injected rename failure');
+             END",
+        )
+        .await
+        .expect("create failure trigger");
+        let parsed = parsed_rename_track("/music/rollback-destination.flac", "Changed");
+
+        assert!(rename_track_row(
+            &db,
+            Path::new("/music/rollback-source.flac"),
+            Path::new("/music/rollback-destination.flac"),
+            Some(&parsed),
+            || true,
+        )
+        .await
+        .is_err());
+        assert_eq!(
+            track::Entity::find_by_id(&source.id)
+                .one(&db)
+                .await
+                .expect("reload rollback source")
+                .expect("rollback source remains"),
+            source
+        );
+        assert_eq!(
+            track::Entity::find_by_id(&destination.id)
+                .one(&db)
+                .await
+                .expect("reload rollback destination")
+                .expect("rollback destination remains"),
+            destination
+        );
+        assert_eq!(
+            playlist_entry::Entity::find()
+                .filter(playlist_entry::Column::PlaylistId.eq(&playlist.id))
+                .order_by_asc(playlist_entry::Column::Position)
+                .all(&db)
+                .await
+                .expect("reload entries after rollback"),
+            entries_before
+        );
     }
 
     #[tokio::test]

--- a/src/local/playlist_manager.rs
+++ b/src/local/playlist_manager.rs
@@ -375,19 +375,32 @@ impl PlaylistManager {
                 continue;
             };
 
-            // If duration was recorded, require a candidate within ±2s
-            // (preserving the previous matching semantics); otherwise take
-            // the first fingerprint match.
-            let best = if let Some(dur) = orphan.match_duration_secs {
-                candidates
-                    .iter()
-                    .find(|t| {
-                        t.duration_secs
-                            .is_some_and(|d| (d - i64::from(dur)).abs() <= 2)
+            // Never choose arbitrarily among duplicate fingerprint matches.
+            // Duration narrows the eligible set when available; the orphan is
+            // left unresolved unless exactly one candidate remains.
+            let best = {
+                let expected_duration = orphan.match_duration_secs;
+                let mut eligible = candidates.iter().copied().filter(|candidate| {
+                    expected_duration.is_none_or(|duration| {
+                        candidate
+                            .duration_secs
+                            .is_some_and(|value| (value - i64::from(duration)).abs() <= 2)
                     })
-                    .copied()
-            } else {
-                candidates.first().copied()
+                });
+                match (eligible.next(), eligible.next()) {
+                    (Some(candidate), None) => Some(candidate),
+                    (Some(_), Some(_)) => {
+                        warn!(
+                            entry = %orphan.id,
+                            title = %orphan.match_title,
+                            artist = %orphan.match_artist,
+                            album = %orphan.match_album,
+                            "Playlist entry has multiple eligible track matches; leaving it orphaned"
+                        );
+                        None
+                    }
+                    _ => None,
+                }
             };
 
             if let Some(best) = best {
@@ -508,7 +521,7 @@ mod tests {
     use sea_orm_migration::MigratorTrait;
 
     use super::PlaylistManager;
-    use crate::db::entities::playlist_entry;
+    use crate::db::entities::{playlist_entry, track};
     use crate::db::migration::Migrator;
 
     /// Open a fresh in-memory SQLite database with all migrations applied.
@@ -537,6 +550,51 @@ mod tests {
         .insert(db)
         .await
         .expect("insert entry");
+    }
+
+    async fn insert_track(
+        db: &DatabaseConnection,
+        id: &str,
+        file_path: &str,
+        title: &str,
+        artist: &str,
+        album: &str,
+        duration_secs: Option<i64>,
+    ) -> track::Model {
+        let model = track::Model {
+            id: id.to_string(),
+            file_path: file_path.to_string(),
+            title: title.to_string(),
+            artist_name: artist.to_string(),
+            album_artist_name: None,
+            album_title: album.to_string(),
+            genre: None,
+            year: None,
+            track_number: None,
+            disc_number: None,
+            duration_secs,
+            bitrate_kbps: None,
+            sample_rate_hz: None,
+            format: None,
+            play_count: 0,
+            date_added: "2026-07-12T00:00:00Z".to_string(),
+            date_modified: "2026-07-12T00:00:00Z".to_string(),
+            file_size_bytes: None,
+        };
+        let active: track::ActiveModel = model.into();
+        active.insert(db).await.expect("insert track")
+    }
+
+    async fn playlist_entries(
+        db: &DatabaseConnection,
+        playlist_id: &str,
+    ) -> Vec<playlist_entry::Model> {
+        playlist_entry::Entity::find()
+            .filter(playlist_entry::Column::PlaylistId.eq(playlist_id))
+            .order_by_asc(playlist_entry::Column::Position)
+            .all(db)
+            .await
+            .expect("load playlist entries")
     }
 
     #[tokio::test]
@@ -584,5 +642,280 @@ mod tests {
         // ...and the entries must follow the requested order.
         let ordered_ids: Vec<String> = entries.iter().map(|e| e.id.clone()).collect();
         assert_eq!(ordered_ids, new_order);
+    }
+
+    #[tokio::test]
+    async fn rename_fallback_relinks_without_changing_playlist_entry_identity() {
+        let db = in_memory_db().await;
+        let manager = PlaylistManager::new(db.clone());
+        let playlist = manager
+            .create_playlist("Rename fallback", false)
+            .await
+            .expect("create playlist");
+        let original = insert_track(
+            &db,
+            "track-before-rename",
+            "/music/before.flac",
+            "Example Song",
+            "Example Artist",
+            "Example Album",
+            Some(240),
+        )
+        .await;
+        manager
+            .add_track(&playlist.id, &original)
+            .await
+            .expect("add original track to playlist");
+        let before = playlist_entries(&db, &playlist.id)
+            .await
+            .pop()
+            .expect("playlist entry before rename");
+
+        // The current watcher fallback for an unpaired rename is delete plus
+        // insert. The FK preserves the playlist entry by nulling its link.
+        track::Entity::delete_by_id(&original.id)
+            .exec(&db)
+            .await
+            .expect("delete old track path");
+        let orphan = playlist_entries(&db, &playlist.id)
+            .await
+            .pop()
+            .expect("orphaned playlist entry");
+        assert_eq!(orphan.track_id, None);
+
+        let replacement = insert_track(
+            &db,
+            "track-after-rename",
+            "/music/after.flac",
+            "Example Song",
+            "Example Artist",
+            "Example Album",
+            Some(240),
+        )
+        .await;
+        assert_eq!(manager.reconcile_all().await.expect("reconcile rename"), 1);
+
+        let after = playlist_entries(&db, &playlist.id)
+            .await
+            .pop()
+            .expect("relinked playlist entry");
+        assert_eq!(after.id, before.id);
+        assert_eq!(after.playlist_id, before.playlist_id);
+        assert_eq!(after.position, before.position);
+        assert_eq!(after.match_title, before.match_title);
+        assert_eq!(after.match_artist, before.match_artist);
+        assert_eq!(after.match_album, before.match_album);
+        assert_eq!(after.match_duration_secs, before.match_duration_secs);
+        assert_eq!(after.track_id.as_deref(), Some(replacement.id.as_str()));
+        assert_eq!(
+            manager
+                .reconcile_all()
+                .await
+                .expect("repeat reconciliation"),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn full_rebuild_relinks_all_unique_tracks_and_preserves_order() {
+        let db = in_memory_db().await;
+        let manager = PlaylistManager::new(db.clone());
+        let playlist = manager
+            .create_playlist("Full rebuild", false)
+            .await
+            .expect("create playlist");
+        let first = insert_track(
+            &db,
+            "track-one-old",
+            "/music/one-old.flac",
+            "Song One",
+            "Artist",
+            "Album",
+            Some(180),
+        )
+        .await;
+        let second = insert_track(
+            &db,
+            "track-two-old",
+            "/music/two-old.flac",
+            "Song Two",
+            "Artist",
+            "Album",
+            Some(200),
+        )
+        .await;
+        manager
+            .add_track(&playlist.id, &first)
+            .await
+            .expect("add first track");
+        manager
+            .add_track(&playlist.id, &second)
+            .await
+            .expect("add second track");
+        let before = playlist_entries(&db, &playlist.id).await;
+
+        track::Entity::delete_many()
+            .exec(&db)
+            .await
+            .expect("clear library for rebuild");
+        assert!(playlist_entries(&db, &playlist.id)
+            .await
+            .iter()
+            .all(|entry| entry.track_id.is_none()));
+
+        // Insert in reverse order to ensure matching is fingerprint-based,
+        // not dependent on table or scan order.
+        let second_new = insert_track(
+            &db,
+            "track-two-new",
+            "/music/two-new.flac",
+            "Song Two",
+            "Artist",
+            "Album",
+            Some(200),
+        )
+        .await;
+        let first_new = insert_track(
+            &db,
+            "track-one-new",
+            "/music/one-new.flac",
+            "Song One",
+            "Artist",
+            "Album",
+            Some(180),
+        )
+        .await;
+
+        assert_eq!(manager.reconcile_all().await.expect("reconcile rebuild"), 2);
+        let after = playlist_entries(&db, &playlist.id).await;
+        assert_eq!(
+            after.iter().map(|entry| &entry.id).collect::<Vec<_>>(),
+            before.iter().map(|entry| &entry.id).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            after.iter().map(|entry| entry.position).collect::<Vec<_>>(),
+            vec![0, 1]
+        );
+        assert_eq!(after[0].track_id.as_deref(), Some(first_new.id.as_str()));
+        assert_eq!(after[1].track_id.as_deref(), Some(second_new.id.as_str()));
+    }
+
+    #[tokio::test]
+    async fn reconciliation_leaves_ambiguous_fingerprint_matches_orphaned() {
+        let db = in_memory_db().await;
+        let manager = PlaylistManager::new(db.clone());
+        let playlist = manager
+            .create_playlist("Ambiguous", false)
+            .await
+            .expect("create playlist");
+        let original = insert_track(
+            &db,
+            "ambiguous-old",
+            "/music/ambiguous-old.flac",
+            "Duplicate",
+            "Artist",
+            "Album",
+            Some(210),
+        )
+        .await;
+        manager
+            .add_track(&playlist.id, &original)
+            .await
+            .expect("add original track");
+        track::Entity::delete_by_id(&original.id)
+            .exec(&db)
+            .await
+            .expect("delete original track");
+        insert_track(
+            &db,
+            "ambiguous-a",
+            "/music/ambiguous-a.flac",
+            "Duplicate",
+            "Artist",
+            "Album",
+            Some(209),
+        )
+        .await;
+        insert_track(
+            &db,
+            "ambiguous-b",
+            "/music/ambiguous-b.flac",
+            "Duplicate",
+            "Artist",
+            "Album",
+            Some(211),
+        )
+        .await;
+
+        assert_eq!(
+            manager
+                .reconcile_all()
+                .await
+                .expect("reconcile ambiguous entry"),
+            0
+        );
+        assert_eq!(playlist_entries(&db, &playlist.id).await[0].track_id, None);
+    }
+
+    #[tokio::test]
+    async fn reconciliation_uses_duration_to_select_the_only_eligible_match() {
+        let db = in_memory_db().await;
+        let manager = PlaylistManager::new(db.clone());
+        let playlist = manager
+            .create_playlist("Duration", false)
+            .await
+            .expect("create playlist");
+        let original = insert_track(
+            &db,
+            "duration-old",
+            "/music/duration-old.flac",
+            "Same Fingerprint",
+            "Artist",
+            "Album",
+            Some(240),
+        )
+        .await;
+        manager
+            .add_track(&playlist.id, &original)
+            .await
+            .expect("add original track");
+        track::Entity::delete_by_id(&original.id)
+            .exec(&db)
+            .await
+            .expect("delete original track");
+        let expected = insert_track(
+            &db,
+            "duration-near",
+            "/music/duration-near.flac",
+            "Same Fingerprint",
+            "Artist",
+            "Album",
+            Some(242),
+        )
+        .await;
+        insert_track(
+            &db,
+            "duration-far",
+            "/music/duration-far.flac",
+            "Same Fingerprint",
+            "Artist",
+            "Album",
+            Some(260),
+        )
+        .await;
+
+        assert_eq!(
+            manager
+                .reconcile_all()
+                .await
+                .expect("reconcile by duration"),
+            1
+        );
+        assert_eq!(
+            playlist_entries(&db, &playlist.id).await[0]
+                .track_id
+                .as_deref(),
+            Some(expected.id.as_str())
+        );
     }
 }

--- a/src/ui/objects/track_object.rs
+++ b/src/ui/objects/track_object.rs
@@ -174,6 +174,13 @@ impl TrackObject {
         self.imp().cover_art_url.replace(url.to_string());
     }
 
+    /// Retarget an existing UI row without replacing its occurrence identity.
+    /// The URI is not a displayed GObject property, so no notify signal is
+    /// required; future playback reads it directly from this row.
+    pub(crate) fn set_uri(&self, uri: &str) {
+        self.imp().uri.replace(uri.to_string());
+    }
+
     pub fn set_track_id(&self, id: &str) {
         self.imp().track_id.replace(id.to_string());
     }

--- a/src/ui/playback.rs
+++ b/src/ui/playback.rs
@@ -37,6 +37,47 @@ fn is_library_source(source_id: &str) -> bool {
     source_id == LOCAL_SOURCE_KEY || source_id.starts_with(PLAYLIST_SOURCE_PREFIX)
 }
 
+/// Overlay committed local-library URIs onto an existing playlist projection.
+///
+/// Playlist rows and the local library share stable track IDs, but each
+/// playlist occurrence owns a distinct row identity. Mutating only the URI in
+/// place preserves duplicate ordering and selection while ensuring a later
+/// click builds its queue from the committed path. Empty replacement URIs are
+/// ignored so a transiently unplayable update cannot strand a valid row.
+pub(super) fn refresh_projected_library_uris(
+    projected_rows: &[TrackObject],
+    committed_local_rows: &[TrackObject],
+) -> usize {
+    if projected_rows.is_empty() || committed_local_rows.is_empty() {
+        return 0;
+    }
+
+    let projected_ids: HashSet<String> = projected_rows.iter().map(TrackObject::track_id).collect();
+    let mut committed_uris = HashMap::with_capacity(projected_ids.len());
+    for track in committed_local_rows {
+        let track_id = track.track_id();
+        if !projected_ids.contains(&track_id) {
+            continue;
+        }
+        let uri = track.uri();
+        if !uri.is_empty() {
+            committed_uris.insert(track_id, uri);
+        }
+    }
+
+    let mut refreshed = 0;
+    for row in projected_rows {
+        let Some(uri) = committed_uris.get(&row.track_id()) else {
+            continue;
+        };
+        if row.uri() != *uri {
+            row.set_uri(uri);
+            refreshed += 1;
+        }
+    }
+    refreshed
+}
+
 /// Stable identity of a track inside the source that supplied its queue.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct PlaybackIdentity {
@@ -793,6 +834,14 @@ mod tests {
         }
     }
 
+    fn projected_row(id: &str, uri: &str) -> TrackObject {
+        let row = TrackObject::new(
+            1, "Title", 60, "Artist", "Album", "", 0, "", 0, 0, 0, "", uri,
+        );
+        row.set_track_id(id);
+        row
+    }
+
     fn ids(session: &PlaybackSession) -> Vec<String> {
         session
             .queue
@@ -926,6 +975,30 @@ mod tests {
         assert_eq!(
             session.queue[0].uri, "https://media.invalid/a",
             "a track with no playable URI keeps the reference the queue captured"
+        );
+    }
+
+    #[test]
+    fn projected_playlist_rows_follow_committed_uris_without_losing_occurrences() {
+        let first = projected_row("a", "file:///music/old-a.flac");
+        let unrelated = projected_row("b", "file:///music/b.flac");
+        let duplicate = projected_row("a", "file:///music/old-a.flac");
+        let rows = vec![first, unrelated, duplicate];
+        let identities: Vec<u64> = rows.iter().map(TrackObject::row_instance_id).collect();
+
+        let renamed = projected_row("a", "file:///music/renamed-a.flac");
+        let empty = projected_row("b", "");
+        assert_eq!(refresh_projected_library_uris(&rows, &[renamed, empty]), 2);
+
+        assert_eq!(rows[0].uri(), "file:///music/renamed-a.flac");
+        assert_eq!(rows[1].uri(), "file:///music/b.flac");
+        assert_eq!(rows[2].uri(), "file:///music/renamed-a.flac");
+        assert_eq!(
+            rows.iter()
+                .map(TrackObject::row_instance_id)
+                .collect::<Vec<_>>(),
+            identities,
+            "URI refresh must preserve duplicate occurrence identity and order"
         );
     }
 

--- a/src/ui/playback.rs
+++ b/src/ui/playback.rs
@@ -20,11 +20,57 @@ use crate::ui::objects::TrackObject;
 
 use super::album_art;
 
+/// The source key of the local library.
+pub const LOCAL_SOURCE_KEY: &str = "local";
+
+/// The source-key prefix of every playlist view. Playlists are projections of
+/// the local library, so their queue items carry library track IDs too.
+pub const PLAYLIST_SOURCE_PREFIX: &str = "playlist:";
+
+/// Whether a queue source is backed by the local library database, and its
+/// track IDs are therefore library track IDs.
+///
+/// Remote backends key tracks by their own native IDs, and external files and
+/// USB items fall back to their URI as an ID ([`TrackObject::track_id`]). A
+/// library update must never reinterpret one of those as one of its own.
+fn is_library_source(source_id: &str) -> bool {
+    source_id == LOCAL_SOURCE_KEY || source_id.starts_with(PLAYLIST_SOURCE_PREFIX)
+}
+
 /// Stable identity of a track inside the source that supplied its queue.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct PlaybackIdentity {
     pub source_id: String,
     pub track_id: String,
+}
+
+/// A committed library change, addressed to the queue by stable track ID.
+///
+/// A rename moves a track's file without changing what it is, so the queue must
+/// re-resolve where to play it from while keeping the identity, position, and
+/// history it captured.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct QueueTrackRefresh {
+    pub uri: String,
+    pub title: String,
+    pub artist: String,
+    pub album: String,
+    pub cover_art_url: String,
+}
+
+impl QueueTrackRefresh {
+    pub fn from_track(track: &TrackObject) -> (String, Self) {
+        (
+            track.track_id(),
+            Self {
+                uri: track.uri(),
+                title: track.title(),
+                artist: track.artist(),
+                album: track.album(),
+                cover_art_url: track.cover_art_url(),
+            },
+        )
+    }
 }
 
 /// Immutable metadata captured when a playback queue is created.
@@ -129,6 +175,65 @@ impl PlaybackSession {
         self.current_index = None;
         self.shuffle = None;
         self.event_generation = self.event_generation.next();
+    }
+
+    pub fn has_queue(&self) -> bool {
+        !self.queue.is_empty()
+    }
+
+    /// Re-resolve queued library items whose track the library just committed a
+    /// change to, and return how many items moved.
+    ///
+    /// A rename preserves a track's identity but not its path, so a queue that
+    /// captured the old URI would hand a dead path to the output the next time
+    /// it loaded that item — on Next, on Previous, and at end of stream, where
+    /// repeat-one replays the current item from the queue rather than the view.
+    /// The item playing right now is refreshed too. The current output is not
+    /// retargeted here, but a subsequent load or replay resolves the path where
+    /// the track now lives.
+    ///
+    /// Items are rewritten in place. Queue length, order, and the cursor are the
+    /// coordinate system that `current_index` and the shuffle history index
+    /// into, so identity — not position — is what an update may address.
+    pub(crate) fn refresh_library_tracks(
+        &mut self,
+        updates: &HashMap<String, QueueTrackRefresh>,
+    ) -> usize {
+        if updates.is_empty() {
+            return 0;
+        }
+
+        let mut refreshed = 0;
+        for item in &mut self.queue {
+            if !is_library_source(&item.identity.source_id) {
+                continue;
+            }
+            let Some(update) = updates.get(&item.identity.track_id) else {
+                continue;
+            };
+            // A track with no playable URI is unplayable (see `play_current`).
+            // Keep the captured reference rather than strand the queue item.
+            if update.uri.is_empty() {
+                continue;
+            }
+            if item.uri == update.uri
+                && item.title == update.title
+                && item.artist == update.artist
+                && item.album == update.album
+                && item.cover_art_url == update.cover_art_url
+            {
+                continue;
+            }
+
+            item.uri = update.uri.clone();
+            item.title = update.title.clone();
+            item.artist = update.artist.clone();
+            item.album = update.album.clone();
+            item.cover_art_url = update.cover_art_url.clone();
+            refreshed += 1;
+        }
+
+        refreshed
     }
 
     pub fn has_current(&self) -> bool {
@@ -688,6 +793,124 @@ mod tests {
             .iter()
             .map(|entry| entry.identity.track_id.clone())
             .collect()
+    }
+
+    fn renamed(uri: &str) -> QueueTrackRefresh {
+        QueueTrackRefresh {
+            uri: uri.to_string(),
+            title: "Title".to_string(),
+            artist: "Artist".to_string(),
+            album: "Album".to_string(),
+            cover_art_url: String::new(),
+        }
+    }
+
+    fn refresh(session: &mut PlaybackSession, track_id: &str, update: QueueTrackRefresh) -> usize {
+        session.refresh_library_tracks(&HashMap::from([(track_id.to_string(), update)]))
+    }
+
+    #[test]
+    fn a_renamed_track_is_re_resolved_in_place_for_next_and_eos() {
+        let mut session = PlaybackSession::default();
+        assert!(session.replace_queue(
+            vec![item("local", "a"), item("local", "b"), item("local", "c")],
+            0,
+        ));
+        // Enter shuffle so the cycle's index bookkeeping is live.
+        assert!(session.advance(RepeatMode::Off, true).is_some());
+        let cursor = session.current_index;
+        let shuffle = session.shuffle.clone().expect("shuffle state exists");
+
+        assert_eq!(
+            refresh(&mut session, "b", renamed("file:///music/renamed/b.flac")),
+            1
+        );
+
+        assert_eq!(session.queue[1].uri, "file:///music/renamed/b.flac");
+        assert_eq!(session.queue[0].uri, "https://media.invalid/a");
+        assert_eq!(
+            ids(&session),
+            ["a", "b", "c"],
+            "identity, order, and length are the coordinates the cursor indexes into"
+        );
+        assert_eq!(session.current_index, cursor);
+        assert_eq!(
+            session.shuffle.as_ref().map(|state| &state.remaining),
+            Some(&shuffle.remaining)
+        );
+    }
+
+    #[test]
+    fn a_refresh_reaches_the_item_playing_right_now() {
+        let mut session = PlaybackSession::default();
+        assert!(session.replace_queue(vec![item("local", "a"), item("local", "b")], 1));
+
+        assert_eq!(
+            refresh(&mut session, "b", renamed("file:///music/renamed/b.flac")),
+            1
+        );
+
+        // Repeat-one replays the current item from the queue, not from the view.
+        assert_eq!(
+            session.current().expect("current item").uri(),
+            "file:///music/renamed/b.flac"
+        );
+    }
+
+    #[test]
+    fn a_playlist_queue_follows_the_same_library_track() {
+        let mut session = PlaybackSession::default();
+        assert!(session.replace_queue(
+            vec![item("playlist:favourites", "a"), item("local", "a")],
+            0,
+        ));
+
+        assert_eq!(
+            refresh(&mut session, "a", renamed("file:///music/renamed/a.flac")),
+            2,
+            "a playlist is a projection of the library, so it holds library track IDs"
+        );
+    }
+
+    #[test]
+    fn a_library_refresh_never_reinterprets_another_source_s_track_id() {
+        let mut session = PlaybackSession::default();
+        let external = QueueItem::external(
+            "file:///downloads/a.flac".to_string(),
+            "External".to_string(),
+            "Artist".to_string(),
+            "Album".to_string(),
+        );
+        assert!(session.replace_queue(
+            vec![
+                external,
+                item("https://subsonic.invalid", "a"),
+                item("local", "a")
+            ],
+            0,
+        ));
+
+        // "a" is a library UUID here, but a remote backend's native ID — and an
+        // external file's URI — are namespaced by their own source.
+        assert_eq!(
+            refresh(&mut session, "a", renamed("file:///music/renamed/a.flac")),
+            1
+        );
+        assert_eq!(session.queue[0].uri, "file:///downloads/a.flac");
+        assert_eq!(session.queue[1].uri, "https://media.invalid/a");
+        assert_eq!(session.queue[2].uri, "file:///music/renamed/a.flac");
+    }
+
+    #[test]
+    fn an_unplayable_update_never_strands_a_queued_track() {
+        let mut session = PlaybackSession::default();
+        assert!(session.replace_queue(vec![item("local", "a")], 0));
+
+        assert_eq!(refresh(&mut session, "a", renamed("")), 0);
+        assert_eq!(
+            session.queue[0].uri, "https://media.invalid/a",
+            "a track with no playable URI keeps the reference the queue captured"
+        );
     }
 
     #[test]

--- a/src/ui/playback.rs
+++ b/src/ui/playback.rs
@@ -7,7 +7,7 @@
 //! - [`format_ms`] — format milliseconds as `m:ss` or `h:mm:ss`
 
 use std::cell::{Cell, RefCell};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use adw::prelude::*;
@@ -59,17 +59,14 @@ pub struct QueueTrackRefresh {
 }
 
 impl QueueTrackRefresh {
-    pub fn from_track(track: &TrackObject) -> (String, Self) {
-        (
-            track.track_id(),
-            Self {
-                uri: track.uri(),
-                title: track.title(),
-                artist: track.artist(),
-                album: track.album(),
-                cover_art_url: track.cover_art_url(),
-            },
-        )
+    pub fn from_track(track: &TrackObject) -> Self {
+        Self {
+            uri: track.uri(),
+            title: track.title(),
+            artist: track.artist(),
+            album: track.album(),
+            cover_art_url: track.cover_art_url(),
+        }
     }
 }
 
@@ -177,8 +174,17 @@ impl PlaybackSession {
         self.event_generation = self.event_generation.next();
     }
 
-    pub fn has_queue(&self) -> bool {
-        !self.queue.is_empty()
+    /// Stable local-library IDs currently retained by the queue.
+    ///
+    /// A full library snapshot can be very large. Publishing this small set
+    /// lets the GTK receiver avoid cloning refresh metadata for tracks the
+    /// queue does not own, while preserving source namespacing.
+    pub(crate) fn library_track_ids(&self) -> HashSet<&str> {
+        self.queue
+            .iter()
+            .filter(|item| is_library_source(&item.identity.source_id))
+            .map(|item| item.identity.track_id.as_str())
+            .collect()
     }
 
     /// Re-resolve queued library items whose track the library just committed a
@@ -864,6 +870,11 @@ mod tests {
             vec![item("playlist:favourites", "a"), item("local", "a")],
             0,
         ));
+        assert_eq!(
+            session.library_track_ids(),
+            HashSet::from(["a"]),
+            "duplicate playlist/local occurrences need one snapshot lookup"
+        );
 
         assert_eq!(
             refresh(&mut session, "a", renamed("file:///music/renamed/a.flac")),
@@ -889,6 +900,11 @@ mod tests {
             ],
             0,
         ));
+        assert_eq!(
+            session.library_track_ids(),
+            HashSet::from(["a"]),
+            "only local-library sources participate in snapshot filtering"
+        );
 
         // "a" is a library UUID here, but a remote backend's native ID — and an
         // external file's URI — are namespaced by their own source.

--- a/src/ui/source_connect.rs
+++ b/src/ui/source_connect.rs
@@ -129,7 +129,8 @@ pub fn setup_source_connect(state: &WindowState) {
                 return;
             }
 
-            *active_source_key.borrow_mut() = format!("playlist:{playlist_id}");
+            *active_source_key.borrow_mut() =
+                format!("{}{playlist_id}", super::playback::PLAYLIST_SOURCE_PREFIX);
 
             // Restore music column layout (not radio).
             apply_radio_columns(&column_view, false);

--- a/src/ui/source_connect.rs
+++ b/src/ui/source_connect.rs
@@ -10,6 +10,7 @@ use tracing::info;
 use crate::local::engine::LibraryEvent;
 
 use super::objects::{SourceObject, TrackObject};
+use super::playback::refresh_projected_library_uris;
 use super::preferences;
 use super::radio::{
     apply_radio_columns, handle_radio_nearme, is_radio_backend, radio_station_to_track_object,
@@ -129,8 +130,9 @@ pub fn setup_source_connect(state: &WindowState) {
                 return;
             }
 
-            *active_source_key.borrow_mut() =
+            let playlist_source_key =
                 format!("{}{playlist_id}", super::playback::PLAYLIST_SOURCE_PREFIX);
+            *active_source_key.borrow_mut() = playlist_source_key.clone();
 
             // Restore music column layout (not radio).
             apply_radio_columns(&column_view, false);
@@ -150,6 +152,9 @@ pub fn setup_source_connect(state: &WindowState) {
             let status_label = status_label.clone();
             let column_view = column_view.clone();
             let pid = playlist_id.clone();
+            let source_tracks_for_load = source_tracks.clone();
+            let active_source_key_for_load = active_source_key.clone();
+            let requested_source_key = playlist_source_key;
 
             let (tracks_tx, tracks_rx) = async_channel::bounded::<String>(1);
 
@@ -190,6 +195,24 @@ pub fn setup_source_connect(state: &WindowState) {
                         serde_json::from_str(&json).unwrap_or_default();
                     let objects: Vec<TrackObject> =
                         tracks.iter().map(arch_track_to_object).collect();
+
+                    // A paired rename may commit while this database result is
+                    // in flight. Overlay the latest committed local paths at
+                    // the GTK publication boundary so either callback order
+                    // converges on the live URI.
+                    if let Some(local_tracks) = source_tracks_for_load.borrow().get("local") {
+                        refresh_projected_library_uris(&objects, local_tracks);
+                    }
+
+                    // A slow playlist query must never replace a source the
+                    // user selected while it was running.
+                    if *active_source_key_for_load.borrow() != requested_source_key {
+                        tracing::debug!(
+                            source = %requested_source_key,
+                            "Ignoring playlist result for an inactive source"
+                        );
+                        return;
+                    }
                     display_tracks(
                         &objects,
                         &track_store,

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -1660,14 +1660,30 @@ pub fn display_tracks(
 /// track lives without changing which track it is. Only the library can say
 /// where it moved to, and only the queue knows it is still holding it.
 fn refresh_playback_queue(session: &Rc<RefCell<PlaybackSession>>, objects: &[TrackObject]) {
-    let mut session = session.borrow_mut();
-    if !session.has_queue() {
+    let updates = {
+        let session = session.borrow();
+        let queue_ids = session.library_track_ids();
+        if queue_ids.is_empty() {
+            return;
+        }
+
+        // FullSync can contain tens of thousands of tracks. Scan the snapshot,
+        // but clone refresh metadata only for the usually small set the queue
+        // owns.
+        let mut updates = HashMap::with_capacity(queue_ids.len());
+        for track in objects {
+            let track_id = track.track_id();
+            if queue_ids.contains(track_id.as_str()) {
+                updates.insert(track_id, QueueTrackRefresh::from_track(track));
+            }
+        }
+        updates
+    };
+    if updates.is_empty() {
         return;
     }
 
-    let updates: HashMap<String, QueueTrackRefresh> =
-        objects.iter().map(QueueTrackRefresh::from_track).collect();
-    let refreshed = session.refresh_library_tracks(&updates);
+    let refreshed = session.borrow_mut().refresh_library_tracks(&updates);
     if refreshed > 0 {
         info!(
             refreshed,

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -29,6 +29,7 @@ use super::persistence::{
 use super::playback::{
     advance_track, format_ms, play_or_start, play_track_at, previous_track, replay_current,
     stop_playback, toggle_or_start, BufferingTracker, PlaybackContext, PlaybackSession,
+    QueueTrackRefresh,
 };
 use super::preferences;
 use super::server_dialogs::{load_saved_servers, remove_saved_server, show_add_server_dialog};
@@ -787,6 +788,7 @@ pub fn build_window(
                 sidebar_sel_for_events,
                 scan_spinner,
                 pending_connection_for_events.clone(),
+                playback_session.clone(),
             );
             return;
         }
@@ -1620,6 +1622,7 @@ pub fn build_window(
         sidebar_sel_for_events,
         scan_spinner,
         pending_connection_for_events,
+        playback_session,
     );
 }
 
@@ -1650,6 +1653,29 @@ pub fn display_tracks(
     column_view.scroll_to(0, None, gtk::ListScrollFlags::NONE, None);
 }
 
+/// Re-resolve queued library items from committed library state.
+///
+/// The playback queue is an immutable snapshot of identities, so it survives
+/// sorting, filtering, and navigation — but a filesystem rename changes where a
+/// track lives without changing which track it is. Only the library can say
+/// where it moved to, and only the queue knows it is still holding it.
+fn refresh_playback_queue(session: &Rc<RefCell<PlaybackSession>>, objects: &[TrackObject]) {
+    let mut session = session.borrow_mut();
+    if !session.has_queue() {
+        return;
+    }
+
+    let updates: HashMap<String, QueueTrackRefresh> =
+        objects.iter().map(QueueTrackRefresh::from_track).collect();
+    let refreshed = session.refresh_library_tracks(&updates);
+    if refreshed > 0 {
+        info!(
+            refreshed,
+            "Re-resolved playback queue items after library change"
+        );
+    }
+}
+
 /// Spawn the library event receiver loop on the GTK main thread.
 #[allow(clippy::too_many_arguments)]
 fn setup_library_events(
@@ -1666,6 +1692,7 @@ fn setup_library_events(
     sidebar_selection: gtk::SingleSelection,
     scan_spinner: gtk::Spinner,
     pending_connection: Rc<RefCell<Option<String>>>,
+    playback_session: Rc<RefCell<PlaybackSession>>,
 ) {
     let browser_widget = browser_widget.clone();
     let column_view = column_view.clone();
@@ -1710,6 +1737,12 @@ fn setup_library_events(
 
                     let objects: Vec<TrackObject> =
                         tracks.iter().map(arch_track_to_object).collect();
+
+                    // A bulk change — a renamed album, a reconciliation — can
+                    // move the files behind tracks the queue is holding. The
+                    // queue owns identities, not rows, so it re-resolves them
+                    // from the snapshot rather than being rebuilt from the view.
+                    refresh_playback_queue(&playback_session, &objects);
 
                     // Store per-source.
                     source_tracks
@@ -1792,6 +1825,11 @@ fn setup_library_events(
                 LibraryEvent::TrackUpserted(track) => {
                     let obj = arch_track_to_object(&track);
                     let uri = obj.uri();
+
+                    // A single-file rename keeps the track's identity and moves
+                    // its path, so a queue holding it must follow the track, not
+                    // the path it was captured at.
+                    refresh_playback_queue(&playback_session, std::slice::from_ref(&obj));
 
                     // Update source_tracks["local"].
                     {

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -27,9 +27,9 @@ use super::persistence::{
     restore_sort_state, save_repeat_mode, save_shuffle, save_sort_state, save_window_geometry,
 };
 use super::playback::{
-    advance_track, format_ms, play_or_start, play_track_at, previous_track, replay_current,
-    stop_playback, toggle_or_start, BufferingTracker, PlaybackContext, PlaybackSession,
-    QueueTrackRefresh,
+    advance_track, format_ms, play_or_start, play_track_at, previous_track,
+    refresh_projected_library_uris, replay_current, stop_playback, toggle_or_start,
+    BufferingTracker, PlaybackContext, PlaybackSession, QueueTrackRefresh, PLAYLIST_SOURCE_PREFIX,
 };
 use super::preferences;
 use super::server_dialogs::{load_saved_servers, remove_saved_server, show_add_server_dialog};
@@ -1692,6 +1692,29 @@ fn refresh_playback_queue(session: &Rc<RefCell<PlaybackSession>>, objects: &[Tra
     }
 }
 
+/// Retarget the rows of an already-open playlist after committed local changes.
+/// The visible store and `master_tracks` share these GObject instances, so an
+/// in-place URI overlay is immediately used by the next click without changing
+/// playlist order, duplicates, or selection identity.
+fn refresh_active_playlist_uris(
+    active_source_key: &Rc<RefCell<String>>,
+    master_tracks: &Rc<RefCell<Vec<TrackObject>>>,
+    committed_local_rows: &[TrackObject],
+) {
+    if !active_source_key
+        .borrow()
+        .starts_with(PLAYLIST_SOURCE_PREFIX)
+    {
+        return;
+    }
+
+    let rows = master_tracks.borrow();
+    let refreshed = refresh_projected_library_uris(&rows, committed_local_rows);
+    if refreshed > 0 {
+        info!(refreshed, "Refreshed active playlist paths");
+    }
+}
+
 /// Spawn the library event receiver loop on the GTK main thread.
 #[allow(clippy::too_many_arguments)]
 fn setup_library_events(
@@ -1753,6 +1776,8 @@ fn setup_library_events(
 
                     let objects: Vec<TrackObject> =
                         tracks.iter().map(arch_track_to_object).collect();
+
+                    refresh_active_playlist_uris(&active_source_key, &master_tracks, &objects);
 
                     // A bulk change — a renamed album, a reconciliation — can
                     // move the files behind tracks the queue is holding. The
@@ -1841,6 +1866,12 @@ fn setup_library_events(
                 LibraryEvent::TrackUpserted(track) => {
                     let obj = arch_track_to_object(&track);
                     let uri = obj.uri();
+
+                    refresh_active_playlist_uris(
+                        &active_source_key,
+                        &master_tracks,
+                        std::slice::from_ref(&obj),
+                    );
 
                     // A single-file rename keeps the track's identity and moves
                     // its path, so a queue holding it must follow the track, not


### PR DESCRIPTION
## Summary

- enforce `playlist_entries.track_id` integrity with a retry-safe migration and conservative reconciliation
- preserve track IDs, history, and playlist links across authoritative paired file and directory renames
- fail closed on dirty subtrees, filesystem swaps, symlinks/reparse points, mount changes, and ambiguous watcher events
- refresh already-captured local and playlist queues by stable track ID after committed renames
- close P1.1 and P1.2 in the remediation tracker while recording the remaining P1.3, P1.9, and P3.1 boundaries

## Why

Playlist links and playback queues could retain stale local-library references after files moved. Directory renames also fell back to a full scan, replacing track IDs and losing direct identity continuity. These changes make the database relationship explicit and preserve identity only when watcher evidence and live filesystem handles prove the mapping is safe.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --release -- -D warnings`
- `cargo test --all-targets` (271 tests)
- `cargo test --release` (271 tests)
- `cargo audit` (passes with the two documented allowed unmaintained warnings)

Release workflow remediation remains intentionally out of scope.
