### PR TITLE
Prepare Tributary 0.5.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Tributary are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.1] — Unreleased
+## [0.5.1] — 2026-07-18
 
 ### Added
 - **An audited implementation roadmap and clean active backlog** — `docs/roadmap.md` now separates
@@ -966,6 +966,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.desktop` file and AppStream metainfo for Linux desktop integration.
 - Windows resource file with icon embedding.
 
+[0.5.1]: https://github.com/jm2/tributary/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/jm2/tributary/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/jm2/tributary/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/jm2/tributary/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/jm2/tributary/compare/v0.3.0...v0.3.1

--- a/data/io.github.tributary.Tributary.metainfo.xml
+++ b/data/io.github.tributary.Tributary.metainfo.xml
@@ -44,6 +44,19 @@
   </screenshots>
 
   <releases>
+    <release version="0.5.1" date="2026-07-18">
+      <description>
+        <p>Security and reliability release:</p>
+        <ul>
+          <li>Unify remote, radio, removable, and external-file source identity and lifecycle handling</li>
+          <li>Keep backend credentials and local file paths behind retained playback-time authority</li>
+          <li>Harden library-root reconciliation, metadata writes, and transactional playlist import</li>
+          <li>Correct smart-playlist, playback, MPD, AirPlay, and Chromecast lifecycle behavior</li>
+          <li>Improve DAAP, Subsonic, Jellyfin, Plex, Radio-Browser, and removable-media reliability</li>
+          <li>Expand accessibility, native packaging verification, CI coverage, and adversarial tests</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.5.0" date="2026-05-08">
       <description>
         <p>Feature release:</p>


### PR DESCRIPTION
## Summary

- date the 0.5.1 changelog for the 2026-07-18 release
- add missing 0.5.1 and 0.5.0 changelog comparison links
- publish the matching 0.5.1 AppStream release notes for Linux packages

The crate and lockfile versions were already prepared as 0.5.1, so this PR intentionally contains no version bump or runtime behavior change.

## Validation

- `git diff --check`
- `cargo fmt --all -- --check`
- `appstreamcli validate --no-net data/io.github.tributary.Tributary.metainfo.xml`
- `xmllint --noout data/io.github.tributary.Tributary.metainfo.xml`
- `cargo metadata --locked --no-deps --format-version 1`
- `cargo test --locked --test packaging_metadata`
- rendered `CHANGELOG.md` with CommonMark to verify the comparison links
