### PR TITLE
Enforce exact-origin authenticated HTTP

### DIFF
--- a/docs/task.md
+++ b/docs/task.md
@@ -184,14 +184,17 @@ explicitly justified and time-bounded.
 
 ### P1.4 Enforce exact-origin authenticated redirects
 
-- [ ] Disable automatic `Referer` for every credential-bearing client.
-- [ ] Compare scheme, hostname, and effective port.
-- [ ] Forbid HTTPS-to-HTTP downgrade.
-- [ ] Apply the policy to API, stream, artwork, and DAAP clients.
-- [ ] Strip credential-bearing URLs from every retained/formatted error.
-- [ ] Stop logging raw DAAP session IDs and authenticated MPD commands.
-- [ ] Add redirect matrix tests using mock servers.
-- [ ] Record implementation: _pending_
+- [x] Disable automatic `Referer` for every app-owned credential-bearing HTTP client.
+- [x] Compare scheme, hostname, and effective port.
+- [x] Forbid HTTPS-to-HTTP downgrade.
+- [x] Apply the policy to app-owned API, authentication, artwork, and DAAP clients.
+- [ ] Route credential-bearing playback streams through the P1.6 app-owned proxy so local,
+  AirPlay, MPD, and Chromecast no longer depend on redirect policies Tributary cannot control.
+- [x] Strip credential-bearing URLs from every retained/formatted HTTP or pipeline error.
+- [x] Stop logging raw DAAP session IDs and authenticated MPD commands.
+- [x] Add redirect matrix tests using mock servers.
+- [x] Record implementation: commit `eb5458f`; 17 focused origin, redirect, Referer, header,
+  redaction, userinfo, DAAP, and MPD tests.
 
 ### P1.5 Enforce response limits while streaming
 
@@ -205,7 +208,8 @@ explicitly justified and time-bounded.
 
 - [ ] Define an opaque short-lived media proxy/ticket design.
 - [ ] Keep backend credentials outside generic `Track` values.
-- [ ] Proxy or mint least-privilege URLs for Chromecast and MPD.
+- [ ] Proxy credential-bearing streams for local, AirPlay, MPD, and Chromecast, and apply the
+  shared exact-origin policy to the proxy's upstream client.
 - [ ] Expire/revoke proxy registrations when playback/session ends.
 - [ ] Threat-model spoofed and compromised LAN receivers.
 - [ ] Record implementation: _pending_
@@ -466,6 +470,16 @@ Record scope or design decisions here so deferred work is explicit.
   The resulting filesystem/database state is reconciled, but eliminating that narrow identity
   boundary requires a future two-phase, non-destructive bootstrap scan rather than guessing from
   file metadata.
+- 2026-07-12 — P1.4 centralizes every app-owned credential-bearing reqwest client behind a
+  no-`Referer`, ten-hop, exact-origin policy comparing HTTP(S) scheme, normalized host, and
+  effective port. Request URLs are removed before reqwest errors are formatted or retained;
+  URL userinfo and backend query credentials are rejected or redacted; DAAP session IDs and MPD
+  command arguments are no longer logged; and GStreamer errors use stable URL-free diagnostics.
+  Direct playback remains deliberately open under P1.6: local and AirPlay streams are fetched by
+  GStreamer, while MPD and Chromecast fetch on external receivers, so Tributary cannot enforce an
+  upstream redirect callback on those transports until it owns the stream through a short-lived
+  proxy/ticket. Disabling redirects only for GStreamer would be both incomplete and potentially
+  breaking, so the playback-stream checkbox remains explicit rather than being claimed complete.
 
 ## Completed work log
 
@@ -482,3 +496,4 @@ Add one line per completed task:
 | 2026-07-12 | P1.1 | `8ec84a5` | Transactional, retry-safe track-FK rebuild with dangling-link cleanup, index preservation, and scan/watcher reconciliation. |
 | 2026-07-12 | P1.2 | `93d03bf`, `b961b7c`, `17babaf`, `000d9c0` | Identity preserved across authoritative paired file and directory renames; queue and active-playlist snapshots re-resolve ID-preserving committed changes by stable track ID. |
 | 2026-07-12 | P1.3 | `4eb79d0` | Watchers install before scanning; bounded nonblocking ingress replays ordinary events and routes overflow, backend loss, rescan notices, and marker changes through retrying authoritative reconciliation. |
+| 2026-07-12 | P1.4a | `eb5458f` | Exact-origin/no-Referer policy and URL-free errors/logging cover every app-owned credential HTTP fetch; receiver-controlled playback streams remain tied to P1.6. |

--- a/docs/task.md
+++ b/docs/task.md
@@ -193,8 +193,8 @@ explicitly justified and time-bounded.
 - [x] Strip credential-bearing URLs from every retained/formatted HTTP or pipeline error.
 - [x] Stop logging raw DAAP session IDs and authenticated MPD commands.
 - [x] Add redirect matrix tests using mock servers.
-- [x] Record implementation: commit `eb5458f`; 17 focused origin, redirect, Referer, header,
-  redaction, userinfo, DAAP, and MPD tests.
+- [x] Record implementation: commit `eb5458f` plus review follow-ups; 18 focused origin,
+  redirect, Referer, header, redaction, userinfo, DAAP, and MPD tests.
 
 ### P1.5 Enforce response limits while streaming
 

--- a/src/audio/airplay_output.rs
+++ b/src/audio/airplay_output.rs
@@ -219,16 +219,11 @@ impl AirPlayOutput {
                 MessageView::Eos(..) => {
                     let _ = tx.try_send(PlayerEvent::ended(generation));
                 }
-                MessageView::Error(err) => {
-                    error!(
-                        error = %err.error(),
-                        debug = ?err.debug(),
-                        "AirPlay pipeline error"
-                    );
-                    let _ = tx.try_send(PlayerEvent::error(
-                        generation,
-                        format!("AirPlay: {}", err.error()),
-                    ));
+                MessageView::Error(_) => {
+                    // GStreamer error/debug strings can embed the authenticated
+                    // source URI. Keep the diagnostic stable and URL-free.
+                    error!("AirPlay pipeline error");
+                    let _ = tx.try_send(PlayerEvent::error(generation, "AirPlay playback failed"));
                 }
                 MessageView::StateChanged(s) => {
                     if let Some(pipeline) = pipeline_weak.upgrade() {

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -38,6 +38,8 @@ use gstreamer as gst;
 use gtk::glib;
 use tracing::{debug, error, info, warn};
 
+pub use crate::http_security::redact_url_secrets;
+
 // ── Events ──────────────────────────────────────────────────────────────
 
 /// Monotonic identity of the playback load that owns a [`PlayerEvent`].
@@ -431,15 +433,13 @@ impl Player {
                     }
                 }
 
-                MessageView::Error(err) => {
-                    error!(
-                        src = ?msg.src().map(|s| s.path_string()),
-                        error = %err.error(),
-                        debug = ?err.debug(),
-                        "Pipeline error"
-                    );
+                MessageView::Error(_) => {
+                    // GStreamer error/debug strings can retain the complete
+                    // authenticated source URI. Emit a stable diagnostic
+                    // instead of leaking backend credentials to logs or UI.
+                    error!("Audio pipeline error");
                     if let Err(e) =
-                        tx.try_send(PlayerEvent::error(generation, err.error().to_string()))
+                        tx.try_send(PlayerEvent::error(generation, "Audio playback failed"))
                     {
                         warn!(error = %e, "dropped Error event — UI consumer may be stalled");
                     }
@@ -707,63 +707,6 @@ fn save_volume(level: f64) {
     }
 }
 
-// ── URL secret redaction ────────────────────────────────────────────────
-
-/// Mask sensitive query parameters in URLs for safe logging.
-///
-/// Redacts `X-Plex-Token`, `api_key`, `session-id` (DAAP session bearer
-/// credential), `t` (Subsonic token), and `s` (Subsonic salt) to prevent
-/// auth credentials from appearing in logs.
-pub fn redact_url_secrets(uri: &str) -> String {
-    // Note: "s" is only redacted when "t" is also present (Subsonic salt+token pair).
-    // This avoids false positives on unrelated URLs that happen to have an "s" param.
-    // "p" is the legacy plaintext password parameter (used by Nextcloud Music etc.).
-    // "session-id" is the DAAP session credential that authorizes every request
-    // to a DAAP session (stream/cover URLs carry it in cleartext on the wire).
-    const SENSITIVE_PARAMS: &[&str] = &["X-Plex-Token", "api_key", "session-id"];
-    const SUBSONIC_TOKEN_PARAMS: &[&str] = &["t", "s"];
-    const SUBSONIC_PASSWORD_PARAMS: &[&str] = &["p"];
-
-    let Ok(mut url) = url::Url::parse(uri) else {
-        return uri.to_string();
-    };
-
-    // Check if this looks like a Subsonic URL.
-    // Token auth: has "t" (token) — we also redact "s" (salt).
-    // Plaintext auth: has "p" AND "u" AND "c" (Subsonic always sends
-    // username and client name alongside "p").  We require all three
-    // to avoid false positives on unrelated URLs with a "p" parameter.
-    let has_subsonic_token = url.query_pairs().any(|(k, _)| k == "t");
-    let has_subsonic_password = url.query_pairs().any(|(k, _)| k == "p")
-        && url.query_pairs().any(|(k, _)| k == "u")
-        && url.query_pairs().any(|(k, _)| k == "c");
-
-    let pairs: Vec<(String, String)> = url
-        .query_pairs()
-        .map(|(k, v)| {
-            let should_redact = SENSITIVE_PARAMS.contains(&k.as_ref())
-                || (has_subsonic_token && SUBSONIC_TOKEN_PARAMS.contains(&k.as_ref()))
-                || (has_subsonic_password && SUBSONIC_PASSWORD_PARAMS.contains(&k.as_ref()));
-            let v = if should_redact {
-                "REDACTED".to_string()
-            } else {
-                v.to_string()
-            };
-            (k.to_string(), v)
-        })
-        .collect();
-
-    if pairs.is_empty() {
-        return uri.to_string();
-    }
-
-    url.query_pairs_mut().clear();
-    for (k, v) in &pairs {
-        url.query_pairs_mut().append_pair(k, v);
-    }
-    url.to_string()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -795,102 +738,6 @@ mod tests {
             assert!(val >= prev, "slider_to_pipeline should be monotonic");
             prev = val;
         }
-    }
-
-    // ── redact_url_secrets tests ────────────────────────────────────
-
-    #[test]
-    fn test_redact_plex_token() {
-        let url = "https://plex.example.com/library?X-Plex-Token=abc123&other=value";
-        let redacted = redact_url_secrets(url);
-        assert!(redacted.contains("X-Plex-Token=REDACTED"));
-        assert!(redacted.contains("other=value"));
-        assert!(!redacted.contains("abc123"));
-    }
-
-    #[test]
-    fn test_redact_api_key() {
-        let url = "https://jellyfin.example.com/Items?api_key=secret123";
-        let redacted = redact_url_secrets(url);
-        assert!(redacted.contains("api_key=REDACTED"));
-        assert!(!redacted.contains("secret123"));
-    }
-
-    #[test]
-    fn test_redact_daap_session_id() {
-        let url =
-            "http://192.168.1.50:3689/databases/1/items/42.flac?session-id=1234567890&other=value";
-        let redacted = redact_url_secrets(url);
-        assert!(redacted.contains("session-id=REDACTED"));
-        assert!(redacted.contains("other=value"));
-        assert!(!redacted.contains("1234567890"));
-    }
-
-    #[test]
-    fn test_redact_subsonic_token_and_salt() {
-        let url = "https://sub.example.com/rest/ping.view?u=admin&t=tokenvalue&s=saltvalue&v=1.16.1&c=tributary";
-        let redacted = redact_url_secrets(url);
-        assert!(redacted.contains("t=REDACTED"));
-        assert!(redacted.contains("s=REDACTED"));
-        assert!(redacted.contains("u=admin")); // username not redacted
-        assert!(redacted.contains("v=1.16.1"));
-        assert!(!redacted.contains("tokenvalue"));
-        assert!(!redacted.contains("saltvalue"));
-    }
-
-    #[test]
-    fn test_redact_no_sensitive_params() {
-        let url = "https://example.com/api?page=1&limit=50";
-        let redacted = redact_url_secrets(url);
-        assert_eq!(redacted, url);
-    }
-
-    #[test]
-    fn test_redact_no_query_params() {
-        let url = "https://example.com/path";
-        let redacted = redact_url_secrets(url);
-        assert_eq!(redacted, url);
-    }
-
-    #[test]
-    fn test_redact_invalid_url() {
-        let url = "not a valid url";
-        let redacted = redact_url_secrets(url);
-        assert_eq!(redacted, url);
-    }
-
-    #[test]
-    fn test_redact_s_param_without_subsonic_token() {
-        // "s" alone (without "t") should NOT be redacted — it could be
-        // an unrelated parameter.
-        let url = "https://example.com/api?s=something&page=1";
-        let redacted = redact_url_secrets(url);
-        assert!(redacted.contains("s=something"));
-    }
-
-    #[test]
-    fn test_redact_subsonic_plaintext_password() {
-        // Nextcloud Music style: p=enc:<hex> with no t= or s= params.
-        let url = "https://nc.example.com/apps/music/subsonic/rest/ping.view?u=admin&p=enc%3A68656c6c6f&v=1.16.1&c=Tributary&f=json";
-        let redacted = redact_url_secrets(url);
-        assert!(
-            redacted.contains("p=REDACTED"),
-            "p= param should be redacted: {redacted}"
-        );
-        assert!(redacted.contains("u=admin")); // username not redacted
-        assert!(redacted.contains("v=1.16.1"));
-        assert!(!redacted.contains("68656c6c6f")); // hex password must not appear
-    }
-
-    #[test]
-    fn test_redact_p_param_without_subsonic_context() {
-        // A "p" parameter on a non-Subsonic URL should NOT be redacted.
-        let url = "https://example.com/api?p=page1&limit=50";
-        let redacted = redact_url_secrets(url);
-        assert!(
-            redacted.contains("p=page1"),
-            "unrelated p= should not be redacted: {redacted}"
-        );
     }
 
     // ── Volume persistence helpers ──────────────────────────────────

--- a/src/audio/mpd_output.rs
+++ b/src/audio/mpd_output.rs
@@ -178,7 +178,8 @@ impl MpdOutput {
             if line.is_empty() {
                 continue;
             }
-            debug!(cmd = %line, "MPD ←");
+            let command = mpd_command_verb(line);
+            debug!(command, "MPD command send");
             stream
                 .write_all(format!("{line}\n").as_bytes())
                 .map_err(|e| format!("Write: {e}"))?;
@@ -195,12 +196,13 @@ impl MpdOutput {
                     .read_line(&mut resp)
                     .map_err(|e| format!("Read: {e}"))?;
                 let resp = resp.trim();
-                debug!(resp = %resp, "MPD →");
                 if resp.starts_with("OK") {
                     break;
                 }
                 if resp.starts_with("ACK") {
-                    warn!(response = %resp, "MPD error");
+                    // MPD can echo the rejected command argument, including a
+                    // credential-bearing stream URL. Keep only the verb.
+                    warn!(command, "MPD command rejected");
                     // Don't fail the whole batch — log and continue.
                     break;
                 }
@@ -209,6 +211,23 @@ impl MpdOutput {
         }
 
         Ok(())
+    }
+}
+
+/// Return the only command detail safe to retain in logs.
+///
+/// Arguments can contain backend bearer URLs, so even sanitised protocol text
+/// must never be used as diagnostic output.
+fn mpd_command_verb(line: &str) -> &'static str {
+    match line.split_ascii_whitespace().next() {
+        Some("clear") => "clear",
+        Some("add") => "add",
+        Some("play") => "play",
+        Some("pause") => "pause",
+        Some("stop") => "stop",
+        Some("seekcur") => "seekcur",
+        Some("status") => "status",
+        _ => "unknown",
     }
 }
 
@@ -369,5 +388,13 @@ mod tests {
         // early — every `"` is escaped.
         assert!(!safe.contains('\n'));
         assert!(!safe.replace("\\\"", "").contains('"'));
+    }
+
+    #[test]
+    fn loggable_mpd_command_never_contains_authenticated_arguments() {
+        let line = r#"add "https://music.test/song.flac?api_key=secret""#;
+        assert_eq!(mpd_command_verb(line), "add");
+        assert!(!mpd_command_verb(line).contains("secret"));
+        assert_eq!(mpd_command_verb("password hunter2"), "unknown");
     }
 }

--- a/src/daap/backend.rs
+++ b/src/daap/backend.rs
@@ -380,9 +380,12 @@ impl crate::architecture::MediaBackend for DaapBackend {
             .get(&url)
             .send()
             .await
-            .map_err(|e| BackendError::ConnectionFailed {
-                message: format!("DAAP ping failed: {e}"),
-                source: Some(Box::new(e)),
+            .map_err(|error| {
+                let error = crate::http_security::strip_request_url(error);
+                BackendError::ConnectionFailed {
+                    message: format!("DAAP ping failed: {error}"),
+                    source: Some(Box::new(error)),
+                }
             })?;
 
         if !resp.status().is_success() {

--- a/src/daap/client.rs
+++ b/src/daap/client.rs
@@ -18,7 +18,9 @@ use url::Url;
 
 use crate::architecture::backend::BackendResult;
 use crate::architecture::error::BackendError;
-use crate::http_security::{authenticated_client_builder, redact_url_secrets, strip_request_url};
+use crate::http_security::{
+    authenticated_client_builder, redact_url_secrets, strip_request_url, validate_base_url,
+};
 
 use super::dmap::{self, DmapNode, DmapValue};
 
@@ -76,7 +78,10 @@ impl DaapClient {
             message: format!("Invalid DAAP server URL: {e}"),
             source: Some(Box::new(e)),
         })?;
-        validate_base_url(&base_url)?;
+        validate_base_url(&base_url).map_err(|message| BackendError::ConnectionFailed {
+            message: message.replace("server URL", "DAAP server URL"),
+            source: None,
+        })?;
 
         let http = build_http_client()?;
 
@@ -466,22 +471,6 @@ fn build_http_client() -> BackendResult<Client> {
         .read_timeout(READ_TIMEOUT)
         .build()
         .map_err(|error| daap_request_error("Failed to build DAAP HTTP client", error))
-}
-
-fn validate_base_url(base_url: &Url) -> BackendResult<()> {
-    if base_url.cannot_be_a_base()
-        || !matches!(base_url.scheme(), "http" | "https")
-        || !base_url.username().is_empty()
-        || base_url.password().is_some()
-    {
-        return Err(BackendError::ConnectionFailed {
-            message:
-                "Invalid DAAP server URL: expected an HTTP(S) URL without embedded credentials"
-                    .to_string(),
-            source: None,
-        });
-    }
-    Ok(())
 }
 
 fn daap_request_error(context: &str, error: reqwest::Error) -> BackendError {

--- a/src/daap/client.rs
+++ b/src/daap/client.rs
@@ -18,6 +18,7 @@ use url::Url;
 
 use crate::architecture::backend::BackendResult;
 use crate::architecture::error::BackendError;
+use crate::http_security::{authenticated_client_builder, redact_url_secrets, strip_request_url};
 
 use super::dmap::{self, DmapNode, DmapValue};
 
@@ -75,19 +76,19 @@ impl DaapClient {
             message: format!("Invalid DAAP server URL: {e}"),
             source: Some(Box::new(e)),
         })?;
+        validate_base_url(&base_url)?;
 
         let http = build_http_client()?;
 
         // ── Step A: Server Info ─────────────────────────────────────
         let server_info_url = format!("{}/server-info", base_url.as_str().trim_end_matches('/'));
-        debug!(url = %server_info_url, "DAAP: requesting server-info");
+        debug!(url = %redact_url_secrets(&server_info_url), "DAAP: requesting server-info");
 
-        let resp = http.get(&server_info_url).send().await.map_err(|e| {
-            BackendError::ConnectionFailed {
-                message: format!("DAAP server-info request failed: {e}"),
-                source: Some(Box::new(e)),
-            }
-        })?;
+        let resp = http
+            .get(&server_info_url)
+            .send()
+            .await
+            .map_err(|error| daap_request_error("DAAP server-info request failed", error))?;
 
         if !resp.status().is_success() {
             return Err(BackendError::ConnectionFailed {
@@ -102,10 +103,7 @@ impl DaapClient {
         let bytes = resp
             .bytes()
             .await
-            .map_err(|e| BackendError::ConnectionFailed {
-                message: format!("Failed to read server-info body: {e}"),
-                source: Some(Box::new(e)),
-            })?;
+            .map_err(|error| daap_request_error("Failed to read server-info body", error))?;
 
         let nodes = dmap::parse_dmap(&bytes)?;
         // The top-level node is typically `msrv` (server-info container).
@@ -125,7 +123,7 @@ impl DaapClient {
 
         // ── Step B: Login ───────────────────────────────────────────
         let login_url = format!("{}/login", base_url.as_str().trim_end_matches('/'));
-        debug!(url = %login_url, "DAAP: requesting login");
+        debug!(url = %redact_url_secrets(&login_url), "DAAP: requesting login");
 
         let mut login_req = http.get(&login_url);
         if let Some(pw) = password {
@@ -137,10 +135,7 @@ impl DaapClient {
         let resp = login_req
             .send()
             .await
-            .map_err(|e| BackendError::ConnectionFailed {
-                message: format!("DAAP login request failed: {e}"),
-                source: Some(Box::new(e)),
-            })?;
+            .map_err(|error| daap_request_error("DAAP login request failed", error))?;
 
         if resp.status() == reqwest::StatusCode::UNAUTHORIZED
             || resp.status() == reqwest::StatusCode::FORBIDDEN
@@ -163,10 +158,7 @@ impl DaapClient {
         let bytes = resp
             .bytes()
             .await
-            .map_err(|e| BackendError::ConnectionFailed {
-                message: format!("Failed to read login body: {e}"),
-                source: Some(Box::new(e)),
-            })?;
+            .map_err(|error| daap_request_error("Failed to read login body", error))?;
 
         let nodes = dmap::parse_dmap(&bytes)?;
         let login_children = unwrap_container(&nodes, b"mlog")?;
@@ -177,7 +169,7 @@ impl DaapClient {
             }
         })?;
 
-        info!(session_id, "DAAP login OK");
+        info!("DAAP login OK");
 
         // ── Step C: Update ──────────────────────────────────────────
         let update_url = format!(
@@ -185,16 +177,13 @@ impl DaapClient {
             base_url.as_str().trim_end_matches('/'),
             session_id
         );
-        debug!(url = %crate::audio::redact_url_secrets(&update_url), "DAAP: requesting update");
+        debug!(url = %redact_url_secrets(&update_url), "DAAP: requesting update");
 
         let resp = // lgtm[rs/cleartext-transmission] DAAP is a LAN-only protocol; plaintext HTTP is by design.
             http.get(&update_url)
                 .send()
                 .await
-                .map_err(|e| BackendError::ConnectionFailed {
-                    message: format!("DAAP update request failed: {e}"),
-                    source: Some(Box::new(e)),
-                })?;
+                .map_err(|error| daap_request_error("DAAP update request failed", error))?;
 
         if !resp.status().is_success() {
             return Err(BackendError::ConnectionFailed {
@@ -209,10 +198,7 @@ impl DaapClient {
         let bytes = resp
             .bytes()
             .await
-            .map_err(|e| BackendError::ConnectionFailed {
-                message: format!("Failed to read update body: {e}"),
-                source: Some(Box::new(e)),
-            })?;
+            .map_err(|error| daap_request_error("Failed to read update body", error))?;
 
         let nodes = dmap::parse_dmap(&bytes)?;
         let update_children = unwrap_container(&nodes, b"mupd")?;
@@ -227,16 +213,13 @@ impl DaapClient {
             session_id,
             revision
         );
-        debug!(url = %crate::audio::redact_url_secrets(&databases_url), "DAAP: requesting databases");
+        debug!(url = %redact_url_secrets(&databases_url), "DAAP: requesting databases");
 
         let resp = // lgtm[rs/cleartext-transmission] DAAP is a LAN-only protocol; plaintext HTTP is by design.
             http.get(&databases_url)
                 .send()
                 .await
-                .map_err(|e| BackendError::ConnectionFailed {
-                    message: format!("DAAP databases request failed: {e}"),
-                    source: Some(Box::new(e)),
-                })?;
+                .map_err(|error| daap_request_error("DAAP databases request failed", error))?;
 
         if !resp.status().is_success() {
             return Err(BackendError::ConnectionFailed {
@@ -251,10 +234,7 @@ impl DaapClient {
         let bytes = resp
             .bytes()
             .await
-            .map_err(|e| BackendError::ConnectionFailed {
-                message: format!("Failed to read databases body: {e}"),
-                source: Some(Box::new(e)),
-            })?;
+            .map_err(|error| daap_request_error("Failed to read databases body", error))?;
 
         let nodes = dmap::parse_dmap(&bytes)?;
         let avdb_children = unwrap_container(&nodes, b"avdb")?;
@@ -279,10 +259,7 @@ impl DaapClient {
         info!(database_id, name = %db_name, "DAAP database discovered");
 
         // ── Step E: Done ────────────────────────────────────────────
-        info!(
-            session_id,
-            database_id, revision, "DAAP session established"
-        );
+        info!(database_id, revision, "DAAP session established");
 
         Ok(Self {
             base_url,
@@ -305,17 +282,14 @@ impl DaapClient {
             self.revision,
             TRACK_META,
         );
-        debug!(url = %crate::audio::redact_url_secrets(&url), "DAAP: fetching tracks");
+        debug!(url = %redact_url_secrets(&url), "DAAP: fetching tracks");
 
         let resp = // lgtm[rs/cleartext-transmission] DAAP is a LAN-only protocol; plaintext HTTP is by design.
             self.http
                 .get(&url)
                 .send()
                 .await
-                .map_err(|e| BackendError::ConnectionFailed {
-                    message: format!("DAAP items request failed: {e}"),
-                    source: Some(Box::new(e)),
-                })?;
+                .map_err(|error| daap_request_error("DAAP items request failed", error))?;
 
         if resp.status() == reqwest::StatusCode::UNAUTHORIZED {
             return Err(BackendError::AuthenticationFailed {
@@ -336,10 +310,7 @@ impl DaapClient {
         let bytes = resp
             .bytes()
             .await
-            .map_err(|e| BackendError::ConnectionFailed {
-                message: format!("Failed to read items body: {e}"),
-                source: Some(Box::new(e)),
-            })?;
+            .map_err(|error| daap_request_error("Failed to read items body", error))?;
 
         let nodes = dmap::parse_dmap(&bytes)?;
 
@@ -406,7 +377,10 @@ impl DaapClient {
         {
             // lgtm[rs/cleartext-transmission] DAAP uses plaintext HTTP by design.
             Ok(_) => info!("DAAP logout OK"),
-            Err(e) => warn!(error = %e, "DAAP logout failed (best-effort)"),
+            Err(error) => {
+                let error = strip_request_url(error);
+                warn!(%error, "DAAP logout failed (best-effort)");
+            }
         }
     }
 
@@ -417,7 +391,9 @@ impl DaapClient {
     /// `Some(true)` for password-protected shares, or `None` on error.
     pub async fn probe_requires_password(server_url: &str) -> Option<bool> {
         let http = build_http_client().ok()?;
-        let url = format!("{}/server-info", server_url.trim_end_matches('/'));
+        let base_url = Url::parse(server_url).ok()?;
+        validate_base_url(&base_url).ok()?;
+        let url = format!("{}/server-info", base_url.as_str().trim_end_matches('/'));
         // Cap the probe at 5s — a malicious or hung DAAP server should
         // not be able to stall the discovery flow forever. The shared
         // client already sets connect/read timeouts; this tighter total
@@ -483,16 +459,37 @@ fn build_http_client() -> BackendResult<Client> {
     );
     headers.insert("Client-DAAP-Access-Index", HeaderValue::from_static("2"));
 
-    Client::builder()
+    authenticated_client_builder()
         .user_agent(format!("{CLIENT_NAME}/{CLIENT_VERSION}"))
         .default_headers(headers)
         .connect_timeout(CONNECT_TIMEOUT)
         .read_timeout(READ_TIMEOUT)
         .build()
-        .map_err(|e| BackendError::ConnectionFailed {
-            message: format!("Failed to build DAAP HTTP client: {e}"),
-            source: Some(Box::new(e)),
-        })
+        .map_err(|error| daap_request_error("Failed to build DAAP HTTP client", error))
+}
+
+fn validate_base_url(base_url: &Url) -> BackendResult<()> {
+    if base_url.cannot_be_a_base()
+        || !matches!(base_url.scheme(), "http" | "https")
+        || !base_url.username().is_empty()
+        || base_url.password().is_some()
+    {
+        return Err(BackendError::ConnectionFailed {
+            message:
+                "Invalid DAAP server URL: expected an HTTP(S) URL without embedded credentials"
+                    .to_string(),
+            source: None,
+        });
+    }
+    Ok(())
+}
+
+fn daap_request_error(context: &str, error: reqwest::Error) -> BackendError {
+    let error = strip_request_url(error);
+    BackendError::ConnectionFailed {
+        message: format!("{context}: {error}"),
+        source: Some(Box::new(error)),
+    }
 }
 
 /// Unwrap the first top-level container node with the given tag,
@@ -544,4 +541,27 @@ fn check_body_size(resp: &reqwest::Response) -> BackendResult<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn daap_base_url_rejects_embedded_credentials_and_non_http_schemes() {
+        let safe = Url::parse("http://music.test:3689/share").expect("safe URL");
+        assert!(validate_base_url(&safe).is_ok());
+
+        for unsafe_url in [
+            "http://user:secret@music.test:3689",
+            "ftp://music.test/share",
+            "music.test:3689",
+        ] {
+            let url = Url::parse(unsafe_url).expect("syntactically valid unsafe URL");
+            let error = validate_base_url(&url).expect_err("unsafe URL must be rejected");
+            let rendered = error.to_string();
+            assert!(!rendered.contains("secret"));
+            assert!(!rendered.contains(unsafe_url));
+        }
+    }
 }

--- a/src/http_security.rs
+++ b/src/http_security.rs
@@ -1,0 +1,416 @@
+//! Shared hardening for HTTP clients that carry authentication credentials.
+
+use reqwest::Url;
+
+const MAX_REDIRECTS: usize = 10;
+const REDACTED: &str = "REDACTED";
+
+/// Start an asynchronous client builder with credential-safe redirect defaults.
+pub fn authenticated_client_builder() -> reqwest::ClientBuilder {
+    reqwest::Client::builder()
+        .referer(false)
+        .redirect(authenticated_redirect_policy())
+}
+
+/// Start a blocking client builder with credential-safe redirect defaults.
+pub fn authenticated_blocking_client_builder() -> reqwest::blocking::ClientBuilder {
+    reqwest::blocking::Client::builder()
+        .referer(false)
+        .redirect(authenticated_redirect_policy())
+}
+
+/// Remove a request URL before an HTTP error is retained or displayed.
+///
+/// Reqwest errors can include the complete request URL, including credentials
+/// carried in its user-info or query string. Removing the URL is safer than
+/// relying on every caller to redact each supported authentication scheme.
+pub fn strip_request_url(error: reqwest::Error) -> reqwest::Error {
+    error.without_url()
+}
+
+/// Mask credentials embedded in a URL before it is written to a log.
+///
+/// In addition to URL user-info, this covers bearer-like query parameters used
+/// by Plex, Jellyfin, DAAP, and Subsonic. The short Subsonic keys are redacted
+/// only when the companion parameters identify the URL as Subsonic, avoiding
+/// false positives on ordinary `s` and `p` parameters.
+pub fn redact_url_secrets(uri: &str) -> String {
+    const SENSITIVE_PARAMS: &[&str] = &["X-Plex-Token", "api_key", "session-id"];
+
+    let Ok(mut url) = Url::parse(uri) else {
+        return uri.to_string();
+    };
+
+    let has_user_info = !url.username().is_empty() || url.password().is_some();
+    if has_user_info {
+        // Parsed HTTP(S) URLs with user-info always support these setters.
+        let _ = url.set_username(REDACTED);
+        if url.password().is_some() {
+            let _ = url.set_password(Some(REDACTED));
+        }
+    }
+
+    let query_pairs: Vec<(String, String)> = url
+        .query_pairs()
+        .map(|(key, value)| (key.into_owned(), value.into_owned()))
+        .collect();
+    let has_subsonic_token = query_pairs.iter().any(|(key, _)| key == "t");
+    let has_subsonic_password = ["p", "u", "c"]
+        .into_iter()
+        .all(|required| query_pairs.iter().any(|(key, _)| key == required));
+
+    let mut redacted_query = false;
+    let query_pairs: Vec<(String, String)> = query_pairs
+        .into_iter()
+        .map(|(key, value)| {
+            let sensitive = SENSITIVE_PARAMS.contains(&key.as_str())
+                || (has_subsonic_token && matches!(key.as_str(), "t" | "s"))
+                || (has_subsonic_password && key == "p");
+            if sensitive {
+                redacted_query = true;
+                (key, REDACTED.to_string())
+            } else {
+                (key, value)
+            }
+        })
+        .collect();
+
+    if !has_user_info && !redacted_query {
+        return uri.to_string();
+    }
+
+    if redacted_query {
+        url.query_pairs_mut().clear();
+        for (key, value) in &query_pairs {
+            url.query_pairs_mut().append_pair(key, value);
+        }
+    }
+    url.to_string()
+}
+
+fn authenticated_redirect_policy() -> reqwest::redirect::Policy {
+    reqwest::redirect::Policy::custom(|attempt| {
+        if attempt.previous().len() > MAX_REDIRECTS {
+            return attempt.error("too many redirects");
+        }
+
+        if attempt
+            .previous()
+            .last()
+            .is_some_and(|previous| same_http_origin(previous, attempt.url()))
+        {
+            attempt.follow()
+        } else {
+            attempt.stop()
+        }
+    })
+}
+
+fn same_http_origin(left: &Url, right: &Url) -> bool {
+    matches!(left.scheme(), "http" | "https")
+        && left.scheme() == right.scheme()
+        && left.host() == right.host()
+        && left.port_or_known_default() == right.port_or_known_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::{SocketAddr, TcpListener, TcpStream};
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Duration;
+
+    fn url(value: &str) -> Url {
+        Url::parse(value).expect("test URL must parse")
+    }
+
+    #[test]
+    fn exact_origin_accepts_default_and_explicit_ports() {
+        assert!(same_http_origin(
+            &url("https://example.com/start"),
+            &url("https://example.com:443/next")
+        ));
+        assert!(same_http_origin(
+            &url("http://example.com:80/start"),
+            &url("http://example.com/next")
+        ));
+    }
+
+    #[test]
+    fn exact_origin_rejects_scheme_host_and_port_changes() {
+        let origin = url("https://example.com:8443/start");
+        assert!(!same_http_origin(
+            &origin,
+            &url("http://example.com:8443/next")
+        ));
+        assert!(!same_http_origin(
+            &origin,
+            &url("https://other.example.com:8443/next")
+        ));
+        assert!(!same_http_origin(
+            &origin,
+            &url("https://example.com:9443/next")
+        ));
+    }
+
+    #[test]
+    fn exact_origin_rejects_non_http_schemes() {
+        assert!(!same_http_origin(
+            &url("file:///tmp/start"),
+            &url("file:///tmp/next")
+        ));
+    }
+
+    #[test]
+    fn redacts_supported_query_credentials() {
+        let plex =
+            redact_url_secrets("https://plex.example/library?X-Plex-Token=plex-secret&other=value");
+        assert!(plex.contains("X-Plex-Token=REDACTED"));
+        assert!(plex.contains("other=value"));
+        assert!(!plex.contains("plex-secret"));
+
+        let jellyfin = redact_url_secrets("https://jellyfin.example/Items?api_key=jellyfin-secret");
+        assert!(jellyfin.contains("api_key=REDACTED"));
+        assert!(!jellyfin.contains("jellyfin-secret"));
+
+        let daap =
+            redact_url_secrets("http://127.0.0.1:3689/databases/1/items?session-id=daap-secret");
+        assert!(daap.contains("session-id=REDACTED"));
+        assert!(!daap.contains("daap-secret"));
+    }
+
+    #[test]
+    fn redacts_subsonic_token_salt_and_contextual_password() {
+        let token = redact_url_secrets(
+            "https://sub.example/rest/ping?t=token-secret&s=salt-secret&u=admin&c=Tributary",
+        );
+        assert!(token.contains("t=REDACTED"));
+        assert!(token.contains("s=REDACTED"));
+        assert!(!token.contains("token-secret"));
+        assert!(!token.contains("salt-secret"));
+
+        let password = redact_url_secrets(
+            "https://sub.example/rest/ping?u=admin&p=enc%3Apassword-secret&c=Tributary",
+        );
+        assert!(password.contains("p=REDACTED"));
+        assert!(!password.contains("password-secret"));
+    }
+
+    #[test]
+    fn redacts_url_user_info() {
+        let redacted =
+            redact_url_secrets("https://private-user:private-password@example.com/music?album=one");
+        assert_eq!(
+            redacted,
+            "https://REDACTED:REDACTED@example.com/music?album=one"
+        );
+        assert!(!redacted.contains("private-user"));
+        assert!(!redacted.contains("private-password"));
+    }
+
+    #[test]
+    fn leaves_unrelated_and_invalid_urls_unchanged() {
+        let ordinary = "https://example.com/api?s=search&p=page&limit=50";
+        assert_eq!(redact_url_secrets(ordinary), ordinary);
+        let invalid = "not a valid url";
+        assert_eq!(redact_url_secrets(invalid), invalid);
+    }
+
+    fn read_request(stream: &mut TcpStream) -> String {
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .expect("set read timeout");
+        let mut bytes = Vec::new();
+        let mut buffer = [0_u8; 1024];
+        while !bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+            let read = stream.read(&mut buffer).expect("read test request");
+            if read == 0 {
+                break;
+            }
+            bytes.extend_from_slice(&buffer[..read]);
+        }
+        String::from_utf8(bytes).expect("HTTP request must be UTF-8")
+    }
+
+    fn spawn_one_response(
+        status: &'static str,
+        location: Option<SocketAddr>,
+    ) -> (SocketAddr, mpsc::Receiver<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let address = listener.local_addr().expect("test server address");
+        let (request_tx, request_rx) = mpsc::channel();
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept test request");
+            let request = read_request(&mut stream);
+            request_tx.send(request).expect("capture test request");
+            let location = location
+                .map(|destination| format!("Location: http://{destination}/target\r\n"))
+                .unwrap_or_default();
+            let response = format!(
+                "HTTP/1.1 {status}\r\n{location}Content-Length: 0\r\nConnection: close\r\n\r\n"
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write test response");
+        });
+        (address, request_rx)
+    }
+
+    #[test]
+    fn follows_same_origin_without_referer_and_preserves_auth_header() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let address = listener.local_addr().expect("test server address");
+        let (request_tx, request_rx) = mpsc::channel();
+        let server = thread::spawn(move || {
+            for index in 0..2 {
+                let (mut stream, _) = listener.accept().expect("accept request");
+                let request = read_request(&mut stream);
+                request_tx.send(request).expect("capture request");
+                let response = if index == 0 {
+                    format!(
+                        "HTTP/1.1 302 Found\r\nLocation: http://{address}/target\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    )
+                } else {
+                    "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".to_string()
+                };
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("write response");
+            }
+        });
+
+        let client = authenticated_blocking_client_builder()
+            .default_headers(reqwest::header::HeaderMap::from_iter([
+                (
+                    reqwest::header::AUTHORIZATION,
+                    reqwest::header::HeaderValue::from_static("Bearer secret"),
+                ),
+                (
+                    reqwest::header::HeaderName::from_static("x-test-auth"),
+                    reqwest::header::HeaderValue::from_static("secret"),
+                ),
+            ]))
+            .build()
+            .expect("build client");
+        let response = client
+            .get(format!("http://{address}/start?api_key=secret"))
+            .send()
+            .expect("same-origin redirect must succeed");
+        assert!(response.status().is_success());
+
+        let first = request_rx.recv().expect("initial request");
+        let second = request_rx.recv().expect("redirected request");
+        let first = first.to_ascii_lowercase();
+        let second = second.to_ascii_lowercase();
+        assert!(first.contains("authorization: bearer secret"));
+        assert!(first.contains("x-test-auth: secret"));
+        assert!(second.contains("authorization: bearer secret"));
+        assert!(second.contains("x-test-auth: secret"));
+        assert!(!second.contains("referer:"));
+        server.join().expect("join server");
+    }
+
+    #[test]
+    fn stops_cross_port_redirect_before_sending_credentials() {
+        let destination = TcpListener::bind("127.0.0.1:0").expect("bind destination");
+        let destination_address = destination.local_addr().expect("destination address");
+        let (origin, origin_rx) = spawn_one_response("302 Found", Some(destination_address));
+        let client = authenticated_blocking_client_builder()
+            .default_headers(reqwest::header::HeaderMap::from_iter([(
+                reqwest::header::HeaderName::from_static("x-test-auth"),
+                reqwest::header::HeaderValue::from_static("secret"),
+            )]))
+            .build()
+            .expect("build client");
+
+        let response = client
+            .get(format!("http://{origin}/start"))
+            .send()
+            .expect("cross-origin redirect must stop cleanly");
+        assert!(response.status().is_redirection());
+        assert!(origin_rx
+            .recv()
+            .expect("origin request")
+            .to_ascii_lowercase()
+            .contains("x-test-auth: secret"));
+        destination
+            .set_nonblocking(true)
+            .expect("make destination nonblocking");
+        assert!(matches!(
+            destination.accept(),
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock
+        ));
+    }
+
+    #[test]
+    fn redirect_loop_is_limited_and_error_url_can_be_stripped() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loop server");
+        let address = listener.local_addr().expect("loop server address");
+        let server = thread::spawn(move || {
+            for _ in 0..=MAX_REDIRECTS {
+                let (mut stream, _) = listener.accept().expect("accept loop request");
+                let _ = read_request(&mut stream);
+                let response = format!(
+                    "HTTP/1.1 302 Found\r\nLocation: http://{address}/loop?api_key=loop-secret\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("write redirect");
+            }
+        });
+        let client = authenticated_blocking_client_builder()
+            .build()
+            .expect("build client");
+        let error = client
+            .get(format!("http://{address}/loop?api_key=loop-secret"))
+            .send()
+            .expect_err("redirect loop must fail");
+        assert!(error.is_redirect());
+        assert!(error.url().is_some());
+        let stripped = strip_request_url(error);
+        assert!(stripped.url().is_none());
+        assert!(!stripped.to_string().contains("loop-secret"));
+        server.join().expect("join loop server");
+    }
+
+    #[test]
+    fn strips_url_from_status_error() {
+        let (address, request_rx) = spawn_one_response("500 Internal Server Error", None);
+        let client = authenticated_blocking_client_builder()
+            .build()
+            .expect("build client");
+        let error = client
+            .get(format!("http://user:password@{address}/?api_key=secret"))
+            .send()
+            .expect("receive error response")
+            .error_for_status()
+            .expect_err("500 must be an error");
+        assert!(error.url().is_some());
+        let stripped = strip_request_url(error);
+        assert!(stripped.url().is_none());
+        let display = stripped.to_string();
+        assert!(!display.contains("user"));
+        assert!(!display.contains("password"));
+        assert!(!display.contains("secret"));
+        let _ = request_rx.recv().expect("error request");
+    }
+
+    #[test]
+    fn asynchronous_builder_can_send_requests() {
+        let (address, request_rx) = spawn_one_response("200 OK", None);
+        let runtime = tokio::runtime::Runtime::new().expect("build runtime");
+        runtime.block_on(async {
+            let response = authenticated_client_builder()
+                .build()
+                .expect("build async client")
+                .get(format!("http://{address}/"))
+                .send()
+                .await
+                .expect("send async request");
+            assert!(response.status().is_success());
+        });
+        let _ = request_rx.recv().expect("async request");
+    }
+}

--- a/src/http_security.rs
+++ b/src/http_security.rs
@@ -28,6 +28,20 @@ pub fn strip_request_url(error: reqwest::Error) -> reqwest::Error {
     error.without_url()
 }
 
+/// Validate an HTTP base URL before credentials are attached to requests.
+pub fn validate_base_url(url: &Url) -> Result<(), &'static str> {
+    if url.cannot_be_a_base()
+        || !matches!(url.scheme(), "http" | "https")
+        || !url.username().is_empty()
+        || url.password().is_some()
+    {
+        return Err(
+            "Invalid server URL: use an http:// or https:// URL without embedded credentials",
+        );
+    }
+    Ok(())
+}
+
 /// Mask credentials embedded in a URL before it is written to a log.
 ///
 /// In addition to URL user-info, this covers bearer-like query parameters used
@@ -161,6 +175,20 @@ mod tests {
             &url("file:///tmp/start"),
             &url("file:///tmp/next")
         ));
+    }
+
+    #[test]
+    fn authenticated_base_urls_reject_opaque_non_http_and_userinfo_inputs() {
+        assert!(validate_base_url(&url("https://music.example.test:443/base")).is_ok());
+        for unsafe_url in [
+            "music.example.test:443",
+            "ftp://music.example.test/base",
+            "https://user:secret@music.example.test/base",
+        ] {
+            let error = validate_base_url(&url(unsafe_url)).expect_err("unsafe base URL");
+            assert!(!error.contains("secret"));
+            assert!(!error.contains(unsafe_url));
+        }
     }
 
     #[test]

--- a/src/jellyfin/client.rs
+++ b/src/jellyfin/client.rs
@@ -10,6 +10,7 @@ use url::Url;
 
 use crate::architecture::backend::BackendResult;
 use crate::architecture::error::BackendError;
+use crate::http_security::{authenticated_client_builder, redact_url_secrets, strip_request_url};
 
 use super::api::{JellyfinAuthRequest, JellyfinAuthResponse};
 
@@ -60,11 +61,15 @@ impl JellyfinClient {
             message: format!("Invalid server URL: {e}"),
             source: Some(Box::new(e)),
         })?;
-        validate_base_url(server_url, &base_url)?;
+        validate_base_url(&base_url)?;
 
         let http = build_http_client(api_key)?;
 
-        info!(server = %base_url, user_id = %user_id, "Jellyfin client created (API key)");
+        info!(
+            server = %redact_url_secrets(base_url.as_str()),
+            user_id = %user_id,
+            "Jellyfin client created (API key)"
+        );
 
         Ok(Self {
             base_url,
@@ -88,7 +93,7 @@ impl JellyfinClient {
             message: format!("Invalid server URL: {e}"),
             source: Some(Box::new(e)),
         })?;
-        validate_base_url(server_url, &base_url)?;
+        validate_base_url(&base_url)?;
 
         // Build a temporary client WITHOUT a token for the auth request.
         let pre_auth_header = format!(
@@ -107,7 +112,7 @@ impl JellyfinClient {
         );
         pre_auth_headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
 
-        let pre_auth_http = Client::builder()
+        let pre_auth_http = authenticated_client_builder()
             .user_agent(CLIENT_NAME)
             .default_headers(pre_auth_headers)
             .connect_timeout(CONNECT_TIMEOUT)
@@ -133,16 +138,19 @@ impl JellyfinClient {
             pw: password.to_string(),
         };
 
-        debug!(url = %crate::audio::redact_url_secrets(auth_url.as_str()), "Jellyfin auth request");
+        debug!(url = %redact_url_secrets(auth_url.as_str()), "Jellyfin auth request");
 
         let resp = pre_auth_http
             .post(auth_url.as_str())
             .json(&body)
             .send()
             .await
-            .map_err(|e| BackendError::ConnectionFailed {
-                message: format!("Auth request failed: {e}"),
-                source: Some(Box::new(e)),
+            .map_err(|e| {
+                let e = strip_request_url(e);
+                BackendError::ConnectionFailed {
+                    message: format!("Auth request failed: {e}"),
+                    source: Some(Box::new(e)),
+                }
             })?;
 
         let status = resp.status();
@@ -163,17 +171,19 @@ impl JellyfinClient {
             });
         }
 
-        let auth_resp: JellyfinAuthResponse =
-            resp.json().await.map_err(|e| BackendError::ParseError {
+        let auth_resp: JellyfinAuthResponse = resp.json().await.map_err(|e| {
+            let e = strip_request_url(e);
+            BackendError::ParseError {
                 message: format!("Failed to parse auth response: {e}"),
                 source: Some(Box::new(e)),
-            })?;
+            }
+        })?;
 
         let api_key = auth_resp.access_token;
         let user_id = auth_resp.user.id;
 
         info!(
-            server = %base_url,
+            server = %redact_url_secrets(base_url.as_str()),
             user = %auth_resp.user.name,
             user_id = %user_id,
             "Jellyfin authentication successful"
@@ -261,9 +271,10 @@ impl JellyfinClient {
             }
         }
 
-        debug!(url = %crate::audio::redact_url_secrets(url.as_str()), "Jellyfin request");
+        debug!(url = %redact_url_secrets(url.as_str()), "Jellyfin request");
 
         let resp = self.http.get(url.as_str()).send().await.map_err(|e| {
+            let e = strip_request_url(e);
             BackendError::ConnectionFailed {
                 message: format!("HTTP request failed: {e}"),
                 source: Some(Box::new(e)),
@@ -288,13 +299,13 @@ impl JellyfinClient {
         // Refuse to buffer an oversized body (DoS guard) before reading it.
         check_body_size(&resp)?;
 
-        let body = resp
-            .json::<T>()
-            .await
-            .map_err(|e| BackendError::ParseError {
+        let body = resp.json::<T>().await.map_err(|e| {
+            let e = strip_request_url(e);
+            BackendError::ParseError {
                 message: format!("Failed to parse Jellyfin JSON: {e}"),
                 source: Some(Box::new(e)),
-            })?;
+            }
+        })?;
 
         Ok(body)
     }
@@ -304,9 +315,10 @@ impl JellyfinClient {
     /// Used for endpoints that return plain text (e.g. `/System/Ping`).
     pub async fn get_text(&self, endpoint: &str) -> BackendResult<String> {
         let url = self.api_url(endpoint);
-        debug!(url = %crate::audio::redact_url_secrets(url.as_str()), "Jellyfin text request");
+        debug!(url = %redact_url_secrets(url.as_str()), "Jellyfin text request");
 
         let resp = self.http.get(url.as_str()).send().await.map_err(|e| {
+            let e = strip_request_url(e);
             BackendError::ConnectionFailed {
                 message: format!("HTTP request failed: {e}"),
                 source: Some(Box::new(e)),
@@ -331,9 +343,12 @@ impl JellyfinClient {
         // Refuse to buffer an oversized body (DoS guard) before reading it.
         check_body_size(&resp)?;
 
-        let text = resp.text().await.map_err(|e| BackendError::ParseError {
-            message: format!("Failed to read Jellyfin response body: {e}"),
-            source: Some(Box::new(e)),
+        let text = resp.text().await.map_err(|e| {
+            let e = strip_request_url(e);
+            BackendError::ParseError {
+                message: format!("Failed to read Jellyfin response body: {e}"),
+                source: Some(Box::new(e)),
+            }
         })?;
 
         Ok(text)
@@ -356,12 +371,11 @@ fn build_http_client(api_key: &str) -> BackendResult<Client> {
     );
     default_headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
 
-    Client::builder()
+    authenticated_client_builder()
         .user_agent(CLIENT_NAME)
         .default_headers(default_headers)
         .connect_timeout(CONNECT_TIMEOUT)
         .read_timeout(READ_TIMEOUT)
-        .redirect(redirect_policy())
         .build()
         .map_err(|e| BackendError::ConnectionFailed {
             message: format!("Failed to build HTTP client: {e}"),
@@ -369,42 +383,24 @@ fn build_http_client(api_key: &str) -> BackendResult<Client> {
         })
 }
 
-/// Redirect policy for API requests.
-///
-/// The `X-Emby-Authorization` token rides on every request as a default
-/// header, and reqwest does NOT strip custom auth headers on cross-host
-/// redirects (only the standard `Authorization`/`Cookie` set).  Follow
-/// only same-host redirects so a compromised or MITM'd server cannot
-/// bounce the client to an attacker host and harvest the token.
-fn redirect_policy() -> reqwest::redirect::Policy {
-    reqwest::redirect::Policy::custom(|attempt| {
-        if attempt.previous().len() > 10 {
-            return attempt.error("too many redirects");
-        }
-        let same_host = {
-            let prev_host = attempt.previous().last().and_then(Url::host_str);
-            prev_host == attempt.url().host_str()
-        };
-        if same_host {
-            attempt.follow()
-        } else {
-            attempt.stop()
-        }
-    })
-}
-
-/// Reject server URLs that would later panic during request building.
+/// Reject server URLs that are unsafe or would panic during request building.
 ///
 /// `Url::parse` accepts opaque, cannot-be-a-base inputs such as a
 /// scheme-less `host:port` (e.g. `myserver:8096`), but `api_url` /
 /// `authenticate` build paths via `path_segments_mut`, which panics on
-/// such URLs.  Surface a clean error instead.
-fn validate_base_url(server_url: &str, base_url: &Url) -> BackendResult<()> {
-    if base_url.cannot_be_a_base() || !matches!(base_url.scheme(), "http" | "https") {
+/// such URLs. Embedded userinfo is also forbidden so credentials cannot be
+/// retained in generated URLs, logs, or request errors. Surface a clean error
+/// without echoing the rejected URL.
+fn validate_base_url(base_url: &Url) -> BackendResult<()> {
+    if base_url.cannot_be_a_base()
+        || !matches!(base_url.scheme(), "http" | "https")
+        || !base_url.username().is_empty()
+        || base_url.password().is_some()
+    {
         return Err(BackendError::ConnectionFailed {
-            message: format!(
-                "Invalid server URL '{server_url}': must start with http:// or https://"
-            ),
+            message:
+                "Invalid server URL: use an http:// or https:// URL without embedded credentials"
+                    .into(),
             source: None,
         });
     }
@@ -429,4 +425,25 @@ fn check_body_size(resp: &reqwest::Response) -> BackendResult<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_embedded_url_credentials_without_echoing_them() {
+        let secret = "userinfo-secret";
+        let error = JellyfinClient::new(
+            &format!("https://embedded-user:{secret}@media.example.test"),
+            "api-key",
+            "user-id",
+        )
+        .err()
+        .expect("embedded URL credentials must be rejected");
+
+        let rendered = error.to_string();
+        assert!(!rendered.contains("embedded-user"));
+        assert!(!rendered.contains(secret));
+    }
 }

--- a/src/jellyfin/client.rs
+++ b/src/jellyfin/client.rs
@@ -10,7 +10,9 @@ use url::Url;
 
 use crate::architecture::backend::BackendResult;
 use crate::architecture::error::BackendError;
-use crate::http_security::{authenticated_client_builder, redact_url_secrets, strip_request_url};
+use crate::http_security::{
+    authenticated_client_builder, redact_url_secrets, strip_request_url, validate_base_url,
+};
 
 use super::api::{JellyfinAuthRequest, JellyfinAuthResponse};
 
@@ -61,7 +63,10 @@ impl JellyfinClient {
             message: format!("Invalid server URL: {e}"),
             source: Some(Box::new(e)),
         })?;
-        validate_base_url(&base_url)?;
+        validate_base_url(&base_url).map_err(|message| BackendError::ConnectionFailed {
+            message: message.to_string(),
+            source: None,
+        })?;
 
         let http = build_http_client(api_key)?;
 
@@ -93,7 +98,10 @@ impl JellyfinClient {
             message: format!("Invalid server URL: {e}"),
             source: Some(Box::new(e)),
         })?;
-        validate_base_url(&base_url)?;
+        validate_base_url(&base_url).map_err(|message| BackendError::ConnectionFailed {
+            message: message.to_string(),
+            source: None,
+        })?;
 
         // Build a temporary client WITHOUT a token for the auth request.
         let pre_auth_header = format!(
@@ -381,30 +389,6 @@ fn build_http_client(api_key: &str) -> BackendResult<Client> {
             message: format!("Failed to build HTTP client: {e}"),
             source: Some(Box::new(e)),
         })
-}
-
-/// Reject server URLs that are unsafe or would panic during request building.
-///
-/// `Url::parse` accepts opaque, cannot-be-a-base inputs such as a
-/// scheme-less `host:port` (e.g. `myserver:8096`), but `api_url` /
-/// `authenticate` build paths via `path_segments_mut`, which panics on
-/// such URLs. Embedded userinfo is also forbidden so credentials cannot be
-/// retained in generated URLs, logs, or request errors. Surface a clean error
-/// without echoing the rejected URL.
-fn validate_base_url(base_url: &Url) -> BackendResult<()> {
-    if base_url.cannot_be_a_base()
-        || !matches!(base_url.scheme(), "http" | "https")
-        || !base_url.username().is_empty()
-        || base_url.password().is_some()
-    {
-        return Err(BackendError::ConnectionFailed {
-            message:
-                "Invalid server URL: use an http:// or https:// URL without embedded credentials"
-                    .into(),
-            source: None,
-        });
-    }
-    Ok(())
 }
 
 /// Reject a response whose declared body exceeds [`MAX_BODY_BYTES`].

--- a/src/jellyfin/client.rs
+++ b/src/jellyfin/client.rs
@@ -433,10 +433,11 @@ mod tests {
 
     #[test]
     fn rejects_embedded_url_credentials_without_echoing_them() {
-        let secret = "userinfo-secret";
+        let secret = uuid::Uuid::new_v4().to_string();
+        let api_key = uuid::Uuid::new_v4().to_string();
         let error = JellyfinClient::new(
             &format!("https://embedded-user:{secret}@media.example.test"),
-            "api-key",
+            &api_key,
             "user-id",
         )
         .err()
@@ -444,6 +445,6 @@ mod tests {
 
         let rendered = error.to_string();
         assert!(!rendered.contains("embedded-user"));
-        assert!(!rendered.contains(secret));
+        assert!(!rendered.contains(&secret));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,7 @@ mod desktop_integration;
 #[allow(dead_code)]
 mod device;
 mod discovery;
+pub(crate) mod http_security;
 #[allow(dead_code)]
 mod jellyfin;
 #[allow(dead_code)]

--- a/src/plex/client.rs
+++ b/src/plex/client.rs
@@ -10,7 +10,9 @@ use url::Url;
 
 use crate::architecture::backend::BackendResult;
 use crate::architecture::error::BackendError;
-use crate::http_security::{authenticated_client_builder, redact_url_secrets, strip_request_url};
+use crate::http_security::{
+    authenticated_client_builder, redact_url_secrets, strip_request_url, validate_base_url,
+};
 
 use super::api::PlexSignInResponse;
 
@@ -62,7 +64,10 @@ impl PlexClient {
             message: format!("Invalid server URL: {e}"),
             source: Some(Box::new(e)),
         })?;
-        validate_base_url(&base_url)?;
+        validate_base_url(&base_url).map_err(|message| BackendError::ConnectionFailed {
+            message: message.to_string(),
+            source: None,
+        })?;
 
         let http = build_http_client(auth_token)?;
 
@@ -92,7 +97,10 @@ impl PlexClient {
             message: format!("Invalid server URL: {e}"),
             source: Some(Box::new(e)),
         })?;
-        validate_base_url(&base_url)?;
+        validate_base_url(&base_url).map_err(|message| BackendError::ConnectionFailed {
+            message: message.to_string(),
+            source: None,
+        })?;
 
         // Build Plex identification headers (no token yet).
         let mut headers = HeaderMap::new();
@@ -329,29 +337,6 @@ fn build_http_client(auth_token: &str) -> BackendResult<Client> {
             message: format!("Failed to build HTTP client: {e}"),
             source: Some(Box::new(e)),
         })
-}
-
-/// Reject server URLs that are unsafe or would panic during request building.
-///
-/// `Url::parse` accepts opaque, cannot-be-a-base inputs such as a
-/// scheme-less `host:port` (e.g. `nas:32400`), but `api_url` builds paths
-/// via `path_segments_mut`, which panics on such URLs. Embedded userinfo is
-/// also forbidden so credentials cannot be retained in generated URLs, logs,
-/// or request errors. Surface a clean error without echoing the rejected URL.
-fn validate_base_url(base_url: &Url) -> BackendResult<()> {
-    if base_url.cannot_be_a_base()
-        || !matches!(base_url.scheme(), "http" | "https")
-        || !base_url.username().is_empty()
-        || base_url.password().is_some()
-    {
-        return Err(BackendError::ConnectionFailed {
-            message:
-                "Invalid server URL: use an http:// or https:// URL without embedded credentials"
-                    .into(),
-            source: None,
-        });
-    }
-    Ok(())
 }
 
 /// Reject a response whose declared body exceeds [`MAX_BODY_BYTES`].

--- a/src/plex/client.rs
+++ b/src/plex/client.rs
@@ -10,6 +10,7 @@ use url::Url;
 
 use crate::architecture::backend::BackendResult;
 use crate::architecture::error::BackendError;
+use crate::http_security::{authenticated_client_builder, redact_url_secrets, strip_request_url};
 
 use super::api::PlexSignInResponse;
 
@@ -61,11 +62,14 @@ impl PlexClient {
             message: format!("Invalid server URL: {e}"),
             source: Some(Box::new(e)),
         })?;
-        validate_base_url(server_url, &base_url)?;
+        validate_base_url(&base_url)?;
 
         let http = build_http_client(auth_token)?;
 
-        info!(server = %base_url, "Plex client created (token)");
+        info!(
+            server = %redact_url_secrets(base_url.as_str()),
+            "Plex client created (token)"
+        );
 
         Ok(Self {
             base_url,
@@ -88,7 +92,7 @@ impl PlexClient {
             message: format!("Invalid server URL: {e}"),
             source: Some(Box::new(e)),
         })?;
-        validate_base_url(server_url, &base_url)?;
+        validate_base_url(&base_url)?;
 
         // Build Plex identification headers (no token yet).
         let mut headers = HeaderMap::new();
@@ -108,7 +112,7 @@ impl PlexClient {
             HeaderValue::from_static("application/x-www-form-urlencoded"),
         );
 
-        let pre_auth_http = Client::builder()
+        let pre_auth_http = authenticated_client_builder()
             .user_agent(CLIENT_NAME)
             .default_headers(headers)
             .connect_timeout(CONNECT_TIMEOUT)
@@ -132,9 +136,12 @@ impl PlexClient {
             .body(form_body)
             .send()
             .await
-            .map_err(|e| BackendError::ConnectionFailed {
-                message: format!("Plex sign-in request failed: {e}"),
-                source: Some(Box::new(e)),
+            .map_err(|e| {
+                let e = strip_request_url(e);
+                BackendError::ConnectionFailed {
+                    message: format!("Plex sign-in request failed: {e}"),
+                    source: Some(Box::new(e)),
+                }
             })?;
 
         let status = resp.status();
@@ -155,16 +162,18 @@ impl PlexClient {
             });
         }
 
-        let sign_in: PlexSignInResponse =
-            resp.json().await.map_err(|e| BackendError::ParseError {
+        let sign_in: PlexSignInResponse = resp.json().await.map_err(|e| {
+            let e = strip_request_url(e);
+            BackendError::ParseError {
                 message: format!("Failed to parse Plex sign-in response: {e}"),
                 source: Some(Box::new(e)),
-            })?;
+            }
+        })?;
 
         let auth_token = sign_in.user.auth_token;
 
         info!(
-            server = %base_url,
+            server = %redact_url_secrets(base_url.as_str()),
             user = ?sign_in.user.username,
             "Plex authentication successful"
         );
@@ -249,9 +258,10 @@ impl PlexClient {
             }
         }
 
-        debug!(url = %crate::audio::redact_url_secrets(url.as_str()), "Plex request");
+        debug!(url = %redact_url_secrets(url.as_str()), "Plex request");
 
         let resp = self.http.get(url.as_str()).send().await.map_err(|e| {
+            let e = strip_request_url(e);
             BackendError::ConnectionFailed {
                 message: format!("HTTP request failed: {e}"),
                 source: Some(Box::new(e)),
@@ -276,13 +286,13 @@ impl PlexClient {
         // Refuse to buffer an oversized body (DoS guard) before reading it.
         check_body_size(&resp)?;
 
-        let body = resp
-            .json::<T>()
-            .await
-            .map_err(|e| BackendError::ParseError {
+        let body = resp.json::<T>().await.map_err(|e| {
+            let e = strip_request_url(e);
+            BackendError::ParseError {
                 message: format!("Failed to parse Plex JSON: {e}"),
                 source: Some(Box::new(e)),
-            })?;
+            }
+        })?;
 
         Ok(body)
     }
@@ -309,12 +319,11 @@ fn build_http_client(auth_token: &str) -> BackendResult<Client> {
     );
     default_headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
 
-    Client::builder()
+    authenticated_client_builder()
         .user_agent(CLIENT_NAME)
         .default_headers(default_headers)
         .connect_timeout(CONNECT_TIMEOUT)
         .read_timeout(READ_TIMEOUT)
-        .redirect(redirect_policy())
         .build()
         .map_err(|e| BackendError::ConnectionFailed {
             message: format!("Failed to build HTTP client: {e}"),
@@ -322,42 +331,23 @@ fn build_http_client(auth_token: &str) -> BackendResult<Client> {
         })
 }
 
-/// Redirect policy for API requests.
-///
-/// The account-wide `X-Plex-Token` rides on every request as a default
-/// header, and reqwest does NOT strip custom auth headers on cross-host
-/// redirects (only the standard `Authorization`/`Cookie` set).  Follow
-/// only same-host redirects so a compromised or MITM'd server cannot
-/// bounce the client to an attacker host and harvest the token.
-fn redirect_policy() -> reqwest::redirect::Policy {
-    reqwest::redirect::Policy::custom(|attempt| {
-        if attempt.previous().len() > 10 {
-            return attempt.error("too many redirects");
-        }
-        let same_host = {
-            let prev_host = attempt.previous().last().and_then(Url::host_str);
-            prev_host == attempt.url().host_str()
-        };
-        if same_host {
-            attempt.follow()
-        } else {
-            attempt.stop()
-        }
-    })
-}
-
-/// Reject server URLs that would later panic during request building.
+/// Reject server URLs that are unsafe or would panic during request building.
 ///
 /// `Url::parse` accepts opaque, cannot-be-a-base inputs such as a
 /// scheme-less `host:port` (e.g. `nas:32400`), but `api_url` builds paths
-/// via `path_segments_mut`, which panics on such URLs.  Surface a clean
-/// error instead.
-fn validate_base_url(server_url: &str, base_url: &Url) -> BackendResult<()> {
-    if base_url.cannot_be_a_base() || !matches!(base_url.scheme(), "http" | "https") {
+/// via `path_segments_mut`, which panics on such URLs. Embedded userinfo is
+/// also forbidden so credentials cannot be retained in generated URLs, logs,
+/// or request errors. Surface a clean error without echoing the rejected URL.
+fn validate_base_url(base_url: &Url) -> BackendResult<()> {
+    if base_url.cannot_be_a_base()
+        || !matches!(base_url.scheme(), "http" | "https")
+        || !base_url.username().is_empty()
+        || base_url.password().is_some()
+    {
         return Err(BackendError::ConnectionFailed {
-            message: format!(
-                "Invalid server URL '{server_url}': must start with http:// or https://"
-            ),
+            message:
+                "Invalid server URL: use an http:// or https:// URL without embedded credentials"
+                    .into(),
             source: None,
         });
     }
@@ -382,4 +372,24 @@ fn check_body_size(resp: &reqwest::Response) -> BackendResult<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_embedded_url_credentials_without_echoing_them() {
+        let secret = "userinfo-secret";
+        let error = PlexClient::new(
+            &format!("https://embedded-user:{secret}@plex.example.test"),
+            "auth-token",
+        )
+        .err()
+        .expect("embedded URL credentials must be rejected");
+
+        let rendered = error.to_string();
+        assert!(!rendered.contains("embedded-user"));
+        assert!(!rendered.contains(secret));
+    }
 }

--- a/src/plex/client.rs
+++ b/src/plex/client.rs
@@ -380,16 +380,17 @@ mod tests {
 
     #[test]
     fn rejects_embedded_url_credentials_without_echoing_them() {
-        let secret = "userinfo-secret";
+        let secret = uuid::Uuid::new_v4().to_string();
+        let auth_token = uuid::Uuid::new_v4().to_string();
         let error = PlexClient::new(
             &format!("https://embedded-user:{secret}@plex.example.test"),
-            "auth-token",
+            &auth_token,
         )
         .err()
         .expect("embedded URL credentials must be rejected");
 
         let rendered = error.to_string();
         assert!(!rendered.contains("embedded-user"));
-        assert!(!rendered.contains(secret));
+        assert!(!rendered.contains(&secret));
     }
 }

--- a/src/subsonic/client.rs
+++ b/src/subsonic/client.rs
@@ -10,7 +10,9 @@ use url::Url;
 
 use crate::architecture::backend::BackendResult;
 use crate::architecture::error::BackendError;
-use crate::http_security::{authenticated_client_builder, redact_url_secrets, strip_request_url};
+use crate::http_security::{
+    authenticated_client_builder, redact_url_secrets, strip_request_url, validate_base_url,
+};
 
 use super::api::SubsonicEnvelope;
 
@@ -90,17 +92,10 @@ impl SubsonicClient {
         // `api_url` via `path_segments_mut`. Embedded userinfo would also be
         // copied into every authenticated URL, so fail cleanly without echoing
         // the rejected URL.
-        if base_url.cannot_be_a_base()
-            || !matches!(base_url.scheme(), "http" | "https")
-            || !base_url.username().is_empty()
-            || base_url.password().is_some()
-        {
-            return Err(BackendError::ConnectionFailed {
-                message: "Invalid server URL: use an http:// or https:// URL without embedded credentials"
-                    .into(),
-                source: None,
-            });
-        }
+        validate_base_url(&base_url).map_err(|message| BackendError::ConnectionFailed {
+            message: message.to_string(),
+            source: None,
+        })?;
 
         // Token auth still transmits (username, salt, md5(password+salt)) in
         // the URL query string.  Over plain HTTP those can be captured by an

--- a/src/subsonic/client.rs
+++ b/src/subsonic/client.rs
@@ -10,6 +10,7 @@ use url::Url;
 
 use crate::architecture::backend::BackendResult;
 use crate::architecture::error::BackendError;
+use crate::http_security::{authenticated_client_builder, redact_url_secrets, strip_request_url};
 
 use super::api::SubsonicEnvelope;
 
@@ -81,16 +82,22 @@ impl SubsonicClient {
             source: Some(Box::new(e)),
         })?;
 
-        // Reject non-hierarchical / wrong-scheme URLs up front.  `Url::parse`
+        // Reject non-hierarchical, wrong-scheme, and credential-bearing URLs
+        // up front. `Url::parse`
         // happily accepts opaque inputs like `localhost:4533` (a scheme-less
         // host:port the user most likely meant as `http://localhost:4533`),
         // but building request paths from such a URL would panic later in
-        // `api_url` via `path_segments_mut`.  Fail cleanly instead.
-        if base_url.cannot_be_a_base() || !matches!(base_url.scheme(), "http" | "https") {
+        // `api_url` via `path_segments_mut`. Embedded userinfo would also be
+        // copied into every authenticated URL, so fail cleanly without echoing
+        // the rejected URL.
+        if base_url.cannot_be_a_base()
+            || !matches!(base_url.scheme(), "http" | "https")
+            || !base_url.username().is_empty()
+            || base_url.password().is_some()
+        {
             return Err(BackendError::ConnectionFailed {
-                message: format!(
-                    "Invalid server URL '{server_url}': must start with http:// or https://"
-                ),
+                message: "Invalid server URL: use an http:// or https:// URL without embedded credentials"
+                    .into(),
                 source: None,
             });
         }
@@ -102,7 +109,7 @@ impl SubsonicClient {
         // plaintext fallback is already HTTPS-gated, token auth was not.
         if base_url.scheme() != "https" {
             warn!(
-                server = %base_url,
+                server = %redact_url_secrets(base_url.as_str()),
                 "Subsonic token auth over an insecure (non-HTTPS) connection: the username, \
                  salt and token are sent in cleartext and can be captured and brute-forced. \
                  Use HTTPS where possible."
@@ -111,7 +118,7 @@ impl SubsonicClient {
 
         let auth = Self::make_token_auth(password);
 
-        let http = Client::builder()
+        let http = authenticated_client_builder()
             .user_agent(CLIENT_NAME)
             .connect_timeout(CONNECT_TIMEOUT)
             .read_timeout(READ_TIMEOUT)
@@ -121,7 +128,11 @@ impl SubsonicClient {
                 source: Some(Box::new(e)),
             })?;
 
-        info!(server = %base_url, user = %username, "Subsonic client created");
+        info!(
+            server = %redact_url_secrets(base_url.as_str()),
+            user = %username,
+            "Subsonic client created"
+        );
 
         Ok(Self {
             base_url,
@@ -160,7 +171,7 @@ impl SubsonicClient {
             });
 
         warn!(
-            server = %self.base_url,
+            server = %redact_url_secrets(self.base_url.as_str()),
             "Switching to hex-encoded plaintext auth (server does not support token auth)"
         );
 
@@ -233,7 +244,7 @@ impl SubsonicClient {
             }
         }
 
-        debug!(url = %crate::audio::redact_url_secrets(url.as_str()), "Subsonic request");
+        debug!(url = %redact_url_secrets(url.as_str()), "Subsonic request");
 
         let resp = self.http.get(url.as_str()).send().await.map_err(|e| {
             // Strip the request URL from the error before it is formatted or
@@ -241,7 +252,7 @@ impl SubsonicClient {
             // plaintext password) in its query string, and reqwest's Display
             // appends the full URL — which would leak the credential into
             // always-on error-level logs on routine transport failures.
-            let e = e.without_url();
+            let e = strip_request_url(e);
             BackendError::ConnectionFailed {
                 message: format!("HTTP request failed: {e}"),
                 source: Some(Box::new(e)),
@@ -261,7 +272,7 @@ impl SubsonicClient {
         let envelope: SubsonicEnvelope = resp.json().await.map_err(|e| {
             // A body-read failure here can also carry the credential-bearing
             // request URL; strip it before formatting/boxing into the error.
-            let e = e.without_url();
+            let e = strip_request_url(e);
             BackendError::ParseError {
                 message: format!("Failed to parse Subsonic JSON: {e}"),
                 source: Some(Box::new(e)),
@@ -336,4 +347,25 @@ fn check_body_size(resp: &reqwest::Response) -> BackendResult<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_embedded_url_credentials_without_echoing_them() {
+        let secret = "userinfo-secret";
+        let error = SubsonicClient::new(
+            &format!("https://embedded-user:{secret}@music.example.test"),
+            "api-user",
+            "api-password",
+        )
+        .err()
+        .expect("embedded URL credentials must be rejected");
+
+        let rendered = error.to_string();
+        assert!(!rendered.contains("embedded-user"));
+        assert!(!rendered.contains(secret));
+    }
 }

--- a/src/subsonic/client.rs
+++ b/src/subsonic/client.rs
@@ -355,17 +355,18 @@ mod tests {
 
     #[test]
     fn rejects_embedded_url_credentials_without_echoing_them() {
-        let secret = "userinfo-secret";
+        let secret = uuid::Uuid::new_v4().to_string();
+        let api_password = uuid::Uuid::new_v4().to_string();
         let error = SubsonicClient::new(
             &format!("https://embedded-user:{secret}@music.example.test"),
             "api-user",
-            "api-password",
+            &api_password,
         )
         .err()
         .expect("embedded URL credentials must be rejected");
 
         let rendered = error.to_string();
         assert!(!rendered.contains("embedded-user"));
-        assert!(!rendered.contains(secret));
+        assert!(!rendered.contains(&secret));
     }
 }

--- a/src/ui/album_art.rs
+++ b/src/ui/album_art.rs
@@ -48,16 +48,25 @@ struct ArtRequest {
 fn art_worker_tx() -> Option<&'static std::sync::mpsc::Sender<ArtRequest>> {
     static TX: OnceLock<Option<std::sync::mpsc::Sender<ArtRequest>>> = OnceLock::new();
     TX.get_or_init(|| {
+        // Build before spawning so a policy-construction failure disables
+        // remote artwork instead of silently restoring reqwest's permissive
+        // default redirect and Referer behavior.
+        let client = match crate::http_security::authenticated_blocking_client_builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .build()
+        {
+            Ok(client) => client,
+            Err(error) => {
+                let error = crate::http_security::strip_request_url(error);
+                tracing::warn!(%error, "Failed to build secure album art HTTP client");
+                return None;
+            }
+        };
+
         let (tx, rx) = std::sync::mpsc::channel::<ArtRequest>();
         let spawn_result = std::thread::Builder::new()
             .name("art-worker".into())
             .spawn(move || {
-                // Build the HTTP client once for the lifetime of this thread.
-                let client = reqwest::blocking::Client::builder()
-                    .timeout(std::time::Duration::from_secs(10))
-                    .build()
-                    .unwrap_or_default();
-
                 while let Ok(req) = rx.recv() {
                     // Check if this request is still current before fetching.
                     if ART_GENERATION.load(Ordering::Relaxed) != req.generation {
@@ -65,25 +74,25 @@ fn art_worker_tx() -> Option<&'static std::sync::mpsc::Sender<ArtRequest>> {
                     }
 
                     match client.get(&req.url).send() {
-                        Ok(resp) if resp.status().is_success() => {
-                            if let Ok(bytes) = resp.bytes() {
+                        Ok(resp) if resp.status().is_success() => match resp.bytes() {
+                            Ok(bytes)
                                 if !bytes.is_empty()
-                                    && ART_GENERATION.load(Ordering::Relaxed) == req.generation
-                                {
-                                    let _ = req.reply_tx.send_blocking(bytes.to_vec());
-                                }
+                                    && ART_GENERATION.load(Ordering::Relaxed) == req.generation =>
+                            {
+                                let _ = req.reply_tx.send_blocking(bytes.to_vec());
                             }
-                        }
+                            Ok(_) => {}
+                            Err(error) => {
+                                let error = crate::http_security::strip_request_url(error);
+                                tracing::debug!(%error, "Failed to read remote album art body");
+                            }
+                        },
                         Ok(resp) => {
                             tracing::debug!(status = %resp.status(), "Remote album art HTTP error");
                         }
-                        Err(e) => {
-                            // Strip the URL: cover-art URLs embed per-backend
-                            // credentials (Subsonic t/s/p, Jellyfin api_key,
-                            // Plex X-Plex-Token, DAAP session-id) in the query
-                            // string, and reqwest's Display would otherwise
-                            // print the full credential-bearing URL.
-                            tracing::debug!(error = %e.without_url(), "Failed to fetch remote album art");
+                        Err(error) => {
+                            let error = crate::http_security::strip_request_url(error);
+                            tracing::debug!(%error, "Failed to fetch remote album art");
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

- centralize app-owned credential HTTP clients behind a no-Referer, ten-hop, exact-origin redirect policy
- compare HTTP(S) scheme, normalized host, and effective port; block cross-origin and downgrade redirects
- apply the policy to Subsonic, Jellyfin, Plex, DAAP, authentication, and remote artwork clients
- strip request URLs before errors are formatted or retained; reject/redact URL userinfo and backend query credentials
- remove raw DAAP session IDs, authenticated MPD arguments/ACKs, and credential-bearing GStreamer diagnostics from logs/UI errors
- document that GStreamer/MPD/Chromecast stream enforcement requires P1.6

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --release -- -D warnings`
- `cargo test --all-targets` (286 passed)
- `cargo test --release` (286 passed)
- focused security matrix: 12 shared origin/redirect/Referer/header/redaction tests plus 5 service/DAAP/MPD tests
- `cargo audit` (passes with the two documented allowed warnings)
- `git diff --check`