### PR TITLE
Explain unsupported playlist additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Unsupported playlist additions now fail visibly and atomically** — Choosing Add to Playlist
+  from an authenticated remote, internet-radio, removable-media, or unknown/pathless source now
+  shows a localized explanation before any runtime task, database connection, or playlist write.
+  Tributary therefore adds nothing instead of silently skipping unsupported rows or modifying only
+  an unexpected subset. The existing Add to Playlist, Remove from Playlist, and Properties context
+  labels now use their shipped translations as well, and the refusal copy is covered across all 13
+  locale catalogs. Local-library playlist behavior is unchanged; durable source-scoped remote
+  playlist entries remain planned separately.
 - **Shuffled Previous and Next now follow a bounded real playback timeline** — Tributary retains
   the current queue occurrence plus ten actual predecessors, walks backward without fabricating a
   random track at the oldest boundary, and replays fixed forward history before drawing again.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Tributary provides a unified interface for managing and streaming music from mul
 | Internet Radio (Top Clicked, Top Voted, Stations Near Me) | ✅ |
 | Tiered geo-location (geo-distance → state → country) | ✅ |
 | Column drag-and-drop reordering with persistence | ✅ |
-| Regular & smart playlists (iTunes-style rules engine) | ✅ Local-library playlists; remote persistence is planned ([#47](https://github.com/jm2/tributary/issues/47)) |
+| Regular & smart playlists (iTunes-style rules engine) | ✅ Local-library playlists; unsupported source additions are explicitly refused, and remote persistence is planned ([#47](https://github.com/jm2/tributary/issues/47)) |
 | Realtime text search filter (title, artist, album, genre) | ✅ |
 | Song metadata editing (Properties dialog with Save/Cancel) | ✅ |
 | Batch metadata editing (multi-select) | ✅ |
@@ -653,6 +653,12 @@ Tributary supports regular and smart playlists for the local library:
 
 - **Regular playlists** — Right-click the Playlists header in the sidebar to create a new playlist. Right-click tracks in the tracklist to add them. Playlists survive library folder changes via fingerprint-based track matching.
 - **Smart playlists** — iTunes-style rules engine with filterable metadata fields, text/numeric/date operators, sorting, and result limiting. Smart playlists are evaluated against the current local library whenever they are opened or exported; they are not stored snapshots. Create them via the sidebar context menu.
+
+**Add to Playlist** currently accepts tracks only from the built-in local library. Invoking it from
+an authenticated remote, internet-radio, removable-media, or other unsupported source shows a
+localized explanation and adds nothing; it never silently writes only a subset. Persisting
+source-scoped remote tracks and importing or synchronizing server-native playlists remain planned
+under [P1.5](docs/task.md#p15--persist-source-scoped-playlists).
 
 #### Importing and exporting playlists
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,7 +6,7 @@ This document explains the product and engineering work that remains **after** t
 remediation. [`task.md`](task.md) is the countable active implementation backlog; the completed
 remediation record is preserved separately in
 [`task-remediation-2026-07.md`](task-remediation-2026-07.md) at **220/223 (98.7%)**, with only three
-real-environment validation records left. The feature backlog is now **1/35 (2.9%)** complete. Neither
+real-environment validation records left. The feature backlog is now **2/35 (5.7%)** complete. Neither
 percentage estimates equal engineering effort, and the historical percentage is not a claim that
 Tributary has implemented every requested product feature.
 
@@ -25,7 +25,9 @@ starts. Historical holistic-review documents are point-in-time findings, not act
   files use the common `SourceRegistry` lifecycle and playback-time authority model.
 - AirPlay 1/RAOP, Chromecast, MPD, and local playback are implemented. AirPlay 2/HomeKit is not.
 - Regular playlists are local-library projections. Remote tracks cannot currently be persisted in
-  them, and Subsonic server-side playlists are not imported.
+  them, and Subsonic server-side playlists are not imported. An Add to Playlist attempt from any
+  unsupported source now explains that boundary in the user's language and performs no database
+  work instead of silently skipping rows.
 - XSPF v1 import/export is implemented with exact path and deterministic normalized-metadata
   matching. Apple/iTunes XML, Google Takeout CSV, M3U, service URLs, and fuzzy matching are not
   direct input modes.
@@ -47,11 +49,11 @@ before starting large protocol or transfer subsystems.
    retained boundary, and starts complete Repeat All cycles without an immediate repeat. Shuffle
    toggles, rollback, lifecycle resets, duplicate occurrences, small queues, and the shared
    header/OS Previous dispatcher are covered by regressions.
-2. **Make remote-to-playlist behavior explicit ([#47]).** The current Add to Playlist action is
-   offered for remote selections, but unsupported rows are only counted in a log message. The
-   smallest slice is a user-visible refusal. Full support is separate: regular playlist entries
-   need persistent source-scoped `(SourceId, TrackId)` identity, disconnected-source semantics,
-   and playback-time resolution; Subsonic server-native playlist import/sync is another slice.
+2. **Completed: make remote-to-playlist behavior explicit ([#47]).** Add to Playlist now snapshots
+   the active source and refuses every non-local selection with a localized, all-or-none dialog
+   before database work. Full support remains separate: regular playlist entries need persistent
+   source-scoped `(SourceId, TrackId)` identity, disconnected-source semantics, and playback-time
+   resolution; Subsonic server-native playlist import/sync is another slice.
 3. **Implement trustworthy local playback history.** The database and UI expose `play_count`, but
    production playback does not increment it and there is no `last_played` field. Consequently the
    seeded Recently Played and Top 25 playlists are present but ordinarily empty for local music.

--- a/docs/task.md
+++ b/docs/task.md
@@ -69,7 +69,8 @@ now-bounded shuffle navigation semantics, and an honest local-only playlist inte
 ### P1.2 — Make unsupported remote playlist actions honest
 
 - [x] When Add to Playlist cannot accept a remote row, show a localized, user-visible result
-  instead of only logging that the row was skipped ([#47](https://github.com/jm2/tributary/issues/47)).
+  instead of only logging that the row was skipped ([#47](https://github.com/jm2/tributary/issues/47);
+  [#133](https://github.com/jm2/tributary/pull/133)).
 
   Keep this slice migration-free. It closes the misleading current interaction while P1.5 designs
   full remote playlist persistence.
@@ -227,4 +228,4 @@ now-bounded shuffle navigation semantics, and an honest local-only playlist inte
 |---|---|---|---|
 | 2026-07-18 | Backlog reset | — | Archived the holistic-review tracker and established the audited feature backlog; no implementation record completed. |
 | 2026-07-18 | P1.1 bounded shuffle history | [#132](https://github.com/jm2/tributary/pull/132) | Retained ten real prior occurrences, fixed forward traversal and complete Repeat All cycles, unified Previous dispatch, made toggle/reset semantics explicit, and added lifecycle/rollback regressions. |
-| 2026-07-18 | P1.2 honest unsupported playlist actions | PR pending | Refused non-local Add to Playlist actions with an all-or-none localized dialog before database work, localized the existing context-menu labels, and regressed the fail-closed source policy plus every shipped catalog. |
+| 2026-07-18 | P1.2 honest unsupported playlist actions | [#133](https://github.com/jm2/tributary/pull/133) | Refused non-local Add to Playlist actions with an all-or-none localized dialog before database work, localized the existing context-menu labels, and regressed the fail-closed source policy plus every shipped catalog. |

--- a/docs/task.md
+++ b/docs/task.md
@@ -21,16 +21,16 @@ state.
 - Do not treat the order below as a release promise. It is a dependency-aware starting order and
   can change as issues receive product decisions and milestones.
 
-Current status: **1/35 (2.9%)** active implementation records complete. This percentage measures
+Current status: **2/35 (5.7%)** active implementation records complete. This percentage measures
 checklist completion, not equal engineering effort: several P3 records are deliberately large
 epics. The archived remediation remains **220/223 (98.7%)** complete; its three open records are
 real-environment validation, not missing implementation.
 
 ## Current focus
 
-P1.1 is complete. Continue with the bounded P1.2 interaction fix, then the playback-history
-foundation in P1.3. The rest of P1 builds on the source-scoped identity already present in the
-runtime and the now-bounded shuffle navigation semantics.
+P1.1 and P1.2 are complete. Continue with the playback-history contract and migration foundation
+in P1.3. The rest of P1 builds on the source-scoped identity already present in the runtime, the
+now-bounded shuffle navigation semantics, and an honest local-only playlist interaction boundary.
 
 ## P1 — Correctness and shared feature foundations
 
@@ -68,11 +68,20 @@ runtime and the now-bounded shuffle navigation semantics.
 
 ### P1.2 — Make unsupported remote playlist actions honest
 
-- [ ] When Add to Playlist cannot accept a remote row, show a localized, user-visible result
+- [x] When Add to Playlist cannot accept a remote row, show a localized, user-visible result
   instead of only logging that the row was skipped ([#47](https://github.com/jm2/tributary/issues/47)).
 
   Keep this slice migration-free. It closes the misleading current interaction while P1.5 designs
   full remote playlist persistence.
+
+  Implemented contract: the context menu snapshots the active source together with its selection.
+  Only the exact built-in `local` view may enter the local-playlist database path. Choosing a
+  destination playlist from an authenticated remote, Radio-Browser, removable source, or any
+  unknown/pathless view now presents a localized all-or-none explanation before a runtime task or
+  database connection is created, so no unsupported selection can be partially written. Existing
+  Add/Remove/Properties menu labels now use their shipped translations as well. Policy regressions
+  fail closed across exact remote/radio/removable identities and malformed keys, and all 13 locale
+  catalogs carry non-fallback result copy. Persistent remote playlist entries remain P1.5.
 
 ### P1.3 — Record trustworthy local playback history
 
@@ -218,3 +227,4 @@ runtime and the now-bounded shuffle navigation semantics.
 |---|---|---|---|
 | 2026-07-18 | Backlog reset | — | Archived the holistic-review tracker and established the audited feature backlog; no implementation record completed. |
 | 2026-07-18 | P1.1 bounded shuffle history | [#132](https://github.com/jm2/tributary/pull/132) | Retained ten real prior occurrences, fixed forward traversal and complete Repeat All cycles, unified Previous dispatch, made toggle/reset semantics explicit, and added lifecycle/rollback regressions. |
+| 2026-07-18 | P1.2 honest unsupported playlist actions | PR pending | Refused non-local Add to Playlist actions with an all-or-none localized dialog before database work, localized the existing context-menu labels, and regressed the fail-closed source policy plus every shipped catalog. |

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -172,6 +172,8 @@ context:
   properties: "Eigenschaften…"
   add_to_playlist: "Zur Wiedergabeliste hinzufügen"
   remove_from_playlist: "Aus Wiedergabeliste entfernen"
+  playlist_add_unsupported_heading: "Titel wurden nicht hinzugefügt"
+  playlist_add_unsupported_body: "Derzeit können nur Titel aus der lokalen Bibliothek von Tributary zu Wiedergabelisten hinzugefügt werden. Aus dieser Quelle wurde nichts hinzugefügt."
 
 # ── Properties dialog ──────────────────────────────────────────────
 properties:

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -205,6 +205,8 @@ context:
   properties: "Properties…"
   add_to_playlist: "Add to Playlist"
   remove_from_playlist: "Remove from Playlist"
+  playlist_add_unsupported_heading: "Tracks Weren’t Added"
+  playlist_add_unsupported_body: "Only tracks in Tributary’s local library can be added to playlists right now. Nothing from this source was added."
 
 # ── Properties dialog ──────────────────────────────────────────────
 properties:

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -172,6 +172,8 @@ context:
   properties: "Propiedades…"
   add_to_playlist: "Añadir a lista de reproducción"
   remove_from_playlist: "Quitar de lista de reproducción"
+  playlist_add_unsupported_heading: "No se añadieron pistas"
+  playlist_add_unsupported_body: "Por ahora, solo se pueden añadir a las listas de reproducción pistas de la biblioteca local de Tributary. No se añadió nada de esta fuente."
 
 # ── Properties dialog ──────────────────────────────────────────────
 properties:

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -172,6 +172,8 @@ context:
   properties: "Propriétés…"
   add_to_playlist: "Ajouter à la liste de lecture"
   remove_from_playlist: "Retirer de la liste de lecture"
+  playlist_add_unsupported_heading: "Les pistes n’ont pas été ajoutées"
+  playlist_add_unsupported_body: "Pour le moment, seules les pistes de la bibliothèque locale de Tributary peuvent être ajoutées aux listes de lecture. Aucune piste provenant de cette source n’a été ajoutée."
 
 # ── Properties dialog ──────────────────────────────────────────────
 properties:

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -172,6 +172,8 @@ context:
   properties: "Proprietà…"
   add_to_playlist: "Aggiungi alla playlist"
   remove_from_playlist: "Rimuovi dalla playlist"
+  playlist_add_unsupported_heading: "I brani non sono stati aggiunti"
+  playlist_add_unsupported_body: "Al momento, è possibile aggiungere alle playlist solo i brani della libreria locale di Tributary. Non è stato aggiunto nulla da questa sorgente."
 
 # ── Properties dialog ──────────────────────────────────────────────
 properties:

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -172,6 +172,8 @@ context:
   properties: "プロパティ…"
   add_to_playlist: "プレイリストに追加"
   remove_from_playlist: "プレイリストから削除"
+  playlist_add_unsupported_heading: "曲は追加されませんでした"
+  playlist_add_unsupported_body: "現在プレイリストに追加できるのは、Tributary のローカルライブラリにある曲だけです。このソースからは何も追加されませんでした。"
 
 # ── Properties dialog ──────────────────────────────────────────────
 properties:

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -172,6 +172,8 @@ context:
   properties: "속성…"
   add_to_playlist: "재생목록에 추가"
   remove_from_playlist: "재생목록에서 제거"
+  playlist_add_unsupported_heading: "트랙이 추가되지 않았습니다"
+  playlist_add_unsupported_body: "현재는 Tributary의 로컬 라이브러리에 있는 트랙만 재생목록에 추가할 수 있습니다. 이 소스에서는 아무것도 추가되지 않았습니다."
 
 # ── Properties dialog ──────────────────────────────────────────────
 properties:

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -172,6 +172,8 @@ context:
   properties: "Eigenschappen…"
   add_to_playlist: "Toevoegen aan afspeellijst"
   remove_from_playlist: "Verwijderen uit afspeellijst"
+  playlist_add_unsupported_heading: "Nummers zijn niet toegevoegd"
+  playlist_add_unsupported_body: "Op dit moment kunnen alleen nummers uit de lokale bibliotheek van Tributary aan afspeellijsten worden toegevoegd. Er is niets uit deze bron toegevoegd."
 
 # ── Properties dialog ──────────────────────────────────────────────
 properties:

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -172,6 +172,8 @@ context:
   properties: "Właściwości…"
   add_to_playlist: "Dodaj do listy odtwarzania"
   remove_from_playlist: "Usuń z listy odtwarzania"
+  playlist_add_unsupported_heading: "Utwory nie zostały dodane"
+  playlist_add_unsupported_body: "Obecnie do list odtwarzania można dodawać tylko utwory z lokalnej biblioteki Tributary. Nie dodano niczego z tego źródła."
 
 # ── Properties dialog ──────────────────────────────────────────────
 properties:

--- a/locales/pt-BR.yml
+++ b/locales/pt-BR.yml
@@ -172,6 +172,8 @@ context:
   properties: "Propriedades…"
   add_to_playlist: "Adicionar à lista de reprodução"
   remove_from_playlist: "Remover da lista de reprodução"
+  playlist_add_unsupported_heading: "As faixas não foram adicionadas"
+  playlist_add_unsupported_body: "No momento, somente as faixas da biblioteca local do Tributary podem ser adicionadas às listas de reprodução. Nada desta fonte foi adicionado."
 
 # ── Properties dialog ──────────────────────────────────────────────
 properties:

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -172,6 +172,8 @@ context:
   properties: "Свойства…"
   add_to_playlist: "Добавить в плейлист"
   remove_from_playlist: "Удалить из плейлиста"
+  playlist_add_unsupported_heading: "Композиции не добавлены"
+  playlist_add_unsupported_body: "Сейчас в плейлисты можно добавлять только композиции из локальной медиатеки Tributary. Из этого источника ничего не добавлено."
 
 # ── Properties dialog ──────────────────────────────────────────────
 properties:

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -172,6 +172,8 @@ context:
   properties: "属性…"
   add_to_playlist: "添加到播放列表"
   remove_from_playlist: "从播放列表中移除"
+  playlist_add_unsupported_heading: "曲目未添加"
+  playlist_add_unsupported_body: "目前，只有 Tributary 本地音乐库中的曲目才能添加到播放列表。此数据源中的内容均未添加。"
 
 # ── Properties dialog ──────────────────────────────────────────────
 properties:

--- a/locales/zh-TW.yml
+++ b/locales/zh-TW.yml
@@ -172,6 +172,8 @@ context:
   properties: "內容…"
   add_to_playlist: "加入播放清單"
   remove_from_playlist: "從播放清單移除"
+  playlist_add_unsupported_heading: "曲目未加入"
+  playlist_add_unsupported_body: "目前，只有 Tributary 本機音樂庫中的曲目才能加入播放清單。此資料來源中的內容均未加入。"
 
 # ── Properties dialog ──────────────────────────────────────────────
 properties:

--- a/src/ui/context_menu.rs
+++ b/src/ui/context_menu.rs
@@ -70,6 +70,65 @@ impl ContextMenuPopupPlan {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PlaylistAddSupport {
+    LocalLibrary,
+    UnsupportedSource,
+}
+
+impl PlaylistAddSupport {
+    fn from_source_key(source_key: &str) -> Self {
+        if source_key == "local" {
+            Self::LocalLibrary
+        } else {
+            Self::UnsupportedSource
+        }
+    }
+
+    fn activation(self) -> PlaylistAddActivation {
+        match self {
+            Self::LocalLibrary => PlaylistAddActivation::WriteLocalPlaylist,
+            Self::UnsupportedSource => PlaylistAddActivation::ExplainUnsupportedSource,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PlaylistAddActivation {
+    WriteLocalPlaylist,
+    ExplainUnsupportedSource,
+}
+
+#[derive(Clone, Copy)]
+struct PlaylistAddInteraction<'a> {
+    window: &'a gtk::glib::WeakRef<adw::ApplicationWindow>,
+    support: PlaylistAddSupport,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct UnsupportedPlaylistAddCopy {
+    heading: String,
+    body: String,
+}
+
+fn unsupported_playlist_add_copy(locale: &str) -> UnsupportedPlaylistAddCopy {
+    UnsupportedPlaylistAddCopy {
+        heading: rust_i18n::t!("context.playlist_add_unsupported_heading", locale = locale)
+            .into_owned(),
+        body: rust_i18n::t!("context.playlist_add_unsupported_body", locale = locale).into_owned(),
+    }
+}
+
+fn show_unsupported_playlist_add_dialog(window: &adw::ApplicationWindow) {
+    let copy = unsupported_playlist_add_copy(&rust_i18n::locale());
+    let dialog = adw::AlertDialog::builder()
+        .heading(&copy.heading)
+        .body(&copy.body)
+        .build();
+    dialog.add_response("ok", rust_i18n::t!("dialogs.ok").as_ref());
+    dialog.present(Some(window));
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum KeyboardContextMenuPropagation {
     Proceed,
     Stop,
@@ -124,6 +183,9 @@ fn expose_context_menu_accessibility(column_view: &gtk::ColumnView) {
 /// open the same selection-snapshotted action model relative to the focused
 /// tracklist, and are consumed only when a non-empty menu was opened.
 pub fn setup_context_menu(state: &WindowState) {
+    // The controllers retaining `popup_menu` live below this window. Keep a
+    // weak handle so the action factory cannot form a window ownership cycle.
+    let window = state.window.downgrade();
     let sm = state.sort_model.clone();
     let sidebar_store = state.sidebar_store.clone();
     let active_source_key = state.active_source_key.clone();
@@ -140,6 +202,7 @@ pub fn setup_context_menu(state: &WindowState) {
         move |cv: &gtk::ColumnView, anchor: Option<gtk::gdk::Rectangle>| {
             let active_key = active_source_key.borrow().clone();
             let is_playlist_view = active_key.starts_with("playlist:");
+            let playlist_add_support = PlaylistAddSupport::from_source_key(&active_key);
 
             // Collect selected track URIs from the MultiSelection model.
             let selection_model = cv.model();
@@ -182,6 +245,10 @@ pub fn setup_context_menu(state: &WindowState) {
                     &sm,
                     &popup_plan.selection,
                     &rt_handle,
+                    PlaylistAddInteraction {
+                        window: &window,
+                        support: playlist_add_support,
+                    },
                 );
             }
 
@@ -425,7 +492,7 @@ fn build_remove_from_playlist_action(
     });
     action_group.add_action(&remove_action);
     menu.append(
-        Some("Remove from Playlist"),
+        Some(rust_i18n::t!("context.remove_from_playlist").as_ref()),
         Some("tracklist-ctx.remove-from-playlist"),
     );
 }
@@ -438,6 +505,7 @@ fn build_add_to_playlist_actions(
     sm: &gtk::SortListModel,
     selection: &SelectionSnapshot,
     rt_handle: &tokio::runtime::Handle,
+    interaction: PlaylistAddInteraction<'_>,
 ) {
     let mut has_playlists = false;
 
@@ -454,7 +522,7 @@ fn build_add_to_playlist_actions(
                     header_action.set_enabled(false);
                     action_group.add_action(&header_action);
                     menu.append(
-                        Some("Add to Playlist"),
+                        Some(rust_i18n::t!("context.add_to_playlist").as_ref()),
                         Some("tracklist-ctx.add-to-playlist-header"),
                     );
                 }
@@ -470,7 +538,16 @@ fn build_add_to_playlist_actions(
                 let add_action = gtk::gio::SimpleAction::new(&action_name, None);
                 let uris = selected_uris;
                 let pid = pl_id.clone();
+                let window = interaction.window.clone();
+                let activation = interaction.support.activation();
                 add_action.connect_activate(move |_, _| {
+                    if activation == PlaylistAddActivation::ExplainUnsupportedSource {
+                        if let Some(window) = window.upgrade() {
+                            show_unsupported_playlist_add_dialog(&window);
+                        }
+                        return;
+                    }
+
                     let uris = uris.clone();
                     let pid = pid.clone();
                     rt.spawn(async move {
@@ -598,7 +675,10 @@ fn build_properties_action(
     });
 
     action_group.add_action(&props_action);
-    menu.append(Some("Properties…"), Some("tracklist-ctx.properties"));
+    menu.append(
+        Some(rust_i18n::t!("context.properties").as_ref()),
+        Some("tracklist-ctx.properties"),
+    );
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -682,6 +762,64 @@ mod tests {
     use std::path::PathBuf;
 
     use super::*;
+
+    #[test]
+    fn playlist_add_support_is_exactly_local_and_fail_closed() {
+        assert_eq!(
+            PlaylistAddSupport::from_source_key("local"),
+            PlaylistAddSupport::LocalLibrary
+        );
+        assert_eq!(
+            PlaylistAddSupport::from_source_key("local").activation(),
+            PlaylistAddActivation::WriteLocalPlaylist
+        );
+
+        let remote = crate::architecture::SourceId::remote(
+            "subsonic",
+            &url::Url::parse("https://music.example.test/root/").expect("remote URL"),
+        )
+        .expect("remote source ID")
+        .to_string();
+        let radio = crate::architecture::SourceId::radio_browser().to_string();
+        let removable = crate::architecture::SourceId::removable("device:opaque-id")
+            .expect("removable source ID")
+            .to_string();
+
+        for source_key in [
+            remote.as_str(),
+            radio.as_str(),
+            removable.as_str(),
+            "playlist:local-view",
+            "remote-looking-but-malformed",
+            "",
+        ] {
+            assert_eq!(
+                PlaylistAddSupport::from_source_key(source_key),
+                PlaylistAddSupport::UnsupportedSource,
+                "{source_key:?} must not enter the local-only playlist write path"
+            );
+            assert_eq!(
+                PlaylistAddSupport::from_source_key(source_key).activation(),
+                PlaylistAddActivation::ExplainUnsupportedSource
+            );
+        }
+    }
+
+    #[test]
+    fn unsupported_playlist_add_copy_is_localized_for_every_catalog() {
+        let english = unsupported_playlist_add_copy("en");
+        assert!(!english.heading.is_empty());
+        assert!(!english.body.is_empty());
+
+        for locale in rust_i18n::available_locales!() {
+            let localized = unsupported_playlist_add_copy(&locale);
+            assert!(!localized.heading.is_empty(), "{locale}: empty heading");
+            assert!(!localized.body.is_empty(), "{locale}: empty body");
+            if locale != "en" {
+                assert_ne!(localized, english, "{locale} must not fall back to English");
+            }
+        }
+    }
 
     #[test]
     fn properties_path_conversion_is_local_and_fail_closed() {

--- a/src/ui/context_menu.rs
+++ b/src/ui/context_menu.rs
@@ -538,11 +538,16 @@ fn build_add_to_playlist_actions(
                 let add_action = gtk::gio::SimpleAction::new(&action_name, None);
                 let uris = selected_uris;
                 let pid = pl_id.clone();
-                let window = interaction.window.clone();
+                // Materialize a fresh owned weak handle for the `'static`
+                // action closure; never let the borrowed factory input escape.
+                let window = interaction
+                    .window
+                    .upgrade()
+                    .map(|window| window.downgrade());
                 let activation = interaction.support.activation();
                 add_action.connect_activate(move |_, _| {
                     if activation == PlaylistAddActivation::ExplainUnsupportedSource {
-                        if let Some(window) = window.upgrade() {
+                        if let Some(window) = window.as_ref().and_then(|window| window.upgrade()) {
                             show_unsupported_playlist_add_dialog(&window);
                         }
                         return;

--- a/src/ui/window_state.rs
+++ b/src/ui/window_state.rs
@@ -24,7 +24,7 @@ use super::source_navigation::{PendingConnection, SourceNavigation, SourceReques
 pub struct WindowState {
     // ── Top-level GTK handles ───────────────────────────────────────
     /// The main application window.
-    /// Used by: source_connect (auth dialogs), playlist_actions (dialogs).
+    /// Used by: source_connect (auth dialogs), playlist_actions (dialogs), context_menu (results).
     pub window: adw::ApplicationWindow,
 
     /// Tokio runtime handle for spawning async background work.


### PR DESCRIPTION
## Summary

- snapshot the active source with each tracklist context-menu selection and refuse every non-local Add to Playlist action before spawning work or opening the database
- present an all-or-none explanatory dialog in all 13 shipped locales while preserving the existing local-library write path
- use the existing translations for Add to Playlist, Remove from Playlist, and Properties labels
- update task.md, the roadmap, README, and changelog to record P1.2 as complete at 2/35 (5.7%) and keep durable remote playlist persistence in P1.5

Related to #47. This intentionally does not close the issue because source-scoped remote playlist persistence remains planned work.

## Validation

- cargo test --all-targets --all-features --locked (20 library, 936 application, 10 packaging tests)
- cargo test --release --all-targets --all-features --locked (20 library, 936 application, 10 packaging tests)
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo clippy --release --all-targets --all-features --locked -- -D warnings
- cargo fmt --all -- --check
- git diff --check

An independent review found and prompted removal of an initial strong GTK window reference; the final action factory retains only a weak window handle and upgrades it on the UI thread when presenting the refusal dialog. The follow-up review found no remaining blocker.
