### PR TITLE
Enforce bounded HTTP response reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4801,6 +4801,7 @@ dependencies = [
  "gdk4-win32",
  "gstreamer",
  "gtk4",
+ "http",
  "libadwaita",
  "local-ip-address",
  "lofty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,7 @@ gstreamer1-libav = "*"
 dbus = "*"
 
 [dev-dependencies]
+http = "1"
 proptest = "1"
 
 [profile.release]

--- a/docs/task.md
+++ b/docs/task.md
@@ -198,11 +198,12 @@ explicitly justified and time-bounded.
 
 ### P1.5 Enforce response limits while streaming
 
-- [ ] Replace `Content-Length`-only checks with counted streaming reads.
-- [ ] Apply caps to API JSON, DAAP, authentication, radio, and album-art responses.
-- [ ] Add overall deadlines in addition to idle timeouts.
-- [ ] Test missing, false, and oversized `Content-Length`, plus endless chunked bodies.
-- [ ] Record implementation: _pending_
+- [x] Replace `Content-Length`-only checks with counted streaming reads.
+- [x] Apply caps to API JSON, DAAP, authentication, radio, and album-art responses.
+- [x] Add overall deadlines in addition to idle timeouts.
+- [x] Test missing, false, and oversized `Content-Length`, plus endless chunked bodies.
+- [x] Record implementation: commit `842341b`; 14 focused counted-size, deadline,
+  timeout-classification, allocation-boundary, URL-redaction, and backend-mapping tests.
 
 ### P1.6 Stop exposing broad bearer tokens to receivers
 
@@ -480,6 +481,14 @@ Record scope or design decisions here so deferred work is explicit.
   upstream redirect callback on those transports until it owns the stream through a short-lived
   proxy/ticket. Disabling redirects only for GStreamer would be both incomplete and potentially
   breaking, so the playback-stream checkbox remains explicit rather than being claimed complete.
+- 2026-07-12 — P1.5 treats every finite HTTP response as an observed byte stream rather than
+  trusting `Content-Length`: Subsonic, Jellyfin, Plex, DAAP, authentication, radio/geolocation,
+  artwork, and MusicBrainz reads now stop at endpoint-specific caps and carry end-to-end request
+  deadlines in addition to idle-read timeouts. Async and blocking collectors classify request
+  timeouts consistently, discard credential-bearing request URLs from retained body errors, and
+  fail cleanly on impossible or unavailable allocations. Audio and live-radio media streams remain
+  deliberately uncapped because they are length-unbounded playback transports; credential-bearing
+  playback still belongs to the cancellable P1.6 proxy/ticket design.
 
 ## Completed work log
 
@@ -497,3 +506,4 @@ Add one line per completed task:
 | 2026-07-12 | P1.2 | `93d03bf`, `b961b7c`, `17babaf`, `000d9c0` | Identity preserved across authoritative paired file and directory renames; queue and active-playlist snapshots re-resolve ID-preserving committed changes by stable track ID. |
 | 2026-07-12 | P1.3 | `4eb79d0` | Watchers install before scanning; bounded nonblocking ingress replays ordinary events and routes overflow, backend loss, rescan notices, and marker changes through retrying authoritative reconciliation. |
 | 2026-07-12 | P1.4a | `eb5458f` | Exact-origin/no-Referer policy and URL-free errors/logging cover every app-owned credential HTTP fetch; receiver-controlled playback streams remain tied to P1.6. |
+| 2026-07-12 | P1.5 | `842341b` | Counted finite-response reads enforce endpoint caps and total deadlines across API, authentication, DAAP, radio, artwork, and metadata clients. |

--- a/src/daap/backend.rs
+++ b/src/daap/backend.rs
@@ -369,33 +369,7 @@ impl crate::architecture::MediaBackend for DaapBackend {
     }
 
     async fn ping(&self) -> BackendResult<()> {
-        // Issue a lightweight server-info request to check connectivity.
-        let url = format!(
-            "{}/server-info",
-            self.client.base_url().as_str().trim_end_matches('/')
-        );
-        let resp = self
-            .client
-            .http_clone()
-            .get(&url)
-            .send()
-            .await
-            .map_err(|error| {
-                let error = crate::http_security::strip_request_url(error);
-                BackendError::ConnectionFailed {
-                    message: format!("DAAP ping failed: {error}"),
-                    source: Some(Box::new(error)),
-                }
-            })?;
-
-        if !resp.status().is_success() {
-            return Err(BackendError::ConnectionFailed {
-                message: format!("DAAP ping HTTP {}", resp.status()),
-                source: None,
-            });
-        }
-
-        Ok(())
+        self.client.ping().await
     }
 
     async fn search(&self, query: &str, limit: usize) -> BackendResult<SearchResults> {

--- a/src/daap/client.rs
+++ b/src/daap/client.rs
@@ -18,6 +18,7 @@ use url::Url;
 
 use crate::architecture::backend::BackendResult;
 use crate::architecture::error::BackendError;
+use crate::http_body::{read_limited, ResponseBodyError};
 use crate::http_security::{
     authenticated_client_builder, redact_url_secrets, strip_request_url, validate_base_url,
 };
@@ -36,11 +37,16 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// library transfer (the timeout resets after each successful read).
 const READ_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Maximum response body we are willing to buffer into memory.  A generous
-/// cap that still rules out a malicious or misbehaving server trying to
-/// exhaust memory with an unbounded body.  Enforced from the
-/// `Content-Length` header before the body is read (see [`check_body_size`]).
-const MAX_BODY_BYTES: u64 = 256 * 1024 * 1024;
+/// Maximum response bodies for handshake/control, database-list, and item-list
+/// requests, respectively.
+const MAX_CONTROL_BODY_BYTES: u64 = 1024 * 1024;
+const MAX_DATABASES_BODY_BYTES: u64 = 8 * 1024 * 1024;
+const MAX_ITEMS_BODY_BYTES: u64 = 256 * 1024 * 1024;
+
+/// End-to-end and body-phase deadlines for finite DAAP requests.
+const CONTROL_RESPONSE_DEADLINE: Duration = Duration::from_secs(30);
+const ITEMS_RESPONSE_DEADLINE: Duration = Duration::from_secs(120);
+const PROBE_RESPONSE_DEADLINE: Duration = Duration::from_secs(5);
 
 /// Client version advertised to the DAAP server.
 const CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -91,6 +97,7 @@ impl DaapClient {
 
         let resp = http
             .get(&server_info_url)
+            .timeout(CONTROL_RESPONSE_DEADLINE)
             .send()
             .await
             .map_err(|error| daap_request_error("DAAP server-info request failed", error))?;
@@ -102,13 +109,9 @@ impl DaapClient {
             });
         }
 
-        // Refuse to buffer an oversized body (DoS guard) before reading it.
-        check_body_size(&resp)?;
-
-        let bytes = resp
-            .bytes()
+        let bytes = read_limited(resp, MAX_CONTROL_BODY_BYTES, CONTROL_RESPONSE_DEADLINE)
             .await
-            .map_err(|error| daap_request_error("Failed to read server-info body", error))?;
+            .map_err(|error| daap_body_error("Failed to read server-info body", error))?;
 
         let nodes = dmap::parse_dmap(&bytes)?;
         // The top-level node is typically `msrv` (server-info container).
@@ -138,6 +141,7 @@ impl DaapClient {
         }
 
         let resp = login_req
+            .timeout(CONTROL_RESPONSE_DEADLINE)
             .send()
             .await
             .map_err(|error| daap_request_error("DAAP login request failed", error))?;
@@ -157,13 +161,9 @@ impl DaapClient {
             });
         }
 
-        // Refuse to buffer an oversized body (DoS guard) before reading it.
-        check_body_size(&resp)?;
-
-        let bytes = resp
-            .bytes()
+        let bytes = read_limited(resp, MAX_CONTROL_BODY_BYTES, CONTROL_RESPONSE_DEADLINE)
             .await
-            .map_err(|error| daap_request_error("Failed to read login body", error))?;
+            .map_err(|error| daap_body_error("Failed to read login body", error))?;
 
         let nodes = dmap::parse_dmap(&bytes)?;
         let login_children = unwrap_container(&nodes, b"mlog")?;
@@ -186,6 +186,7 @@ impl DaapClient {
 
         let resp = // lgtm[rs/cleartext-transmission] DAAP is a LAN-only protocol; plaintext HTTP is by design.
             http.get(&update_url)
+                .timeout(CONTROL_RESPONSE_DEADLINE)
                 .send()
                 .await
                 .map_err(|error| daap_request_error("DAAP update request failed", error))?;
@@ -197,13 +198,9 @@ impl DaapClient {
             });
         }
 
-        // Refuse to buffer an oversized body (DoS guard) before reading it.
-        check_body_size(&resp)?;
-
-        let bytes = resp
-            .bytes()
+        let bytes = read_limited(resp, MAX_CONTROL_BODY_BYTES, CONTROL_RESPONSE_DEADLINE)
             .await
-            .map_err(|error| daap_request_error("Failed to read update body", error))?;
+            .map_err(|error| daap_body_error("Failed to read update body", error))?;
 
         let nodes = dmap::parse_dmap(&bytes)?;
         let update_children = unwrap_container(&nodes, b"mupd")?;
@@ -222,6 +219,7 @@ impl DaapClient {
 
         let resp = // lgtm[rs/cleartext-transmission] DAAP is a LAN-only protocol; plaintext HTTP is by design.
             http.get(&databases_url)
+                .timeout(CONTROL_RESPONSE_DEADLINE)
                 .send()
                 .await
                 .map_err(|error| daap_request_error("DAAP databases request failed", error))?;
@@ -233,13 +231,9 @@ impl DaapClient {
             });
         }
 
-        // Refuse to buffer an oversized body (DoS guard) before reading it.
-        check_body_size(&resp)?;
-
-        let bytes = resp
-            .bytes()
+        let bytes = read_limited(resp, MAX_DATABASES_BODY_BYTES, CONTROL_RESPONSE_DEADLINE)
             .await
-            .map_err(|error| daap_request_error("Failed to read databases body", error))?;
+            .map_err(|error| daap_body_error("Failed to read databases body", error))?;
 
         let nodes = dmap::parse_dmap(&bytes)?;
         let avdb_children = unwrap_container(&nodes, b"avdb")?;
@@ -292,6 +286,7 @@ impl DaapClient {
         let resp = // lgtm[rs/cleartext-transmission] DAAP is a LAN-only protocol; plaintext HTTP is by design.
             self.http
                 .get(&url)
+                .timeout(ITEMS_RESPONSE_DEADLINE)
                 .send()
                 .await
                 .map_err(|error| daap_request_error("DAAP items request failed", error))?;
@@ -309,13 +304,9 @@ impl DaapClient {
             });
         }
 
-        // Refuse to buffer an oversized body (DoS guard) before reading it.
-        check_body_size(&resp)?;
-
-        let bytes = resp
-            .bytes()
+        let bytes = read_limited(resp, MAX_ITEMS_BODY_BYTES, ITEMS_RESPONSE_DEADLINE)
             .await
-            .map_err(|error| daap_request_error("Failed to read items body", error))?;
+            .map_err(|error| daap_body_error("Failed to read items body", error))?;
 
         let nodes = dmap::parse_dmap(&bytes)?;
 
@@ -329,6 +320,34 @@ impl DaapClient {
 
         // Convert from borrowed slices to owned Vecs.
         Ok(mlit_items.into_iter().map(|s| s.to_vec()).collect())
+    }
+
+    /// Issue a bounded server-info request to verify the active server is
+    /// still responsive.
+    pub async fn ping(&self) -> BackendResult<()> {
+        let url = format!(
+            "{}/server-info",
+            self.base_url.as_str().trim_end_matches('/')
+        );
+        let resp = self
+            .http
+            .get(&url)
+            .timeout(CONTROL_RESPONSE_DEADLINE)
+            .send()
+            .await
+            .map_err(|error| daap_request_error("DAAP ping failed", error))?;
+
+        if !resp.status().is_success() {
+            return Err(BackendError::ConnectionFailed {
+                message: format!("DAAP ping HTTP {}", resp.status()),
+                source: None,
+            });
+        }
+
+        read_limited(resp, MAX_CONTROL_BODY_BYTES, CONTROL_RESPONSE_DEADLINE)
+            .await
+            .map_err(|error| daap_body_error("Failed to read DAAP ping body", error))?;
+        Ok(())
     }
 
     /// Construct a cover art URL for a track.
@@ -405,16 +424,16 @@ impl DaapClient {
         // per-request timeout keeps the discovery probe snappy.
         let resp = http
             .get(&url)
-            .timeout(Duration::from_secs(5))
+            .timeout(PROBE_RESPONSE_DEADLINE)
             .send()
             .await
             .ok()?;
         if !resp.status().is_success() {
             return None;
         }
-        // Refuse to buffer an oversized body (DoS guard) before reading it.
-        check_body_size(&resp).ok()?;
-        let bytes = resp.bytes().await.ok()?;
+        let bytes = read_limited(resp, MAX_CONTROL_BODY_BYTES, PROBE_RESPONSE_DEADLINE)
+            .await
+            .ok()?;
         let nodes = dmap::parse_dmap(&bytes).ok()?;
         let children = match dmap::find_node(&nodes, b"msrv") {
             Some(node) => match &node.data {
@@ -445,11 +464,6 @@ impl DaapClient {
     pub fn database_id(&self) -> u32 {
         self.database_id
     }
-
-    /// Clone the inner HTTP client (cheap — `reqwest::Client` is `Arc`-based).
-    pub fn http_clone(&self) -> Client {
-        self.http.clone()
-    }
 }
 
 // ── Internal helpers ────────────────────────────────────────────────────
@@ -478,6 +492,24 @@ fn daap_request_error(context: &str, error: reqwest::Error) -> BackendError {
     BackendError::ConnectionFailed {
         message: format!("{context}: {error}"),
         source: Some(Box::new(error)),
+    }
+}
+
+fn daap_body_error(context: &str, error: ResponseBodyError) -> BackendError {
+    match error {
+        error @ (ResponseBodyError::TooLarge { .. }
+        | ResponseBodyError::InvalidLimit { .. }
+        | ResponseBodyError::AllocationFailed { .. }) => BackendError::ConnectionFailed {
+            message: error.to_string(),
+            source: None,
+        },
+        ResponseBodyError::DeadlineExceeded { deadline } => BackendError::Timeout {
+            duration_secs: deadline.as_secs(),
+        },
+        error => BackendError::ConnectionFailed {
+            message: format!("{context}: {error}"),
+            source: Some(Box::new(error)),
+        },
     }
 }
 
@@ -512,29 +544,21 @@ fn unwrap_nested_container<'a>(
     unwrap_container(parent_children, tag)
 }
 
-/// Reject a response whose declared body exceeds [`MAX_BODY_BYTES`].
-///
-/// A lightweight, best-effort DoS guard: it inspects only the
-/// `Content-Length` header, so a chunked response sent without a length is
-/// not covered here — the client's `read_timeout` still bounds a stalled or
-/// slow-trickling transfer in that case.
-fn check_body_size(resp: &reqwest::Response) -> BackendResult<()> {
-    if let Some(len) = resp.content_length() {
-        if len > MAX_BODY_BYTES {
-            return Err(BackendError::ConnectionFailed {
-                message: format!(
-                    "Response body too large: {len} bytes exceeds the {MAX_BODY_BYTES}-byte cap"
-                ),
-                source: None,
-            });
-        }
-    }
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn maps_response_body_deadline_to_timeout() {
+        let error = daap_body_error(
+            "body",
+            ResponseBodyError::DeadlineExceeded {
+                deadline: Duration::from_secs(7),
+            },
+        );
+
+        assert!(matches!(error, BackendError::Timeout { duration_secs: 7 }));
+    }
 
     #[test]
     fn daap_base_url_rejects_embedded_credentials_and_non_http_schemes() {

--- a/src/http_body.rs
+++ b/src/http_body.rs
@@ -182,7 +182,7 @@ fn append_limited(
         });
     }
 
-    body.try_reserve_exact(chunk.len())
+    body.try_reserve(chunk.len())
         .map_err(|_| ResponseBodyError::AllocationFailed {
             requested: new_observed,
         })?;

--- a/src/http_body.rs
+++ b/src/http_body.rs
@@ -1,0 +1,417 @@
+//! Bounded response-body collection for finite HTTP API responses.
+//!
+//! `Content-Length` is only an advisory early-rejection signal. Every body is
+//! counted as it is read so missing or dishonest length headers cannot turn a
+//! finite API response into unbounded memory growth.
+
+use std::io::Read;
+use std::time::{Duration, Instant};
+
+use thiserror::Error;
+
+/// Failure while collecting a finite HTTP response body.
+#[derive(Debug, Error)]
+pub enum ResponseBodyError {
+    /// The declared or observed body size exceeded the configured cap.
+    #[error("response body too large: reported size {size} bytes exceeds the {limit}-byte cap")]
+    TooLarge { size: u64, limit: u64 },
+
+    /// The configured cap cannot be represented safely by a `Vec<u8>`.
+    #[error("response body cap {requested} bytes exceeds the supported {maximum}-byte maximum")]
+    InvalidLimit { requested: u64, maximum: u64 },
+
+    /// Memory for an otherwise in-policy body could not be reserved.
+    #[error("unable to reserve memory for a {requested}-byte response body")]
+    AllocationFailed { requested: u64 },
+
+    /// The body did not complete within its wall-clock deadline.
+    #[error("response body deadline exceeded after {deadline:?}")]
+    DeadlineExceeded { deadline: Duration },
+
+    /// An asynchronous response body failed while being decoded or read.
+    #[error("failed to read response body: {0}")]
+    Transport(#[source] reqwest::Error),
+
+    /// A blocking response body failed while being decoded or read.
+    ///
+    /// Only the I/O category is retained because a blocking reqwest error can
+    /// otherwise format the complete request URL.
+    #[error("failed to read response body ({kind:?})")]
+    BlockingTransport { kind: std::io::ErrorKind },
+}
+
+/// Collect an asynchronous response body with an observed-byte cap and total
+/// body deadline.
+///
+/// Callers should also set `RequestBuilder::timeout` so DNS, connection setup,
+/// headers, and this body read share an end-to-end request deadline. This
+/// helper independently bounds the body phase and remains authoritative about
+/// the number of bytes accepted.
+pub async fn read_limited(
+    mut response: reqwest::Response,
+    max_bytes: u64,
+    deadline: Duration,
+) -> Result<Vec<u8>, ResponseBodyError> {
+    validate_limit(max_bytes)?;
+    reject_declared_length(response.content_length(), max_bytes)?;
+
+    tokio::time::timeout(deadline, async move {
+        let started = tokio::time::Instant::now();
+        let mut body = Vec::new();
+        let mut observed = 0_u64;
+
+        loop {
+            if started.elapsed() >= deadline {
+                return Err(ResponseBodyError::DeadlineExceeded { deadline });
+            }
+
+            let chunk = match response.chunk().await {
+                Ok(chunk) => chunk,
+                Err(error) if error.is_timeout() => {
+                    return Err(ResponseBodyError::DeadlineExceeded { deadline });
+                }
+                Err(error) => {
+                    return Err(ResponseBodyError::Transport(
+                        crate::http_security::strip_request_url(error),
+                    ));
+                }
+            };
+
+            if started.elapsed() >= deadline {
+                return Err(ResponseBodyError::DeadlineExceeded { deadline });
+            }
+
+            let Some(chunk) = chunk else {
+                return Ok(body);
+            };
+            append_limited(&mut body, &mut observed, &chunk, max_bytes)?;
+        }
+    })
+    .await
+    .map_err(|_| ResponseBodyError::DeadlineExceeded { deadline })?
+}
+
+/// Collect a blocking response body with an observed-byte cap and cooperative
+/// wall-clock deadline.
+///
+/// Blocking reqwest enforces its request timeout on each individual read. The
+/// elapsed-time checks here additionally stop an endless body that keeps
+/// producing data before that idle timeout. Callers **must** set this deadline
+/// (or a shorter one) on `RequestBuilder::timeout`; a synchronous `Read` cannot
+/// otherwise be preempted while it is stalled inside the operating system.
+pub fn read_limited_blocking(
+    mut response: reqwest::blocking::Response,
+    max_bytes: u64,
+    deadline: Duration,
+) -> Result<Vec<u8>, ResponseBodyError> {
+    validate_limit(max_bytes)?;
+    reject_declared_length(response.content_length(), max_bytes)?;
+
+    let started = Instant::now();
+    let mut body = Vec::new();
+    let mut observed = 0_u64;
+    let mut buffer = [0_u8; 16 * 1024];
+
+    loop {
+        if started.elapsed() >= deadline {
+            return Err(ResponseBodyError::DeadlineExceeded { deadline });
+        }
+
+        let read = match response.read(&mut buffer) {
+            Ok(read) => read,
+            Err(error) if started.elapsed() >= deadline || blocking_error_is_timeout(&error) => {
+                return Err(ResponseBodyError::DeadlineExceeded { deadline });
+            }
+            Err(error) => {
+                return Err(ResponseBodyError::BlockingTransport { kind: error.kind() });
+            }
+        };
+
+        if started.elapsed() >= deadline {
+            return Err(ResponseBodyError::DeadlineExceeded { deadline });
+        }
+        if read == 0 {
+            return Ok(body);
+        }
+
+        append_limited(&mut body, &mut observed, &buffer[..read], max_bytes)?;
+    }
+}
+
+fn blocking_error_is_timeout(error: &std::io::Error) -> bool {
+    error.kind() == std::io::ErrorKind::TimedOut
+        || error
+            .get_ref()
+            .and_then(|source| source.downcast_ref::<reqwest::Error>())
+            .is_some_and(reqwest::Error::is_timeout)
+}
+
+fn validate_limit(max_bytes: u64) -> Result<(), ResponseBodyError> {
+    let maximum = isize::MAX as u64;
+    if max_bytes > maximum {
+        return Err(ResponseBodyError::InvalidLimit {
+            requested: max_bytes,
+            maximum,
+        });
+    }
+    Ok(())
+}
+
+fn reject_declared_length(declared: Option<u64>, max_bytes: u64) -> Result<(), ResponseBodyError> {
+    if let Some(observed) = declared.filter(|declared| *declared > max_bytes) {
+        return Err(ResponseBodyError::TooLarge {
+            size: observed,
+            limit: max_bytes,
+        });
+    }
+    Ok(())
+}
+
+fn append_limited(
+    body: &mut Vec<u8>,
+    observed: &mut u64,
+    chunk: &[u8],
+    max_bytes: u64,
+) -> Result<(), ResponseBodyError> {
+    let chunk_len = u64::try_from(chunk.len()).unwrap_or(u64::MAX);
+    let new_observed = observed.checked_add(chunk_len).unwrap_or(u64::MAX);
+    if new_observed > max_bytes {
+        return Err(ResponseBodyError::TooLarge {
+            size: new_observed,
+            limit: max_bytes,
+        });
+    }
+
+    body.try_reserve_exact(chunk.len())
+        .map_err(|_| ResponseBodyError::AllocationFailed {
+            requested: new_observed,
+        })?;
+    body.extend_from_slice(chunk);
+    *observed = new_observed;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        append_limited, read_limited, read_limited_blocking, reject_declared_length,
+        validate_limit, ResponseBodyError,
+    };
+    use std::io::{Read, Write};
+    use std::net::{SocketAddr, TcpListener, TcpStream};
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Duration;
+
+    fn async_response(body: Vec<u8>) -> reqwest::Response {
+        http::Response::builder()
+            .status(200)
+            .body(body)
+            .expect("test response must build")
+            .into()
+    }
+
+    fn blocking_response(body: Vec<u8>) -> reqwest::blocking::Response {
+        http::Response::builder()
+            .status(200)
+            .body(body)
+            .expect("test response must build")
+            .into()
+    }
+
+    fn accept_request(listener: &TcpListener) -> TcpStream {
+        let (mut stream, _) = listener.accept().expect("test client must connect");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .expect("test read timeout must apply");
+        stream
+            .set_write_timeout(Some(Duration::from_secs(2)))
+            .expect("test write timeout must apply");
+        let mut request = [0_u8; 2048];
+        let _ = stream.read(&mut request);
+        stream
+    }
+
+    fn spawn_endless_server() -> (SocketAddr, mpsc::Sender<()>, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("test listener must bind");
+        let address = listener.local_addr().expect("listener has address");
+        let (stop_tx, stop_rx) = mpsc::channel();
+        let server = thread::spawn(move || {
+            let mut stream = accept_request(&listener);
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n",
+                )
+                .expect("headers must write");
+            for _ in 0..400 {
+                if stop_rx.try_recv().is_ok() || stream.write_all(b"1\r\nx\r\n").is_err() {
+                    break;
+                }
+                thread::sleep(Duration::from_millis(5));
+            }
+        });
+        (address, stop_tx, server)
+    }
+
+    fn spawn_stalled_server() -> (SocketAddr, mpsc::Sender<()>, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("test listener must bind");
+        let address = listener.local_addr().expect("listener has address");
+        let (stop_tx, stop_rx) = mpsc::channel();
+        let server = thread::spawn(move || {
+            let mut stream = accept_request(&listener);
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 8\r\nConnection: close\r\n\r\n")
+                .expect("headers must write");
+            let _ = stop_rx.recv_timeout(Duration::from_secs(2));
+        });
+        (address, stop_tx, server)
+    }
+
+    fn stop_server(stop: mpsc::Sender<()>, server: thread::JoinHandle<()>) {
+        let _ = stop.send(());
+        server.join().expect("test server must stop");
+    }
+
+    #[test]
+    fn counted_chunks_override_missing_and_false_small_declared_lengths() {
+        for declared in [None, Some(1)] {
+            reject_declared_length(declared, 8).expect("small or absent declaration is advisory");
+            let mut body = Vec::new();
+            let mut observed = 0;
+            let error = append_limited(&mut body, &mut observed, &[b'x'; 9], 8)
+                .expect_err("observed bytes must enforce the cap");
+            assert!(matches!(
+                error,
+                ResponseBodyError::TooLarge { size: 9, limit: 8 }
+            ));
+        }
+    }
+
+    #[test]
+    fn oversized_declared_length_is_rejected_early() {
+        let error = reject_declared_length(Some(9), 8)
+            .expect_err("oversized declaration must fail before collection");
+        assert!(matches!(
+            error,
+            ResponseBodyError::TooLarge { size: 9, limit: 8 }
+        ));
+    }
+
+    #[test]
+    fn unrepresentable_vec_limit_is_rejected() {
+        let error = validate_limit(u64::MAX).expect_err("impossible Vec cap must be rejected");
+        assert!(matches!(error, ResponseBodyError::InvalidLimit { .. }));
+    }
+
+    #[tokio::test]
+    async fn async_reader_accepts_exact_cap() {
+        let body = read_limited(async_response(vec![b'x'; 8]), 8, Duration::from_secs(1))
+            .await
+            .expect("exact cap must be accepted");
+        assert_eq!(body, vec![b'x'; 8]);
+    }
+
+    #[test]
+    fn blocking_reader_accepts_exact_cap() {
+        let body =
+            read_limited_blocking(blocking_response(vec![b'x'; 8]), 8, Duration::from_secs(1))
+                .expect("exact cap must be accepted");
+        assert_eq!(body, vec![b'x'; 8]);
+    }
+
+    #[tokio::test]
+    async fn async_reader_deadlines_an_endless_chunked_body() {
+        let (address, stop, server) = spawn_endless_server();
+        let response = reqwest::Client::new()
+            .get(format!("http://{address}/endless"))
+            .timeout(Duration::from_secs(1))
+            .send()
+            .await
+            .expect("test request must receive headers");
+        let result = read_limited(response, 1024, Duration::from_millis(40)).await;
+        stop_server(stop, server);
+
+        assert!(matches!(
+            result,
+            Err(ResponseBodyError::DeadlineExceeded { .. })
+        ));
+    }
+
+    #[test]
+    fn blocking_reader_deadlines_an_endless_chunked_body() {
+        let (address, stop, server) = spawn_endless_server();
+        let response = reqwest::blocking::Client::new()
+            .get(format!("http://{address}/endless"))
+            .timeout(Duration::from_secs(1))
+            .send()
+            .expect("test request must receive headers");
+        let result = read_limited_blocking(response, 1024, Duration::from_millis(40));
+        stop_server(stop, server);
+
+        assert!(matches!(
+            result,
+            Err(ResponseBodyError::DeadlineExceeded { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn async_request_timeout_is_classified_as_a_body_deadline() {
+        let (address, stop, server) = spawn_stalled_server();
+        let response = reqwest::Client::new()
+            .get(format!("http://{address}/stalled"))
+            .timeout(Duration::from_millis(500))
+            .send()
+            .await
+            .expect("test request must receive headers");
+        let result = read_limited(response, 16, Duration::from_secs(1)).await;
+        stop_server(stop, server);
+
+        assert!(matches!(
+            result,
+            Err(ResponseBodyError::DeadlineExceeded { .. })
+        ));
+    }
+
+    #[test]
+    fn blocking_request_timeout_is_classified_as_a_body_deadline() {
+        let (address, stop, server) = spawn_stalled_server();
+        let response = reqwest::blocking::Client::new()
+            .get(format!("http://{address}/stalled"))
+            .timeout(Duration::from_millis(500))
+            .send()
+            .expect("test request must receive headers");
+        let result = read_limited_blocking(response, 16, Duration::from_secs(1));
+        stop_server(stop, server);
+
+        assert!(matches!(
+            result,
+            Err(ResponseBodyError::DeadlineExceeded { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn async_transport_errors_do_not_retain_the_request_url() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("test listener must bind");
+        let address = listener.local_addr().expect("listener has address");
+        let secret = uuid::Uuid::new_v4().to_string();
+        let server = thread::spawn(move || {
+            let mut stream = accept_request(&listener);
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 8\r\nConnection: close\r\n\r\nx")
+                .expect("truncated response must write");
+        });
+
+        let response = reqwest::Client::new()
+            .get(format!("http://{address}/body?token={secret}"))
+            .timeout(Duration::from_secs(1))
+            .send()
+            .await
+            .expect("test request must receive headers");
+        let result = read_limited(response, 16, Duration::from_secs(1)).await;
+        server.join().expect("test server must stop");
+        let rendered = result.expect_err("truncated body must fail").to_string();
+
+        assert!(!rendered.contains(&secret));
+        assert!(!rendered.contains(&address.to_string()));
+    }
+}

--- a/src/jellyfin/client.rs
+++ b/src/jellyfin/client.rs
@@ -10,6 +10,7 @@ use url::Url;
 
 use crate::architecture::backend::BackendResult;
 use crate::architecture::error::BackendError;
+use crate::http_body::{read_limited, ResponseBodyError};
 use crate::http_security::{
     authenticated_client_builder, redact_url_secrets, strip_request_url, validate_base_url,
 };
@@ -31,11 +32,16 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// (the timeout resets after each successful read).
 const READ_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Maximum response body we are willing to buffer into memory.  A generous
-/// cap that still rules out a malicious or misbehaving server trying to
-/// exhaust memory with an unbounded body.  Enforced from the
-/// `Content-Length` header before the body is read (see [`check_body_size`]).
-const MAX_BODY_BYTES: u64 = 256 * 1024 * 1024;
+/// Maximum response bodies for authentication, API JSON, and small text
+/// endpoints, respectively.
+const MAX_AUTH_BODY_BYTES: u64 = 1024 * 1024;
+const MAX_API_BODY_BYTES: u64 = 256 * 1024 * 1024;
+const MAX_TEXT_BODY_BYTES: u64 = 64 * 1024;
+
+/// End-to-end and body-phase deadlines for each finite request class.
+const AUTH_RESPONSE_DEADLINE: Duration = Duration::from_secs(30);
+const API_RESPONSE_DEADLINE: Duration = Duration::from_secs(120);
+const TEXT_RESPONSE_DEADLINE: Duration = Duration::from_secs(15);
 
 /// Holds credentials and a reusable `reqwest::Client` with the
 /// `X-Emby-Authorization` header pre-configured on every request.
@@ -151,6 +157,7 @@ impl JellyfinClient {
         let resp = pre_auth_http
             .post(auth_url.as_str())
             .json(&body)
+            .timeout(AUTH_RESPONSE_DEADLINE)
             .send()
             .await
             .map_err(|e| {
@@ -179,13 +186,15 @@ impl JellyfinClient {
             });
         }
 
-        let auth_resp: JellyfinAuthResponse = resp.json().await.map_err(|e| {
-            let e = strip_request_url(e);
-            BackendError::ParseError {
+        let body = read_limited(resp, MAX_AUTH_BODY_BYTES, AUTH_RESPONSE_DEADLINE)
+            .await
+            .map_err(|error| response_body_error("Failed to parse auth response", error))?;
+
+        let auth_resp: JellyfinAuthResponse =
+            serde_json::from_slice(&body).map_err(|e| BackendError::ParseError {
                 message: format!("Failed to parse auth response: {e}"),
                 source: Some(Box::new(e)),
-            }
-        })?;
+            })?;
 
         let api_key = auth_resp.access_token;
         let user_id = auth_resp.user.id;
@@ -281,13 +290,19 @@ impl JellyfinClient {
 
         debug!(url = %redact_url_secrets(url.as_str()), "Jellyfin request");
 
-        let resp = self.http.get(url.as_str()).send().await.map_err(|e| {
-            let e = strip_request_url(e);
-            BackendError::ConnectionFailed {
-                message: format!("HTTP request failed: {e}"),
-                source: Some(Box::new(e)),
-            }
-        })?;
+        let resp = self
+            .http
+            .get(url.as_str())
+            .timeout(API_RESPONSE_DEADLINE)
+            .send()
+            .await
+            .map_err(|e| {
+                let e = strip_request_url(e);
+                BackendError::ConnectionFailed {
+                    message: format!("HTTP request failed: {e}"),
+                    source: Some(Box::new(e)),
+                }
+            })?;
 
         let status = resp.status();
 
@@ -304,15 +319,13 @@ impl JellyfinClient {
             });
         }
 
-        // Refuse to buffer an oversized body (DoS guard) before reading it.
-        check_body_size(&resp)?;
+        let body = read_limited(resp, MAX_API_BODY_BYTES, API_RESPONSE_DEADLINE)
+            .await
+            .map_err(|error| response_body_error("Failed to parse Jellyfin JSON", error))?;
 
-        let body = resp.json::<T>().await.map_err(|e| {
-            let e = strip_request_url(e);
-            BackendError::ParseError {
-                message: format!("Failed to parse Jellyfin JSON: {e}"),
-                source: Some(Box::new(e)),
-            }
+        let body = serde_json::from_slice::<T>(&body).map_err(|e| BackendError::ParseError {
+            message: format!("Failed to parse Jellyfin JSON: {e}"),
+            source: Some(Box::new(e)),
         })?;
 
         Ok(body)
@@ -325,13 +338,19 @@ impl JellyfinClient {
         let url = self.api_url(endpoint);
         debug!(url = %redact_url_secrets(url.as_str()), "Jellyfin text request");
 
-        let resp = self.http.get(url.as_str()).send().await.map_err(|e| {
-            let e = strip_request_url(e);
-            BackendError::ConnectionFailed {
-                message: format!("HTTP request failed: {e}"),
-                source: Some(Box::new(e)),
-            }
-        })?;
+        let resp = self
+            .http
+            .get(url.as_str())
+            .timeout(TEXT_RESPONSE_DEADLINE)
+            .send()
+            .await
+            .map_err(|e| {
+                let e = strip_request_url(e);
+                BackendError::ConnectionFailed {
+                    message: format!("HTTP request failed: {e}"),
+                    source: Some(Box::new(e)),
+                }
+            })?;
 
         let status = resp.status();
 
@@ -348,16 +367,10 @@ impl JellyfinClient {
             });
         }
 
-        // Refuse to buffer an oversized body (DoS guard) before reading it.
-        check_body_size(&resp)?;
-
-        let text = resp.text().await.map_err(|e| {
-            let e = strip_request_url(e);
-            BackendError::ParseError {
-                message: format!("Failed to read Jellyfin response body: {e}"),
-                source: Some(Box::new(e)),
-            }
-        })?;
+        let body = read_limited(resp, MAX_TEXT_BODY_BYTES, TEXT_RESPONSE_DEADLINE)
+            .await
+            .map_err(|error| response_body_error("Failed to read Jellyfin response body", error))?;
+        let text = String::from_utf8_lossy(&body).into_owned();
 
         Ok(text)
     }
@@ -391,29 +404,39 @@ fn build_http_client(api_key: &str) -> BackendResult<Client> {
         })
 }
 
-/// Reject a response whose declared body exceeds [`MAX_BODY_BYTES`].
-///
-/// A lightweight, best-effort DoS guard: it inspects only the
-/// `Content-Length` header, so a chunked response sent without a length is
-/// not covered here — the client's `read_timeout` still bounds a stalled or
-/// slow-trickling transfer in that case.
-fn check_body_size(resp: &reqwest::Response) -> BackendResult<()> {
-    if let Some(len) = resp.content_length() {
-        if len > MAX_BODY_BYTES {
-            return Err(BackendError::ConnectionFailed {
-                message: format!(
-                    "Response body too large: {len} bytes exceeds the {MAX_BODY_BYTES}-byte cap"
-                ),
-                source: None,
-            });
-        }
+fn response_body_error(context: &str, error: ResponseBodyError) -> BackendError {
+    match error {
+        error @ (ResponseBodyError::TooLarge { .. }
+        | ResponseBodyError::InvalidLimit { .. }
+        | ResponseBodyError::AllocationFailed { .. }) => BackendError::ConnectionFailed {
+            message: error.to_string(),
+            source: None,
+        },
+        ResponseBodyError::DeadlineExceeded { deadline } => BackendError::Timeout {
+            duration_secs: deadline.as_secs(),
+        },
+        error => BackendError::ParseError {
+            message: format!("{context}: {error}"),
+            source: Some(Box::new(error)),
+        },
     }
-    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn maps_response_body_deadline_to_timeout() {
+        let error = response_body_error(
+            "body",
+            ResponseBodyError::DeadlineExceeded {
+                deadline: Duration::from_secs(7),
+            },
+        );
+
+        assert!(matches!(error, BackendError::Timeout { duration_secs: 7 }));
+    }
 
     #[test]
     fn rejects_embedded_url_credentials_without_echoing_them() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,7 @@ mod desktop_integration;
 #[allow(dead_code)]
 mod device;
 mod discovery;
+pub(crate) mod http_body;
 pub(crate) mod http_security;
 #[allow(dead_code)]
 mod jellyfin;

--- a/src/plex/client.rs
+++ b/src/plex/client.rs
@@ -10,6 +10,7 @@ use url::Url;
 
 use crate::architecture::backend::BackendResult;
 use crate::architecture::error::BackendError;
+use crate::http_body::{read_limited, ResponseBodyError};
 use crate::http_security::{
     authenticated_client_builder, redact_url_secrets, strip_request_url, validate_base_url,
 };
@@ -34,11 +35,13 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// (the timeout resets after each successful read).
 const READ_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Maximum response body we are willing to buffer into memory.  A generous
-/// cap that still rules out a malicious or misbehaving server trying to
-/// exhaust memory with an unbounded body.  Enforced from the
-/// `Content-Length` header before the body is read (see [`check_body_size`]).
-const MAX_BODY_BYTES: u64 = 256 * 1024 * 1024;
+/// Maximum response bodies for authentication and API JSON, respectively.
+const MAX_AUTH_BODY_BYTES: u64 = 1024 * 1024;
+const MAX_API_BODY_BYTES: u64 = 256 * 1024 * 1024;
+
+/// End-to-end and body-phase deadlines for each finite request class.
+const AUTH_RESPONSE_DEADLINE: Duration = Duration::from_secs(30);
+const API_RESPONSE_DEADLINE: Duration = Duration::from_secs(120);
 
 /// Holds credentials and a reusable `reqwest::Client` with the
 /// `X-Plex-Token` header pre-configured on every request.
@@ -142,6 +145,7 @@ impl PlexClient {
         let resp = pre_auth_http
             .post(PLEX_TV_SIGN_IN)
             .body(form_body)
+            .timeout(AUTH_RESPONSE_DEADLINE)
             .send()
             .await
             .map_err(|e| {
@@ -170,13 +174,15 @@ impl PlexClient {
             });
         }
 
-        let sign_in: PlexSignInResponse = resp.json().await.map_err(|e| {
-            let e = strip_request_url(e);
-            BackendError::ParseError {
+        let body = read_limited(resp, MAX_AUTH_BODY_BYTES, AUTH_RESPONSE_DEADLINE)
+            .await
+            .map_err(|error| response_body_error("Failed to parse Plex sign-in response", error))?;
+
+        let sign_in: PlexSignInResponse =
+            serde_json::from_slice(&body).map_err(|e| BackendError::ParseError {
                 message: format!("Failed to parse Plex sign-in response: {e}"),
                 source: Some(Box::new(e)),
-            }
-        })?;
+            })?;
 
         let auth_token = sign_in.user.auth_token;
 
@@ -268,13 +274,19 @@ impl PlexClient {
 
         debug!(url = %redact_url_secrets(url.as_str()), "Plex request");
 
-        let resp = self.http.get(url.as_str()).send().await.map_err(|e| {
-            let e = strip_request_url(e);
-            BackendError::ConnectionFailed {
-                message: format!("HTTP request failed: {e}"),
-                source: Some(Box::new(e)),
-            }
-        })?;
+        let resp = self
+            .http
+            .get(url.as_str())
+            .timeout(API_RESPONSE_DEADLINE)
+            .send()
+            .await
+            .map_err(|e| {
+                let e = strip_request_url(e);
+                BackendError::ConnectionFailed {
+                    message: format!("HTTP request failed: {e}"),
+                    source: Some(Box::new(e)),
+                }
+            })?;
 
         let status = resp.status();
 
@@ -291,15 +303,13 @@ impl PlexClient {
             });
         }
 
-        // Refuse to buffer an oversized body (DoS guard) before reading it.
-        check_body_size(&resp)?;
+        let body = read_limited(resp, MAX_API_BODY_BYTES, API_RESPONSE_DEADLINE)
+            .await
+            .map_err(|error| response_body_error("Failed to parse Plex JSON", error))?;
 
-        let body = resp.json::<T>().await.map_err(|e| {
-            let e = strip_request_url(e);
-            BackendError::ParseError {
-                message: format!("Failed to parse Plex JSON: {e}"),
-                source: Some(Box::new(e)),
-            }
+        let body = serde_json::from_slice::<T>(&body).map_err(|e| BackendError::ParseError {
+            message: format!("Failed to parse Plex JSON: {e}"),
+            source: Some(Box::new(e)),
         })?;
 
         Ok(body)
@@ -339,29 +349,39 @@ fn build_http_client(auth_token: &str) -> BackendResult<Client> {
         })
 }
 
-/// Reject a response whose declared body exceeds [`MAX_BODY_BYTES`].
-///
-/// A lightweight, best-effort DoS guard: it inspects only the
-/// `Content-Length` header, so a chunked response sent without a length is
-/// not covered here — the client's `read_timeout` still bounds a stalled or
-/// slow-trickling transfer in that case.
-fn check_body_size(resp: &reqwest::Response) -> BackendResult<()> {
-    if let Some(len) = resp.content_length() {
-        if len > MAX_BODY_BYTES {
-            return Err(BackendError::ConnectionFailed {
-                message: format!(
-                    "Response body too large: {len} bytes exceeds the {MAX_BODY_BYTES}-byte cap"
-                ),
-                source: None,
-            });
-        }
+fn response_body_error(context: &str, error: ResponseBodyError) -> BackendError {
+    match error {
+        error @ (ResponseBodyError::TooLarge { .. }
+        | ResponseBodyError::InvalidLimit { .. }
+        | ResponseBodyError::AllocationFailed { .. }) => BackendError::ConnectionFailed {
+            message: error.to_string(),
+            source: None,
+        },
+        ResponseBodyError::DeadlineExceeded { deadline } => BackendError::Timeout {
+            duration_secs: deadline.as_secs(),
+        },
+        error => BackendError::ParseError {
+            message: format!("{context}: {error}"),
+            source: Some(Box::new(error)),
+        },
     }
-    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn maps_response_body_deadline_to_timeout() {
+        let error = response_body_error(
+            "body",
+            ResponseBodyError::DeadlineExceeded {
+                deadline: Duration::from_secs(7),
+            },
+        );
+
+        assert!(matches!(error, BackendError::Timeout { duration_secs: 7 }));
+    }
 
     #[test]
     fn rejects_embedded_url_credentials_without_echoing_them() {

--- a/src/radio/client.rs
+++ b/src/radio/client.rs
@@ -20,6 +20,12 @@ const FALLBACK_API_HOST: &str = "de1.api.radio-browser.info";
 /// HTTP request timeout for all Radio-Browser and geolocation requests.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
 
+/// Maximum buffered Radio-Browser station-list response.
+const MAX_STATION_BODY_BYTES: u64 = 8 * 1024 * 1024;
+
+/// Maximum buffered response from an IP geolocation provider.
+const MAX_GEOLOCATION_BODY_BYTES: u64 = 256 * 1024;
+
 /// Radio-Browser API client.
 pub struct RadioBrowserClient {
     /// Base URL for API requests (e.g. `https://de1.api.radio-browser.info`).
@@ -44,7 +50,7 @@ impl RadioBrowserClient {
                 tracing::warn!(
                     error = %e,
                     "Failed to build configured reqwest::Client for Radio-Browser; \
-                     falling back to default (no timeout)"
+                     falling back to the default client with per-request deadlines"
                 );
                 reqwest::Client::default()
             }
@@ -151,28 +157,39 @@ impl RadioBrowserClient {
     /// Filters out stations with non-HTTP(S) stream URLs for safety.
     async fn fetch_stations(&self, url: &str) -> Vec<RadioStation> {
         debug!(url = %url, "Fetching radio stations");
-        match self.client.get(url).send().await {
+        match self.client.get(url).timeout(REQUEST_TIMEOUT).send().await {
             // lgtm[rs/cleartext-transmission] Base URL is always HTTPS; station stream URLs may be HTTP but carry no sensitive data.
-            Ok(resp) => match resp.json::<Vec<RadioStation>>().await {
-                Ok(stations) => {
-                    // Filter out stations with non-HTTP(S) stream URLs
-                    // to prevent file:// or other scheme injection.
-                    let safe: Vec<RadioStation> = stations
-                        .into_iter()
-                        .filter(|s| {
-                            let url = s.url_resolved.to_lowercase();
-                            url.starts_with("http://") || url.starts_with("https://")
-                        })
-                        .collect();
-                    info!(count = safe.len(), "Radio stations fetched (filtered)");
-                    safe
+            Ok(resp) => {
+                match crate::http_body::read_limited(resp, MAX_STATION_BODY_BYTES, REQUEST_TIMEOUT)
+                    .await
+                {
+                    Ok(body) => match serde_json::from_slice::<Vec<RadioStation>>(&body) {
+                        Ok(stations) => {
+                            // Filter out stations with non-HTTP(S) stream URLs
+                            // to prevent file:// or other scheme injection.
+                            let safe: Vec<RadioStation> = stations
+                                .into_iter()
+                                .filter(|s| {
+                                    let url = s.url_resolved.to_lowercase();
+                                    url.starts_with("http://") || url.starts_with("https://")
+                                })
+                                .collect();
+                            info!(count = safe.len(), "Radio stations fetched (filtered)");
+                            safe
+                        }
+                        Err(e) => {
+                            warn!(error = %e, "Failed to parse radio station response");
+                            Vec::new()
+                        }
+                    },
+                    Err(e) => {
+                        warn!(error = %e, "Failed to read radio station response");
+                        Vec::new()
+                    }
                 }
-                Err(e) => {
-                    warn!(error = %e, "Failed to parse radio station response");
-                    Vec::new()
-                }
-            },
+            }
             Err(e) => {
+                let e = crate::http_security::strip_request_url(e);
                 warn!(error = %e, "Failed to fetch radio stations");
                 Vec::new()
             }
@@ -238,8 +255,16 @@ pub async fn fetch_geolocation() -> Option<GeoLocation> {
 
 /// Try ipapi.co geolocation.
 async fn try_ipapi_co(client: &reqwest::Client) -> Option<GeoLocation> {
-    let resp = client.get("https://ipapi.co/json/").send().await.ok()?;
-    let data: IpApiCoResponse = resp.json().await.ok()?;
+    let resp = client
+        .get("https://ipapi.co/json/")
+        .timeout(REQUEST_TIMEOUT)
+        .send()
+        .await
+        .ok()?;
+    let body = crate::http_body::read_limited(resp, MAX_GEOLOCATION_BODY_BYTES, REQUEST_TIMEOUT)
+        .await
+        .ok()?;
+    let data: IpApiCoResponse = serde_json::from_slice(&body).ok()?;
     if !data.error && (data.latitude != 0.0 || data.longitude != 0.0) {
         Some(GeoLocation {
             latitude: data.latitude,
@@ -254,8 +279,16 @@ async fn try_ipapi_co(client: &reqwest::Client) -> Option<GeoLocation> {
 
 /// Try ipwho.is geolocation.
 async fn try_ipwhois(client: &reqwest::Client) -> Option<GeoLocation> {
-    let resp = client.get("https://ipwho.is/").send().await.ok()?;
-    let data: IpWhoIsResponse = resp.json().await.ok()?;
+    let resp = client
+        .get("https://ipwho.is/")
+        .timeout(REQUEST_TIMEOUT)
+        .send()
+        .await
+        .ok()?;
+    let body = crate::http_body::read_limited(resp, MAX_GEOLOCATION_BODY_BYTES, REQUEST_TIMEOUT)
+        .await
+        .ok()?;
+    let data: IpWhoIsResponse = serde_json::from_slice(&body).ok()?;
     if data.success && (data.latitude != 0.0 || data.longitude != 0.0) {
         Some(GeoLocation {
             latitude: data.latitude,
@@ -272,10 +305,14 @@ async fn try_ipwhois(client: &reqwest::Client) -> Option<GeoLocation> {
 async fn try_freeipapi(client: &reqwest::Client) -> Option<GeoLocation> {
     let resp = client
         .get("https://freeipapi.com/api/json")
+        .timeout(REQUEST_TIMEOUT)
         .send()
         .await
         .ok()?;
-    let data: FreeIpApiResponse = resp.json().await.ok()?;
+    let body = crate::http_body::read_limited(resp, MAX_GEOLOCATION_BODY_BYTES, REQUEST_TIMEOUT)
+        .await
+        .ok()?;
+    let data: FreeIpApiResponse = serde_json::from_slice(&body).ok()?;
     if data.latitude != 0.0 || data.longitude != 0.0 {
         Some(GeoLocation {
             latitude: data.latitude,

--- a/src/subsonic/client.rs
+++ b/src/subsonic/client.rs
@@ -10,6 +10,7 @@ use url::Url;
 
 use crate::architecture::backend::BackendResult;
 use crate::architecture::error::BackendError;
+use crate::http_body::{read_limited, ResponseBodyError};
 use crate::http_security::{
     authenticated_client_builder, redact_url_secrets, strip_request_url, validate_base_url,
 };
@@ -31,11 +32,11 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// (the timeout resets after each successful read).
 const READ_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Maximum response body we are willing to buffer into memory.  A generous
-/// cap that still rules out a malicious or misbehaving server trying to
-/// exhaust memory with an unbounded body.  Enforced from the
-/// `Content-Length` header before the body is read (see [`check_body_size`]).
-const MAX_BODY_BYTES: u64 = 256 * 1024 * 1024;
+/// Maximum response body we are willing to buffer into memory for API JSON.
+const MAX_API_BODY_BYTES: u64 = 256 * 1024 * 1024;
+
+/// End-to-end and body-phase deadline for finite API requests.
+const API_RESPONSE_DEADLINE: Duration = Duration::from_secs(120);
 
 /// Authentication mode used for API requests.
 #[derive(Clone)]
@@ -241,18 +242,24 @@ impl SubsonicClient {
 
         debug!(url = %redact_url_secrets(url.as_str()), "Subsonic request");
 
-        let resp = self.http.get(url.as_str()).send().await.map_err(|e| {
-            // Strip the request URL from the error before it is formatted or
-            // boxed: it carries the auth token + salt (or the hex-encoded
-            // plaintext password) in its query string, and reqwest's Display
-            // appends the full URL — which would leak the credential into
-            // always-on error-level logs on routine transport failures.
-            let e = strip_request_url(e);
-            BackendError::ConnectionFailed {
-                message: format!("HTTP request failed: {e}"),
-                source: Some(Box::new(e)),
-            }
-        })?;
+        let resp = self
+            .http
+            .get(url.as_str())
+            .timeout(API_RESPONSE_DEADLINE)
+            .send()
+            .await
+            .map_err(|e| {
+                // Strip the request URL from the error before it is formatted or
+                // boxed: it carries the auth token + salt (or the hex-encoded
+                // plaintext password) in its query string, and reqwest's Display
+                // appends the full URL — which would leak the credential into
+                // always-on error-level logs on routine transport failures.
+                let e = strip_request_url(e);
+                BackendError::ConnectionFailed {
+                    message: format!("HTTP request failed: {e}"),
+                    source: Some(Box::new(e)),
+                }
+            })?;
 
         if !resp.status().is_success() {
             return Err(BackendError::ConnectionFailed {
@@ -261,18 +268,15 @@ impl SubsonicClient {
             });
         }
 
-        // Refuse to buffer an oversized body (DoS guard) before reading it.
-        check_body_size(&resp)?;
+        let body = read_limited(resp, MAX_API_BODY_BYTES, API_RESPONSE_DEADLINE)
+            .await
+            .map_err(|error| response_body_error("Failed to parse Subsonic JSON", error))?;
 
-        let envelope: SubsonicEnvelope = resp.json().await.map_err(|e| {
-            // A body-read failure here can also carry the credential-bearing
-            // request URL; strip it before formatting/boxing into the error.
-            let e = strip_request_url(e);
-            BackendError::ParseError {
+        let envelope: SubsonicEnvelope =
+            serde_json::from_slice(&body).map_err(|e| BackendError::ParseError {
                 message: format!("Failed to parse Subsonic JSON: {e}"),
                 source: Some(Box::new(e)),
-            }
-        })?;
+            })?;
 
         if envelope.response.status != "ok" {
             let msg = envelope
@@ -324,29 +328,39 @@ impl SubsonicClient {
     }
 }
 
-/// Reject a response whose declared body exceeds [`MAX_BODY_BYTES`].
-///
-/// A lightweight, best-effort DoS guard: it inspects only the
-/// `Content-Length` header, so a chunked response sent without a length is
-/// not covered here — the client's `read_timeout` still bounds a stalled or
-/// slow-trickling transfer in that case.
-fn check_body_size(resp: &reqwest::Response) -> BackendResult<()> {
-    if let Some(len) = resp.content_length() {
-        if len > MAX_BODY_BYTES {
-            return Err(BackendError::ConnectionFailed {
-                message: format!(
-                    "Response body too large: {len} bytes exceeds the {MAX_BODY_BYTES}-byte cap"
-                ),
-                source: None,
-            });
-        }
+fn response_body_error(context: &str, error: ResponseBodyError) -> BackendError {
+    match error {
+        error @ (ResponseBodyError::TooLarge { .. }
+        | ResponseBodyError::InvalidLimit { .. }
+        | ResponseBodyError::AllocationFailed { .. }) => BackendError::ConnectionFailed {
+            message: error.to_string(),
+            source: None,
+        },
+        ResponseBodyError::DeadlineExceeded { deadline } => BackendError::Timeout {
+            duration_secs: deadline.as_secs(),
+        },
+        error => BackendError::ParseError {
+            message: format!("{context}: {error}"),
+            source: Some(Box::new(error)),
+        },
     }
-    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn maps_response_body_deadline_to_timeout() {
+        let error = response_body_error(
+            "body",
+            ResponseBodyError::DeadlineExceeded {
+                deadline: Duration::from_secs(7),
+            },
+        );
+
+        assert!(matches!(error, BackendError::Timeout { duration_secs: 7 }));
+    }
 
     #[test]
     fn rejects_embedded_url_credentials_without_echoing_them() {

--- a/src/ui/album_art.rs
+++ b/src/ui/album_art.rs
@@ -10,6 +10,9 @@ use std::sync::OnceLock;
 
 use gtk::glib;
 
+const REMOTE_ART_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+const MAX_REMOTE_ART_BYTES: u64 = 32 * 1024 * 1024;
+
 /// Global generation counter for album art requests.  Incremented on
 /// every track change; the worker checks this before sending results
 /// back to the GTK thread so stale fetches are silently dropped.
@@ -52,7 +55,7 @@ fn art_worker_tx() -> Option<&'static std::sync::mpsc::Sender<ArtRequest>> {
         // remote artwork instead of silently restoring reqwest's permissive
         // default redirect and Referer behavior.
         let client = match crate::http_security::authenticated_blocking_client_builder()
-            .timeout(std::time::Duration::from_secs(10))
+            .timeout(REMOTE_ART_TIMEOUT)
             .build()
         {
             Ok(client) => client,
@@ -73,20 +76,26 @@ fn art_worker_tx() -> Option<&'static std::sync::mpsc::Sender<ArtRequest>> {
                         continue; // Stale — user already changed tracks.
                     }
 
-                    match client.get(&req.url).send() {
-                        Ok(resp) if resp.status().is_success() => match resp.bytes() {
-                            Ok(bytes)
-                                if !bytes.is_empty()
-                                    && ART_GENERATION.load(Ordering::Relaxed) == req.generation =>
-                            {
-                                let _ = req.reply_tx.send_blocking(bytes.to_vec());
+                    match client.get(&req.url).timeout(REMOTE_ART_TIMEOUT).send() {
+                        Ok(resp) if resp.status().is_success() => {
+                            match crate::http_body::read_limited_blocking(
+                                resp,
+                                MAX_REMOTE_ART_BYTES,
+                                REMOTE_ART_TIMEOUT,
+                            ) {
+                                Ok(bytes)
+                                    if !bytes.is_empty()
+                                        && ART_GENERATION.load(Ordering::Relaxed)
+                                            == req.generation =>
+                                {
+                                    let _ = req.reply_tx.send_blocking(bytes);
+                                }
+                                Ok(_) => {}
+                                Err(error) => {
+                                    tracing::debug!(%error, "Failed to read remote album art body");
+                                }
                             }
-                            Ok(_) => {}
-                            Err(error) => {
-                                let error = crate::http_security::strip_request_url(error);
-                                tracing::debug!(%error, "Failed to read remote album art body");
-                            }
-                        },
+                        }
                         Ok(resp) => {
                             tracing::debug!(status = %resp.status(), "Remote album art HTTP error");
                         }

--- a/src/ui/properties_dialog.rs
+++ b/src/ui/properties_dialog.rs
@@ -495,6 +495,9 @@ fn add_info_row(container: &gtk::Box, label: &str, value: &str) {
 
 // ── MusicBrainz lookup ──────────────────────────────────────────────────
 
+const MUSICBRAINZ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+const MAX_MUSICBRAINZ_BODY_BYTES: u64 = 4 * 1024 * 1024;
+
 /// Result from a MusicBrainz recording search.
 #[derive(Debug, Clone, Default)]
 struct MusicBrainzResult {
@@ -522,18 +525,24 @@ fn musicbrainz_lookup(title: &str, artist: &str) -> Option<MusicBrainzResult> {
     );
 
     let client = reqwest::blocking::Client::builder()
-        .timeout(std::time::Duration::from_secs(10))
+        .timeout(MUSICBRAINZ_TIMEOUT)
         .user_agent("Tributary/0.3.0 (https://github.com/jm2/tributary)")
         .build()
         .ok()?;
 
-    let resp = client.get(&url).send().ok()?;
+    let resp = client.get(&url).timeout(MUSICBRAINZ_TIMEOUT).send().ok()?;
     if !resp.status().is_success() {
         warn!(status = %resp.status(), "MusicBrainz API error");
         return None;
     }
 
-    let json: serde_json::Value = resp.json().ok()?;
+    let body = crate::http_body::read_limited_blocking(
+        resp,
+        MAX_MUSICBRAINZ_BODY_BYTES,
+        MUSICBRAINZ_TIMEOUT,
+    )
+    .ok()?;
+    let json: serde_json::Value = serde_json::from_slice(&body).ok()?;
     let recordings = json.get("recordings")?.as_array()?;
     let recording = recordings.first()?;
 


### PR DESCRIPTION
Summary:
- replace Content-Length-only guards with counted async and blocking body reads
- apply endpoint-specific caps and end-to-end deadlines to backend APIs, authentication, DAAP, radio/geolocation, artwork, MusicBrainz, and DAAP ping
- preserve uncapped audio/live-radio streaming for the P1.6 proxy design
- classify deadline, allocation, and URL-sanitized transport failures consistently

Validation:
- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo clippy --release -- -D warnings
- cargo test --all-targets (301 passed)
- cargo test --release (301 passed)
- cargo audit (no vulnerabilities; two documented allowed unmaintained warnings)
- git diff --check
- 14 focused P1.5 tests