### PR TITLE
Require exclusive control for MPD playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   or Tributary instance shares the playback partition. The confirmation is persisted as an
   explicit mode and participates in output identity, so reselecting an upgraded active endpoint
   rebuilds it instead of being mistaken for a no-op. Legacy entries deserialize unconfirmed and
-  every load intent fails with localized re-add/confirm/reselect guidance before cleanup, MPD
-  connection, MPD state or option commands, protected-media tickets, or queue mutation—even when
-  media was already rejected as malformed, unsupported, or inactive before worker dispatch.
+  every load intent fails with localized re-add/confirm/reselect guidance before optimistic
+  Buffering state, output-epoch advancement, worker enqueue/cleanup, MPD connection, MPD state or
+  option commands, protected-media tickets, or queue mutation—even when media was already rejected
+  as malformed, unsupported, or inactive. The synchronous refusal leaves the exact queue item
+  retryable, so another Play re-shows the guidance instead of toggling an empty MPD session; an
+  independent worker gate retains the same fail-closed contract for internal callers.
   Re-adding the exact host and port with the checkbox upgrades that entry in place without renaming
   it, dropping siblings, or creating a duplicate. Existing song-ID ownership checks remain in
   force: observing a foreign current song violates the exclusive-control promise but still causes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,12 +42,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   or Tributary instance shares the playback partition. The confirmation is persisted as an
   explicit mode and participates in output identity, so reselecting an upgraded active endpoint
   rebuilds it instead of being mistaken for a no-op. Legacy entries deserialize unconfirmed and
-  playback fails with localized re-add/confirm/reselect guidance before any MPD connection, MPD
-  state or option command, protected-media ticket, or queue mutation. Re-adding the exact host and
-  port with the checkbox upgrades that entry in place without renaming it, dropping siblings, or
-  creating a duplicate. Existing song-ID ownership checks remain in force: observing a foreign
-  current song violates the exclusive-control promise but still causes conservative
-  relinquishment/retention rather than a racy stop or delete.
+  every load intent fails with localized re-add/confirm/reselect guidance before cleanup, MPD
+  connection, MPD state or option commands, protected-media tickets, or queue mutation—even when
+  media was already rejected as malformed, unsupported, or inactive before worker dispatch.
+  Re-adding the exact host and port with the checkbox upgrades that entry in place without renaming
+  it, dropping siblings, or creating a duplicate. Existing song-ID ownership checks remain in
+  force: observing a foreign current song violates the exclusive-control promise but still causes
+  conservative relinquishment/retention rather than a racy stop or delete.
 - **Coverage is now representative and threshold-gated** — The sole comparable report moves to
   a dedicated Linux x86_64 job pinned to Rust 1.92.0, matching LLVM tools, cargo-llvm-cov 0.8.7,
   the committed dependency graph, every host target, and every feature. UI, Jellyfin, Plex,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Credential-bearing media tickets now expire** — Every upstream proxy ticket has a hard, absolute, non-sliding 24-hour lifetime from registration in addition to earlier playback-lifecycle revocation. It is usable only before its monotonic deadline; a lookup at or after that boundary atomically removes it and returns the same 404 as an unknown or revoked route. GET and byte-range requests, pause, seek, and receiver status do not renew the deadline, so a compromised receiver cannot perpetuate the bearer. A response admitted before expiry may finish afterward, but every later lookup fails. Local-file routes retain their existing server-lifetime behavior because they front no backend credential.
 
 ### Changed
+- **MPD playback now requires explicit exclusive partition control** — MPD exposes pause, stop,
+  and its `repeat`, `random`, `single`, and `consume` settings as partition-wide mutations, with no
+  atomic command that can prove Tributary still owns the current song. The Add Output dialog now
+  explains that scope in every supported locale and requires confirmation that no other controller
+  or Tributary instance shares the playback partition. The confirmation is persisted as an
+  explicit mode and participates in output identity, so reselecting an upgraded active endpoint
+  rebuilds it instead of being mistaken for a no-op. Legacy entries deserialize unconfirmed and
+  playback fails with localized re-add/confirm/reselect guidance before any MPD connection, MPD
+  state or option command, protected-media ticket, or queue mutation. Re-adding the exact host and
+  port with the checkbox upgrades that entry in place without renaming it, dropping siblings, or
+  creating a duplicate. Existing song-ID ownership checks remain in force: observing a foreign
+  current song violates the exclusive-control promise but still causes conservative
+  relinquishment/retention rather than a racy stop or delete.
 - **Coverage is now representative and threshold-gated** — The sole comparable report moves to
   a dedicated Linux x86_64 job pinned to Rust 1.92.0, matching LLVM tools, cargo-llvm-cov 0.8.7,
   the committed dependency graph, every host target, and every feature. UI, Jellyfin, Plex,

--- a/README.md
+++ b/README.md
@@ -78,15 +78,16 @@ it is configured as an output. Each load sets the four MPD options above to off,
 settings can remain changed after playback.
 
 The confirmation is persisted in `outputs.json`. Entries saved by an older Tributary release have
-no confirmation and fail closed before any MPD connection, playback-state or option command, or
-protected-media ticket is created. The common gate also precedes cleanup and media-validation
-failures, so malformed, unsupported, or inactive media cannot bypass the same confirmation
-guidance. Re-add the same host and port and select the exclusive-control checkbox to upgrade that
-entry in place; Tributary preserves its existing name and does not add a duplicate. If that legacy
-output was already selected, select its row again so the confirmed mode rebuilds the output before
-playback. If a foreign current song is nevertheless observed after confirmation, Tributary still
-relinquishes ownership and conservatively retains its queued ID rather than risking disruption of
-the foreign playback.
+no confirmation and fail closed before optimistic Buffering state, output-epoch advancement,
+worker enqueue or cleanup, any MPD connection, playback-state or option command, or protected-media
+ticket. The worker independently repeats the gate, and malformed, unsupported, or inactive media
+cannot bypass the same confirmation guidance. A refused queue item remains retryable, so another
+Play re-shows the guidance rather than toggling an empty MPD session. Re-add the same host and port
+and select the exclusive-control checkbox to upgrade that entry in place; Tributary preserves its
+existing name and does not add a duplicate. If that legacy output was already selected, select its
+row again so the confirmed mode rebuilds the output before playback. If a foreign current song is
+nevertheless observed after confirmation, Tributary still relinquishes ownership and
+conservatively retains its queued ID rather than risking disruption of the foreign playback.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Tributary provides a unified interface for managing and streaming music from mul
 | Network connection guard (prevents duplicate auth) | ✅ |
 | i18n/l10n framework (13 languages, auto locale detection) | ✅ |
 | Audio output selector (local + MPD, iTunes AirPlay-style) | ✅ |
-| MPD output backend (sink-only, TCP with security hardening) | ✅ |
+| MPD output backend (sink-only, TCP with security hardening) | ✅ Requires explicit exclusive-control confirmation |
 | Output switching (click to swap local ↔ MPD) | ✅ |
 | AirPlay 1 (RAOP) output | ✅ Requires GStreamer's `raopsink` element (ships in `gst-plugins-bad`); a missing element fails with an actionable install message |
 | AirPlay 2 / HomeKit output | ❌ Not yet supported — see [AirPlay 2 roadmap](#airplay-2-roadmap) below |
@@ -66,6 +66,25 @@ Tributary provides a unified interface for managing and streaming music from mul
 | Linux and macOS file associations | ✅ |
 | Cross-platform: Linux, macOS, Windows | ✅ |
 | Light & dark mode | ✅ Automatic (libadwaita) |
+
+### MPD output safety
+
+MPD exposes pause, stop, and its `repeat`, `random`, `single`, and `consume` options as
+partition-wide commands; it does not provide an atomic “change this only if Tributary still owns
+the current song” operation. Tributary therefore plays through an MPD output only after **Add
+Output** confirms that this Tributary instance has exclusive control of that playback partition.
+Do not use another MPD controller or another Tributary instance against the same partition while
+it is configured as an output. Each load sets the four MPD options above to off, and those daemon
+settings can remain changed after playback.
+
+The confirmation is persisted in `outputs.json`. Entries saved by an older Tributary release have
+no confirmation and fail closed before any MPD connection, playback-state or option command, or
+protected-media ticket is created. Re-add the same host and port and select the exclusive-control
+checkbox to upgrade that entry in place; Tributary preserves its existing name and does not add a
+duplicate. If that legacy output was already selected, select its row again so the confirmed mode
+rebuilds the output before playback. If a foreign current song is nevertheless observed after
+confirmation, Tributary still relinquishes ownership and conservatively retains its queued ID
+rather than risking disruption of the foreign playback.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -79,12 +79,14 @@ settings can remain changed after playback.
 
 The confirmation is persisted in `outputs.json`. Entries saved by an older Tributary release have
 no confirmation and fail closed before any MPD connection, playback-state or option command, or
-protected-media ticket is created. Re-add the same host and port and select the exclusive-control
-checkbox to upgrade that entry in place; Tributary preserves its existing name and does not add a
-duplicate. If that legacy output was already selected, select its row again so the confirmed mode
-rebuilds the output before playback. If a foreign current song is nevertheless observed after
-confirmation, Tributary still relinquishes ownership and conservatively retains its queued ID
-rather than risking disruption of the foreign playback.
+protected-media ticket is created. The common gate also precedes cleanup and media-validation
+failures, so malformed, unsupported, or inactive media cannot bypass the same confirmation
+guidance. Re-add the same host and port and select the exclusive-control checkbox to upgrade that
+entry in place; Tributary preserves its existing name and does not add a duplicate. If that legacy
+output was already selected, select its row again so the confirmed mode rebuilds the output before
+playback. If a foreign current song is nevertheless observed after confirmation, Tributary still
+relinquishes ownership and conservatively retains its queued ID rather than risking disruption of
+the foreign playback.
 
 ## Architecture
 

--- a/docs/task.md
+++ b/docs/task.md
@@ -50,10 +50,11 @@ executions in PR #111.
 P2.10's final exclusive-control behavior is implemented on
 `agent/p2.10-mpd-exclusive` branch, but its two remaining boxes and the progress numerator stay
 open at this pre-CI stage. Legacy MPD outputs remain unconfirmed until the exact endpoint is
-re-added with the required localized checkbox; an unconfirmed worker rejects playback before any
-cleanup, MPD connection, MPD state/option command, protected-media ticket, or queue mutation,
-including for media rejected before worker dispatch. This branch builds on P3.5's accepted
-exact-toolchain baseline.
+re-added with the required localized checkbox; their public load boundary rejects playback before
+optimistic Buffering state, epoch advancement, worker enqueue/cleanup, MPD connection, MPD
+state/option commands, protected-media tickets, or queue mutation. The exact queue generation
+remains retryable, while a second worker gate covers internal callers and media rejected before
+dispatch. This branch builds on P3.5's accepted exact-toolchain baseline.
 The release-workflow dry run remains deliberately deferred rather than being counted as unfinished
 P0 remediation.
 
@@ -1086,13 +1087,17 @@ error that tells the user what to install.
   of appending a duplicate. The mode participates in `OutputTarget` identity, so false-to-true
   migration makes reselecting an already-active legacy endpoint reconstruct it rather than taking
   the same-host/port no-op path. The ordered worker receives a typed
-  Unconfirmed/Exclusive mode and rejects every unconfirmed load intent before cleanup, Buffering,
-  connection, partition-wide repeat/random/single/consume or playback-state commands, proxy-ticket
-  registration, queue insertion, play, or status. The common gate includes media already rejected
-  as malformed, unsupported, or inactive before worker dispatch and emits the same fixed localized
-  re-add/confirm/reselect guidance. Seven focused net-new tests cover legacy
+  Unconfirmed/Exclusive mode. The public output boundary rejects every unconfirmed load before
+  optimistic Buffering, output-epoch advancement, worker enqueue/cleanup, connection,
+  partition-wide repeat/random/single/consume or playback-state commands, proxy-ticket
+  registration, queue insertion, play, or status. Its synchronous acceptance result marks the
+  exact UI queue generation retryable without invalidating the queued error, so later Play reloads
+  and re-shows guidance rather than toggling an empty output. The worker independently repeats the
+  gate for every load intent, including media already rejected as malformed, unsupported, or
+  inactive before dispatch. Nine focused net-new tests cover legacy
   deserialization/approved serialization, exact upsert and sibling preservation, mode-sensitive
-  output identity, zero MPD and proxy action for protected and pre-rejected loads, and all-catalog
+  output identity, boundary/worker zero MPD and proxy action for direct, protected, resolved, and
+  pre-rejected loads, exact-generation retry behavior, and all-catalog
   warning/confirmation/failure localization.
 - [x] Retain only redacted ACK error codes so cleanup can distinguish a missing song ID from a
   permission or argument rejection without keeping server-controlled text. The response parser
@@ -1418,14 +1423,15 @@ as does the deliberately deferred live release-workflow run.
 Most recent local branch validation (2026-07-17, P2.10 exclusive-control slice stacked on P3.5,
 before PR CI): `cargo check --all-targets --all-features --locked`, strict all-target/all-feature
 Clippy, and `cargo test --all-targets --all-features --locked` pass in debug and release. Each full
-profile passes 18 library, 725 application, and 10 repository-metadata tests (753 total); all 82
-focused MPD tests pass. Seven net-new regressions cover legacy default-false deserialization and
+profile passes 18 library, 727 application, and 10 repository-metadata tests (755 total); all 83
+focused MPD tests pass. Nine net-new regressions cover legacy default-false deserialization and
 approved-mode serialization, exact in-place upgrade with name/sibling preservation, repeat-upsert
 deduplication, mode-sensitive output identity, worker-level zero-connection/state/ticket/queue
-action for protected and pre-rejected loads, and warning/confirmation/failure localization across
-all 13 catalogs. The first restricted
-release run denied every loopback bind at the test environment boundary; an immediate rerun with
-loopback access passed all 753 tests. `cargo audit` reports no vulnerability and only the two
+action for protected and pre-rejected loads, public-boundary refusal before Buffering/epoch/enqueue
+for direct and typed media, exact-generation retry state, and warning/confirmation/failure
+localization across all 13 catalogs. The first restricted release run denied every loopback bind at
+the test environment boundary; an immediate rerun with loopback access passed all 755 tests.
+`cargo audit` reports no vulnerability and only the two
 tracked allowed unmaintained warnings; desktop and AppStream validation,
 `cargo fmt --all -- --check`, and `git diff --check` pass. No dependency or lockfile changed. The
 P2.10 boxes and 196/223 progress snapshot remain deliberately open pending PR CI; P3.5's
@@ -1653,9 +1659,11 @@ Record scope or design decisions here so deferred work is explicit.
   repeat, random, single, and consume commands are global to the selected playback partition; a
   named partition can still be joined by another client and is not a lock. Legacy saved endpoints
   default to unconfirmed and cannot load until re-added with the required one-controller checkbox.
-  The worker owns the final common gate so an unconfirmed load—including a pre-dispatch media
-  rejection—cannot clean up, connect, issue MPD state/options, register a protected ticket, or
-  mutate the queue even if a caller bypasses GTK. Confirmation
+  The public output boundary rejects an unconfirmed load before Buffering, epoch advancement, or
+  worker enqueue and marks the exact UI generation retryable; the worker owns an independent final
+  gate so every load intent—including a pre-dispatch media rejection—cannot clean up, connect,
+  issue MPD state/options, register a protected ticket, or mutate the queue even if a caller
+  bypasses GTK. Confirmation
   authorizes the unavoidable global operations but does not weaken foreign-song defenses: an
   observed foreign ID proves the deployment promise was violated, and Tributary still relinquishes
   ownership without a racy stop or deletion.
@@ -1967,10 +1975,11 @@ Record scope or design decisions here so deferred work is explicit.
   or mismatched ACK-like input poisons the connection. MPD's index, echo, and free-form text are
   then discarded.
   P2.10's final slice makes shared/unconfirmed playback unsupported: the persisted mode defaults
-  false for legacy entries, and the worker rejects every load intent before cleanup, an MPD
-  connection, state or option command, or protected ticket, including media failures classified
-  before dispatch. Re-adding the exact endpoint with the required localized
-  checkbox upgrades it in place. If a foreign current song is later observed in confirmed
+  false for legacy entries. The public boundary refuses loads before Buffering, epoch advancement,
+  enqueue, or cleanup and retains a retryable UI generation; a defense-in-depth worker gate rejects
+  every load intent before an MPD connection, state or option command, or protected ticket,
+  including media failures classified before dispatch. Re-adding the exact endpoint with the
+  required localized checkbox upgrades it in place. If a foreign current song is later observed in confirmed
   exclusive mode, Tributary deliberately relinquishes the session without deleting its queued ID,
   including during explicit Stop and shutdown. Revalidation plus `deleteid` is not atomic, so the
   foreign client could select that ID between the two operations. A stale response that reports
@@ -2188,7 +2197,7 @@ Add one line per completed task:
 | 2026-07-16 | P2.10 bounded MPD ingress (partial) | PR #105 | Replaces the unbounded worker channel with a capacity-64 epoch-aware deque plus a coalesced capacity-one wake signal. Below the cap commands remain exact FIFO; a newer lifecycle epoch atomically purges stale backlog, and only saturation folds adjacent same-epoch transient controls before deterministic oldest-transient eviction keeps the newest intent. Wake handling retains one absolute polling deadline, receiver loss clears pending work, and no enqueue waits on network I/O. Six regressions include a real held-ACK peer proving prompt enqueue, no command pipelining, and ordered Seek/Play execution after release. PR #106 and PR #107 follow with cancellable resolution and slow-greeting/real-IPv6 coverage; only exclusive-control/global-option semantics remain open. |
 | 2026-07-16 | P2.10 cancellable MPD resolution (partial) | PR #106 | Replaces blocking `ToSocketAddrs` with a process-lifetime private-context GIO resolver. Capacity-64, 1-KiB-host ingress processes at most 16 requests per context tick and caps active operations at eight; overload fails closed and callbacks run between batches. One absolute load/probe deadline spans resolution, connection, and greeting, while lifecycle supersession or result loss cancels GIO and late callback sends/drops remain on the resolver thread. Numeric addresses bypass DNS; enumerated results preserve order and IPv6 flowinfo/scope while deduplicating to 32. Nine net-new regressions plus one expanded raw/bracketed IPv6 case cover the contract. PR #107 follows with slow-greeting/real-IPv6 socket coverage; only exclusive-control/global-option semantics remain open. |
 | 2026-07-16 | P2.10 MPD real-socket coverage (partial) | PR #107 | Completes the compound socket-coverage item begun by PR #105's held-ACK FIFO peer. A channel-held silent first IPv4 greeting proves the shared absolute deadline preserves a fair slice for a later address without sleeps or elapsed-time thresholds. A real `::1` listener proves numeric resolution, connection, greeting, and IPv6 client/peer addresses; only an unavailable initial IPv6 bind skips that capability-specific case. Two net-new regressions bring the focused MPD suite to 79. Only exclusive-control/global-option semantics remain open. |
-| 2026-07-17 | P2.10 MPD exclusive-control contract (pre-CI) | `agent/p2.10-mpd-exclusive` | Persists an explicit legacy-default-false mode; requires localized partition-wide warning and one-controller confirmation; upgrades an exact endpoint in place; makes mode part of output identity; and gates every unconfirmed load intent—including pre-dispatch media rejection—in the ordered worker before cleanup, MPD connection/state/options, protected tickets, or queue mutation. Foreign-ID relinquishment remains fail-safe even when the confirmed deployment promise is violated. Seven focused migration, upsert, identity, protected/pre-rejected zero-action, and localization tests cover the slice; both P2.10 boxes remain open until PR CI and the final PR record. |
+| 2026-07-17 | P2.10 MPD exclusive-control contract (pre-CI) | `agent/p2.10-mpd-exclusive` | Persists an explicit legacy-default-false mode; requires localized partition-wide warning and one-controller confirmation; upgrades an exact endpoint in place; makes mode part of output identity; refuses unconfirmed public loads before Buffering/epoch/enqueue while retaining retry state; and independently gates every load intent—including pre-dispatch rejection—in the worker before cleanup, MPD connection/state/options, protected tickets, or queue mutation. Foreign-ID relinquishment remains fail-safe even when the confirmed deployment promise is violated. Nine focused migration, upsert, identity, boundary/worker zero-action, retry, and localization tests cover the slice; both P2.10 boxes remain open until PR CI and the final PR record. |
 | 2026-07-15 | P2.11 protected-playback urgent slice | PR #96 | Shared pooled upstream transport with independent connect/header/body-idle budgets; validated direct-only local and AirPlay ticket sources; localized fixed-category, secret-free proxy/GStreamer/backend diagnostics; one-shot terminal handling; and 13 focused regressions including an isolated poisoned-proxy process plus catalog-wide translation checks. Retained mDNS routing and packaged full-backend Windows playback remain open. |
 | 2026-07-15 | P2.11 retained mDNS address routing | PR #97 | Exact service-instance ownership, bounded origin-indexed duplicate aggregation, bounded ephemeral exact-origin routes through applicable API/auth clients and protected stream/artwork pools, unchanged hostname/Host/TLS/proxy behavior, pre-network loss invalidation, and DAAP bearer isolation in revocable typed requests. Thirty new focused regressions plus strengthened DAAP-lifecycle and cast-proxy integration coverage exercise route canonicalization, IPv6 scope, discovery update/removal/alias/cap semantics, stalled resolvers, explicit-proxy preservation, backend propagation, auth-attempt ownership, end-to-end Host/auth/ticket containment, and ephemeral UI identity. Full packaged-Windows/backend playback validation remains open. |
 | 2026-07-16 | P2.11 deterministic HTTP compatibility (partial) | PR #108 | Preserves exact escaped reverse-proxy prefixes across DAAP stream/artwork and Subsonic API/media construction, carries DAAP's four fixed protocol headers through a separate strict non-secret allowlist into protected stream and artwork fetches, retains receiver `Range` as the only forwarded header, proves existing typed Subsonic HTTP-200 failures, and exercises explicit upstream proxy selection at the asynchronous protected-fetch boundary. Seven net-new regressions cover the contracts. At PR #108, full fake GStreamer, packaged source-policy, and live Windows playback validation remained open; the following slice closes the fake-GStreamer part. |

--- a/docs/task.md
+++ b/docs/task.md
@@ -31,13 +31,14 @@ has eight independently verifiable tasks rather than the original three compound
 in-scope counts exclude the two deferred P0.7
 live-workflow verification boxes and the withdrawn P2.6 false finding; section-summary and
 global-validation gate boxes are not task progress:
-**196/223 (87.9%)** in-scope checklist items complete: **50/50 P0**, **64/64 P1**, **74/79 P2**,
+**198/223 (88.8%)** in-scope checklist items complete: **50/50 P0**, **64/64 P1**, **76/79 P2**,
 and **8/30 P3** after those exclusions. This incorporates the four P2.9 boxes closed by PR #99
 and the seven remaining P2.6 boxes closed by PR #100, plus the five P2.7 platform-cache boxes
 closed by PR #101, the four P2.8 Chromecast-deadline boxes closed by PR #102, and the three P2.10
 ACK/terminal/orphan-semantics boxes implemented in PR #104, the bounded-ingress box implemented in
 PR #105, the cancellable resolver box implemented in PR #106, and the
-held-ACK/slow-greeting/real-IPv6 coverage box completed by PR #107, since the earlier snapshot. The
+held-ACK/slow-greeting/real-IPv6 coverage box completed by PR #107, and the final exclusive-control
+contract plus implementation record accepted in PR #112, since the earlier snapshot. The
 deterministic protected-HTTP compatibility box under P2.11 is also complete in PR #108. The
 process-isolated real-GStreamer fake-backend box under P2.11 is complete in PR #109. The packaged
 Windows plugin/source-policy/decode proof is complete in PR #110 after successful native x86_64 and
@@ -47,14 +48,13 @@ document already labels its diagram as intended and names the shipping abstracti
 P3.5 now reports every Linux-host source area in one pinned aggregate, keeps different native
 source sets as informational reports, and enforces the baseline accepted by two exact pinned PR
 executions in PR #111.
-P2.10's final exclusive-control behavior is implemented on
-`agent/p2.10-mpd-exclusive` branch, but its two remaining boxes and the progress numerator stay
-open at this pre-CI stage. Legacy MPD outputs remain unconfirmed until the exact endpoint is
+P2.10 is complete in PR #112. Legacy MPD outputs remain unconfirmed until the exact endpoint is
 re-added with the required localized checkbox; their public load boundary rejects playback before
 optimistic Buffering state, epoch advancement, worker enqueue/cleanup, MPD connection, MPD
 state/option commands, protected-media tickets, or queue mutation. The exact queue generation
 remains retryable, while a second worker gate covers internal callers and media rejected before
-dispatch. This branch builds on P3.5's accepted exact-toolchain baseline.
+dispatch. Two actionable Codex findings were fixed before the final `91536ab` review found no
+further issues, and the exact-toolchain/native PR matrix accepted the result.
 The release-workflow dry run remains deliberately deferred rather than being counted as unfinished
 P0 remediation.
 
@@ -1076,11 +1076,11 @@ error that tells the user what to install.
   newest intent survives. Lifecycle commands advance the epoch and therefore cannot be crowded out.
   Stale wake tokens share one absolute receive deadline and cannot postpone authoritative polling;
   receiver loss clears pending work and fails the current operation closed.
-- [ ] Eliminate the shared-partition race between ownership revalidation and MPD's global pause or
+- [x] Eliminate the shared-partition race between ownership revalidation and MPD's global pause or
   stop commands, and the unguarded global side effects of load-time option resets, or require a
-  detectable exclusive-control configuration. Implemented on `agent/p2.10-mpd-exclusive`, pending
-  PR CI before acceptance: `SavedOutput.exclusive_control` is persisted with a Serde default of
-  false, so legacy endpoints fail closed. Add Output gives a localized partition-wide warning,
+  detectable exclusive-control configuration. Accepted in PR #112:
+  `SavedOutput.exclusive_control` is persisted with a Serde default of false, so legacy endpoints
+  fail closed. Add Output gives a localized partition-wide warning,
   keeps Add disabled until the user confirms no other MPD controller or Tributary instance shares
   the partition, and rechecks the confirmation before probing and saving. Re-adding an exact
   legacy host and port upgrades only that entry in place, preserving its name and siblings instead
@@ -1135,12 +1135,15 @@ error that tells the user what to install.
   exercises numeric resolution through connection and greeting, and requires IPv6 client and peer
   addresses once that initial capability check succeeds. PR #106's raw/bracketed numeric IPv6 and
   GIO scope/flowinfo conversion coverage remains the lower-level complement.
-- [ ] Record implementation: partial slices now include PR #104's ACK/terminal/orphan semantics
+- [x] Record implementation: partial slices include PR #104's ACK/terminal/orphan semantics
   with seven regressions, PR #105's bounded ingress/held-ACK FIFO with six regressions, and PR #106's
   cancellable bounded resolver with nine net-new regressions plus one expanded numeric-IPv6 case,
-  followed by PR #107's two real-socket fairness/IPv6 regressions. The final exclusive-control
-  implementation is committed locally on `agent/p2.10-mpd-exclusive`; final PR number and CI
-  acceptance remain pending before P2.10 is recorded complete.
+  followed by PR #107's two real-socket fairness/IPv6 regressions. PR #112 completes P2.10 with the
+  persisted exclusive-control contract, exact in-place legacy upgrade, mode-aware output
+  reconstruction, public-boundary and defense-in-depth worker gates, retryable synchronous
+  refusal, foreign-ID conservative relinquishment, all-catalog guidance, and nine focused final
+  regressions. Code-head CI run `29602279148` and the associated analysis/CodeQL checks passed on
+  every supported native/package target; final Codex review of `91536ab` found no further issues.
 
 ### P2.11 Bound protected remote-playback startup and expose safe diagnostics
 
@@ -1420,8 +1423,8 @@ PR #94's containerized Flatpak build proved the manifest-local source generation
 policy, but a local installed interactive portal/physical-media smoke pass remains outstanding,
 as does the deliberately deferred live release-workflow run.
 
-Most recent local branch validation (2026-07-17, P2.10 exclusive-control slice stacked on P3.5,
-before PR CI): `cargo check --all-targets --all-features --locked`, strict all-target/all-feature
+Most recent accepted validation (2026-07-17, PR #112 P2.10 exclusive-control slice):
+`cargo check --all-targets --all-features --locked`, strict all-target/all-feature
 Clippy, and `cargo test --all-targets --all-features --locked` pass in debug and release. Each full
 profile passes 18 library, 727 application, and 10 repository-metadata tests (755 total); all 83
 focused MPD tests pass. Nine net-new regressions cover legacy default-false deserialization and
@@ -1434,8 +1437,12 @@ the test environment boundary; an immediate rerun with loopback access passed al
 `cargo audit` reports no vulnerability and only the two
 tracked allowed unmaintained warnings; desktop and AppStream validation,
 `cargo fmt --all -- --check`, and `git diff --check` pass. No dependency or lockfile changed. The
-P2.10 boxes and 196/223 progress snapshot remain deliberately open pending PR CI; P3.5's
-exact-toolchain acceptance is already recorded by PR #111.
+exact pinned PR run `29602279148` passed MSRV, audit, metadata, representative coverage, Linux
+x86_64/aarch64, Flatpak, macOS aarch64, Windows x86_64/aarch64, and checksum jobs. Its 49,451-line
+report covered 33,191 lines (67.12%, artifact `8415577394`) against the accepted 66.9% floor.
+CodeQL and all three static-analysis jobs passed; final Codex review of `91536ab` reported no
+issues after both earlier findings were fixed and resolved. P2.10 is complete at 198/223 overall
+and 76/79 P2; P3.5's exact-toolchain acceptance remains recorded by PR #111.
 
 Most recent local branch validation (2026-07-17, P3.5 representative-coverage slice before CI):
 `cargo fmt --all -- --check`, strict all-target/all-feature Clippy in debug and release, and
@@ -1654,8 +1661,9 @@ failed following a successful install; the separate Cargo cache remains enabled.
 
 Record scope or design decisions here so deferred work is explicit.
 
-- 2026-07-17 — P2.10 requires an explicit, persisted exclusive-control promise rather than
-  pretending MPD offers an ownership lock or conditional partition mutation. MPD's pause, stop,
+- 2026-07-17 — PR #112 completes P2.10 by requiring an explicit, persisted
+  exclusive-control promise rather than pretending MPD offers an ownership lock or conditional
+  partition mutation. MPD's pause, stop,
   repeat, random, single, and consume commands are global to the selected playback partition; a
   named partition can still be joined by another client and is not a lock. Legacy saved endpoints
   default to unconfirmed and cannot load until re-added with the required one-controller checkbox.
@@ -1979,10 +1987,11 @@ Record scope or design decisions here so deferred work is explicit.
   enqueue, or cleanup and retains a retryable UI generation; a defense-in-depth worker gate rejects
   every load intent before an MPD connection, state or option command, or protected ticket,
   including media failures classified before dispatch. Re-adding the exact endpoint with the
-  required localized checkbox upgrades it in place. If a foreign current song is later observed in confirmed
-  exclusive mode, Tributary deliberately relinquishes the session without deleting its queued ID,
-  including during explicit Stop and shutdown. Revalidation plus `deleteid` is not atomic, so the
-  foreign client could select that ID between the two operations. A stale response that reports
+  required localized checkbox upgrades it in place. If a foreign current song is later observed
+  in confirmed exclusive mode, Tributary deliberately relinquishes the session without deleting
+  its queued ID, including during explicit Stop and shutdown. Revalidation plus `deleteid` is not
+  atomic, so a foreign client could select that ID between the two operations. A stale response
+  that reports
   foreign ownership drops the old session before replacement cleanup can target the retained ID.
   Protected tickets are revoked and no retained entry contains a backend credential, but a direct
   entry may remain playable and a protected entry may remain selectable until its revoked route
@@ -2001,8 +2010,8 @@ Record scope or design decisions here so deferred work is explicit.
   and preserve IPv6 flowinfo and scope. PR #107 proves the per-address greeting deadline is fair to
   a later resolved address after an accepted first peer stays silent, and exercises the complete
   numeric `::1` resolution/connect/greeting path against a real listener when IPv6 loopback is
-  available. MPD still has no ID-scoped pause or conditional compare-and-act; P2.10's final branch
-  therefore requires a detectable persisted exclusive-control configuration and fails every
+  available. MPD still has no ID-scoped pause or conditional compare-and-act; PR #112 therefore
+  requires a detectable persisted exclusive-control configuration and fails every
   unconfirmed load closed rather than overstating protocol isolation as part of P1.8.
 - 2026-07-15 — P1.9 separates the source whose rows remain visible from the user's current
   navigation intent. Each selection advances one monotonic generation and records an exact
@@ -2197,7 +2206,7 @@ Add one line per completed task:
 | 2026-07-16 | P2.10 bounded MPD ingress (partial) | PR #105 | Replaces the unbounded worker channel with a capacity-64 epoch-aware deque plus a coalesced capacity-one wake signal. Below the cap commands remain exact FIFO; a newer lifecycle epoch atomically purges stale backlog, and only saturation folds adjacent same-epoch transient controls before deterministic oldest-transient eviction keeps the newest intent. Wake handling retains one absolute polling deadline, receiver loss clears pending work, and no enqueue waits on network I/O. Six regressions include a real held-ACK peer proving prompt enqueue, no command pipelining, and ordered Seek/Play execution after release. PR #106 and PR #107 follow with cancellable resolution and slow-greeting/real-IPv6 coverage; only exclusive-control/global-option semantics remain open. |
 | 2026-07-16 | P2.10 cancellable MPD resolution (partial) | PR #106 | Replaces blocking `ToSocketAddrs` with a process-lifetime private-context GIO resolver. Capacity-64, 1-KiB-host ingress processes at most 16 requests per context tick and caps active operations at eight; overload fails closed and callbacks run between batches. One absolute load/probe deadline spans resolution, connection, and greeting, while lifecycle supersession or result loss cancels GIO and late callback sends/drops remain on the resolver thread. Numeric addresses bypass DNS; enumerated results preserve order and IPv6 flowinfo/scope while deduplicating to 32. Nine net-new regressions plus one expanded raw/bracketed IPv6 case cover the contract. PR #107 follows with slow-greeting/real-IPv6 socket coverage; only exclusive-control/global-option semantics remain open. |
 | 2026-07-16 | P2.10 MPD real-socket coverage (partial) | PR #107 | Completes the compound socket-coverage item begun by PR #105's held-ACK FIFO peer. A channel-held silent first IPv4 greeting proves the shared absolute deadline preserves a fair slice for a later address without sleeps or elapsed-time thresholds. A real `::1` listener proves numeric resolution, connection, greeting, and IPv6 client/peer addresses; only an unavailable initial IPv6 bind skips that capability-specific case. Two net-new regressions bring the focused MPD suite to 79. Only exclusive-control/global-option semantics remain open. |
-| 2026-07-17 | P2.10 MPD exclusive-control contract (pre-CI) | `agent/p2.10-mpd-exclusive` | Persists an explicit legacy-default-false mode; requires localized partition-wide warning and one-controller confirmation; upgrades an exact endpoint in place; makes mode part of output identity; refuses unconfirmed public loads before Buffering/epoch/enqueue while retaining retry state; and independently gates every load intent—including pre-dispatch rejection—in the worker before cleanup, MPD connection/state/options, protected tickets, or queue mutation. Foreign-ID relinquishment remains fail-safe even when the confirmed deployment promise is violated. Nine focused migration, upsert, identity, boundary/worker zero-action, retry, and localization tests cover the slice; both P2.10 boxes remain open until PR CI and the final PR record. |
+| 2026-07-17 | P2.10 MPD exclusive-control contract | PR #112 | Persists an explicit legacy-default-false mode; requires localized partition-wide warning and one-controller confirmation; upgrades an exact endpoint in place; makes mode part of output identity; refuses unconfirmed public loads before Buffering/epoch/enqueue while retaining retry state; and independently gates every load intent—including pre-dispatch rejection—in the worker before cleanup, MPD connection/state/options, protected tickets, or queue mutation. Foreign-ID relinquishment remains fail-safe even when the confirmed deployment promise is violated. Nine focused migration, upsert, identity, boundary/worker zero-action, retry, and localization tests cover the final slice. Two actionable Codex findings were fixed and resolved; the final review and full native/package CI matrix passed. |
 | 2026-07-15 | P2.11 protected-playback urgent slice | PR #96 | Shared pooled upstream transport with independent connect/header/body-idle budgets; validated direct-only local and AirPlay ticket sources; localized fixed-category, secret-free proxy/GStreamer/backend diagnostics; one-shot terminal handling; and 13 focused regressions including an isolated poisoned-proxy process plus catalog-wide translation checks. Retained mDNS routing and packaged full-backend Windows playback remain open. |
 | 2026-07-15 | P2.11 retained mDNS address routing | PR #97 | Exact service-instance ownership, bounded origin-indexed duplicate aggregation, bounded ephemeral exact-origin routes through applicable API/auth clients and protected stream/artwork pools, unchanged hostname/Host/TLS/proxy behavior, pre-network loss invalidation, and DAAP bearer isolation in revocable typed requests. Thirty new focused regressions plus strengthened DAAP-lifecycle and cast-proxy integration coverage exercise route canonicalization, IPv6 scope, discovery update/removal/alias/cap semantics, stalled resolvers, explicit-proxy preservation, backend propagation, auth-attempt ownership, end-to-end Host/auth/ticket containment, and ephemeral UI identity. Full packaged-Windows/backend playback validation remains open. |
 | 2026-07-16 | P2.11 deterministic HTTP compatibility (partial) | PR #108 | Preserves exact escaped reverse-proxy prefixes across DAAP stream/artwork and Subsonic API/media construction, carries DAAP's four fixed protocol headers through a separate strict non-secret allowlist into protected stream and artwork fetches, retains receiver `Range` as the only forwarded header, proves existing typed Subsonic HTTP-200 failures, and exercises explicit upstream proxy selection at the asynchronous protected-fetch boundary. Seven net-new regressions cover the contracts. At PR #108, full fake GStreamer, packaged source-policy, and live Windows playback validation remained open; the following slice closes the fake-GStreamer part. |

--- a/docs/task.md
+++ b/docs/task.md
@@ -47,6 +47,12 @@ document already labels its diagram as intended and names the shipping abstracti
 P3.5 now reports every Linux-host source area in one pinned aggregate, keeps different native
 source sets as informational reports, and enforces the baseline accepted by two exact pinned PR
 executions in PR #111.
+P2.10's final exclusive-control behavior is implemented on
+`agent/p2.10-mpd-exclusive` branch, but its two remaining boxes and the progress numerator stay
+open at this pre-CI stage. Legacy MPD outputs remain unconfirmed until the exact endpoint is
+re-added with the required localized checkbox; an unconfirmed worker rejects playback before any
+MPD connection, MPD state/option command, protected-media ticket, or queue mutation. This branch
+builds on P3.5's accepted exact-toolchain baseline.
 The release-workflow dry run remains deliberately deferred rather than being counted as unfinished
 P0 remediation.
 
@@ -1070,7 +1076,22 @@ error that tells the user what to install.
   receiver loss clears pending work and fails the current operation closed.
 - [ ] Eliminate the shared-partition race between ownership revalidation and MPD's global pause or
   stop commands, and the unguarded global side effects of load-time option resets, or require a
-  detectable exclusive-control configuration.
+  detectable exclusive-control configuration. Implemented on `agent/p2.10-mpd-exclusive`, pending
+  PR CI before acceptance: `SavedOutput.exclusive_control` is persisted with a Serde default of
+  false, so legacy endpoints fail closed. Add Output gives a localized partition-wide warning,
+  keeps Add disabled until the user confirms no other MPD controller or Tributary instance shares
+  the partition, and rechecks the confirmation before probing and saving. Re-adding an exact
+  legacy host and port upgrades only that entry in place, preserving its name and siblings instead
+  of appending a duplicate. The mode participates in `OutputTarget` identity, so false-to-true
+  migration makes reselecting an already-active legacy endpoint reconstruct it rather than taking
+  the same-host/port no-op path. The ordered worker receives a typed
+  Unconfirmed/Exclusive mode and rejects every unconfirmed valid load before cleanup, Buffering,
+  connection, partition-wide repeat/random/single/consume or playback-state commands, proxy-ticket
+  registration, queue insertion, play, or status. It emits fixed localized
+  re-add/confirm/reselect guidance. Six focused net-new tests cover legacy
+  deserialization/approved serialization, exact upsert and sibling preservation, mode-sensitive
+  output identity, zero MPD and proxy action, and all-catalog warning/confirmation/failure
+  localization.
 - [x] Retain only redacted ACK error codes so cleanup can distinguish a missing song ID from a
   permission or argument rejection without keeping server-controlled text. The response parser
   retains only a closed typed code from MPD's numeric ACK header and discards the command-list
@@ -1088,15 +1109,15 @@ error that tells the user what to install.
   deleted/cleared it or for another external reason—so Tributary reports ownership loss and never
   emits a false end-of-track event; any other ACK is a real cleanup failure, not absence evidence.
 - [x] Clean up or deliberately retain Tributary's queued ID after an observed foreign replacement
-  without disturbing foreign playback. Shared-partition mode deliberately retains it: status and
-  `deleteid` cannot form one conditional operation, so the foreign client could select Tributary's
-  ID between revalidation and deletion. Tributary relinquishes the session and revokes any
-  protected ticket, leaving a possibly playable direct-media entry—or a protected entry whose
-  revoked opaque ticket will fail—rather than risking deletion of what has become current. No
-  retained entry carries a backend credential. A stale response that discovers foreign ownership
-  also drops its old session before a replacement Load can target the retained ID. Automatic orphan
-  removal remains deferred until the open exclusive-control configuration work can make that
-  mutation safe.
+  without disturbing foreign playback. Unconfirmed/legacy outputs cannot load. In confirmed
+  exclusive mode, a foreign current ID means the one-controller contract was violated; status and
+  `deleteid` still cannot form one conditional operation, so the foreign client could select
+  Tributary's ID between revalidation and deletion. Tributary therefore relinquishes the session
+  and revokes any protected ticket, leaving a possibly playable direct-media entry—or a protected
+  entry whose revoked opaque ticket will fail—rather than risking deletion of what has become
+  current. No retained entry carries a backend credential. A stale response that discovers foreign
+  ownership also drops its old session before a replacement Load can target the retained ID. This
+  defense remains deliberately stricter than trusting the exclusivity promise.
 - [x] Add held-ACK worker FIFO, slow-first-greeting fairness, and real IPv6 loopback coverage.
   PR #105 supplies the real-TCP held-ACK FIFO case: Pause's ACK is withheld while Seek, Play, and a
   fence enqueue promptly; no later protocol command is pipelined before the ACK, and the retained
@@ -1110,9 +1131,9 @@ error that tells the user what to install.
 - [ ] Record implementation: partial slices now include PR #104's ACK/terminal/orphan semantics
   with seven regressions, PR #105's bounded ingress/held-ACK FIFO with six regressions, and PR #106's
   cancellable bounded resolver with nine net-new regressions plus one expanded numeric-IPv6 case,
-  followed by PR #107's two real-socket fairness/IPv6 regressions. Only the
-  exclusive-control/global-option item remains open before P2.10 as a whole can be recorded
-  complete.
+  followed by PR #107's two real-socket fairness/IPv6 regressions. The final exclusive-control
+  implementation is committed locally on `agent/p2.10-mpd-exclusive`; final PR number and CI
+  acceptance remain pending before P2.10 is recorded complete.
 
 ### P2.11 Bound protected remote-playback startup and expose safe diagnostics
 
@@ -1392,6 +1413,21 @@ PR #94's containerized Flatpak build proved the manifest-local source generation
 policy, but a local installed interactive portal/physical-media smoke pass remains outstanding,
 as does the deliberately deferred live release-workflow run.
 
+Most recent local branch validation (2026-07-17, P2.10 exclusive-control slice stacked on P3.5,
+before PR CI): `cargo check --all-targets --all-features --locked`, strict all-target/all-feature
+Clippy, and `cargo test --all-targets --all-features --locked` pass in debug and release. Each full
+profile passes 18 library, 724 application, and 10 repository-metadata tests (752 total); all 81
+focused MPD tests pass. Six net-new regressions cover legacy default-false deserialization and
+approved-mode serialization, exact in-place upgrade with name/sibling preservation, repeat-upsert
+deduplication, mode-sensitive output identity, worker-level zero-connection/state/ticket/queue
+action, and warning/confirmation/failure localization across all 13 catalogs. The first restricted
+release run denied every loopback bind at the test environment boundary; an immediate rerun with
+loopback access passed all 752 tests. `cargo audit` reports no vulnerability and only the two
+tracked allowed unmaintained warnings; desktop and AppStream validation,
+`cargo fmt --all -- --check`, and `git diff --check` pass. No dependency or lockfile changed. The
+P2.10 boxes and 196/223 progress snapshot remain deliberately open pending PR CI; P3.5's
+exact-toolchain acceptance is already recorded by PR #111.
+
 Most recent local branch validation (2026-07-17, P3.5 representative-coverage slice before CI):
 `cargo fmt --all -- --check`, strict all-target/all-feature Clippy in debug and release, and
 `cargo test --all-targets --all-features --locked` in debug and release pass. Each profile passes
@@ -1608,6 +1644,17 @@ failed following a successful install; the separate Cargo cache remains enabled.
 ## Decisions
 
 Record scope or design decisions here so deferred work is explicit.
+
+- 2026-07-17 — P2.10 requires an explicit, persisted exclusive-control promise rather than
+  pretending MPD offers an ownership lock or conditional partition mutation. MPD's pause, stop,
+  repeat, random, single, and consume commands are global to the selected playback partition; a
+  named partition can still be joined by another client and is not a lock. Legacy saved endpoints
+  default to unconfirmed and cannot load until re-added with the required one-controller checkbox.
+  The worker owns the final gate so an unconfirmed load cannot connect, issue MPD state/options,
+  register a protected ticket, or mutate the queue even if a caller bypasses GTK. Confirmation
+  authorizes the unavoidable global operations but does not weaken foreign-song defenses: an
+  observed foreign ID proves the deployment promise was violated, and Tributary still relinquishes
+  ownership without a racy stop or deletion.
 
 - 2026-07-17 — P3.5 uses one exactly pinned Linux x86_64 aggregate as the comparable coverage
   threshold. Splitting unit and integration runs would fragment one host's denominator without
@@ -1915,14 +1962,17 @@ Record scope or design decisions here so deferred work is explicit.
   expected command echo are validated before only the closed numeric code is retained; malformed
   or mismatched ACK-like input poisons the connection. MPD's index, echo, and free-form text are
   then discarded.
-  When a foreign current song is observed, shared-partition mode deliberately relinquishes the
-  session without deleting Tributary's queued ID, including during explicit Stop and shutdown.
-  Revalidation plus `deleteid` is not atomic, so the foreign client could select that ID between
-  the two operations. A stale response that reports foreign ownership drops the old session before
-  replacement cleanup can target the retained ID. Protected tickets are revoked and no retained
-  entry contains a backend credential, but a direct entry may remain playable and a protected
-  entry may remain selectable until its revoked route fails. Cleanup of those retained IDs waits
-  for a detectable exclusive-control mode. PR #105's bounded command ingress preserves exact FIFO
+  P2.10's final slice makes shared/unconfirmed playback unsupported: the persisted mode defaults
+  false for legacy entries, and the worker rejects those loads before an MPD connection, state or
+  option command, or protected ticket. Re-adding the exact endpoint with the required localized
+  checkbox upgrades it in place. If a foreign current song is later observed in confirmed
+  exclusive mode, Tributary deliberately relinquishes the session without deleting its queued ID,
+  including during explicit Stop and shutdown. Revalidation plus `deleteid` is not atomic, so the
+  foreign client could select that ID between the two operations. A stale response that reports
+  foreign ownership drops the old session before replacement cleanup can target the retained ID.
+  Protected tickets are revoked and no retained entry contains a backend credential, but a direct
+  entry may remain playable and a protected entry may remain selectable until its revoked route
+  fails. PR #105's bounded command ingress preserves exact FIFO
   below 64 pending commands, atomically replaces older-epoch backlog, and only under saturation
   folds adjacent same-epoch transient controls before deterministically evicting the oldest
   remaining transient. A capacity-one wake signal never carries commands and stale wake tokens
@@ -1937,10 +1987,9 @@ Record scope or design decisions here so deferred work is explicit.
   and preserve IPv6 flowinfo and scope. PR #107 proves the per-address greeting deadline is fair to
   a later resolved address after an accepted first peer stays silent, and exercises the complete
   numeric `::1` resolution/connect/greeting path against a real listener when IPv6 loopback is
-  available. MPD still has no ID-scoped pause or conditional compare-and-act, so another client can
-  race between status revalidation and a global pause or stop, and load-time option resets remain
-  global and unguarded. That exclusive-control/global-option improvement is the only remaining
-  P2.10 behavior item and is not overstated as part of P1.8.
+  available. MPD still has no ID-scoped pause or conditional compare-and-act; P2.10's final branch
+  therefore requires a detectable persisted exclusive-control configuration and fails every
+  unconfirmed load closed rather than overstating protocol isolation as part of P1.8.
 - 2026-07-15 — P1.9 separates the source whose rows remain visible from the user's current
   navigation intent. Each selection advances one monotonic generation and records an exact
   `{source_key, generation}` request; completion has three explicit dispositions: ignore a
@@ -2134,6 +2183,7 @@ Add one line per completed task:
 | 2026-07-16 | P2.10 bounded MPD ingress (partial) | PR #105 | Replaces the unbounded worker channel with a capacity-64 epoch-aware deque plus a coalesced capacity-one wake signal. Below the cap commands remain exact FIFO; a newer lifecycle epoch atomically purges stale backlog, and only saturation folds adjacent same-epoch transient controls before deterministic oldest-transient eviction keeps the newest intent. Wake handling retains one absolute polling deadline, receiver loss clears pending work, and no enqueue waits on network I/O. Six regressions include a real held-ACK peer proving prompt enqueue, no command pipelining, and ordered Seek/Play execution after release. PR #106 and PR #107 follow with cancellable resolution and slow-greeting/real-IPv6 coverage; only exclusive-control/global-option semantics remain open. |
 | 2026-07-16 | P2.10 cancellable MPD resolution (partial) | PR #106 | Replaces blocking `ToSocketAddrs` with a process-lifetime private-context GIO resolver. Capacity-64, 1-KiB-host ingress processes at most 16 requests per context tick and caps active operations at eight; overload fails closed and callbacks run between batches. One absolute load/probe deadline spans resolution, connection, and greeting, while lifecycle supersession or result loss cancels GIO and late callback sends/drops remain on the resolver thread. Numeric addresses bypass DNS; enumerated results preserve order and IPv6 flowinfo/scope while deduplicating to 32. Nine net-new regressions plus one expanded raw/bracketed IPv6 case cover the contract. PR #107 follows with slow-greeting/real-IPv6 socket coverage; only exclusive-control/global-option semantics remain open. |
 | 2026-07-16 | P2.10 MPD real-socket coverage (partial) | PR #107 | Completes the compound socket-coverage item begun by PR #105's held-ACK FIFO peer. A channel-held silent first IPv4 greeting proves the shared absolute deadline preserves a fair slice for a later address without sleeps or elapsed-time thresholds. A real `::1` listener proves numeric resolution, connection, greeting, and IPv6 client/peer addresses; only an unavailable initial IPv6 bind skips that capability-specific case. Two net-new regressions bring the focused MPD suite to 79. Only exclusive-control/global-option semantics remain open. |
+| 2026-07-17 | P2.10 MPD exclusive-control contract (pre-CI) | `agent/p2.10-mpd-exclusive` | Persists an explicit legacy-default-false mode; requires localized partition-wide warning and one-controller confirmation; upgrades an exact endpoint in place; makes mode part of output identity; and gates unconfirmed loads in the ordered worker before MPD connection/state/options, protected tickets, or queue mutation. Foreign-ID relinquishment remains fail-safe even when the confirmed deployment promise is violated. Six focused migration, upsert, identity, zero-action, and localization tests cover the slice; both P2.10 boxes remain open until PR CI and the final PR record. |
 | 2026-07-15 | P2.11 protected-playback urgent slice | PR #96 | Shared pooled upstream transport with independent connect/header/body-idle budgets; validated direct-only local and AirPlay ticket sources; localized fixed-category, secret-free proxy/GStreamer/backend diagnostics; one-shot terminal handling; and 13 focused regressions including an isolated poisoned-proxy process plus catalog-wide translation checks. Retained mDNS routing and packaged full-backend Windows playback remain open. |
 | 2026-07-15 | P2.11 retained mDNS address routing | PR #97 | Exact service-instance ownership, bounded origin-indexed duplicate aggregation, bounded ephemeral exact-origin routes through applicable API/auth clients and protected stream/artwork pools, unchanged hostname/Host/TLS/proxy behavior, pre-network loss invalidation, and DAAP bearer isolation in revocable typed requests. Thirty new focused regressions plus strengthened DAAP-lifecycle and cast-proxy integration coverage exercise route canonicalization, IPv6 scope, discovery update/removal/alias/cap semantics, stalled resolvers, explicit-proxy preservation, backend propagation, auth-attempt ownership, end-to-end Host/auth/ticket containment, and ephemeral UI identity. Full packaged-Windows/backend playback validation remains open. |
 | 2026-07-16 | P2.11 deterministic HTTP compatibility (partial) | PR #108 | Preserves exact escaped reverse-proxy prefixes across DAAP stream/artwork and Subsonic API/media construction, carries DAAP's four fixed protocol headers through a separate strict non-secret allowlist into protected stream and artwork fetches, retains receiver `Range` as the only forwarded header, proves existing typed Subsonic HTTP-200 failures, and exercises explicit upstream proxy selection at the asynchronous protected-fetch boundary. Seven net-new regressions cover the contracts. At PR #108, full fake GStreamer, packaged source-policy, and live Windows playback validation remained open; the following slice closes the fake-GStreamer part. |

--- a/docs/task.md
+++ b/docs/task.md
@@ -51,8 +51,9 @@ P2.10's final exclusive-control behavior is implemented on
 `agent/p2.10-mpd-exclusive` branch, but its two remaining boxes and the progress numerator stay
 open at this pre-CI stage. Legacy MPD outputs remain unconfirmed until the exact endpoint is
 re-added with the required localized checkbox; an unconfirmed worker rejects playback before any
-MPD connection, MPD state/option command, protected-media ticket, or queue mutation. This branch
-builds on P3.5's accepted exact-toolchain baseline.
+cleanup, MPD connection, MPD state/option command, protected-media ticket, or queue mutation,
+including for media rejected before worker dispatch. This branch builds on P3.5's accepted
+exact-toolchain baseline.
 The release-workflow dry run remains deliberately deferred rather than being counted as unfinished
 P0 remediation.
 
@@ -1085,13 +1086,14 @@ error that tells the user what to install.
   of appending a duplicate. The mode participates in `OutputTarget` identity, so false-to-true
   migration makes reselecting an already-active legacy endpoint reconstruct it rather than taking
   the same-host/port no-op path. The ordered worker receives a typed
-  Unconfirmed/Exclusive mode and rejects every unconfirmed valid load before cleanup, Buffering,
+  Unconfirmed/Exclusive mode and rejects every unconfirmed load intent before cleanup, Buffering,
   connection, partition-wide repeat/random/single/consume or playback-state commands, proxy-ticket
-  registration, queue insertion, play, or status. It emits fixed localized
-  re-add/confirm/reselect guidance. Six focused net-new tests cover legacy
+  registration, queue insertion, play, or status. The common gate includes media already rejected
+  as malformed, unsupported, or inactive before worker dispatch and emits the same fixed localized
+  re-add/confirm/reselect guidance. Seven focused net-new tests cover legacy
   deserialization/approved serialization, exact upsert and sibling preservation, mode-sensitive
-  output identity, zero MPD and proxy action, and all-catalog warning/confirmation/failure
-  localization.
+  output identity, zero MPD and proxy action for protected and pre-rejected loads, and all-catalog
+  warning/confirmation/failure localization.
 - [x] Retain only redacted ACK error codes so cleanup can distinguish a missing song ID from a
   permission or argument rejection without keeping server-controlled text. The response parser
   retains only a closed typed code from MPD's numeric ACK header and discards the command-list
@@ -1416,13 +1418,14 @@ as does the deliberately deferred live release-workflow run.
 Most recent local branch validation (2026-07-17, P2.10 exclusive-control slice stacked on P3.5,
 before PR CI): `cargo check --all-targets --all-features --locked`, strict all-target/all-feature
 Clippy, and `cargo test --all-targets --all-features --locked` pass in debug and release. Each full
-profile passes 18 library, 724 application, and 10 repository-metadata tests (752 total); all 81
-focused MPD tests pass. Six net-new regressions cover legacy default-false deserialization and
+profile passes 18 library, 725 application, and 10 repository-metadata tests (753 total); all 82
+focused MPD tests pass. Seven net-new regressions cover legacy default-false deserialization and
 approved-mode serialization, exact in-place upgrade with name/sibling preservation, repeat-upsert
 deduplication, mode-sensitive output identity, worker-level zero-connection/state/ticket/queue
-action, and warning/confirmation/failure localization across all 13 catalogs. The first restricted
+action for protected and pre-rejected loads, and warning/confirmation/failure localization across
+all 13 catalogs. The first restricted
 release run denied every loopback bind at the test environment boundary; an immediate rerun with
-loopback access passed all 752 tests. `cargo audit` reports no vulnerability and only the two
+loopback access passed all 753 tests. `cargo audit` reports no vulnerability and only the two
 tracked allowed unmaintained warnings; desktop and AppStream validation,
 `cargo fmt --all -- --check`, and `git diff --check` pass. No dependency or lockfile changed. The
 P2.10 boxes and 196/223 progress snapshot remain deliberately open pending PR CI; P3.5's
@@ -1650,8 +1653,9 @@ Record scope or design decisions here so deferred work is explicit.
   repeat, random, single, and consume commands are global to the selected playback partition; a
   named partition can still be joined by another client and is not a lock. Legacy saved endpoints
   default to unconfirmed and cannot load until re-added with the required one-controller checkbox.
-  The worker owns the final gate so an unconfirmed load cannot connect, issue MPD state/options,
-  register a protected ticket, or mutate the queue even if a caller bypasses GTK. Confirmation
+  The worker owns the final common gate so an unconfirmed load—including a pre-dispatch media
+  rejection—cannot clean up, connect, issue MPD state/options, register a protected ticket, or
+  mutate the queue even if a caller bypasses GTK. Confirmation
   authorizes the unavoidable global operations but does not weaken foreign-song defenses: an
   observed foreign ID proves the deployment promise was violated, and Tributary still relinquishes
   ownership without a racy stop or deletion.
@@ -1963,8 +1967,9 @@ Record scope or design decisions here so deferred work is explicit.
   or mismatched ACK-like input poisons the connection. MPD's index, echo, and free-form text are
   then discarded.
   P2.10's final slice makes shared/unconfirmed playback unsupported: the persisted mode defaults
-  false for legacy entries, and the worker rejects those loads before an MPD connection, state or
-  option command, or protected ticket. Re-adding the exact endpoint with the required localized
+  false for legacy entries, and the worker rejects every load intent before cleanup, an MPD
+  connection, state or option command, or protected ticket, including media failures classified
+  before dispatch. Re-adding the exact endpoint with the required localized
   checkbox upgrades it in place. If a foreign current song is later observed in confirmed
   exclusive mode, Tributary deliberately relinquishes the session without deleting its queued ID,
   including during explicit Stop and shutdown. Revalidation plus `deleteid` is not atomic, so the
@@ -2183,7 +2188,7 @@ Add one line per completed task:
 | 2026-07-16 | P2.10 bounded MPD ingress (partial) | PR #105 | Replaces the unbounded worker channel with a capacity-64 epoch-aware deque plus a coalesced capacity-one wake signal. Below the cap commands remain exact FIFO; a newer lifecycle epoch atomically purges stale backlog, and only saturation folds adjacent same-epoch transient controls before deterministic oldest-transient eviction keeps the newest intent. Wake handling retains one absolute polling deadline, receiver loss clears pending work, and no enqueue waits on network I/O. Six regressions include a real held-ACK peer proving prompt enqueue, no command pipelining, and ordered Seek/Play execution after release. PR #106 and PR #107 follow with cancellable resolution and slow-greeting/real-IPv6 coverage; only exclusive-control/global-option semantics remain open. |
 | 2026-07-16 | P2.10 cancellable MPD resolution (partial) | PR #106 | Replaces blocking `ToSocketAddrs` with a process-lifetime private-context GIO resolver. Capacity-64, 1-KiB-host ingress processes at most 16 requests per context tick and caps active operations at eight; overload fails closed and callbacks run between batches. One absolute load/probe deadline spans resolution, connection, and greeting, while lifecycle supersession or result loss cancels GIO and late callback sends/drops remain on the resolver thread. Numeric addresses bypass DNS; enumerated results preserve order and IPv6 flowinfo/scope while deduplicating to 32. Nine net-new regressions plus one expanded raw/bracketed IPv6 case cover the contract. PR #107 follows with slow-greeting/real-IPv6 socket coverage; only exclusive-control/global-option semantics remain open. |
 | 2026-07-16 | P2.10 MPD real-socket coverage (partial) | PR #107 | Completes the compound socket-coverage item begun by PR #105's held-ACK FIFO peer. A channel-held silent first IPv4 greeting proves the shared absolute deadline preserves a fair slice for a later address without sleeps or elapsed-time thresholds. A real `::1` listener proves numeric resolution, connection, greeting, and IPv6 client/peer addresses; only an unavailable initial IPv6 bind skips that capability-specific case. Two net-new regressions bring the focused MPD suite to 79. Only exclusive-control/global-option semantics remain open. |
-| 2026-07-17 | P2.10 MPD exclusive-control contract (pre-CI) | `agent/p2.10-mpd-exclusive` | Persists an explicit legacy-default-false mode; requires localized partition-wide warning and one-controller confirmation; upgrades an exact endpoint in place; makes mode part of output identity; and gates unconfirmed loads in the ordered worker before MPD connection/state/options, protected tickets, or queue mutation. Foreign-ID relinquishment remains fail-safe even when the confirmed deployment promise is violated. Six focused migration, upsert, identity, zero-action, and localization tests cover the slice; both P2.10 boxes remain open until PR CI and the final PR record. |
+| 2026-07-17 | P2.10 MPD exclusive-control contract (pre-CI) | `agent/p2.10-mpd-exclusive` | Persists an explicit legacy-default-false mode; requires localized partition-wide warning and one-controller confirmation; upgrades an exact endpoint in place; makes mode part of output identity; and gates every unconfirmed load intent—including pre-dispatch media rejection—in the ordered worker before cleanup, MPD connection/state/options, protected tickets, or queue mutation. Foreign-ID relinquishment remains fail-safe even when the confirmed deployment promise is violated. Seven focused migration, upsert, identity, protected/pre-rejected zero-action, and localization tests cover the slice; both P2.10 boxes remain open until PR CI and the final PR record. |
 | 2026-07-15 | P2.11 protected-playback urgent slice | PR #96 | Shared pooled upstream transport with independent connect/header/body-idle budgets; validated direct-only local and AirPlay ticket sources; localized fixed-category, secret-free proxy/GStreamer/backend diagnostics; one-shot terminal handling; and 13 focused regressions including an isolated poisoned-proxy process plus catalog-wide translation checks. Retained mDNS routing and packaged full-backend Windows playback remain open. |
 | 2026-07-15 | P2.11 retained mDNS address routing | PR #97 | Exact service-instance ownership, bounded origin-indexed duplicate aggregation, bounded ephemeral exact-origin routes through applicable API/auth clients and protected stream/artwork pools, unchanged hostname/Host/TLS/proxy behavior, pre-network loss invalidation, and DAAP bearer isolation in revocable typed requests. Thirty new focused regressions plus strengthened DAAP-lifecycle and cast-proxy integration coverage exercise route canonicalization, IPv6 scope, discovery update/removal/alias/cap semantics, stalled resolvers, explicit-proxy preservation, backend propagation, auth-attempt ownership, end-to-end Host/auth/ticket containment, and ephemeral UI identity. Full packaged-Windows/backend playback validation remains open. |
 | 2026-07-16 | P2.11 deterministic HTTP compatibility (partial) | PR #108 | Preserves exact escaped reverse-proxy prefixes across DAAP stream/artwork and Subsonic API/media construction, carries DAAP's four fixed protocol headers through a separate strict non-secret allowlist into protected stream and artwork fetches, retains receiver `Range` as the only forwarded header, proves existing typed Subsonic HTTP-200 failures, and exercises explicit upstream proxy selection at the asynchronous protected-fetch boundary. Seven net-new regressions cover the contracts. At PR #108, full fake GStreamer, packaged source-policy, and live Windows playback validation remained open; the following slice closes the fake-GStreamer part. |

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -123,6 +123,8 @@ dialogs:
   output_name_placeholder: "Wohnzimmer MPD"
   output_host: "Host"
   output_port: "Port"
+  output_exclusive_control_warning: "MPD-Befehle für Pause, Stopp, Wiederholen, Zufall, Einzelwiedergabe und Verbrauch betreffen die gesamte Wiedergabepartition. Teilen Sie sie nicht mit einem anderen Controller oder einer anderen Tributary-Instanz."
+  output_exclusive_control_confirmation: "Ich bestätige, dass Tributary die exklusive Kontrolle über diese MPD-Wiedergabepartition hat."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:
@@ -223,6 +225,7 @@ errors:
     audio_output_failed: "Audioausgabe ist fehlgeschlagen"
     playback_failed: "Audiowiedergabe ist fehlgeschlagen"
     airplay_raopsink_missing: "AirPlay benötigt das GStreamer-Element raopsink – bitte das Paket gst-plugins-bad installieren und Tributary neu starten"
+    mpd_exclusive_control_required: "Fügen Sie diese MPD-Ausgabe erneut hinzu, bestätigen Sie die exklusive Partitionskontrolle und wählen Sie sie dann vor der Wiedergabe erneut aus"
 
 # ── About dialog ───────────────────────────────────────────────────
 about:

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -128,6 +128,8 @@ dialogs:
   output_name_placeholder: "Living Room MPD"
   output_host: "Host"
   output_port: "Port"
+  output_exclusive_control_warning: "MPD pause, stop, repeat, random, single, and consume commands affect the entire playback partition. Do not share it with another controller or Tributary instance."
+  output_exclusive_control_confirmation: "I confirm Tributary has exclusive control of this MPD playback partition."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:
@@ -256,6 +258,7 @@ errors:
     audio_output_failed: "Audio output failed"
     playback_failed: "Audio playback failed"
     airplay_raopsink_missing: "AirPlay requires GStreamer's raopsink element — install the gst-plugins-bad package and restart Tributary"
+    mpd_exclusive_control_required: "Re-add this MPD output, confirm exclusive partition control, then select it again before playback"
 
 # ── About dialog ───────────────────────────────────────────────────
 about:

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -123,6 +123,8 @@ dialogs:
   output_name_placeholder: "MPD sala de estar"
   output_host: "Host"
   output_port: "Puerto"
+  output_exclusive_control_warning: "Los comandos de MPD para pausar, detener, repetir, aleatorio, único y consumir afectan a toda la partición de reproducción. No la comparta con otro controlador ni con otra instancia de Tributary."
+  output_exclusive_control_confirmation: "Confirmo que Tributary tiene el control exclusivo de esta partición de reproducción de MPD."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:
@@ -223,6 +225,7 @@ errors:
     audio_output_failed: "Falló la salida de audio"
     playback_failed: "Falló la reproducción de audio"
     airplay_raopsink_missing: "AirPlay requiere el elemento raopsink de GStreamer: instale el paquete gst-plugins-bad y reinicie Tributary"
+    mpd_exclusive_control_required: "Vuelva a agregar esta salida MPD, confirme el control exclusivo de la partición y vuelva a seleccionarla antes de reproducir"
 
 # ── About dialog ───────────────────────────────────────────────────
 about:

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -123,6 +123,8 @@ dialogs:
   output_name_placeholder: "MPD salon"
   output_host: "Hôte"
   output_port: "Port"
+  output_exclusive_control_warning: "Les commandes MPD de pause, arrêt, répétition, lecture aléatoire, lecture unique et consommation affectent toute la partition de lecture. Ne la partagez pas avec un autre contrôleur ou une autre instance de Tributary."
+  output_exclusive_control_confirmation: "Je confirme que Tributary contrôle exclusivement cette partition de lecture MPD."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:
@@ -223,6 +225,7 @@ errors:
     audio_output_failed: "La sortie audio a échoué"
     playback_failed: "La lecture audio a échoué"
     airplay_raopsink_missing: "AirPlay nécessite l'élément raopsink de GStreamer — installez le paquet gst-plugins-bad puis redémarrez Tributary"
+    mpd_exclusive_control_required: "Ajoutez à nouveau cette sortie MPD, confirmez le contrôle exclusif de la partition, puis sélectionnez-la à nouveau avant la lecture"
 
 # ── About dialog ───────────────────────────────────────────────────
 about:

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -123,6 +123,8 @@ dialogs:
   output_name_placeholder: "MPD soggiorno"
   output_host: "Host"
   output_port: "Porta"
+  output_exclusive_control_warning: "I comandi MPD pausa, arresto, ripetizione, casuale, singolo e consumo influiscono sull'intera partizione di riproduzione. Non condividerla con un altro controller o un'altra istanza di Tributary."
+  output_exclusive_control_confirmation: "Confermo che Tributary ha il controllo esclusivo di questa partizione di riproduzione MPD."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:
@@ -223,6 +225,7 @@ errors:
     audio_output_failed: "Si è verificato un errore nell’uscita audio"
     playback_failed: "La riproduzione audio non è riuscita"
     airplay_raopsink_missing: "AirPlay richiede l'elemento raopsink di GStreamer: installa il pacchetto gst-plugins-bad e riavvia Tributary"
+    mpd_exclusive_control_required: "Aggiungi di nuovo questa uscita MPD, conferma il controllo esclusivo della partizione, quindi selezionala di nuovo prima della riproduzione"
 
 # ── About dialog ───────────────────────────────────────────────────
 about:

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -123,6 +123,8 @@ dialogs:
   output_name_placeholder: "リビングルーム MPD"
   output_host: "ホスト"
   output_port: "ポート"
+  output_exclusive_control_warning: "MPD の一時停止、停止、リピート、ランダム、シングル、consume コマンドは再生パーティション全体に影響します。別のコントローラーや Tributary インスタンスと共有しないでください。"
+  output_exclusive_control_confirmation: "Tributary がこの MPD 再生パーティションを排他的に制御することを確認します。"
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:
@@ -223,6 +225,7 @@ errors:
     audio_output_failed: "オーディオ出力に失敗しました"
     playback_failed: "オーディオ再生に失敗しました"
     airplay_raopsink_missing: "AirPlay には GStreamer の raopsink エレメントが必要です。gst-plugins-bad パッケージをインストールしてから Tributary を再起動してください"
+    mpd_exclusive_control_required: "この MPD 出力を再追加してパーティションの排他的制御を確認し、再生前にもう一度選択してください"
 
 # ── About dialog ───────────────────────────────────────────────────
 about:

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -123,6 +123,8 @@ dialogs:
   output_name_placeholder: "거실 MPD"
   output_host: "호스트"
   output_port: "포트"
+  output_exclusive_control_warning: "MPD의 일시 정지, 정지, 반복, 무작위, 단일 및 consume 명령은 전체 재생 파티션에 영향을 줍니다. 다른 컨트롤러나 Tributary 인스턴스와 공유하지 마세요."
+  output_exclusive_control_confirmation: "Tributary가 이 MPD 재생 파티션을 독점 제어함을 확인합니다."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:
@@ -223,6 +225,7 @@ errors:
     audio_output_failed: "오디오 출력에 실패했습니다"
     playback_failed: "오디오 재생에 실패했습니다"
     airplay_raopsink_missing: "AirPlay를 사용하려면 GStreamer의 raopsink 요소가 필요합니다. gst-plugins-bad 패키지를 설치한 후 Tributary를 다시 시작하세요"
+    mpd_exclusive_control_required: "이 MPD 출력을 다시 추가하고 파티션 독점 제어를 확인한 다음 재생 전에 다시 선택하세요"
 
 # ── About dialog ───────────────────────────────────────────────────
 about:

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -123,6 +123,8 @@ dialogs:
   output_name_placeholder: "Woonkamer MPD"
   output_host: "Host"
   output_port: "Poort"
+  output_exclusive_control_warning: "MPD-opdrachten voor pauzeren, stoppen, herhalen, willekeurig, enkel en verbruiken beïnvloeden de hele afspeelpartitie. Deel deze niet met een andere controller of Tributary-instantie."
+  output_exclusive_control_confirmation: "Ik bevestig dat Tributary exclusieve controle over deze MPD-afspeelpartitie heeft."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:
@@ -223,6 +225,7 @@ errors:
     audio_output_failed: "De audio-uitvoer is mislukt"
     playback_failed: "Het afspelen van audio is mislukt"
     airplay_raopsink_missing: "AirPlay vereist het GStreamer-element raopsink – installeer het pakket gst-plugins-bad en start Tributary opnieuw"
+    mpd_exclusive_control_required: "Voeg deze MPD-uitvoer opnieuw toe, bevestig exclusieve partitiecontrole en selecteer deze opnieuw vóór het afspelen"
 
 # ── About dialog ───────────────────────────────────────────────────
 about:

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -123,6 +123,8 @@ dialogs:
   output_name_placeholder: "Salon MPD"
   output_host: "Host"
   output_port: "Port"
+  output_exclusive_control_warning: "Polecenia MPD wstrzymania, zatrzymania, powtarzania, losowania, trybu pojedynczego i zużywania dotyczą całej partycji odtwarzania. Nie udostępniaj jej innemu kontrolerowi ani innej instancji Tributary."
+  output_exclusive_control_confirmation: "Potwierdzam, że Tributary ma wyłączną kontrolę nad tą partycją odtwarzania MPD."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:
@@ -223,6 +225,7 @@ errors:
     audio_output_failed: "Wystąpił błąd wyjścia dźwięku"
     playback_failed: "Odtwarzanie dźwięku nie powiodło się"
     airplay_raopsink_missing: "AirPlay wymaga elementu raopsink z GStreamera — zainstaluj pakiet gst-plugins-bad i uruchom Tributary ponownie"
+    mpd_exclusive_control_required: "Dodaj ponownie to wyjście MPD, potwierdź wyłączną kontrolę nad partycją, a następnie wybierz je ponownie przed odtwarzaniem"
 
 # ── About dialog ───────────────────────────────────────────────────
 about:

--- a/locales/pt-BR.yml
+++ b/locales/pt-BR.yml
@@ -123,6 +123,8 @@ dialogs:
   output_name_placeholder: "MPD sala de estar"
   output_host: "Host"
   output_port: "Porta"
+  output_exclusive_control_warning: "Os comandos MPD de pausar, parar, repetir, aleatório, único e consumir afetam toda a partição de reprodução. Não a compartilhe com outro controlador ou outra instância do Tributary."
+  output_exclusive_control_confirmation: "Confirmo que o Tributary tem controle exclusivo desta partição de reprodução MPD."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:
@@ -223,6 +225,7 @@ errors:
     audio_output_failed: "Falha na saída de áudio"
     playback_failed: "Falha na reprodução de áudio"
     airplay_raopsink_missing: "O AirPlay requer o elemento raopsink do GStreamer — instale o pacote gst-plugins-bad e reinicie o Tributary"
+    mpd_exclusive_control_required: "Adicione novamente esta saída MPD, confirme o controle exclusivo da partição e selecione-a novamente antes da reprodução"
 
 # ── About dialog ───────────────────────────────────────────────────
 about:

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -123,6 +123,8 @@ dialogs:
   output_name_placeholder: "MPD гостиная"
   output_host: "Хост"
   output_port: "Порт"
+  output_exclusive_control_warning: "Команды MPD паузы, остановки, повтора, случайного и одиночного воспроизведения и consume влияют на весь раздел воспроизведения. Не используйте его совместно с другим контроллером или экземпляром Tributary."
+  output_exclusive_control_confirmation: "Я подтверждаю, что Tributary имеет исключительный контроль над этим разделом воспроизведения MPD."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:
@@ -223,6 +225,7 @@ errors:
     audio_output_failed: "Сбой аудиовыхода"
     playback_failed: "Сбой воспроизведения аудио"
     airplay_raopsink_missing: "Для AirPlay требуется элемент raopsink из GStreamer — установите пакет gst-plugins-bad и перезапустите Tributary"
+    mpd_exclusive_control_required: "Повторно добавьте этот выход MPD, подтвердите исключительный контроль раздела, затем снова выберите его перед воспроизведением"
 
 # ── About dialog ───────────────────────────────────────────────────
 about:

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -123,6 +123,8 @@ dialogs:
   output_name_placeholder: "客厅 MPD"
   output_host: "主机"
   output_port: "端口"
+  output_exclusive_control_warning: "MPD 的暂停、停止、重复、随机、单曲和 consume 命令会影响整个播放分区。请勿与其他控制器或 Tributary 实例共享。"
+  output_exclusive_control_confirmation: "我确认 Tributary 独占控制此 MPD 播放分区。"
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:
@@ -223,6 +225,7 @@ errors:
     audio_output_failed: "音频输出失败"
     playback_failed: "音频播放失败"
     airplay_raopsink_missing: "AirPlay 需要 GStreamer 的 raopsink 元素。请安装 gst-plugins-bad 软件包，然后重新启动 Tributary"
+    mpd_exclusive_control_required: "请重新添加此 MPD 输出，确认对分区的独占控制，然后在播放前再次选择它"
 
 # ── About dialog ───────────────────────────────────────────────────
 about:

--- a/locales/zh-TW.yml
+++ b/locales/zh-TW.yml
@@ -123,6 +123,8 @@ dialogs:
   output_name_placeholder: "客廳 MPD"
   output_host: "主機"
   output_port: "連接埠"
+  output_exclusive_control_warning: "MPD 的暫停、停止、重複、隨機、單曲和 consume 指令會影響整個播放分割區。請勿與其他控制器或 Tributary 執行個體共用。"
+  output_exclusive_control_confirmation: "我確認 Tributary 獨佔控制此 MPD 播放分割區。"
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:
@@ -223,6 +225,7 @@ errors:
     audio_output_failed: "音訊輸出失敗"
     playback_failed: "音訊播放失敗"
     airplay_raopsink_missing: "AirPlay 需要 GStreamer 的 raopsink 元素。請安裝 gst-plugins-bad 套件，然後重新啟動 Tributary"
+    mpd_exclusive_control_required: "請重新新增此 MPD 輸出，確認對分割區的獨佔控制，然後在播放前再次選取它"
 
 # ── About dialog ───────────────────────────────────────────────────
 about:

--- a/src/audio/airplay_output.rs
+++ b/src/audio/airplay_output.rs
@@ -433,7 +433,7 @@ impl AudioOutput for AirPlayOutput {
         true
     }
 
-    fn load_uri(&self, uri: &str) {
+    fn load_uri(&self, uri: &str) -> bool {
         info!("AirPlay: loading URI");
         let generation = self.event_generation();
         let _ = self
@@ -441,15 +441,17 @@ impl AudioOutput for AirPlayOutput {
             .try_send(PlayerEvent::state(generation, PlayerState::Buffering));
 
         self.finish_load(generation, self.open_session(uri));
+        true
     }
 
-    fn load_resolved(&self, request: ResolvedHttpRequest) {
+    fn load_resolved(&self, request: ResolvedHttpRequest) -> bool {
         info!("AirPlay: loading resolved media");
         let generation = self.event_generation();
         let _ = self
             .event_tx
             .try_send(PlayerEvent::state(generation, PlayerState::Buffering));
         self.finish_load(generation, self.open_resolved_session(request));
+        true
     }
 
     fn set_event_generation(&self, generation: PlayerEventGeneration) {

--- a/src/audio/chromecast_output.rs
+++ b/src/audio/chromecast_output.rs
@@ -1846,7 +1846,7 @@ impl AudioOutput for ChromecastOutput {
         true
     }
 
-    fn load_uri(&self, uri: &str) {
+    fn load_uri(&self, uri: &str) -> bool {
         let owner = self.next_owner();
         let kind = match self.resolve_uri(uri) {
             Ok(uri) => CommandKind::Load {
@@ -1856,9 +1856,10 @@ impl AudioOutput for ChromecastOutput {
             Err(failure) => CommandKind::RejectLoad { failure },
         };
         let _ = self.enqueue(owner, kind);
+        true
     }
 
-    fn load_resolved(&self, request: ResolvedHttpRequest) {
+    fn load_resolved(&self, request: ResolvedHttpRequest) -> bool {
         let owner = self.next_owner();
         let kind = match self.resolve_request(request) {
             Ok(uri) => CommandKind::Load {
@@ -1868,6 +1869,7 @@ impl AudioOutput for ChromecastOutput {
             Err(failure) => CommandKind::RejectLoad { failure },
         };
         let _ = self.enqueue(owner, kind);
+        true
     }
 
     fn set_event_generation(&self, generation: PlayerEventGeneration) {

--- a/src/audio/local_output.rs
+++ b/src/audio/local_output.rs
@@ -33,12 +33,14 @@ impl AudioOutput for LocalOutput {
         true
     }
 
-    fn load_uri(&self, uri: &str) {
+    fn load_uri(&self, uri: &str) -> bool {
         self.player.load_uri(uri);
+        true
     }
 
-    fn load_resolved(&self, request: ResolvedHttpRequest) {
+    fn load_resolved(&self, request: ResolvedHttpRequest) -> bool {
         self.player.load_resolved(request);
+        true
     }
 
     fn set_event_generation(&self, generation: PlayerEventGeneration) {

--- a/src/audio/mpd_output.rs
+++ b/src/audio/mpd_output.rs
@@ -46,6 +46,26 @@ const MAX_MPD_RESOLVER_HOST_BYTES: usize = 1024;
 /// One load-sized command plus a bounded burst of small playback controls.
 const MAX_PENDING_WORKER_COMMANDS: usize = 64;
 
+/// Whether this output is allowed to issue MPD's partition-wide playback and
+/// option commands. MPD exposes no atomic ownership check for those commands,
+/// so playback remains fail-closed until the user explicitly confirms that no
+/// other controller or Tributary instance shares the partition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpdControlMode {
+    Unconfirmed,
+    Exclusive,
+}
+
+impl From<bool> for MpdControlMode {
+    fn from(exclusive_control: bool) -> Self {
+        if exclusive_control {
+            Self::Exclusive
+        } else {
+            Self::Unconfirmed
+        }
+    }
+}
+
 pub struct MpdOutput {
     #[allow(dead_code)]
     display_name: String,
@@ -412,6 +432,12 @@ struct MpdFailure {
     operation: &'static str,
     connection_usable: bool,
     ack_code: Option<MpdAckCode>,
+    user_message: Option<MpdUserMessage>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum MpdUserMessage {
+    ExclusiveControlRequired,
 }
 
 impl MpdFailure {
@@ -420,6 +446,7 @@ impl MpdFailure {
             operation,
             connection_usable: false,
             ack_code: None,
+            user_message: None,
         }
     }
 
@@ -428,6 +455,7 @@ impl MpdFailure {
             operation,
             connection_usable: true,
             ack_code: None,
+            user_message: None,
         }
     }
 
@@ -436,6 +464,16 @@ impl MpdFailure {
             operation,
             connection_usable: true,
             ack_code,
+            user_message: None,
+        }
+    }
+
+    const fn exclusive_control_required() -> Self {
+        Self {
+            operation: "exclusive control confirmation",
+            connection_usable: false,
+            ack_code: None,
+            user_message: Some(MpdUserMessage::ExclusiveControlRequired),
         }
     }
 }
@@ -445,7 +483,20 @@ fn opaque_mpd_failure<E>(operation: &'static str, _error: E) -> MpdFailure {
 }
 
 fn mpd_failure_message(failure: MpdFailure) -> String {
-    format!("MPD {} failed", failure.operation)
+    match failure.user_message {
+        Some(MpdUserMessage::ExclusiveControlRequired) => {
+            mpd_exclusive_control_required_message(&rust_i18n::locale())
+        }
+        None => format!("MPD {} failed", failure.operation),
+    }
+}
+
+fn mpd_exclusive_control_required_message(locale: &str) -> String {
+    rust_i18n::t!(
+        "errors.playback.mpd_exclusive_control_required",
+        locale = locale
+    )
+    .into_owned()
 }
 
 type MpdResult<T> = Result<T, MpdFailure>;
@@ -1705,6 +1756,7 @@ enum MpdMedia {
 
 fn spawn_mpd_worker<C>(
     connector: C,
+    control_mode: MpdControlMode,
     intent_epoch: Arc<AtomicU64>,
     cache: Arc<Mutex<MpdCache>>,
     event_tx: async_channel::Sender<PlayerEvent>,
@@ -1721,6 +1773,7 @@ where
             run_mpd_worker(
                 connector,
                 worker_rx,
+                control_mode,
                 intent_epoch,
                 cache,
                 event_tx,
@@ -1734,9 +1787,11 @@ where
     worker_tx
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_mpd_worker<C>(
     mut connector: C,
     worker_rx: WorkerCommandReceiver,
+    control_mode: MpdControlMode,
     intent_epoch: Arc<AtomicU64>,
     cache: Arc<Mutex<MpdCache>>,
     event_tx: async_channel::Sender<PlayerEvent>,
@@ -1761,6 +1816,7 @@ fn run_mpd_worker<C>(
                             &mut active,
                             command.owner,
                             MpdMedia::Direct(uri),
+                            control_mode,
                             &proxy,
                             &intent_epoch,
                             &cache,
@@ -1775,6 +1831,7 @@ fn run_mpd_worker<C>(
                             &mut active,
                             command.owner,
                             MpdMedia::Protected(MpdUpstream::Legacy(upstream)),
+                            control_mode,
                             &proxy,
                             &intent_epoch,
                             &cache,
@@ -1789,6 +1846,7 @@ fn run_mpd_worker<C>(
                             &mut active,
                             command.owner,
                             MpdMedia::Protected(MpdUpstream::Resolved(request)),
+                            control_mode,
                             &proxy,
                             &intent_epoch,
                             &cache,
@@ -1887,6 +1945,7 @@ fn handle_load<C>(
     active: &mut Option<WorkerSession<C::Connection>>,
     owner: CommandOwner,
     media: MpdMedia,
+    control_mode: MpdControlMode,
     proxy: &ProxyServices,
     intent_epoch: &AtomicU64,
     cache: &Mutex<MpdCache>,
@@ -1895,6 +1954,21 @@ fn handle_load<C>(
 ) where
     C: MpdConnector,
 {
+    // This gate intentionally precedes cleanup, Buffering publication,
+    // connection, partition-wide option resets, proxy tickets, and queue
+    // mutation. A legacy/unconfirmed saved endpoint therefore has no MPD or
+    // protected-media side effects; re-adding it with the explicit checkbox
+    // is the only supported upgrade path.
+    if control_mode != MpdControlMode::Exclusive {
+        fail_current(
+            owner,
+            MpdFailure::exclusive_control_required(),
+            intent_epoch,
+            cache,
+            event_tx,
+        );
+        return;
+    }
     match cleanup_session(active, owner, CleanupKind::Targeted, intent_epoch, timing) {
         CleanupOutcome::Completed => {}
         CleanupOutcome::Failed(failure) => {
@@ -2766,10 +2840,10 @@ where
                     }
                 }
             }
-            // A foreign current id does not authorize either a global stop or
-            // a racy targeted delete. Another client could select our queued
-            // id between this status and deleteid, so deliberately retain it
-            // until exclusive-control work can make cleanup conditional.
+            // A foreign current id means the exclusive-control contract was
+            // violated. It still does not authorize either a global stop or a
+            // racy targeted delete: another client could select our queued id
+            // between this status and deleteid, so deliberately retain it.
             Ok(status) if status.song_id.is_some() => return CleanupOutcome::Completed,
             // No current id authorizes only the targeted cleanup below.
             Ok(_) => {}
@@ -2912,9 +2986,10 @@ impl MpdOutput {
         display_name: &str,
         host: &str,
         port: u16,
+        control_mode: MpdControlMode,
         event_tx: async_channel::Sender<PlayerEvent>,
     ) -> Self {
-        info!(host = %host, port, name = %display_name, "MPD output configured");
+        info!(host = %host, port, name = %display_name, ?control_mode, "MPD output configured");
         let intent_epoch = Arc::new(AtomicU64::new(0));
         let cache = Arc::new(Mutex::new(MpdCache::default()));
         let proxy = ProxyServices::production();
@@ -2923,6 +2998,7 @@ impl MpdOutput {
                 host: host.to_string(),
                 port,
             },
+            control_mode,
             Arc::clone(&intent_epoch),
             Arc::clone(&cache),
             event_tx.clone(),
@@ -3561,6 +3637,28 @@ mod tests {
             timing: WorkerTiming,
             proxy: ProxyServices,
         ) -> Self {
+            Self::new_with_mode_and_proxy(shared, timing, proxy, MpdControlMode::Exclusive)
+        }
+
+        fn new_unconfirmed_with_proxy(shared: Arc<FakeShared>, proxy: ProxyServices) -> Self {
+            Self::new_with_mode_and_proxy(
+                shared,
+                WorkerTiming {
+                    operation: Duration::from_secs(2),
+                    poll: Duration::from_hours(1),
+                    tick: Duration::from_millis(10),
+                },
+                proxy,
+                MpdControlMode::Unconfirmed,
+            )
+        }
+
+        fn new_with_mode_and_proxy(
+            shared: Arc<FakeShared>,
+            timing: WorkerTiming,
+            proxy: ProxyServices,
+            control_mode: MpdControlMode,
+        ) -> Self {
             let (tx, rx) = worker_command_channel(MAX_PENDING_WORKER_COMMANDS);
             let epoch = Arc::new(AtomicU64::new(0));
             let cache = Arc::new(Mutex::new(MpdCache::default()));
@@ -3572,6 +3670,7 @@ mod tests {
                 run_mpd_worker(
                     FakeConnector { shared },
                     rx,
+                    control_mode,
                     epoch_for_worker,
                     cache_for_worker,
                     event_tx,
@@ -3644,6 +3743,66 @@ mod tests {
     fn protected_load(uri: &str) -> CommandKind {
         CommandKind::ProtectedLoad {
             upstream: Box::new(Url::parse(uri).expect("protected test URL")),
+        }
+    }
+
+    #[test]
+    fn unconfirmed_partition_rejects_load_before_any_connection_state_or_ticket_action() {
+        let shared = FakeShared::new();
+        let proxy_shared = FakeProxyShared::new();
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let proxy = fake_proxy_services(Arc::clone(&proxy_shared), &runtime);
+        let harness = Harness::new_unconfirmed_with_proxy(Arc::clone(&shared), proxy);
+        let owner = harness.next_owner(17);
+
+        harness.send(
+            owner,
+            protected_load("https://music.test/private.flac?token=must-not-leave"),
+        );
+        harness.fence(owner);
+
+        assert!(shared.actions().is_empty(), "no MPD operation is allowed");
+        assert!(shared.added_uris().is_empty(), "no queue URI is allowed");
+        assert!(
+            proxy_shared
+                .starts
+                .lock()
+                .expect("proxy starts lock")
+                .is_empty(),
+            "no protected-media ticket is allowed"
+        );
+        assert_eq!(harness.cache().state, PlayerState::Stopped);
+        let events = harness.events();
+        assert!(matches!(
+            events.as_slice(),
+            [
+                PlayerEvent::StateChanged {
+                    state: PlayerState::Stopped,
+                    ..
+                },
+                PlayerEvent::Error { message, .. }
+            ] if message == &mpd_exclusive_control_required_message(&rust_i18n::locale())
+        ));
+        assert!(!events.iter().any(|event| matches!(
+            event,
+            PlayerEvent::StateChanged {
+                state: PlayerState::Buffering | PlayerState::Playing | PlayerState::Paused,
+                ..
+            }
+        )));
+        harness.shutdown();
+    }
+
+    #[test]
+    fn exclusive_control_requirement_is_localized_for_every_catalog() {
+        let english = mpd_exclusive_control_required_message("en");
+        assert!(!english.is_empty());
+        for locale in rust_i18n::available_locales!() {
+            let localized = mpd_exclusive_control_required_message(&locale);
+            assert!(!localized.is_empty(), "{locale}");
+            if locale != "en" {
+                assert_ne!(localized, english, "{locale} must not fall back to English");
+            }
         }
     }
 
@@ -6364,6 +6523,7 @@ mod tests {
                     port: address.port(),
                 },
                 worker_rx,
+                MpdControlMode::Exclusive,
                 worker_epoch,
                 worker_cache,
                 event_tx,

--- a/src/audio/mpd_output.rs
+++ b/src/audio/mpd_output.rs
@@ -116,6 +116,16 @@ enum CommandKind {
 }
 
 impl CommandKind {
+    fn is_load_intent(&self) -> bool {
+        matches!(
+            self,
+            Self::Load { .. }
+                | Self::ProtectedLoad { .. }
+                | Self::ResolvedLoad { .. }
+                | Self::RejectLoad { .. }
+        )
+    }
+
     fn is_transient_control(&self) -> bool {
         matches!(
             self,
@@ -1809,6 +1819,19 @@ fn run_mpd_worker<C>(
         };
         match worker_rx.recv_timeout(wait) {
             Ok(command) => {
+                // Apply the partition-ownership contract to every load intent,
+                // including media rejected before dispatch. This precedes
+                // cleanup as well as every connection, MPD, and proxy action.
+                if control_mode != MpdControlMode::Exclusive && command.kind.is_load_intent() {
+                    fail_current(
+                        command.owner,
+                        MpdFailure::exclusive_control_required(),
+                        &intent_epoch,
+                        &cache,
+                        &event_tx,
+                    );
+                    continue;
+                }
                 let poll_after = match command.kind {
                     CommandKind::Load { uri } => {
                         handle_load(
@@ -1816,7 +1839,6 @@ fn run_mpd_worker<C>(
                             &mut active,
                             command.owner,
                             MpdMedia::Direct(uri),
-                            control_mode,
                             &proxy,
                             &intent_epoch,
                             &cache,
@@ -1831,7 +1853,6 @@ fn run_mpd_worker<C>(
                             &mut active,
                             command.owner,
                             MpdMedia::Protected(MpdUpstream::Legacy(upstream)),
-                            control_mode,
                             &proxy,
                             &intent_epoch,
                             &cache,
@@ -1846,7 +1867,6 @@ fn run_mpd_worker<C>(
                             &mut active,
                             command.owner,
                             MpdMedia::Protected(MpdUpstream::Resolved(request)),
-                            control_mode,
                             &proxy,
                             &intent_epoch,
                             &cache,
@@ -1945,7 +1965,6 @@ fn handle_load<C>(
     active: &mut Option<WorkerSession<C::Connection>>,
     owner: CommandOwner,
     media: MpdMedia,
-    control_mode: MpdControlMode,
     proxy: &ProxyServices,
     intent_epoch: &AtomicU64,
     cache: &Mutex<MpdCache>,
@@ -1954,21 +1973,6 @@ fn handle_load<C>(
 ) where
     C: MpdConnector,
 {
-    // This gate intentionally precedes cleanup, Buffering publication,
-    // connection, partition-wide option resets, proxy tickets, and queue
-    // mutation. A legacy/unconfirmed saved endpoint therefore has no MPD or
-    // protected-media side effects; re-adding it with the explicit checkbox
-    // is the only supported upgrade path.
-    if control_mode != MpdControlMode::Exclusive {
-        fail_current(
-            owner,
-            MpdFailure::exclusive_control_required(),
-            intent_epoch,
-            cache,
-            event_tx,
-        );
-        return;
-    }
     match cleanup_session(active, owner, CleanupKind::Targeted, intent_epoch, timing) {
         CleanupOutcome::Completed => {}
         CleanupOutcome::Failed(failure) => {
@@ -3746,8 +3750,7 @@ mod tests {
         }
     }
 
-    #[test]
-    fn unconfirmed_partition_rejects_load_before_any_connection_state_or_ticket_action() {
+    fn assert_unconfirmed_load_has_no_side_effect(kind: CommandKind) {
         let shared = FakeShared::new();
         let proxy_shared = FakeProxyShared::new();
         let runtime = tokio::runtime::Runtime::new().expect("test runtime");
@@ -3755,10 +3758,7 @@ mod tests {
         let harness = Harness::new_unconfirmed_with_proxy(Arc::clone(&shared), proxy);
         let owner = harness.next_owner(17);
 
-        harness.send(
-            owner,
-            protected_load("https://music.test/private.flac?token=must-not-leave"),
-        );
+        harness.send(owner, kind);
         harness.fence(owner);
 
         assert!(shared.actions().is_empty(), "no MPD operation is allowed");
@@ -3791,6 +3791,20 @@ mod tests {
             }
         )));
         harness.shutdown();
+    }
+
+    #[test]
+    fn unconfirmed_partition_rejects_load_before_any_connection_state_or_ticket_action() {
+        assert_unconfirmed_load_has_no_side_effect(protected_load(
+            "https://music.test/private.flac?token=must-not-leave",
+        ));
+    }
+
+    #[test]
+    fn unconfirmed_partition_rejects_preclassified_failure_before_cleanup() {
+        assert_unconfirmed_load_has_no_side_effect(CommandKind::RejectLoad {
+            failure: MpdFailure::new("media URI validation"),
+        });
     }
 
     #[test]

--- a/src/audio/mpd_output.rs
+++ b/src/audio/mpd_output.rs
@@ -72,6 +72,7 @@ pub struct MpdOutput {
     event_tx: async_channel::Sender<PlayerEvent>,
     event_generation: AtomicU64,
     volume: f64,
+    control_mode: MpdControlMode,
     intent_epoch: Arc<AtomicU64>,
     cache: Arc<Mutex<MpdCache>>,
     proxy: ProxyServices,
@@ -3014,6 +3015,7 @@ impl MpdOutput {
             event_tx,
             event_generation: AtomicU64::new(0),
             volume: 1.0,
+            control_mode,
             intent_epoch,
             cache,
             proxy,
@@ -3093,6 +3095,25 @@ impl MpdOutput {
         cache.position_ms = None;
         owner
     }
+
+    fn ensure_load_allowed(&self) -> bool {
+        if self.control_mode == MpdControlMode::Exclusive {
+            return true;
+        }
+
+        // Reject at the public output boundary before begin_load can advance
+        // the epoch or publish optimistic Buffering state. The worker repeats
+        // the check as defense in depth for any future/internal caller that
+        // bypasses this boundary.
+        fail_current(
+            self.current_owner(),
+            MpdFailure::exclusive_control_required(),
+            &self.intent_epoch,
+            &self.cache,
+            &self.event_tx,
+        );
+        false
+    }
 }
 
 impl AudioOutput for MpdOutput {
@@ -3108,7 +3129,10 @@ impl AudioOutput for MpdOutput {
         false
     }
 
-    fn load_uri(&self, uri: &str) {
+    fn load_uri(&self, uri: &str) -> bool {
+        if !self.ensure_load_allowed() {
+            return false;
+        }
         let owner = self.begin_load();
         let kind = match encode_mpd_arg(uri) {
             Err(failure) => CommandKind::RejectLoad { failure },
@@ -3123,9 +3147,13 @@ impl AudioOutput for MpdOutput {
             },
         };
         self.enqueue(owner, kind);
+        true
     }
 
-    fn load_resolved(&self, request: ResolvedHttpRequest) {
+    fn load_resolved(&self, request: ResolvedHttpRequest) -> bool {
+        if !self.ensure_load_allowed() {
+            return false;
+        }
         let owner = self.begin_load();
         let kind = if request.is_active() {
             CommandKind::ResolvedLoad {
@@ -3137,6 +3165,7 @@ impl AudioOutput for MpdOutput {
             }
         };
         self.enqueue(owner, kind);
+        true
     }
 
     fn set_event_generation(&self, generation: PlayerEventGeneration) {
@@ -5756,6 +5785,59 @@ mod tests {
     }
 
     #[test]
+    fn unconfirmed_public_loads_reject_before_begin_load_and_remain_retryable() {
+        let (event_tx, event_rx) = async_channel::unbounded();
+        let intent_epoch = Arc::new(AtomicU64::new(0));
+        let cache = Arc::new(Mutex::new(MpdCache::default()));
+        let (worker_tx, worker_rx) = worker_command_channel(MAX_PENDING_WORKER_COMMANDS);
+        let output = MpdOutput {
+            display_name: "legacy".to_string(),
+            event_tx,
+            event_generation: AtomicU64::new(9),
+            volume: 1.0,
+            control_mode: MpdControlMode::Unconfirmed,
+            intent_epoch: Arc::clone(&intent_epoch),
+            cache: Arc::clone(&cache),
+            proxy: ProxyServices::production(),
+            worker_tx,
+        };
+
+        assert!(!output.load_uri("file:///music/retry.flac"));
+        let request = ResolvedHttpRequest::new(
+            Url::parse("https://music.test/retry.flac").expect("resolved endpoint"),
+        )
+        .expect("active resolved request");
+        assert!(!output.load_resolved(request));
+
+        assert_eq!(intent_epoch.load(Ordering::SeqCst), 0);
+        let snapshot = *cache.lock().expect("cache lock");
+        assert_eq!(snapshot.state, PlayerState::Stopped);
+        assert_eq!(snapshot.position_ms, None);
+        assert!(
+            worker_rx.pop_pending().is_none(),
+            "rejected loads never reach the worker"
+        );
+        for _ in 0..2 {
+            assert!(matches!(
+                event_rx.try_recv(),
+                Ok(PlayerEvent::StateChanged {
+                    generation,
+                    state: PlayerState::Stopped,
+                }) if generation.as_raw() == 9
+            ));
+            assert!(matches!(
+                event_rx.try_recv(),
+                Ok(PlayerEvent::Error {
+                    generation,
+                    message,
+                }) if generation.as_raw() == 9
+                    && message == mpd_exclusive_control_required_message(&rust_i18n::locale())
+            ));
+        }
+        assert!(event_rx.try_recv().is_err());
+    }
+
+    #[test]
     fn load_resets_cached_track_before_the_worker_receives_it() {
         let (event_tx, _event_rx) = async_channel::unbounded();
         let intent_epoch = Arc::new(AtomicU64::new(0));
@@ -5769,13 +5851,14 @@ mod tests {
             event_tx,
             event_generation: AtomicU64::new(7),
             volume: 1.0,
+            control_mode: MpdControlMode::Exclusive,
             intent_epoch: Arc::clone(&intent_epoch),
             cache: Arc::clone(&cache),
             proxy: ProxyServices::production(),
             worker_tx,
         };
 
-        output.load_uri("https://music.test/new");
+        assert!(output.load_uri("https://music.test/new"));
 
         let snapshot = *cache.lock().expect("cache lock");
         assert_eq!(snapshot.state, PlayerState::Buffering);
@@ -5802,13 +5885,14 @@ mod tests {
             event_tx,
             event_generation: AtomicU64::new(1),
             volume: 1.0,
+            control_mode: MpdControlMode::Exclusive,
             intent_epoch,
             cache,
             proxy: ProxyServices::production(),
             worker_tx,
         };
 
-        output.load_uri("https://music.test/stream?api_key=worker-secret");
+        assert!(output.load_uri("https://music.test/stream?api_key=worker-secret"));
         assert!(matches!(
             worker_rx
                 .recv_timeout(Duration::from_secs(2))
@@ -5818,7 +5902,7 @@ mod tests {
                 if upstream.as_str().contains("api_key=worker-secret")
         ));
 
-        output.load_uri("HTTPS://[malformed");
+        assert!(output.load_uri("HTTPS://[malformed"));
         assert!(matches!(
             worker_rx
                 .recv_timeout(Duration::from_secs(2))
@@ -5828,7 +5912,7 @@ mod tests {
                 if failure.operation == "media URI validation"
         ));
 
-        output.load_uri("Albums/Artist/track.flac");
+        assert!(output.load_uri("Albums/Artist/track.flac"));
         assert!(matches!(
             worker_rx
                 .recv_timeout(Duration::from_secs(2))
@@ -5847,6 +5931,7 @@ mod tests {
             event_tx,
             event_generation: AtomicU64::new(3),
             volume: 1.0,
+            control_mode: MpdControlMode::Exclusive,
             intent_epoch: Arc::new(AtomicU64::new(0)),
             cache: Arc::new(Mutex::new(MpdCache::default())),
             proxy: ProxyServices::production(),
@@ -5856,7 +5941,7 @@ mod tests {
             Url::parse("https://music.test/clean/track.flac?track=42").expect("clean endpoint");
         let request = ResolvedHttpRequest::new(endpoint.clone()).expect("resolved request");
 
-        output.load_resolved(request);
+        assert!(output.load_resolved(request));
 
         let command = worker_rx
             .recv_timeout(Duration::from_secs(2))

--- a/src/audio/output.rs
+++ b/src/audio/output.rs
@@ -76,7 +76,13 @@ pub trait AudioOutput {
     /// Implementations must classify it at this boundary: a supported
     /// credential-bearing URL may reach only Tributary's app-owned proxy, not
     /// a playback library, daemon, or receiver.
-    fn load_uri(&self, uri: &str);
+    ///
+    /// Returns `false` only when the output synchronously rejects the load
+    /// before starting it. Such a rejection must emit an actionable
+    /// [`PlayerEvent::Error`](super::PlayerEvent::Error); the caller keeps the
+    /// current queue item in a retryable state instead of treating it as
+    /// loaded media.
+    fn load_uri(&self, uri: &str) -> bool;
 
     /// Load one backend-resolved authenticated request and start playback.
     ///
@@ -84,7 +90,9 @@ pub trait AudioOutput {
     /// implementations must put the request behind an app-owned opaque ticket
     /// before invoking GStreamer, MPD, or a receiver. The endpoint and its
     /// authentication material must never fall through to a direct URI load.
-    fn load_resolved(&self, request: ResolvedHttpRequest);
+    /// The return value has the same synchronous-acceptance contract as
+    /// [`load_uri`](Self::load_uri).
+    fn load_resolved(&self, request: ResolvedHttpRequest) -> bool;
 
     /// Tag subsequent events with the playback load that owns them.
     ///

--- a/src/ui/output_dialogs.rs
+++ b/src/ui/output_dialogs.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
 /// A saved audio output entry in `outputs.json`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SavedOutput {
     /// Output type: `"mpd"` (extensible to `"airplay"` etc.).
     #[serde(rename = "type")]
@@ -18,6 +18,17 @@ pub struct SavedOutput {
     pub host: String,
     /// Port for MPD connections (typically 6600).
     pub port: u16,
+    /// Whether the user confirmed that Tributary exclusively controls this
+    /// MPD playback partition. Legacy entries deliberately default to false.
+    #[serde(default)]
+    pub exclusive_control: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SavedOutputUpsert {
+    Added,
+    Upgraded,
+    Unchanged,
 }
 
 /// Path to `outputs.json`: `<data_dir>/tributary/outputs.json`.
@@ -45,23 +56,72 @@ fn save_outputs(outputs: &[SavedOutput]) {
     }
 }
 
-/// Add an output to `outputs.json` (dedup by host:port).
-pub fn add_saved_output(output_type: &str, name: &str, host: &str, port: u16) {
-    let mut outputs = load_saved_outputs();
-    let key = format!("{host}:{port}");
-    if !outputs
-        .iter()
-        .any(|o| format!("{}:{}", o.host, o.port) == key)
+fn upsert_saved_output(
+    outputs: &mut Vec<SavedOutput>,
+    output_type: &str,
+    name: &str,
+    host: &str,
+    port: u16,
+    exclusive_control: bool,
+) -> SavedOutputUpsert {
+    if let Some(existing) = outputs
+        .iter_mut()
+        .find(|output| output.host == host && output.port == port)
     {
-        outputs.push(SavedOutput {
-            output_type: output_type.to_string(),
-            name: name.to_string(),
-            host: host.to_string(),
-            port,
-        });
-        save_outputs(&outputs);
-        info!(host = %host, port, "Output added to outputs.json");
+        // Re-adding a legacy endpoint is the explicit migration path. Preserve
+        // its existing type and display name so the already-rendered selector
+        // row remains an exact representation of the saved entry.
+        if exclusive_control && !existing.exclusive_control {
+            existing.exclusive_control = true;
+            return SavedOutputUpsert::Upgraded;
+        }
+        return SavedOutputUpsert::Unchanged;
     }
+
+    outputs.push(SavedOutput {
+        output_type: output_type.to_string(),
+        name: name.to_string(),
+        host: host.to_string(),
+        port,
+        exclusive_control,
+    });
+    SavedOutputUpsert::Added
+}
+
+/// Add or explicitly upgrade an output in `outputs.json` (dedup by host:port).
+pub fn add_saved_output(
+    output_type: &str,
+    name: &str,
+    host: &str,
+    port: u16,
+    exclusive_control: bool,
+) -> SavedOutputUpsert {
+    let mut outputs = load_saved_outputs();
+    let outcome = upsert_saved_output(
+        &mut outputs,
+        output_type,
+        name,
+        host,
+        port,
+        exclusive_control,
+    );
+    if !matches!(outcome, SavedOutputUpsert::Unchanged) {
+        save_outputs(&outputs);
+        info!(host = %host, port, ?outcome, "Output saved to outputs.json");
+    }
+    outcome
+}
+
+fn exclusive_control_warning(locale: &str) -> String {
+    rust_i18n::t!("dialogs.output_exclusive_control_warning", locale = locale).into_owned()
+}
+
+fn exclusive_control_confirmation(locale: &str) -> String {
+    rust_i18n::t!(
+        "dialogs.output_exclusive_control_confirmation",
+        locale = locale
+    )
+    .into_owned()
 }
 
 /// Remove an output from `outputs.json` by host:port.
@@ -115,6 +175,24 @@ pub fn show_add_output_dialog(window: &adw::ApplicationWindow, output_list: &gtk
     port_spin.set_value(6600.0);
     port_spin.set_hexpand(true);
 
+    let exclusive_warning = gtk::Label::builder()
+        .label(exclusive_control_warning(&rust_i18n::locale()))
+        .halign(gtk::Align::Start)
+        .wrap(true)
+        .max_width_chars(52)
+        .build();
+    let exclusive_confirmation_label = gtk::Label::builder()
+        .label(exclusive_control_confirmation(&rust_i18n::locale()))
+        .halign(gtk::Align::Start)
+        .wrap(true)
+        .max_width_chars(52)
+        .xalign(0.0)
+        .build();
+    let exclusive_confirmation = gtk::CheckButton::builder()
+        .child(&exclusive_confirmation_label)
+        .halign(gtk::Align::Start)
+        .build();
+
     // Use a GtkGrid for consistent label alignment.
     let grid = gtk::Grid::builder()
         .row_spacing(12)
@@ -144,16 +222,24 @@ pub fn show_add_output_dialog(window: &adw::ApplicationWindow, output_list: &gtk
     grid.attach(&host_entry, 1, 1, 1, 1);
     grid.attach(&port_label, 0, 2, 1, 1);
     grid.attach(&port_spin, 1, 2, 1, 1);
+    grid.attach(&exclusive_warning, 0, 3, 2, 1);
+    grid.attach(&exclusive_confirmation, 0, 4, 2, 1);
 
     dialog.set_extra_child(Some(&grid));
+    dialog.set_response_enabled("add", false);
+    let dialog_for_confirmation = dialog.clone();
+    exclusive_confirmation.connect_toggled(move |confirmation| {
+        dialog_for_confirmation.set_response_enabled("add", confirmation.is_active());
+    });
 
     let output_list = output_list.clone();
     let name_entry_c = name_entry.clone();
     let host_entry_c = host_entry.clone();
     let port_spin_c = port_spin.clone();
+    let exclusive_confirmation_c = exclusive_confirmation.clone();
 
     dialog.connect_response(None, move |_dialog, response| {
-        if response != "add" {
+        if response != "add" || !exclusive_confirmation_c.is_active() {
             return;
         }
 
@@ -187,15 +273,18 @@ pub fn show_add_output_dialog(window: &adw::ApplicationWindow, output_list: &gtk
                             version = %version,
                             "MPD output added successfully"
                         );
-                        add_saved_output("mpd", &name, &host, port);
+                        let outcome = add_saved_output("mpd", &name, &host, port, true);
 
-                        // Add row to the output selector popover.
-                        let row = super::header_bar::build_output_row(
-                            &name,
-                            "network-server-symbolic",
-                            false,
-                        );
-                        output_list.append(&row);
+                        // A legacy endpoint is upgraded in place; its row is
+                        // already present and retains its saved display name.
+                        if outcome == SavedOutputUpsert::Added {
+                            let row = super::header_bar::build_output_row(
+                                &name,
+                                "network-server-symbolic",
+                                false,
+                            );
+                            output_list.append(&row);
+                        }
                     }
                     Err(e) => {
                         warn!(
@@ -211,4 +300,77 @@ pub fn show_add_output_dialog(window: &adw::ApplicationWindow, output_list: &gtk
     });
 
     dialog.present(Some(window));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_output_defaults_to_unconfirmed_and_approved_output_serializes_mode() {
+        let legacy = r#"[{"type":"mpd","name":"Legacy","host":"mpd.local","port":6600}]"#;
+        let mut outputs: Vec<SavedOutput> = serde_json::from_str(legacy).expect("legacy JSON");
+        assert!(!outputs[0].exclusive_control);
+
+        assert_eq!(
+            upsert_saved_output(&mut outputs, "mpd", "Replacement", "mpd.local", 6600, true),
+            SavedOutputUpsert::Upgraded
+        );
+        let serialized = serde_json::to_string(&outputs).expect("approved JSON");
+        assert!(serialized.contains(r#""exclusive_control":true"#));
+    }
+
+    #[test]
+    fn endpoint_upsert_upgrades_in_place_without_renaming_or_dropping_siblings() {
+        let mut outputs = vec![
+            SavedOutput {
+                output_type: "mpd".to_string(),
+                name: "Living Room".to_string(),
+                host: "mpd.local".to_string(),
+                port: 6600,
+                exclusive_control: false,
+            },
+            SavedOutput {
+                output_type: "mpd".to_string(),
+                name: "Office".to_string(),
+                host: "office.local".to_string(),
+                port: 6601,
+                exclusive_control: true,
+            },
+        ];
+        let sibling = outputs[1].clone();
+
+        assert_eq!(
+            upsert_saved_output(&mut outputs, "mpd", "Renamed", "mpd.local", 6600, true),
+            SavedOutputUpsert::Upgraded
+        );
+        assert_eq!(outputs.len(), 2);
+        assert_eq!(outputs[0].name, "Living Room");
+        assert!(outputs[0].exclusive_control);
+        assert_eq!(outputs[1], sibling);
+        assert_eq!(
+            upsert_saved_output(&mut outputs, "mpd", "Renamed", "mpd.local", 6600, true),
+            SavedOutputUpsert::Unchanged
+        );
+        assert_eq!(outputs.len(), 2);
+    }
+
+    #[test]
+    fn exclusive_control_warning_and_confirmation_are_localized_everywhere() {
+        let english_warning = exclusive_control_warning("en");
+        let english_confirmation = exclusive_control_confirmation("en");
+        for locale in rust_i18n::available_locales!() {
+            let warning = exclusive_control_warning(&locale);
+            let confirmation = exclusive_control_confirmation(&locale);
+            assert!(!warning.is_empty(), "{locale} warning");
+            assert!(!confirmation.is_empty(), "{locale} confirmation");
+            if locale != "en" {
+                assert_ne!(warning, english_warning, "{locale} warning fallback");
+                assert_ne!(
+                    confirmation, english_confirmation,
+                    "{locale} confirmation fallback"
+                );
+            }
+        }
+    }
 }

--- a/src/ui/output_switch.rs
+++ b/src/ui/output_switch.rs
@@ -12,7 +12,7 @@ use tracing::info;
 
 use crate::audio::airplay_output::AirPlayOutput;
 use crate::audio::chromecast_output::ChromecastOutput;
-use crate::audio::mpd_output::MpdOutput;
+use crate::audio::mpd_output::{MpdControlMode, MpdOutput};
 use crate::audio::output::AudioOutput;
 use crate::audio::PlayerEvent;
 
@@ -23,9 +23,18 @@ use super::playback::PlaybackSession;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OutputTarget {
     Local,
-    Mpd { host: String, port: u16 },
-    AirPlay { host: String, port: u16 },
-    Chromecast { address: SocketAddr },
+    Mpd {
+        host: String,
+        port: u16,
+        exclusive_control: bool,
+    },
+    AirPlay {
+        host: String,
+        port: u16,
+    },
+    Chromecast {
+        address: SocketAddr,
+    },
 }
 
 fn output_change_required(active: &OutputTarget, requested: &OutputTarget) -> bool {
@@ -207,6 +216,7 @@ fn target_for_row(
     saved.get(mpd_idx).map(|entry| OutputTarget::Mpd {
         host: entry.host.clone(),
         port: entry.port,
+        exclusive_control: entry.exclusive_control,
     })
 }
 
@@ -335,8 +345,14 @@ fn handle_mpd_switch(
     if let Some(entry) = saved.get(mpd_idx) {
         park_local_if_needed(active_output, parked_local, event_sender);
 
-        let mpd = MpdOutput::new(&entry.name, &entry.host, entry.port, event_sender.clone())
-            .with_runtime(rt_handle.clone());
+        let mpd = MpdOutput::new(
+            &entry.name,
+            &entry.host,
+            entry.port,
+            MpdControlMode::from(entry.exclusive_control),
+            event_sender.clone(),
+        )
+        .with_runtime(rt_handle.clone());
         *active_output.borrow_mut() = Box::new(mpd);
         info!(
             name = %entry.name,
@@ -391,6 +407,7 @@ fn park_local_if_needed(
             "_dummy",
             "127.0.0.1",
             1,
+            MpdControlMode::Unconfirmed,
             event_sender.clone(),
         ));
         let local = std::mem::replace(&mut *active_output.borrow_mut(), dummy);
@@ -449,8 +466,24 @@ mod tests {
         let current = OutputTarget::Mpd {
             host: "music.local".to_string(),
             port: 6600,
+            exclusive_control: true,
         };
         assert!(!output_change_required(&current, &current));
+    }
+
+    #[test]
+    fn approving_the_same_mpd_endpoint_is_a_real_output_change() {
+        let unconfirmed = OutputTarget::Mpd {
+            host: "music.local".to_string(),
+            port: 6600,
+            exclusive_control: false,
+        };
+        let exclusive = OutputTarget::Mpd {
+            host: "music.local".to_string(),
+            port: 6600,
+            exclusive_control: true,
+        };
+        assert!(output_change_required(&unconfirmed, &exclusive));
     }
 
     #[test]

--- a/src/ui/playback.rs
+++ b/src/ui/playback.rs
@@ -200,9 +200,10 @@ pub struct PlaybackSession {
     /// Play/toggle requests are accepted as no-ops until the exact request is
     /// handed to the output, so they cannot revive a superseded track.
     pending_resolution: Option<PlayerEventGeneration>,
-    /// The current protected reference failed before reaching an output. A
-    /// later Play/Toggle retries resolution instead of issuing `play()` to an
-    /// output that has no loaded media.
+    /// The current item failed before reaching an output or was synchronously
+    /// rejected by it. A later Play/Toggle retries the load (and protected
+    /// resolution when applicable) instead of issuing `play()` to an output
+    /// that has no loaded media.
     resolution_failed: bool,
 }
 
@@ -379,6 +380,19 @@ impl PlaybackSession {
         true
     }
 
+    /// Retain a synchronously rejected item as an explicit retryable load.
+    ///
+    /// The generation remains current so the output's required actionable
+    /// error is still displayed. A later Play begins a fresh generation and
+    /// attempts the load again instead of toggling an empty output session.
+    fn mark_load_rejected(&mut self, generation: PlayerEventGeneration) -> bool {
+        if self.pending_resolution.is_some() || !self.accepts_event_generation(generation) {
+            return false;
+        }
+        self.resolution_failed = true;
+        true
+    }
+
     /// Turn a protected output failure into a fresh-resolution retry state.
     ///
     /// Resolution has already finished by the time `load_resolved` reaches an
@@ -388,6 +402,10 @@ impl PlaybackSession {
     /// generation also rejects any delayed state emitted by the failed load.
     pub(crate) fn mark_protected_load_failed(&mut self, generation: PlayerEventGeneration) -> bool {
         if self.pending_resolution.is_some()
+            // A synchronously rejected load is already retryable and never
+            // created output state to stop. Keep its generation current so
+            // the queued guidance remains visible without issuing cleanup.
+            || self.resolution_failed
             || !self.accepts_event_generation(generation)
             || !self.current().is_some_and(|item| {
                 crate::source_registry::is_media_reference(item.uri())
@@ -733,7 +751,11 @@ fn play_current(ctx: &PlaybackContext) -> bool {
             match resolved {
                 Ok(request) if request.is_active() => {
                     if session.borrow_mut().finish_pending_resolution(generation) {
-                        active_output.borrow().load_resolved(request);
+                        let accepted = active_output.borrow().load_resolved(request);
+                        if !accepted {
+                            let marked = session.borrow_mut().mark_load_rejected(generation);
+                            debug_assert!(marked, "current resolved load remains retryable");
+                        }
                     }
                 }
                 Ok(_) => {
@@ -771,7 +793,11 @@ fn play_current(ctx: &PlaybackContext) -> bool {
 
     let generation = ctx.session.borrow_mut().begin_event_generation();
     ctx.active_output.borrow().set_event_generation(generation);
-    ctx.active_output.borrow().load_uri(&playback_uri);
+    let accepted = ctx.active_output.borrow().load_uri(&playback_uri);
+    if !accepted {
+        let marked = ctx.session.borrow_mut().mark_load_rejected(generation);
+        debug_assert!(marked, "current direct load remains retryable");
+    }
     update_now_playing_ui(ctx, &item, identity.as_ref(), Some(&playback_uri));
 
     true
@@ -1421,7 +1447,7 @@ mod tests {
     }
 
     #[test]
-    fn protected_output_error_retries_resolution_but_direct_error_does_not() {
+    fn accepted_protected_output_error_retries_resolution_but_direct_error_does_not() {
         let mut protected = PlaybackSession::default();
         assert!(protected.replace_queue(vec![protected_item("remote", "a")], 0));
         let failed_load = protected.begin_pending_resolution();
@@ -1448,6 +1474,27 @@ mod tests {
         assert!(!direct.mark_protected_load_failed(direct_load));
         assert!(!direct.resolution_failed);
         assert!(direct.accepts_event_generation(direct_load));
+    }
+
+    #[test]
+    fn synchronous_load_rejection_keeps_exact_direct_generation_retryable() {
+        let mut session = PlaybackSession::default();
+        assert!(session.replace_queue(vec![item("local", "a")], 0));
+        let rejected = session.begin_event_generation();
+
+        assert!(session.mark_load_rejected(rejected));
+        assert!(session.resolution_failed);
+        assert!(session.accepts_event_generation(rejected));
+        assert!(
+            !session.mark_protected_load_failed(rejected),
+            "synchronous refusal has no output state to stop"
+        );
+
+        let retry = session.begin_event_generation();
+        assert_ne!(retry, rejected);
+        assert!(!session.resolution_failed);
+        assert!(!session.mark_load_rejected(rejected));
+        assert!(session.mark_load_rejected(retry));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- require an explicit persisted exclusive-control mode before Tributary may drive MPD's partition-wide playback and option commands
- default every legacy `outputs.json` entry to unconfirmed, and provide a localized Add Output warning plus required one-controller confirmation in all 13 catalogs
- upgrade an exact legacy host/port in place without renaming it, dropping siblings, or adding a duplicate; include the mode in output identity so reselecting an upgraded active endpoint rebuilds it
- reject unconfirmed loads at the public output boundary before optimistic Buffering, epoch advancement, enqueue, or cleanup; retain the exact UI generation as retryable so another Play re-shows guidance instead of toggling an empty session
- independently gate every load intent—including media already classified as malformed, unsupported, or inactive—in the ordered worker before connection, MPD state/options, protected-media ticket creation, queue mutation, play, or status
- retain the existing conservative foreign-song behavior even after confirmation: a violated exclusivity promise relinquishes ownership without a racy global stop or targeted delete
- update README, CHANGELOG, and `docs/task.md` with the user recovery path, threat boundary, accepted CI/review evidence, and final tracker state

## Safety contract

MPD has no conditional command that couples ownership revalidation to `pause`, `stop`, `repeat`, `random`, `single`, or `consume`. This PR therefore uses the tracker's permitted fail-closed alternative: the user must confirm that the selected MPD partition is controlled only by this Tributary instance. A legacy/unconfirmed endpoint cannot enter optimistic Buffering, advance its output epoch, enqueue work, create a connection/proxy ticket/queue entry, or perform an MPD side effect during playback. The runtime error directs the user to re-add the endpoint, confirm exclusive control, and reselect it; synchronous load acceptance keeps both direct and resolved queue items retryable.

## Tracker

The accepted exclusive-control behavior and implementation record close the final two P2.10 boxes, moving the tracker to **198/223 (88.8%)**, with P2 at **76/79**. The remaining three P2 items are live/manual hardware, installed-Flatpak, and packaged-Windows server checks.

## Validation

- debug and release `cargo check --all-targets --all-features --locked`
- strict debug and release all-target/all-feature Clippy
- debug and release full suites: 18 library + 727 application + 10 repository tests = 755 per profile
- all 83 focused MPD tests
- nine net-new regressions covering legacy migration/serialization, exact in-place upsert and sibling preservation, mode-aware identity, public-boundary refusal before Buffering/epoch/enqueue for direct and typed loads, worker zero connection/MPD/ticket/queue action for protected and pre-rejected loads, exact-generation retry behavior, and all-catalog localization
- `cargo audit`: no vulnerabilities; only the two tracked allowed unmaintained warnings
- desktop/AppStream validation, formatting, and `git diff --check`
- code-head CI run `29602279148`: MSRV, audit, metadata, representative coverage, Linux x86_64/aarch64, Flatpak, macOS aarch64, Windows x86_64/aarch64, and checksums all green
- 67.12% line coverage (33,191/49,451; artifact `8415577394`) against the accepted 66.9% floor
- CodeQL and all three static-analysis jobs green; final Codex review of `91536ab` found no further issues after both actionable review findings were fixed and resolved

The first restricted release test attempt denied 59 unrelated loopback binds with `Operation not permitted`; an immediate loopback-enabled rerun passed all 755 tests. No dependency or lockfile changed.
