### PR TITLE
Harden shuffled playback history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to Tributary are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Shuffled Previous and Next now follow a bounded real playback timeline** — Tributary retains
+  the current queue occurrence plus ten actual predecessors, walks backward without fabricating a
+  random track at the oldest boundary, and replays fixed forward history before drawing again.
+  Duplicate tracks remain distinct queue occurrences; one- and two-item queues, repeat Off/All/One,
+  navigation rollback, and queue/output/source lifecycle boundaries are explicitly regressed.
+  Repeat All now starts complete queue-occurrence cycles and avoids immediately repeating the
+  rollover track instead of omitting that occurrence from the new cycle. Either shuffle toggle
+  starts a fresh traversal without changing the current item. The header button and operating-system
+  media controls also share one Previous dispatcher: positions above three seconds restart, exactly
+  three seconds still navigates, and a retained-boundary Previous restarts the current item.
+
 ## [0.5.1] — 2026-07-18
 
 ### Added
@@ -966,6 +980,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.desktop` file and AppStream metainfo for Linux desktop integration.
 - Windows resource file with icon embedding.
 
+[Unreleased]: https://github.com/jm2/tributary/compare/v0.5.1...HEAD
 [0.5.1]: https://github.com/jm2/tributary/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/jm2/tributary/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/jm2/tributary/compare/v0.4.0...v0.4.1

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Tributary provides a unified interface for managing and streaming music from mul
 | GStreamer audio playback (`playbin3`) | ✅ |
 | MPRIS / SMTC / macOS Now Playing integration (`souvlaki`) | ✅ |
 | Playback controls (play/pause, next/prev, seek, volume) | ✅ |
-| Shuffle & repeat (off / all / one) with actual Previous history and persistence | ✅ Bounded Repeat All/test hardening is tracked in [P1.1](docs/task.md#p11--harden-and-document-existing-shuffled-playback-history) |
+| Shuffle & repeat (off / all / one) with bounded actual Previous/forward history and persistence | ✅ |
 | Column sort persistence | ✅ |
 | Subsonic / Navidrome / Nextcloud Music backend | ✅ |
 | Jellyfin backend | ✅ |
@@ -741,8 +741,13 @@ podcasts. Tributary deliberately does not guess through any of those gaps.
 ### Playback Controls
 
 - **Play/Pause** — click the circular play button, or double-click any track in the tracklist
-- **Next / Previous** — skip buttons; Previous restarts the current track if more than 3 seconds in
-- **Shuffle** — randomises track order (avoids repeating the current track)
+- **Next / Previous** — skip buttons and OS media controls share the same behavior. More than three
+  seconds into a track, Previous first restarts it; otherwise it walks the actual prior queue
+  occurrence. After walking backward, Next replays that fixed forward history before randomizing.
+- **Shuffle** — randomises complete queue-occurrence cycles without an immediate rollover repeat.
+  Tributary retains the current occurrence plus ten real predecessors; the oldest retained boundary
+  restarts instead of inventing a random predecessor. Toggling shuffle starts a fresh traversal at
+  the unchanged current track.
 - **Repeat** — cycles through Off → All → One
 - **Seek** — drag the progress scrubber
 - **Volume** — drag the volume slider (cubic perceptual curve)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,7 +6,7 @@ This document explains the product and engineering work that remains **after** t
 remediation. [`task.md`](task.md) is the countable active implementation backlog; the completed
 remediation record is preserved separately in
 [`task-remediation-2026-07.md`](task-remediation-2026-07.md) at **220/223 (98.7%)**, with only three
-real-environment validation records left. The new feature backlog starts at **0/35 (0%)**. Neither
+real-environment validation records left. The feature backlog is now **1/35 (2.9%)** complete. Neither
 percentage estimates equal engineering effort, and the historical percentage is not a claim that
 Tributary has implemented every requested product feature.
 
@@ -31,6 +31,9 @@ starts. Historical holistic-review documents are point-in-time findings, not act
   direct input modes.
 - Mounted removable filesystems can be browsed and played. Copy/sync, MTP-only devices, automount,
   eject, and pathless removable tag mutation are not implemented.
+- Shuffled playback retains the current queue occurrence plus ten real predecessors. Previous and
+  subsequent forward navigation follow that fixed history, Repeat All uses complete bounded
+  occurrence cycles, and the header and OS media controls share one exact restart threshold.
 
 ## Proposed implementation order
 
@@ -39,12 +42,11 @@ before starting large protocol or transfer subsystems.
 
 ### 1. Correct the playlist and playback-history contracts
 
-1. **Make shuffled navigation follow real history.** `PlaybackSession` already keeps visited queue
-   indices, but the user-facing Previous/Next path needs an end-to-end regression and bounded
-   repeat-all semantics. Previous should walk actual queue occurrences, Next after Previous should
-   walk forward history before drawing another random occurrence, and the fixed history budget
-   should retain the current occurrence plus ten real predecessors without weakening per-cycle
-   no-repeat behavior.
+1. **Completed: make shuffled navigation follow real history.** `PlaybackSession` now retains a
+   bounded occurrence timeline, walks backward and forward through real selections, stops at the
+   retained boundary, and starts complete Repeat All cycles without an immediate repeat. Shuffle
+   toggles, rollback, lifecycle resets, duplicate occurrences, small queues, and the shared
+   header/OS Previous dispatcher are covered by regressions.
 2. **Make remote-to-playlist behavior explicit ([#47]).** The current Add to Playlist action is
    offered for remote selections, but unsupported rows are only counted in a log message. The
    smallest slice is a user-visible refusal. Full support is separate: regular playlist entries

--- a/docs/task.md
+++ b/docs/task.md
@@ -37,7 +37,7 @@ runtime and the now-bounded shuffle navigation semantics.
 ### P1.1 — Harden and document existing shuffled playback history
 
 - [x] Bound, specify, and fully regress the existing occurrence-aware shuffle history
-  (implementation PR; number added immediately after publication).
+  ([#132](https://github.com/jm2/tributary/pull/132)).
 
   Acceptance criteria:
 
@@ -217,4 +217,4 @@ runtime and the now-bounded shuffle navigation semantics.
 | Date | Task | PR | Result |
 |---|---|---|---|
 | 2026-07-18 | Backlog reset | — | Archived the holistic-review tracker and established the audited feature backlog; no implementation record completed. |
-| 2026-07-18 | P1.1 bounded shuffle history | Pending publication | Retained ten real prior occurrences, fixed forward traversal and complete Repeat All cycles, unified Previous dispatch, made toggle/reset semantics explicit, and added lifecycle/rollback regressions. |
+| 2026-07-18 | P1.1 bounded shuffle history | [#132](https://github.com/jm2/tributary/pull/132) | Retained ten real prior occurrences, fixed forward traversal and complete Repeat All cycles, unified Previous dispatch, made toggle/reset semantics explicit, and added lifecycle/rollback regressions. |

--- a/docs/task.md
+++ b/docs/task.md
@@ -21,22 +21,23 @@ state.
 - Do not treat the order below as a release promise. It is a dependency-aware starting order and
   can change as issues receive product decisions and milestones.
 
-Status at reset: **0/35 (0%)** active implementation records complete. This percentage measures
+Current status: **1/35 (2.9%)** active implementation records complete. This percentage measures
 checklist completion, not equal engineering effort: several P3 records are deliberately large
 epics. The archived remediation remains **220/223 (98.7%)** complete; its three open records are
 real-environment validation, not missing implementation.
 
 ## Current focus
 
-Start with P1.1, then the bounded P1.2 interaction fix and the playback-history foundation in
-P1.3. The rest of P1 builds on the source-scoped identity already present in the runtime and the
-history semantics established here.
+P1.1 is complete. Continue with the bounded P1.2 interaction fix, then the playback-history
+foundation in P1.3. The rest of P1 builds on the source-scoped identity already present in the
+runtime and the now-bounded shuffle navigation semantics.
 
 ## P1 — Correctness and shared feature foundations
 
 ### P1.1 — Harden and document existing shuffled playback history
 
-- [ ] Bound, specify, and fully regress the existing occurrence-aware shuffle history.
+- [x] Bound, specify, and fully regress the existing occurrence-aware shuffle history
+  (implementation PR; number added immediately after publication).
 
   Acceptance criteria:
 
@@ -56,11 +57,14 @@ history semantics established here.
   - Tests cover multi-step backward/forward traversal in `PlaybackSession` and pin both the header
     button and operating-system media-control dispatch to that path.
 
-  Current note: `PlaybackSession` already retains visited queue indices; Previous moves departed
-  indices back to the LIFO remaining set, so multiple Next calls after multiple Previous calls
-  replay the actual forward sequence. Both user-facing Previous entry points already use that
-  helper after the intentional three-second restart check. The open work is bounded Repeat All and
-  boundary/toggle semantics plus broader regression coverage—not a second shuffle implementation.
+  Implemented contract: `PlaybackSession` retains a chronological timeline capped at the current
+  queue occurrence plus ten real predecessors, with an explicit cursor separate from the active
+  cycle's randomized bag. Previous never fabricates or wraps at the retained boundary; Next first
+  replays fixed forward history. Repeat All rolls into complete occurrence-permutation cycles
+  without an immediate boundary repeat, while Repeat One remains an end-of-stream policy. Either
+  shuffle-button transition starts a fresh traversal at the unchanged current item. The header
+  button and OS media action now share the exact `> 3000 ms` restart dispatcher, and regressions
+  cover duplicates, one/two-item queues, rollback, resets, and preservation boundaries.
 
 ### P1.2 — Make unsupported remote playlist actions honest
 
@@ -213,3 +217,4 @@ history semantics established here.
 | Date | Task | PR | Result |
 |---|---|---|---|
 | 2026-07-18 | Backlog reset | — | Archived the holistic-review tracker and established the audited feature backlog; no implementation record completed. |
+| 2026-07-18 | P1.1 bounded shuffle history | Pending publication | Retained ten real prior occurrences, fixed forward traversal and complete Repeat All cycles, unified Previous dispatch, made toggle/reset semantics explicit, and added lifecycle/rollback regressions. |

--- a/src/ui/output_switch.rs
+++ b/src/ui/output_switch.rs
@@ -401,6 +401,7 @@ mod tests {
 
     use super::*;
     use crate::audio::PlayerEventGeneration;
+    use crate::ui::header_bar::RepeatMode;
 
     #[derive(Debug, Default)]
     struct FakeOutputState {
@@ -577,14 +578,26 @@ mod tests {
         let (mut active_output, local_state) = FakeOutput::boxed("local", OutputType::Local, 0);
         let mut parked_local = None;
         let mut active_target = OutputTarget::Local;
-        let queue_item = super::super::playback::QueueItem::direct_for_test(
-            "file:///tmp/example.flac".to_string(),
-            "Example".to_string(),
-            "Artist".to_string(),
-            "Album".to_string(),
-        );
+        let queue_item = |name: &str| {
+            super::super::playback::QueueItem::direct_for_test(
+                format!("file:///tmp/{name}.flac"),
+                name.to_string(),
+                "Artist".to_string(),
+                "Album".to_string(),
+            )
+        };
         let mut session = PlaybackSession::default();
-        assert!(session.replace_queue(vec![queue_item], 0));
+        assert!(session.replace_queue(
+            vec![
+                queue_item("first"),
+                queue_item("second"),
+                queue_item("third")
+            ],
+            0,
+        ));
+        assert!(session.advance_for_test(RepeatMode::Off, true).is_some());
+        let prior_shuffle_identity = session.current_identity().cloned();
+        assert!(session.advance_for_test(RepeatMode::Off, true).is_some());
         let local_load = session
             .load_current_direct(active_output.as_ref())
             .expect("local queue item reaches the active output");
@@ -609,6 +622,14 @@ mod tests {
         assert!(session.accepts_event_generation(local_event.generation()));
         assert_eq!(local_state.borrow().stops, 0);
         assert!(parked_local.is_none());
+        assert!(session.previous_for_test(RepeatMode::All, true).is_some());
+        assert_eq!(
+            session.current_identity(),
+            prior_shuffle_identity.as_ref(),
+            "same-output reselection preserves shuffle history"
+        );
+        assert!(session.advance_for_test(RepeatMode::Off, true).is_some());
+        assert_eq!(session.current_identity(), local_identity.as_ref());
 
         let remote_target = OutputTarget::Mpd {
             host: "music.local".to_string(),

--- a/src/ui/playback.rs
+++ b/src/ui/playback.rs
@@ -7,7 +7,7 @@
 //! - [`format_ms`] — format milliseconds as `m:ss` or `h:mm:ss`
 
 use std::cell::{Cell, RefCell};
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::rc::Rc;
 
 use adw::prelude::*;
@@ -28,6 +28,10 @@ pub const LOCAL_SOURCE_KEY: &str = "local";
 /// The source-key prefix of every playlist view. Playlists are projections of
 /// the local library, so their queue items carry library track IDs too.
 pub const PLAYLIST_SOURCE_PREFIX: &str = "playlist:";
+
+/// Previous restarts the current item only after this position. At exactly
+/// three seconds it still walks the queue or retained shuffle history.
+const PREVIOUS_RESTART_THRESHOLD_MS: u64 = 3_000;
 
 /// Whether a queue source is backed by the local library database, and its
 /// track IDs are therefore library track IDs.
@@ -321,12 +325,48 @@ impl QueueItem {
     }
 }
 
-#[derive(Clone, Debug)]
+/// Maximum number of real queue occurrences retained before the current one.
+const SHUFFLE_PRIOR_LIMIT: usize = 10;
+const SHUFFLE_TIMELINE_CAPACITY: usize = SHUFFLE_PRIOR_LIMIT + 1;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 struct ShuffleState {
-    /// Items visited in this shuffle cycle, ending with the current item.
-    history: Vec<usize>,
-    /// Items not yet visited in this cycle.
+    /// Bounded chronological playback timeline. `cursor` identifies the
+    /// current occurrence; entries after it are fixed forward history created
+    /// by Previous and must be replayed before another random draw.
+    history: VecDeque<usize>,
+    cursor: usize,
+    /// Queue occurrences not yet drawn from the active shuffle cycle.
     remaining: Vec<usize>,
+}
+
+impl ShuffleState {
+    fn current(&self) -> Option<usize> {
+        self.history.get(self.cursor).copied()
+    }
+
+    fn step_forward(&mut self) -> Option<usize> {
+        let next = self.cursor.checked_add(1)?;
+        let selected = self.history.get(next).copied()?;
+        self.cursor = next;
+        Some(selected)
+    }
+
+    fn step_back(&mut self) -> Option<usize> {
+        self.cursor = self.cursor.checked_sub(1)?;
+        self.current()
+    }
+
+    fn record_selection(&mut self, selected: usize) {
+        debug_assert_eq!(self.cursor + 1, self.history.len());
+        self.history.push_back(selected);
+        self.cursor += 1;
+        if self.history.len() > SHUFFLE_TIMELINE_CAPACITY {
+            let removed = self.history.pop_front();
+            debug_assert!(removed.is_some());
+            self.cursor -= 1;
+        }
+    }
 }
 
 /// Playback-owned queue and cursor.
@@ -335,9 +375,11 @@ struct ShuffleState {
 /// external file), reaches the unrepeated end, stops playback, or changes the
 /// output target. Sorting, filtering, and sidebar navigation never mutate it.
 /// Sequential Next/Previous follow snapshot order; repeat-all wraps that
-/// snapshot. Shuffle visits every snapshot item once per cycle, Previous walks
-/// shuffle history, and repeat-all starts a new shuffled cycle. Repeat-one is
-/// an EOS policy implemented by [`replay_current`], so manual Next still moves.
+/// snapshot. Shuffle visits every snapshot occurrence once per cycle, retains
+/// the current occurrence plus ten real predecessors, and replays fixed
+/// forward history after Previous before drawing again. Reaching the retained
+/// boundary never invents a predecessor. Repeat-one is an EOS policy
+/// implemented by [`replay_current`], so manual Next still moves.
 #[derive(Clone, Debug, Default)]
 pub struct PlaybackSession {
     queue: Vec<QueueItem>,
@@ -375,6 +417,13 @@ impl PlaybackSession {
         self.event_generation = self.event_generation.next();
         self.pending_resolution = None;
         self.resolution_failed = false;
+    }
+
+    /// Start a fresh shuffle traversal without changing the queue or current
+    /// item. The UI calls this for either direction of a shuffle toggle, so an
+    /// old randomized path cannot unexpectedly reappear after a mode change.
+    pub(crate) fn reset_shuffle_navigation(&mut self) {
+        self.shuffle = None;
     }
 
     /// Clear playback only when the current queue belongs to `source_id`.
@@ -632,9 +681,26 @@ impl PlaybackSession {
             .collect();
         fastrand::shuffle(&mut remaining);
         self.shuffle = Some(ShuffleState {
-            history: vec![current],
+            history: VecDeque::from([current]),
+            cursor: 0,
             remaining,
         });
+    }
+
+    /// Start a complete Repeat All cycle while avoiding an immediate repeat at
+    /// the rollover boundary. Unlike the initial cycle (whose manually chosen
+    /// current item is already counted), every later cycle contains every
+    /// queue occurrence exactly once.
+    fn refill_shuffle_cycle(state: &mut ShuffleState, queue_len: usize, current: usize) {
+        state.remaining = (0..queue_len).collect();
+        fastrand::shuffle(&mut state.remaining);
+        if queue_len > 1 && state.remaining.last() == Some(&current) {
+            // Condition the uniform permutation on a different first draw by
+            // swapping the boundary item with a uniformly selected earlier
+            // slot. Choosing a fixed slot would bias otherwise valid cycles.
+            let replacement = fastrand::usize(0..(queue_len - 1));
+            state.remaining.swap(replacement, queue_len - 1);
+        }
     }
 
     fn advance(&mut self, repeat_mode: RepeatMode, shuffle: bool) -> Option<usize> {
@@ -661,25 +727,31 @@ impl PlaybackSession {
         }
 
         let state = self.shuffle.as_mut()?;
+        if let Some(selected) = state.step_forward() {
+            self.current_index = Some(selected);
+            self.pending_resolution = None;
+            self.resolution_failed = false;
+            return Some(selected);
+        }
+
         if state.remaining.is_empty() {
             if repeat_mode != RepeatMode::All {
                 return None;
             }
-            state.remaining = (0..self.queue.len())
-                .filter(|&index| index != current)
-                .collect();
-            fastrand::shuffle(&mut state.remaining);
 
             // A one-item queue repeats itself under repeat-all.
-            if state.remaining.is_empty() {
+            if self.queue.len() == 1 {
+                state.record_selection(current);
                 self.pending_resolution = None;
                 self.resolution_failed = false;
                 return Some(current);
             }
+
+            Self::refill_shuffle_cycle(state, self.queue.len(), current);
         }
 
         let selected = state.remaining.pop()?;
-        state.history.push(selected);
+        state.record_selection(selected);
         self.current_index = Some(selected);
         self.pending_resolution = None;
         self.resolution_failed = false;
@@ -708,32 +780,29 @@ impl PlaybackSession {
             self.initialize_shuffle();
         }
         let state = self.shuffle.as_mut()?;
-        if state.history.len() > 1 {
-            if let Some(departed) = state.history.pop() {
-                state.remaining.push(departed);
-            }
-            let selected = *state.history.last()?;
-            self.current_index = Some(selected);
-            self.pending_resolution = None;
-            self.resolution_failed = false;
-            return Some(selected);
-        }
-
-        if repeat_mode != RepeatMode::All {
-            return None;
-        }
-
-        let mut candidates: Vec<usize> = (0..self.queue.len())
-            .filter(|&index| index != current)
-            .collect();
-        fastrand::shuffle(&mut candidates);
-        let selected = candidates.pop().unwrap_or(current);
-        state.history = vec![selected];
-        state.remaining = candidates;
+        let selected = state.step_back()?;
         self.current_index = Some(selected);
         self.pending_resolution = None;
         self.resolution_failed = false;
         Some(selected)
+    }
+
+    #[cfg(test)]
+    pub(super) fn advance_for_test(
+        &mut self,
+        repeat_mode: RepeatMode,
+        shuffle: bool,
+    ) -> Option<usize> {
+        self.advance(repeat_mode, shuffle)
+    }
+
+    #[cfg(test)]
+    pub(super) fn previous_for_test(
+        &mut self,
+        repeat_mode: RepeatMode,
+        shuffle: bool,
+    ) -> Option<usize> {
+        self.previous(repeat_mode, shuffle)
     }
 }
 
@@ -1354,21 +1423,11 @@ fn find_queue_item_position(
 /// Returns `true` if a new track was loaded, `false` if we've reached
 /// the end (caller should reset to idle).
 pub fn advance_track(ctx: &PlaybackContext, repeat_mode: RepeatMode, shuffle: bool) -> bool {
-    let previous = ctx.session.borrow().clone();
-    if ctx
-        .session
-        .borrow_mut()
-        .advance(repeat_mode, shuffle)
-        .is_none()
-    {
-        return false;
-    }
-    if play_current(ctx) {
-        true
-    } else {
-        *ctx.session.borrow_mut() = previous;
-        false
-    }
+    navigate_and_play(
+        ctx.session.as_ref(),
+        |session| session.advance(repeat_mode, shuffle),
+        || play_current(ctx),
+    )
 }
 
 /// Explicit Next behavior. Natural EOS uses [`advance_track`] directly so an
@@ -1389,31 +1448,78 @@ pub fn advance_track_from_user(
 /// heuristic belongs to the UI/key callers, which know what threshold
 /// they want to use. Returns `true` if a new track was loaded.
 pub fn previous_track(ctx: &PlaybackContext, repeat_mode: RepeatMode, shuffle: bool) -> bool {
-    let previous = ctx.session.borrow().clone();
-    if ctx
-        .session
-        .borrow_mut()
-        .previous(repeat_mode, shuffle)
-        .is_none()
-    {
+    navigate_and_play(
+        ctx.session.as_ref(),
+        |session| session.previous(repeat_mode, shuffle),
+        || play_current(ctx),
+    )
+}
+
+fn navigate_and_play(
+    session: &RefCell<PlaybackSession>,
+    navigate: impl FnOnce(&mut PlaybackSession) -> Option<usize>,
+    play: impl FnOnce() -> bool,
+) -> bool {
+    let previous = session.borrow().clone();
+    let selected = {
+        let mut session = session.borrow_mut();
+        navigate(&mut session)
+    };
+    if selected.is_none() {
         return false;
     }
-    if play_current(ctx) {
+    if play() {
         true
     } else {
-        *ctx.session.borrow_mut() = previous;
+        *session.borrow_mut() = previous;
         false
     }
 }
 
-/// Explicit Previous behavior, which supersedes an older OS-open delivery.
-pub fn previous_track_from_user(
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PreviousDispatch {
+    Stepped,
+    Restarted,
+}
+
+fn dispatch_previous(
+    position_ms: u64,
+    step: impl FnOnce() -> bool,
+    restart: impl FnOnce(),
+) -> PreviousDispatch {
+    if position_ms > PREVIOUS_RESTART_THRESHOLD_MS {
+        restart();
+        return PreviousDispatch::Restarted;
+    }
+
+    if step() {
+        PreviousDispatch::Stepped
+    } else {
+        restart();
+        PreviousDispatch::Restarted
+    }
+}
+
+/// Shared header-button and OS-media-control Previous behavior.
+///
+/// The output position borrow is deliberately released before navigation can
+/// load another item. This keeps both entry points on one exact threshold and
+/// avoids carrying a `RefCell` borrow into output callbacks.
+pub fn previous_or_restart_from_user(
     ctx: &PlaybackContext,
     repeat_mode: RepeatMode,
     shuffle: bool,
-) -> bool {
+) {
     super::open_files::invalidate_admission();
-    previous_track(ctx, repeat_mode, shuffle)
+    let position_ms = {
+        let output = ctx.active_output.borrow();
+        output.position_ms().unwrap_or(0)
+    };
+    let _ = dispatch_previous(
+        position_ms,
+        || previous_track(ctx, repeat_mode, shuffle),
+        || ctx.active_output.borrow().seek_to(0),
+    );
 }
 
 /// Replay the current queue item without consulting the mutable view.
@@ -2070,12 +2176,189 @@ mod tests {
         assert_eq!(visited, HashSet::from(["a".into(), "b".into(), "c".into()]));
         assert_eq!(session.advance(RepeatMode::Off, true), None);
 
-        // Repeat-all starts another shuffle cycle instead of ending.
-        assert!(session.advance(RepeatMode::All, true).is_some());
+        // Repeat-all starts a complete new cycle and does not immediately
+        // repeat the item at the rollover boundary.
+        let rollover_from = session.current_index.expect("current index");
+        let first = session
+            .advance(RepeatMode::All, true)
+            .expect("repeat-all begins another cycle");
+        assert_ne!(first, rollover_from);
+        let state = session.shuffle.as_ref().expect("shuffle state");
+        assert_eq!(state.remaining.len(), 2);
+        assert!(state.remaining.contains(&rollover_from));
+
+        let mut second_cycle = HashSet::from([first]);
+        for _ in 0..2 {
+            second_cycle.insert(
+                session
+                    .advance(RepeatMode::All, true)
+                    .expect("the complete repeat cycle remains available"),
+            );
+        }
+        assert_eq!(second_cycle, HashSet::from([0, 1, 2]));
     }
 
     #[test]
-    fn shuffled_previous_follows_play_history() {
+    fn shuffled_previous_and_next_walk_exact_occurrence_history() {
+        let mut session = PlaybackSession::default();
+        assert!(session.replace_queue(
+            vec![
+                item("source", "a"),
+                item("source", "b"),
+                item("source", "c"),
+                item("source", "d"),
+                item("source", "e"),
+                item("source", "f"),
+                item("source", "g"),
+                item("source", "h"),
+            ],
+            0,
+        ));
+
+        let mut actual = vec![0];
+        for _ in 0..4 {
+            actual.push(
+                session
+                    .advance(RepeatMode::Off, true)
+                    .expect("unvisited shuffle occurrence"),
+            );
+        }
+
+        for expected in actual[1..4].iter().rev() {
+            assert_eq!(session.previous(RepeatMode::All, true), Some(*expected));
+        }
+        for expected in &actual[2..=4] {
+            assert_eq!(
+                session.advance(RepeatMode::Off, true),
+                Some(*expected),
+                "fixed forward history precedes another random draw"
+            );
+        }
+
+        let drawn = session
+            .advance(RepeatMode::Off, true)
+            .expect("an unvisited random occurrence follows forward history");
+        assert!(!actual.contains(&drawn));
+    }
+
+    #[test]
+    fn shuffle_history_is_bounded_and_never_fabricates_a_predecessor() {
+        let mut session = PlaybackSession::default();
+        assert!(session.replace_queue(
+            vec![
+                item("source", "a"),
+                item("source", "b"),
+                item("source", "c"),
+                item("source", "d"),
+            ],
+            0,
+        ));
+
+        let mut actual = vec![0];
+        for _ in 0..40 {
+            actual.push(
+                session
+                    .advance(RepeatMode::All, true)
+                    .expect("repeat-all keeps selecting occurrences"),
+            );
+            let state = session.shuffle.as_ref().expect("shuffle state");
+            assert!(state.history.len() <= SHUFFLE_TIMELINE_CAPACITY);
+            assert!(state.cursor < state.history.len());
+        }
+
+        let retained = actual[actual.len() - SHUFFLE_TIMELINE_CAPACITY..].to_vec();
+        assert_eq!(
+            session
+                .shuffle
+                .as_ref()
+                .expect("shuffle state")
+                .history
+                .iter()
+                .copied()
+                .collect::<Vec<_>>(),
+            retained
+        );
+
+        for expected in retained[..SHUFFLE_PRIOR_LIMIT].iter().rev() {
+            assert_eq!(session.previous(RepeatMode::All, true), Some(*expected));
+        }
+        let boundary = session.shuffle.clone();
+        assert_eq!(session.previous(RepeatMode::All, true), None);
+        assert_eq!(
+            session.shuffle, boundary,
+            "the retained boundary is a no-op"
+        );
+
+        for expected in &retained[1..] {
+            assert_eq!(session.advance(RepeatMode::Off, true), Some(*expected));
+        }
+    }
+
+    #[test]
+    fn duplicate_tracks_remain_distinct_shuffle_occurrences() {
+        let mut first = item("source", "duplicate");
+        first.occurrence = 0;
+        let other = item("source", "other");
+        let mut duplicate = item("source", "duplicate");
+        duplicate.occurrence = 1;
+
+        let mut session = PlaybackSession::default();
+        assert!(session.replace_queue(vec![first, other, duplicate], 0));
+        let mut visited = vec![(0, 0)];
+        for _ in 0..2 {
+            let index = session
+                .advance(RepeatMode::Off, true)
+                .expect("distinct queue occurrence");
+            visited.push((index, session.current().expect("current").occurrence));
+        }
+        assert_eq!(
+            visited
+                .iter()
+                .map(|(index, _)| *index)
+                .collect::<HashSet<_>>(),
+            HashSet::from([0, 1, 2])
+        );
+        assert!(visited.contains(&(0, 0)));
+        assert!(visited.contains(&(2, 1)));
+
+        let previous = visited[1];
+        assert_eq!(session.previous(RepeatMode::Off, true), Some(previous.0));
+        assert_eq!(session.current().expect("current").occurrence, previous.1);
+        assert_eq!(session.advance(RepeatMode::Off, true), Some(visited[2].0));
+        assert_eq!(session.current().expect("current").occurrence, visited[2].1);
+    }
+
+    #[test]
+    fn one_and_two_item_shuffle_repeat_semantics_are_explicit() {
+        let mut one = PlaybackSession::default();
+        assert!(one.replace_queue(vec![item("source", "only")], 0));
+        assert_eq!(one.advance(RepeatMode::Off, true), None);
+        assert_eq!(one.advance(RepeatMode::One, true), None);
+        for _ in 0..20 {
+            assert_eq!(one.advance(RepeatMode::All, true), Some(0));
+        }
+        assert_eq!(
+            one.shuffle.as_ref().expect("shuffle state").history.len(),
+            SHUFFLE_TIMELINE_CAPACITY
+        );
+        for _ in 0..SHUFFLE_PRIOR_LIMIT {
+            assert_eq!(one.previous(RepeatMode::All, true), Some(0));
+        }
+        assert_eq!(one.previous(RepeatMode::All, true), None);
+
+        let mut two = PlaybackSession::default();
+        assert!(two.replace_queue(vec![item("source", "left"), item("source", "right")], 0,));
+        assert_eq!(two.advance(RepeatMode::Off, true), Some(1));
+        assert_eq!(two.advance(RepeatMode::One, true), None);
+        assert_eq!(two.previous(RepeatMode::All, true), Some(0));
+        assert_eq!(two.advance(RepeatMode::Off, true), Some(1));
+        for expected in [0, 1, 0, 1, 0, 1] {
+            assert_eq!(two.advance(RepeatMode::All, true), Some(expected));
+        }
+    }
+
+    #[test]
+    fn shuffle_toggle_resets_navigation_but_preserves_the_current_item() {
         let mut session = PlaybackSession::default();
         assert!(session.replace_queue(
             vec![
@@ -2086,10 +2369,197 @@ mod tests {
             0,
         ));
         assert!(session.advance(RepeatMode::Off, true).is_some());
-        let previous_id = current_id(&session).to_string();
+        let current = session.current_index;
+        assert!(session.shuffle.is_some());
+
+        // Either button transition deliberately starts a fresh traversal.
+        session.reset_shuffle_navigation();
+        assert_eq!(session.current_index, current);
+        assert!(session.shuffle.is_none());
+        assert_eq!(session.previous(RepeatMode::All, true), None);
+        assert_eq!(session.current_index, current);
+
+        session.reset_shuffle_navigation();
+        let current = session.current_index.expect("current");
+        let expected = if current + 1 < session.queue.len() {
+            current + 1
+        } else {
+            0
+        };
+        assert_eq!(session.advance(RepeatMode::All, false), Some(expected));
+        assert!(session.shuffle.is_none());
+    }
+
+    #[test]
+    fn rejected_navigation_before_output_handoff_restores_all_shuffle_state() {
+        let mut original = PlaybackSession::default();
+        assert!(original.replace_queue(
+            vec![
+                item("source", "a"),
+                item("source", "b"),
+                item("source", "c"),
+                item("source", "d"),
+            ],
+            0,
+        ));
+        assert!(original.advance(RepeatMode::Off, true).is_some());
+        assert!(original.advance(RepeatMode::Off, true).is_some());
+        let expected_index = original.current_index;
+        let expected_shuffle = original.shuffle.clone();
+        let session = RefCell::new(original);
+
+        assert!(!navigate_and_play(
+            &session,
+            |session| session.advance(RepeatMode::Off, true),
+            || false,
+        ));
+        assert_eq!(session.borrow().current_index, expected_index);
+        assert_eq!(session.borrow().shuffle, expected_shuffle);
+
+        assert!(!navigate_and_play(
+            &session,
+            |session| session.previous(RepeatMode::All, true),
+            || false,
+        ));
+        assert_eq!(session.borrow().current_index, expected_index);
+        assert_eq!(session.borrow().shuffle, expected_shuffle);
+
+        // Once an output handoff is initiated, the selected occurrence is a
+        // committed retry target; synchronous output rejection is handled by
+        // the existing retry state rather than rolling navigation back.
+        assert!(navigate_and_play(
+            &session,
+            |session| session.advance(RepeatMode::Off, true),
+            || true,
+        ));
+        assert_ne!(session.borrow().current_index, expected_index);
+    }
+
+    #[test]
+    fn queue_lifecycle_resets_and_non_navigation_updates_preserve_shuffle_history() {
+        let mut session = PlaybackSession::default();
+        assert!(session.replace_queue(
+            vec![item("local", "a"), item("local", "b"), item("local", "c")],
+            0,
+        ));
         assert!(session.advance(RepeatMode::Off, true).is_some());
-        assert!(session.previous(RepeatMode::Off, true).is_some());
-        assert_eq!(current_id(&session), previous_id);
+        let history = session.shuffle.clone();
+
+        assert_eq!(refresh(&mut session, "a", refreshed_metadata()), 1);
+        assert_eq!(session.shuffle, history);
+        let pending = session.begin_pending_resolution();
+        assert!(session.accepts_event_generation(pending));
+        assert!(session.cancel_pending_resolution_for_retry());
+        assert_eq!(
+            session.shuffle, history,
+            "pending-resolution Pause preserves navigation"
+        );
+        assert!(!session.clear_if_source("another-source"));
+        assert_eq!(session.shuffle, history);
+
+        assert!(session.replace_queue(vec![item("source", "replacement")], 0));
+        assert!(session.shuffle.is_none(), "a new queue resets history");
+
+        assert!(session.replace_queue(vec![item("source", "a"), item("source", "b")], 0,));
+        assert!(session.advance(RepeatMode::Off, true).is_some());
+        assert!(session.clear_if_source("source"));
+        assert!(
+            session.shuffle.is_none(),
+            "source retirement resets history"
+        );
+
+        assert!(session.replace_queue(vec![item("source", "a"), item("source", "b")], 0,));
+        assert!(session.advance(RepeatMode::Off, true).is_some());
+        let (output, output_state) = RecordingOutput::new(0);
+        stop_owned_playback(&mut session, &output);
+        assert!(session.shuffle.is_none(), "Stop resets history");
+        assert_eq!(output_state.borrow().stops, 1);
+    }
+
+    #[test]
+    fn shared_previous_dispatch_pins_threshold_step_and_boundary_restart() {
+        let steps = Cell::new(0);
+        let restarts = Cell::new(0);
+        assert_eq!(
+            dispatch_previous(
+                PREVIOUS_RESTART_THRESHOLD_MS + 1,
+                || {
+                    steps.set(steps.get() + 1);
+                    true
+                },
+                || restarts.set(restarts.get() + 1),
+            ),
+            PreviousDispatch::Restarted
+        );
+        assert_eq!(steps.get(), 0);
+        assert_eq!(restarts.get(), 1);
+
+        assert_eq!(
+            dispatch_previous(
+                PREVIOUS_RESTART_THRESHOLD_MS,
+                || {
+                    steps.set(steps.get() + 1);
+                    true
+                },
+                || restarts.set(restarts.get() + 1),
+            ),
+            PreviousDispatch::Stepped
+        );
+        assert_eq!(steps.get(), 1);
+        assert_eq!(restarts.get(), 1);
+
+        assert_eq!(
+            dispatch_previous(
+                0,
+                || {
+                    steps.set(steps.get() + 1);
+                    false
+                },
+                || restarts.set(restarts.get() + 1),
+            ),
+            PreviousDispatch::Restarted
+        );
+        assert_eq!(steps.get(), 2);
+        assert_eq!(restarts.get(), 2);
+    }
+
+    #[test]
+    fn a_restart_then_early_previous_walks_the_real_shuffle_timeline() {
+        let mut session = PlaybackSession::default();
+        assert!(session.replace_queue(
+            vec![
+                item("source", "a"),
+                item("source", "b"),
+                item("source", "c")
+            ],
+            0,
+        ));
+        assert!(session.advance(RepeatMode::Off, true).is_some());
+        let state = session.shuffle.as_ref().expect("shuffle state");
+        let expected_previous = state.history[state.cursor - 1];
+        let current = session.current_index;
+        let restarts = Cell::new(0);
+
+        assert_eq!(
+            dispatch_previous(
+                PREVIOUS_RESTART_THRESHOLD_MS + 1,
+                || session.previous(RepeatMode::All, true).is_some(),
+                || restarts.set(restarts.get() + 1),
+            ),
+            PreviousDispatch::Restarted
+        );
+        assert_eq!(session.current_index, current);
+
+        assert_eq!(
+            dispatch_previous(
+                0,
+                || session.previous(RepeatMode::All, true).is_some(),
+                || restarts.set(restarts.get() + 1),
+            ),
+            PreviousDispatch::Stepped
+        );
+        assert_eq!(session.current_index, Some(expected_previous));
+        assert_eq!(restarts.get(), 1);
     }
 
     #[test]

--- a/src/ui/playback.rs
+++ b/src/ui/playback.rs
@@ -358,14 +358,16 @@ impl ShuffleState {
     }
 
     fn record_selection(&mut self, selected: usize) {
-        debug_assert_eq!(self.cursor + 1, self.history.len());
+        debug_assert_eq!(self.cursor.checked_add(1), Some(self.history.len()));
         self.history.push_back(selected);
-        self.cursor += 1;
         if self.history.len() > SHUFFLE_TIMELINE_CAPACITY {
             let removed = self.history.pop_front();
             debug_assert!(removed.is_some());
-            self.cursor -= 1;
         }
+        // A recorded selection is always the timeline frontier. Deriving the
+        // cursor from the retained deque avoids arithmetic underflow while
+        // restoring that invariant even if a caller arrived with stale state.
+        self.cursor = self.history.len() - 1;
     }
 }
 

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -30,7 +30,7 @@ use super::persistence::{
 };
 use super::playback::{
     advance_track, advance_track_from_user, format_ms, play_or_start, play_track_at,
-    previous_track_from_user, refresh_projected_library_uris, replay_current, stop_playback,
+    previous_or_restart_from_user, refresh_projected_library_uris, replay_current, stop_playback,
     toggle_or_start, BufferingTracker, PlaybackContext, PlaybackSession, QueueTrackRefresh,
     PLAYLIST_SOURCE_PREFIX,
 };
@@ -53,10 +53,6 @@ const SIDEBAR_POS: i32 = 200;
 
 /// Browser paned default position (px from top of right content area).
 const BROWSER_POS: i32 = 220;
-
-/// If the user presses Previous when more than this many ms into a track,
-/// restart the current track instead of going back.
-const PREV_RESTART_THRESHOLD_MS: u64 = 3000;
 
 /// User trust decisions are serialized by the engine; this bounded queue
 /// prevents a stalled engine from accumulating unbounded confirmations.
@@ -2060,22 +2056,11 @@ pub fn build_window(
                             advance_track_from_user(&ctx, repeat_mode.get(), shuffle.is_active());
                         }
                         MediaAction::Previous => {
-                            super::open_files::invalidate_admission();
-                            // Mirror the header-bar heuristic: if we're past
-                            // the restart threshold, restart the current track.
-                            let position_ms = active_output.borrow().position_ms().unwrap_or(0);
-                            if position_ms > PREV_RESTART_THRESHOLD_MS {
-                                active_output.borrow().seek_to(0);
-                            } else {
-                                let stepped = previous_track_from_user(
-                                    &ctx,
-                                    repeat_mode.get(),
-                                    shuffle.is_active(),
-                                );
-                                if !stepped {
-                                    active_output.borrow().seek_to(0);
-                                }
-                            }
+                            previous_or_restart_from_user(
+                                &ctx,
+                                repeat_mode.get(),
+                                shuffle.is_active(),
+                            );
                         }
                     }
                 }
@@ -2131,9 +2116,13 @@ pub fn build_window(
             save_repeat_mode(mode.get());
         });
     }
-    hb.shuffle_button.connect_toggled(move |btn| {
-        save_shuffle(btn.is_active());
-    });
+    {
+        let playback_session = playback_session.clone();
+        hb.shuffle_button.connect_toggled(move |btn| {
+            playback_session.borrow_mut().reset_shuffle_navigation();
+            save_shuffle(btn.is_active());
+        });
+    }
 
     // ── Wire output selector row-click handler ──────────────────────
     {
@@ -2348,15 +2337,7 @@ pub fn build_window(
         let playback_source_registry = source_registry.clone();
 
         hb.prev_button.connect_clicked(move |_| {
-            super::open_files::invalidate_admission();
-            // If more than 3 s into the track, restart it.
-            let position_ms = active_output.borrow().position_ms().unwrap_or(0);
-            if position_ms > PREV_RESTART_THRESHOLD_MS {
-                active_output.borrow().seek_to(0);
-                return;
-            }
-
-            let stepped = previous_track_from_user(
+            previous_or_restart_from_user(
                 &PlaybackContext {
                     model: sm.clone(),
                     active_source_key: active_source_key.clone(),
@@ -2374,12 +2355,6 @@ pub fn build_window(
                 repeat_mode.get(),
                 shuffle.is_active(),
             );
-
-            // If we couldn't step back (track 0 with repeat off, or no
-            // current track), restart whatever is playing instead.
-            if !stepped {
-                active_output.borrow().seek_to(0);
-            }
         });
     }
 


### PR DESCRIPTION
## What changed

- bound shuffled playback navigation to the current queue occurrence plus ten real predecessors
- keep backward and forward history separate from each complete randomized Repeat All cycle
- stop Previous at the retained boundary instead of fabricating a random predecessor
- make one-item replays, duplicate occurrences, shuffle toggles, rollback, and lifecycle resets explicit
- route both the header button and operating-system Previous action through one borrow-safe three-second dispatcher
- update the active tracker, roadmap, README, and changelog to the implemented contract

## Why

The existing shuffle state remembered visited indices, but its history grew without a bound under Repeat All, its oldest-boundary Previous selected a new random track, and rollover bags omitted one occurrence from later cycles. The two user-facing Previous handlers also duplicated the restart heuristic.

This makes shuffled navigation follow the user's actual playback timeline with a fixed memory budget and one consistent UI/media-control path.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --release --all-targets -- -D warnings`
- `cargo test -- --test-threads=4` — 20 library + 934 application + 10 packaging tests passed
- `cargo test --release -- --test-threads=4` — 20 library + 934 application + 10 packaging tests passed
- three independent static reviews; all actionable findings resolved
