### PR TITLE
Stop handing MPD the user's server credentials (P1.6, part 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Chromecast no longer receives your server credentials** — Casting a track from Subsonic, Jellyfin, or Plex used to hand the Chromecast the stream URL with your credential still in it: your Plex token, your Jellyfin API key, or — with Subsonic's plaintext auth mode — your **actual password**, hex-encoded and trivially reversible. That credential went to a device Tributary does not control, over a LAN it does not control, and was retained in the device's media session. Tributary now fetches the stream itself and gives the device only an opaque, single-use ticket, revoked when playback stops. Internet radio and other unauthenticated streams are unaffected and still play directly.
 
-> **Known exposure, not yet fixed:** the same problem remains for **MPD**, which is still sent the credential-bearing URL over a plaintext connection. Tracked as P1.6.
+- **MPD no longer receives your server credentials either** — MPD fetches media itself, so the same stream URL was sent to the daemon over its **plaintext** TCP connection, crossing the network in the clear and being retained in the daemon's queue state and `mpd.log`. It now receives the same opaque ticket the Chromecast does. If the proxy cannot be started, the track is refused rather than sent in the clear.
 
 ### Changed
 - **Minimum supported Rust version raised to 1.85.**

--- a/docs/task.md
+++ b/docs/task.md
@@ -267,8 +267,9 @@ revocation.
   the credential stop being copied through the UI layer at all. Build it to serve P3.1's
   "resolve playable URLs at playback time" as well, rather than twice.
 - [ ] Give tickets a TTL in addition to revocation, so a ticket cannot outlive a crashed session.
-- [x] Record implementation: Chromecast proxy in commit `c6aa7df`; 6 focused classification,
-  credential-detection, and pass-through tests. MPD and credential-free `Track` values remain open.
+- [x] Record implementation: Chromecast proxy in commit `c6aa7df`, MPD in commit `73e91f4`; 8
+  focused classification, credential-detection, refusal, and pass-through tests. Credential-free
+  `Track` values and ticket TTLs remain open.
 
 Acceptance criteria: no credential belonging to a remote backend is ever transmitted to a
 device or daemon Tributary does not own. **Chromecast and MPD both meet this now.** What remains

--- a/docs/task.md
+++ b/docs/task.md
@@ -254,10 +254,12 @@ revocation.
 - [x] Threat-model spoofed and compromised LAN receivers: a hostile receiver now obtains a
   single-media ticket, revoked on stop and superseded on the next load, instead of an account
   credential.
-- [ ] Route **MPD** through the same proxy. MPD still sends the credential-bearing URL via `addid`
-  over **plaintext TCP**, so it crosses the LAN in the clear and lands in the daemon's queue state
-  and `mpd.log`. Blocked only by sequencing: `audio/mpd_output.rs` is owned by P1.8 (PR #76). The
-  proxy it needs already exists — this is a small change once that lands.
+- [x] Route **MPD** through the same proxy. MPD sent the credential-bearing URL via `addid` over
+  **plaintext TCP**, so it crossed the LAN in the clear and landed in the daemon's queue state and
+  `mpd.log`. It now receives an opaque ticket. If the proxy cannot start, the load is **refused**
+  rather than sent in the clear — a fallback would defeat the point, and a test fails loudly if
+  anyone adds one. The server is renamed `MediaProxy` (`audio/media_proxy.rs`), since it is no
+  longer Chromecast-specific.
 - [ ] Keep backend credentials outside generic `Track` values: drop the credential from
   `Track.stream_url` and add a backend `resolve_stream(&track) -> (Url, HeaderMap)` called at
   playback time, moving `X-Plex-Token` / `api_key` / Subsonic `u,t,s,p` out of the query string
@@ -269,8 +271,10 @@ revocation.
   credential-detection, and pass-through tests. MPD and credential-free `Track` values remain open.
 
 Acceptance criteria: no credential belonging to a remote backend is ever transmitted to a
-device or daemon Tributary does not own. **Chromecast now meets this; MPD does not yet.** Closing
-the MPD half also closes P1.4's last checkbox.
+device or daemon Tributary does not own. **Chromecast and MPD both meet this now.** What remains
+under P1.6 is defence in depth rather than an open leak: the credential is still *copied* through
+the UI layer inside `Track.stream_url` (it just no longer leaves the process), and tickets are
+revoked rather than TTL-bounded.
 
 ### P1.7 Serialize Chromecast lifecycle and commands
 

--- a/src/audio/chromecast_output.rs
+++ b/src/audio/chromecast_output.rs
@@ -14,7 +14,7 @@ use std::time::{Duration, Instant};
 
 use tracing::{error, info};
 
-use super::cast_http_server::CastHttpServer;
+use super::media_proxy::MediaProxy;
 use super::output::{AudioOutput, OutputType};
 use super::{PlayerEvent, PlayerEventGeneration, PlayerState};
 
@@ -32,7 +32,7 @@ pub struct ChromecastOutput {
     event_generation: AtomicU64,
     volume: f64,
     current_state: Arc<Mutex<PlayerState>>,
-    cast_server: Arc<Mutex<Option<CastHttpServer>>>,
+    cast_server: Arc<Mutex<Option<MediaProxy>>>,
     rt_handle: Option<tokio::runtime::Handle>,
     intent_epoch: Arc<AtomicU64>,
     worker_tx: mpsc::Sender<WorkerCommand>,
@@ -1541,7 +1541,7 @@ impl ChromecastOutput {
     }
 
     /// Start the LAN media server if it is not already running.
-    fn ensure_cast_server(&self) -> CastResult<std::sync::MutexGuard<'_, Option<CastHttpServer>>> {
+    fn ensure_cast_server(&self) -> CastResult<std::sync::MutexGuard<'_, Option<MediaProxy>>> {
         let mut server_guard = self
             .cast_server
             .lock()
@@ -1553,7 +1553,7 @@ impl ChromecastOutput {
                 .as_ref()
                 .ok_or_else(|| CastFailure::new("media server startup"))?;
             let server = runtime
-                .block_on(CastHttpServer::start())
+                .block_on(MediaProxy::start())
                 .map_err(|error| opaque_cast_failure("media server startup", error))?;
             info!(addr = %server.addr(), "Cast HTTP server started");
             *server_guard = Some(server);
@@ -2822,7 +2822,7 @@ mod tests {
     fn raw_cast_error_context_is_discarded() {
         let failure = opaque_cast_failure(
             "media load",
-            "request failed for https://music.test/cast/token-secret?api_key=query-secret",
+            "request failed for https://music.test/media/token-secret?api_key=query-secret",
         );
         let message = cast_failure_message(failure);
         assert_eq!(message, "Chromecast media load failed");

--- a/src/audio/media_proxy.rs
+++ b/src/audio/media_proxy.rs
@@ -72,7 +72,7 @@ struct ServerState {
 }
 
 /// A running cast HTTP server instance.
-pub struct CastHttpServer {
+pub struct MediaProxy {
     /// The socket address the server is listening on (LAN IP + port).
     addr: SocketAddr,
     /// Registered ticket map (shared with the axum handler).
@@ -81,7 +81,7 @@ pub struct CastHttpServer {
     abort_handle: tokio::task::AbortHandle,
 }
 
-impl CastHttpServer {
+impl MediaProxy {
     /// Start a new cast HTTP server bound to the machine's LAN IP.
     ///
     /// The server binds to port 0 (OS-assigned) on the first
@@ -125,7 +125,7 @@ impl CastHttpServer {
         };
 
         let app = Router::new()
-            .route("/cast/{id}", get(serve_media))
+            .route("/media/{id}", get(serve_media))
             .with_state(state);
 
         let listener = TcpListener::bind(SocketAddr::from((ipv4, 0))).await?;
@@ -149,7 +149,7 @@ impl CastHttpServer {
     /// Register a local file for serving.
     ///
     /// Returns the full HTTP URL that a Chromecast can load to stream
-    /// the file, e.g. `http://192.168.1.42:54321/cast/<uuid>.flac`.
+    /// the file, e.g. `http://192.168.1.42:54321/media/<uuid>.flac`.
     ///
     /// Local entries are insert-only: they are not expired and remain servable
     /// for the lifetime of the server (the app session). That is acceptable
@@ -214,7 +214,7 @@ impl CastHttpServer {
     }
 
     fn ticket_url(&self, ticket: &str) -> String {
-        format!("http://{}/cast/{}", self.addr, ticket)
+        format!("http://{}/media/{}", self.addr, ticket)
     }
 
     /// The socket address the server is listening on.
@@ -223,7 +223,7 @@ impl CastHttpServer {
     }
 }
 
-impl Drop for CastHttpServer {
+impl Drop for MediaProxy {
     fn drop(&mut self) {
         self.abort_handle.abort();
     }

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -23,9 +23,9 @@
 //! to the pattern used by [`LibraryEngine`](crate::local::engine::LibraryEngine).
 
 pub mod airplay_output;
-pub mod cast_http_server;
 pub mod chromecast_output;
 pub mod local_output;
+pub mod media_proxy;
 pub mod mpd_output;
 pub mod output;
 

--- a/src/audio/mpd_output.rs
+++ b/src/audio/mpd_output.rs
@@ -16,6 +16,7 @@ use std::time::{Duration, Instant};
 
 use tracing::{debug, error, info};
 
+use super::media_proxy::MediaProxy;
 use super::output::{AudioOutput, OutputType};
 use super::{PlayerEvent, PlayerEventGeneration, PlayerState};
 
@@ -41,6 +42,13 @@ pub struct MpdOutput {
     intent_epoch: Arc<AtomicU64>,
     cache: Arc<Mutex<MpdCache>>,
     worker_tx: mpsc::Sender<WorkerCommand>,
+    /// LAN media proxy, started on demand for credential-bearing streams.
+    ///
+    /// MPD fetches media itself, so a credential-bearing URL sent to it would
+    /// cross the network in the clear — the MPD protocol is plaintext TCP — and
+    /// be retained in the daemon's queue state and `mpd.log`.
+    media_proxy: Arc<Mutex<Option<MediaProxy>>>,
+    rt_handle: Option<tokio::runtime::Handle>,
 }
 
 #[derive(Clone, Copy)]
@@ -1794,6 +1802,80 @@ impl MpdOutput {
             intent_epoch,
             cache,
             worker_tx,
+            media_proxy: Arc::new(Mutex::new(None)),
+            rt_handle: tokio::runtime::Handle::try_current().ok(),
+        }
+    }
+
+    /// Supply the tokio runtime used to start the LAN media proxy.
+    ///
+    /// Without it, a credential-bearing stream cannot be proxied — and is then
+    /// refused rather than sent to the daemon in the clear.
+    #[must_use]
+    pub fn with_runtime(mut self, handle: tokio::runtime::Handle) -> Self {
+        self.rt_handle = Some(handle);
+        self
+    }
+
+    /// Replace a credential-bearing stream URL with an opaque proxy ticket.
+    ///
+    /// MPD is a receiver: it fetches the media itself. Sending it a Subsonic,
+    /// Jellyfin, or Plex stream URL would put the user's token — or, under
+    /// Subsonic's plaintext auth mode, the user's *password* — onto a plaintext
+    /// TCP connection, into the daemon's queue state file, and into `mpd.log`.
+    ///
+    /// Anything without a credential (internet radio, a plain HTTP stream, a
+    /// local path the daemon can already reach) is passed through untouched.
+    fn shield_credentials(&self, uri: &str) -> MpdResult<String> {
+        // Any new load retires the previous ticket, whatever the new track is.
+        self.revoke_proxy_tickets();
+
+        let Ok(parsed) = url::Url::parse(uri) else {
+            return Ok(uri.to_string());
+        };
+        if !matches!(parsed.scheme(), "http" | "https")
+            || !crate::http_security::url_carries_credentials(&parsed)
+        {
+            return Ok(uri.to_string());
+        }
+
+        let proxy = self.ensure_media_proxy()?;
+        let proxy = proxy
+            .as_ref()
+            .ok_or_else(|| MpdFailure::new("media proxy startup"))?;
+        Ok(proxy.register_upstream(&parsed))
+    }
+
+    /// Start the LAN media proxy if it is not already running.
+    fn ensure_media_proxy(&self) -> MpdResult<std::sync::MutexGuard<'_, Option<MediaProxy>>> {
+        let mut guard = self
+            .media_proxy
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+
+        if guard.is_none() {
+            let runtime = self
+                .rt_handle
+                .as_ref()
+                .ok_or_else(|| MpdFailure::new("media proxy startup"))?;
+            let proxy = runtime
+                .block_on(MediaProxy::start())
+                .map_err(|error| opaque_mpd_failure("media proxy startup", error))?;
+            info!(addr = %proxy.addr(), "MPD media proxy started");
+            *guard = Some(proxy);
+        }
+
+        Ok(guard)
+    }
+
+    /// Drop every credential-bearing ticket the proxy is holding.
+    fn revoke_proxy_tickets(&self) {
+        let guard = self
+            .media_proxy
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        if let Some(proxy) = guard.as_ref() {
+            proxy.revoke_upstreams();
         }
     }
 
@@ -1864,10 +1946,14 @@ impl AudioOutput for MpdOutput {
             cache.state = PlayerState::Buffering;
             cache.position_ms = None;
         }
-        let kind = match encode_mpd_arg(uri) {
-            Ok(_) => CommandKind::Load {
-                uri: uri.to_string(),
-            },
+        // Never hand the daemon a credential. If the stream carries one and the
+        // proxy cannot be started, the load is *refused* — sending it in the
+        // clear as a fallback would defeat the whole point.
+        let kind = match self
+            .shield_credentials(uri)
+            .and_then(|safe_uri| encode_mpd_arg(&safe_uri).map(|_| safe_uri))
+        {
+            Ok(safe_uri) => CommandKind::Load { uri: safe_uri },
             Err(failure) => CommandKind::RejectLoad { failure },
         };
         self.enqueue(owner, kind);
@@ -1887,6 +1973,9 @@ impl AudioOutput for MpdOutput {
     }
 
     fn stop(&self) {
+        // Retire the credential ticket as soon as playback is meant to end, so
+        // the daemon cannot re-fetch the protected stream afterwards.
+        self.revoke_proxy_tickets();
         let owner = self.next_owner();
         {
             let mut cache = self
@@ -3439,6 +3528,8 @@ mod tests {
             intent_epoch: Arc::clone(&intent_epoch),
             cache: Arc::clone(&cache),
             worker_tx,
+            media_proxy: Arc::new(Mutex::new(None)),
+            rt_handle: None,
         };
 
         output.load_uri("https://music.test/new");
@@ -3780,5 +3871,78 @@ mod tests {
         .expect("second address connects");
         assert_eq!(connection.version, "OK MPD 0.24.0");
         server.join().expect("fake server stopped");
+    }
+
+    // ── P1.6: credentials must never reach the MPD daemon ─────────────
+
+    fn proxyless_output() -> (MpdOutput, mpsc::Receiver<WorkerCommand>) {
+        let (event_tx, _event_rx) = async_channel::unbounded();
+        let (worker_tx, worker_rx) = mpsc::channel();
+        let output = MpdOutput {
+            display_name: "test".to_string(),
+            event_tx,
+            event_generation: AtomicU64::new(0),
+            volume: 1.0,
+            intent_epoch: Arc::new(AtomicU64::new(0)),
+            cache: Arc::new(Mutex::new(MpdCache::default())),
+            worker_tx,
+            media_proxy: Arc::new(Mutex::new(None)),
+            // No runtime: the proxy cannot start.
+            rt_handle: None,
+        };
+        (output, worker_rx)
+    }
+
+    /// The bug. MPD fetches media itself, so the stream URL went to the daemon
+    /// over a plaintext TCP connection — and into its queue state and mpd.log.
+    ///
+    /// With no runtime the proxy cannot start, so the load must be *refused*.
+    /// Falling back to sending the URL in the clear would defeat the point, and
+    /// this test fails loudly if anyone ever adds that fallback.
+    #[test]
+    fn a_credential_bearing_stream_is_never_sent_to_the_daemon() {
+        let leaks = [
+            "https://plex.test/library/parts/1/a.flac?X-Plex-Token=plex-secret",
+            "https://jellyfin.test/Audio/1/stream?api_key=jellyfin-secret",
+            "https://sub.test/rest/stream.view?u=me&t=tok-secret&s=salt&c=Tributary&id=1",
+            // Subsonic plaintext auth: this is the user's password.
+            "https://sub.test/rest/stream.view?u=me&p=enc%3A70617373&c=Tributary&id=1",
+            "https://me:hunter2@music.test/stream.flac",
+        ];
+
+        for uri in leaks {
+            let (output, worker_rx) = proxyless_output();
+            output.load_uri(uri);
+
+            let command = worker_rx.recv().expect("queued command");
+            match command.kind {
+                CommandKind::RejectLoad { .. } => {}
+                CommandKind::Load { uri: sent } => {
+                    panic!("credential-bearing URL was sent to the MPD daemon: {sent}")
+                }
+                _ => panic!("unexpected command for {uri}"),
+            }
+        }
+    }
+
+    /// Unauthenticated streams still reach the daemon directly. Relaying live
+    /// radio through this process would buy nothing.
+    #[test]
+    fn an_unauthenticated_stream_still_reaches_the_daemon() {
+        for uri in [
+            "http://radio.test/stream.mp3",
+            "https://radio.test/listen?bitrate=128&format=mp3",
+            // Ordinary `s`/`p` on a non-Subsonic service are not credentials.
+            "https://radio.test/search?s=jazz&p=2",
+        ] {
+            let (output, worker_rx) = proxyless_output();
+            output.load_uri(uri);
+
+            let command = worker_rx.recv().expect("queued command");
+            assert!(
+                matches!(command.kind, CommandKind::Load { uri: ref sent } if sent == uri),
+                "{uri} should be passed to the daemon untouched"
+            );
+        }
     }
 }

--- a/src/ui/output_switch.rs
+++ b/src/ui/output_switch.rs
@@ -159,6 +159,7 @@ pub fn setup_output_selector(
                     &parked_local,
                     &event_sender,
                     &volume_scale,
+                    &rt_handle,
                 );
             }
         }
@@ -322,6 +323,7 @@ fn handle_mpd_switch(
     parked_local: &Rc<RefCell<Option<Box<dyn AudioOutput>>>>,
     event_sender: &async_channel::Sender<PlayerEvent>,
     volume_scale: &gtk::Scale,
+    rt_handle: &tokio::runtime::Handle,
 ) {
     let saved = load_saved_outputs();
     let mpd_idx = mpd_index_before_row(list_box, idx);
@@ -329,7 +331,10 @@ fn handle_mpd_switch(
     if let Some(entry) = saved.get(mpd_idx) {
         park_local_if_needed(active_output, parked_local, event_sender);
 
-        let mpd = MpdOutput::new(&entry.name, &entry.host, entry.port, event_sender.clone());
+        // The runtime lets MPD start the LAN media proxy, so a credential-bearing
+        // stream is never sent to the daemon over its plaintext connection.
+        let mpd = MpdOutput::new(&entry.name, &entry.host, entry.port, event_sender.clone())
+            .with_runtime(rt_handle.clone());
         *active_output.borrow_mut() = Box::new(mpd);
         info!(
             name = %entry.name,

--- a/src/ui/playback.rs
+++ b/src/ui/playback.rs
@@ -585,10 +585,12 @@ fn play_current(ctx: &PlaybackContext) -> bool {
         }
     };
 
-    // Local (`file://`) library tracks are cast to the device by the
-    // Chromecast output itself, which serves them over its embedded LAN
-    // `CastHttpServer` (see `ChromecastOutput::resolve_uri`); local, MPD and
-    // AirPlay outputs play them directly. No output swap is needed here.
+    // Local (`file://`) library tracks are cast to the device by the Chromecast
+    // output itself, which serves them over its embedded LAN `MediaProxy` (see
+    // `ChromecastOutput::resolve_uri`); local and AirPlay outputs play them
+    // directly. Receiver-fetched outputs (Chromecast, MPD) also route
+    // credential-bearing remote streams through that proxy, so the credential
+    // never reaches the device. No output swap is needed here.
 
     tracing::debug!("Playing track");
 


### PR DESCRIPTION
Closes the other half of the credential leak that #78 fixed for Chromecast — and it is the **worse** half.

## The bug

MPD is a receiver: it fetches the media itself. So a Subsonic, Jellyfin, or Plex stream URL was sent to the daemon via `addid` — over the MPD protocol's **plaintext TCP** connection. The credential crossed the network in the clear, and was retained in the daemon's queue state file and in `mpd.log`.

Chromecast at least fetched over whatever transport the URL named. MPD's own control channel is unencrypted, so the credential was exposed to any passive observer on the LAN before the daemon even made a request.

With Subsonic's plaintext auth mode, that credential is `p=enc:<hex>` — the user's **actual password**, hex-encoded and trivially reversible. Not a revocable token.

## The fix

The proxy already existed from #78, so MPD takes the same path: a credential-bearing URL is registered as an upstream ticket, Tributary fetches it in-process, and the daemon is given only `http://<lan-ip>:<port>/media/<uuid>`.

**If the proxy cannot start, the load is refused.** Sending the URL in the clear as a fallback would defeat the entire point. The test asserts the refusal, so it fails loudly if anyone ever adds that fallback — verified by removing the guard and watching it fail.

Unauthenticated streams (internet radio) still go straight to the daemon. Relaying a live radio stream through this process would buy nothing.

The server is renamed `MediaProxy` (`audio/media_proxy.rs`) now that it backs both outputs and is no longer Chromecast-specific; the route is `/media/` rather than `/cast/`.

## What P1.6 still leaves open

Both receivers now meet the acceptance criteria, so what remains is defence in depth rather than an open leak:

- The credential is still *copied* through the UI layer inside `Track.stream_url` — it just no longer leaves the process. Removing it entirely means resolving stream URLs at playback time, which is also what P3.1 wants.
- Tickets are revoked (on every new load, and on stop) but not TTL-bounded, so one could outlive a crashed session.

## Verification

`cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo clippy --release -- -D warnings`, `cargo test --all-targets` (**383 pass**), `cargo test --release`, `cargo audit` (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtMAXeFZRf65wKgcmLgeGs