### PR TITLE
Define durable playback history contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gain a nullable UTC epoch-millisecond `last_played` value, while the architecture model safely
   rejects out-of-range stored timestamps. Migration 10 preserves every nonnegative legacy play
   count, repairs negative corruption to zero, never invents a timestamp from file or library dates,
-  validates interrupted SQLite upgrades, and supports down/up retry. A pure per-occurrence state
-  counts observed forward playback at half of a positive duration rounded up and capped at four
-  minutes; missing or zero duration uses the four-minute fallback or an unskipped authoritative
+  validates interrupted SQLite upgrades (including SQLite's equivalent nullable `INTEGER`
+  spelling while rejecting incompatible shapes), and supports down/up retry. A pure per-occurrence
+  state counts observed forward playback at half of a positive duration rounded up and capped at
+  four minutes; missing or zero duration uses the four-minute fallback or an unskipped authoritative
   natural end. Duration freezes on the first positive value; seeks, neutral retry/resume anchors,
   and restarts earn no jump credit; only a forward user seek suppresses the early unknown-duration
   end rule; backward replay preserves accumulated listening; and the count signal latches once.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Local playback history now has a durable contract and schema foundation** — Local track rows
+  gain a nullable UTC epoch-millisecond `last_played` value, while the architecture model safely
+  rejects out-of-range stored timestamps. Migration 10 preserves every nonnegative legacy play
+  count, repairs negative corruption to zero, never invents a timestamp from file or library dates,
+  validates interrupted SQLite upgrades, and supports down/up retry. A pure per-occurrence state
+  counts observed forward playback at half of a positive duration rounded up and capped at four
+  minutes; missing or zero duration uses the four-minute fallback or an unskipped authoritative
+  natural end. Duration freezes on the first positive value; seeks, neutral retry/resume anchors,
+  and restarts earn no jump credit; only a forward user seek suppresses the early unknown-duration
+  end rule; backward replay preserves accumulated listening; and the count signal latches once.
+  Production playback-event writes, Plays-column refresh, and deterministic Recently Played
+  and Top 25 behavior remain the next two P1.3 slices and are not claimed by this foundation.
+
 ### Fixed
 - **Unsupported playlist additions now fail visibly and atomically** — Choosing Add to Playlist
   from an authenticated remote, internet-radio, removable-media, or unknown/pathless source now

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Tributary provides a unified interface for managing and streaming music from mul
 | USB file transfer (copy to device with progress) | ❌ Planned ([#8](https://github.com/jm2/tributary/issues/8)) |
 | Multiple music library directories | ✅ |
 | Playlist import/export (XSPF) | ✅ |
-| Default smart playlists (Recently Added, Recently Played, Top 25) | ⚠️ Seeded; Recently Played and Top 25 need durable playback history ([P1.3](docs/task.md#p13--record-trustworthy-local-playback-history)) |
+| Durable local playback history | ⚠️ Contract, schema, and tested progress accounting are implemented; playback-event persistence is next ([contract](docs/playback-history.md)) |
+| Default smart playlists (Recently Added, Recently Played, Top 25) | ⚠️ Seeded; Recently Played and Top 25 still await history persistence and deterministic consumers ([P1.3](docs/task.md#p13--record-trustworthy-local-playback-history)) |
 | Track ratings | ❌ Planned ([#37](https://github.com/jm2/tributary/issues/37)) |
 | Window position persistence | ✅ |
 | Windows 11 Snap Layout support | ✅ |
@@ -465,13 +466,14 @@ src/
 │   ├── entities/
 │   │   └── track.rs        # SeaORM entity for tracks table
 │   └── migration/
-│       └── m20250101_000001_create_tables.rs
+│       └── *.rs            # Ordered, retry-safe SQLite schema migrations
 ├── desktop_integration/
 │   └── mod.rs              # OS media controls via souvlaki (MPRIS/SMTC/Now Playing)
 ├── local/
 │   ├── mod.rs              # Local backend root
 │   ├── backend.rs          # MediaBackend impl (LocalBackend)
 │   ├── engine.rs           # Async scan + notify FS watcher + LibraryEvent channel
+│   ├── playback_history.rs # Pure counted-play occurrence accounting
 │   ├── tag_parser.rs       # lofty audio tag extraction
 │   ├── tag_writer.rs       # lofty audio tag writing (MP3, M4A, OGG, FLAC)
 │   ├── playlist_manager.rs # Regular + smart playlist CRUD
@@ -757,6 +759,11 @@ podcasts. Tributary deliberately does not guess through any of those gaps.
 - **Repeat** — cycles through Off → All → One
 - **Seek** — drag the progress scrubber
 - **Volume** — drag the volume slider (cubic perceptual curve)
+
+The [local playback-history contract](docs/playback-history.md) defines a counted play as half of a
+known duration, rounded up and capped at four minutes, with a conservative unknown-duration rule.
+Its schema and progress accounting are present, but this build does not yet persist production
+playback events or update Recently Played and Top 25; those are the next two P1.3 slices.
 
 ### Keyboard Shortcuts
 

--- a/docs/playback-history.md
+++ b/docs/playback-history.md
@@ -93,10 +93,12 @@ Migration 10 has intentionally conservative legacy behavior:
 - never infer listening history from date-added, date-modified, file mtime, or playlist dates.
 
 The migration validates an already-present column before completing an interrupted SQLite upgrade
-and supports down/up retry. Rolling it down necessarily discards stored last-played timestamps but
-preserves tracks and play counts; reapplying starts those timestamps as null. No history index is
-added yet because smart playlists currently materialize the local table before evaluation; an
-index would add write cost without serving the current query path.
+and supports down/up retry. Fresh schema uses the declared `BIGINT` spelling; validation also accepts
+SQLite's equivalent nullable, default-free `INTEGER` spelling while rejecting incompatible type,
+nullability, default, or primary-key shapes. Rolling the migration down necessarily discards stored
+last-played timestamps but preserves tracks and play counts; reapplying starts those timestamps as
+null. No history index is added yet because smart playlists currently materialize the local table
+before evaluation; an index would add write cost without serving the current query path.
 
 The persistence slice must atomically saturate `play_count` at `i32::MAX` and set
 `last_played_at_ms` to `max(existing, event_timestamp)`. This prevents integer overflow and keeps a

--- a/docs/playback-history.md
+++ b/docs/playback-history.md
@@ -1,0 +1,147 @@
+# Playback-history contract
+
+Status: foundation implemented on 2026-07-18; production event persistence and smart-playlist
+consumers remain the next two P1.3 slices.
+
+This document defines when Tributary may record a local play and how that history is represented.
+The contract is deliberately stricter than "a load was requested": rejected media, stale output
+events, retries, seeks, and wall-clock changes must not manufacture listening history.
+
+## Scope and ownership
+
+- Durable history belongs only to the exact built-in local library. A track played through a local
+  regular or smart playlist updates the underlying local track by its stable `TrackId`.
+- Authenticated remotes, Radio-Browser, removable media, and ephemeral operating-system-opened
+  files do not write into the local `tracks` table. Any source-owned remote count remains remote
+  metadata and remote `last_played` remains unknown to this schema. Source-specific history or
+  synchronization requires a separate ownership and privacy decision.
+- One `PlaybackHistoryProgress` value belongs to one queue occurrence, not merely one track ID or
+  one output load generation. Duplicate queue entries can therefore count independently.
+
+## Playback occurrences
+
+A new occurrence begins when Tributary successfully adopts:
+
+- an explicitly selected track or a new queue;
+- the next or previous queue occurrence;
+- an end-of-stream auto-advance; or
+- a Repeat One replay after natural end of stream.
+
+Pause/resume, seeking, the three-second Previous restart, buffering, an output retry, and a
+same-track output handoff remain the same occurrence. They re-anchor the state rather than creating
+a second count opportunity. Replacing the queue, Stop, application restart, or retiring the owning
+source ends the old occurrence; partial credit is intentionally in-memory only. A failed or
+rejected candidate never becomes a countable occurrence, a terminal error is not natural end, and
+a retry generation cannot count separately from the occurrence it is recovering.
+
+## Counted-play threshold
+
+For a positive known duration, one occurrence counts after this much observed forward playback:
+
+```text
+min(ceil(duration_ms / 2), 240_000 ms)
+```
+
+The first positive duration is authoritative for that occurrence and freezes the threshold. The
+library duration may supply it at occurrence creation; otherwise the first positive duration from
+the accepted output may supply it later. Zero means unknown, and later disagreement cannot move a
+frozen threshold. If already-observed credit meets the newly lowered threshold, accepting that
+duration emits the occurrence's one count decision immediately.
+
+An unknown-duration occurrence counts after 240,000 milliseconds of observed forward playback. It
+may instead count at authoritative natural end of stream only when no forward user seek supplied
+evidence that unobserved content was skipped. Natural end does not grant an unobserved tail to
+known-duration media.
+
+## Creditable evidence
+
+- Only position events already accepted for the occurrence's current output generation can earn
+  credit. A strictly advancing sample contributes its delta from the previous anchor.
+- Pause and buffering time earn nothing. Duplicate or unexpectedly regressed samples earn nothing.
+- Before the next sample after seek, restart, retry, resume, or same-occurrence output handoff, the
+  coordinator re-anchors the state without crediting the jump.
+- A forward user seek earns no credit and permanently records skip evidence for the
+  unknown-duration end-of-stream rule. A backward or equal seek preserves earlier listening
+  credit. A retry, resume, or output-handoff re-anchor earns no credit but is not user skip evidence.
+- Replaying content after a backward seek may earn new observed listening time, but the occurrence's
+  one-shot latch still permits at most one count.
+- Progress accounting uses positions and monotonic sequencing, never elapsed UTC time. The UTC
+  clock is sampled only when the one-shot threshold decision is emitted—whether by a position
+  crossing, late duration acceptance, or qualifying unknown-duration natural end.
+
+"Exactly once" means once per adopted occurrence in the running playback session. Crash-replay
+exactly-once semantics would require a durable occurrence-ID ledger and are not claimed here.
+
+## Durable representation and migration
+
+Local `tracks` rows retain the existing non-null signed `play_count` and gain:
+
+```text
+last_played_at_ms BIGINT NULL
+```
+
+`last_played_at_ms` is a UTC Unix timestamp in milliseconds captured at the counted-play decision.
+`NULL` means that Tributary has no trustworthy counted-play instant. The architecture model exposes
+it as `Option<DateTime<Utc>>`; an out-of-range stored timestamp safely maps to `None`, and older
+serialized tracks that omit the field deserialize as unknown.
+
+Migration 10 has intentionally conservative legacy behavior:
+
+- preserve every zero or positive play count;
+- normalize a corrupt negative play count to zero;
+- leave `last_played_at_ms` null for every existing row, including rows with a positive count; and
+- never infer listening history from date-added, date-modified, file mtime, or playlist dates.
+
+The migration validates an already-present column before completing an interrupted SQLite upgrade
+and supports down/up retry. Rolling it down necessarily discards stored last-played timestamps but
+preserves tracks and play counts; reapplying starts those timestamps as null. No history index is
+added yet because smart playlists currently materialize the local table before evaluation; an
+index would add write cost without serving the current query path.
+
+The persistence slice must atomically saturate `play_count` at `i32::MAX` and set
+`last_played_at_ms` to `max(existing, event_timestamp)`. This prevents integer overflow and keeps a
+regressed system clock from making the newest recorded play appear older.
+
+## Integration boundary
+
+The foundation slice adds the schema, model conversion, and pure progress state only. It does not
+yet write history during playback, refresh the Plays column, or change seeded smart-playlist
+results.
+
+The next slice must:
+
+1. own the progress state in `PlaybackSession` separately from output load generations;
+2. feed it only generation-accepted duration, position, discontinuity, and natural-end events;
+3. latch before dispatching asynchronous persistence so duplicate ticks cannot enqueue duplicates;
+4. update one exact local track ID atomically, treating a concurrently deleted row as a no-op;
+5. publish a stable-ID history update only after commit; and
+6. refresh the local row plus active and cached playlist projections without disturbing queue
+   identity.
+
+AirPlay currently needs either periodic accepted position publication or explicit coverage of its
+authoritative natural-end path before the cross-output contract is complete.
+
+## Smart-playlist consumers
+
+The final P1.3 slice will make the seeded consumers deterministic:
+
+- **Recently Played:** tracks with a non-null `last_played` in the preceding 14 days, newest first,
+  with stable track identity as the final tie-breaker.
+- **Top 25 Most Played:** tracks with `play_count > 0`, selected by descending play count, then
+  descending last-played time, then stable track identity.
+
+Legacy positive counts remain eligible for Top 25. A legacy null `last_played` never qualifies for
+Recently Played until a real counted occurrence supplies one. Empty history produces intentional
+empty playlists rather than a match-all fallback. Existing seeded playlists may be migrated only
+when their smart flag and exact serialized historical rules still match Tributary's old defaults;
+renamed or edited user playlists must be preserved.
+
+## Required validation
+
+The progress component pins half-duration rounding, the four-minute cap, missing and zero duration,
+late duration discovery, exact threshold edges, duplicate and regressed samples, pause/retry
+re-anchoring, forward and backward seeks, restart, Repeat One occurrence separation, known and
+unknown natural end, forward-skip suppression, and the one-shot latch. Integration coverage in the
+next slice must additionally prove rejected loads, stale generations, duplicate output ticks,
+source/output replacement, deleted rows, count saturation, post-commit UI publication, and every
+supported output's progress or natural-end path.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,7 +6,7 @@ This document explains the product and engineering work that remains **after** t
 remediation. [`task.md`](task.md) is the countable active implementation backlog; the completed
 remediation record is preserved separately in
 [`task-remediation-2026-07.md`](task-remediation-2026-07.md) at **220/223 (98.7%)**, with only three
-real-environment validation records left. The feature backlog is now **2/35 (5.7%)** complete. Neither
+real-environment validation records left. The feature backlog is now **3/35 (8.6%)** complete. Neither
 percentage estimates equal engineering effort, and the historical percentage is not a claim that
 Tributary has implemented every requested product feature.
 
@@ -36,6 +36,10 @@ starts. Historical holistic-review documents are point-in-time findings, not act
 - Shuffled playback retains the current queue occurrence plus ten real predecessors. Previous and
   subsequent forward navigation follow that fixed history, Repeat All uses complete bounded
   occurrence cycles, and the header and OS media controls share one exact restart threshold.
+- Local tracks now have a migrated nullable UTC-millisecond `last_played` field and a tested pure
+  counted-play state. The [playback-history contract](playback-history.md) defines occurrence,
+  threshold, duration, seek/retry/restart, clock, and legacy semantics. Production playback-event
+  persistence, live UI refresh, and useful Recently Played/Top 25 consumers are not implemented yet.
 
 ## Proposed implementation order
 
@@ -54,11 +58,14 @@ before starting large protocol or transfer subsystems.
    before database work. Full support remains separate: regular playlist entries need persistent
    source-scoped `(SourceId, TrackId)` identity, disconnected-source semantics, and playback-time
    resolution; Subsonic server-native playlist import/sync is another slice.
-3. **Implement trustworthy local playback history.** The database and UI expose `play_count`, but
-   production playback does not increment it and there is no `last_played` field. Consequently the
-   seeded Recently Played and Top 25 playlists are present but ordinarily empty for local music.
-   Define the counted-play threshold, repeat/seek behavior, durable update path, and smart-playlist
-   refresh semantics before building features that consume this history.
+3. **In progress: implement trustworthy local playback history.** The durable schema and
+   [counted-play contract](playback-history.md) are complete: local rows can represent a trustworthy
+   last-played instant, corrupt negative legacy counts are repaired, and a pure per-occurrence state
+   pins half-duration/four-minute, seek, retry, restart, duration, and natural-end semantics. Next,
+   connect only generation-accepted playback events to one atomic stable-ID update and refresh the
+   affected row/projections. Then make Recently Played and Top 25 deterministic and migrate only
+   untouched historical defaults. Until those two slices land, production playback still does not
+   write history and the seeded consumers remain ordinarily empty.
 4. **Add ratings ([#37]).** Decide whether ratings are app-local, written to tags, synchronized to
    capable servers, or some explicit combination. Then add schema/model/backend propagation, an
    editable and sortable column, smart-playlist rules, and mixed-capability behavior.
@@ -127,7 +134,7 @@ mistaken for work already underway.
 
 | Issue | Current implementation state | Likely implementation shape |
 |---|---|---|
-| [#57 — Rhythmbox playlists, play counts, and ratings](https://github.com/jm2/tributary/issues/57) | No direct importer. XSPF conversion and a dormant local play-count field are only partial foundations. | Playback history and ratings first; then transactional, idempotent migration with conflict reporting. |
+| [#57 — Rhythmbox playlists, play counts, and ratings](https://github.com/jm2/tributary/issues/57) | No direct importer. XSPF conversion plus the migrated playback-history representation and threshold contract are partial foundations; production history writes and ratings remain incomplete. | Complete playback history and ratings first; then transactional, idempotent migration with conflict reporting. |
 | [#50 — Last.fm scrobbling](https://github.com/jm2/tributary/issues/50) | No Last.fm client or scrobble pipeline. | Authorization, secret storage, authoritative thresholds, retry/offline queue, and privacy UX. |
 | [#49 — Equalizer](https://github.com/jm2/tributary/issues/49) | No equalizer or audio-filter configuration. | GStreamer DSP design plus explicit behavior for every output backend. |
 | [#47 — Remote/Subsonic tracks in playlists](https://github.com/jm2/tributary/issues/47) | Remote rows are skipped by the local-only playlist writer; the failure is not user-visible. | Immediate UX fix, then source-scoped playlist schema/resolution; server playlist sync separately. |

--- a/docs/task.md
+++ b/docs/task.md
@@ -89,7 +89,7 @@ shuffle navigation semantics, and an honest local-only playlist interaction boun
 
 - [x] Define and migrate the durable playback-history contract: counted-play threshold,
   `last_played`, repeat/seek/restart semantics, clock representation, and legacy-row behavior
-  ([contract](playback-history.md); implementing PR pending).
+  ([contract](playback-history.md); [#134](https://github.com/jm2/tributary/pull/134)).
 - [ ] Persist play-count and last-played updates from authoritative playback events exactly once,
   without counting rejected loads, stale generations, or retries, and refresh affected UI state.
 - [ ] Make Recently Played and Top 25 reflect the new history contract deterministically, including
@@ -239,4 +239,4 @@ shuffle navigation semantics, and an honest local-only playlist interaction boun
 | 2026-07-18 | Backlog reset | — | Archived the holistic-review tracker and established the audited feature backlog; no implementation record completed. |
 | 2026-07-18 | P1.1 bounded shuffle history | [#132](https://github.com/jm2/tributary/pull/132) | Retained ten real prior occurrences, fixed forward traversal and complete Repeat All cycles, unified Previous dispatch, made toggle/reset semantics explicit, and added lifecycle/rollback regressions. |
 | 2026-07-18 | P1.2 honest unsupported playlist actions | [#133](https://github.com/jm2/tributary/pull/133) | Refused non-local Add to Playlist actions with an all-or-none localized dialog before database work, localized the existing context-menu labels, and regressed the fail-closed source policy plus every shipped catalog. |
-| 2026-07-18 | P1.3 playback-history contract and schema | Pending | Defined occurrence, threshold, duration, seek/retry/restart, clock, and legacy contracts; added migration 10 plus safe model conversion and a pure one-shot progress state. Production event writes and smart-playlist consumers remain the next two records. |
+| 2026-07-18 | P1.3 playback-history contract and schema | [#134](https://github.com/jm2/tributary/pull/134) | Defined occurrence, threshold, duration, seek/retry/restart, clock, and legacy contracts; added migration 10 plus safe model conversion and a pure one-shot progress state. Production event writes and smart-playlist consumers remain the next two records. |

--- a/docs/task.md
+++ b/docs/task.md
@@ -21,16 +21,17 @@ state.
 - Do not treat the order below as a release promise. It is a dependency-aware starting order and
   can change as issues receive product decisions and milestones.
 
-Current status: **2/35 (5.7%)** active implementation records complete. This percentage measures
+Current status: **3/35 (8.6%)** active implementation records complete. This percentage measures
 checklist completion, not equal engineering effort: several P3 records are deliberately large
 epics. The archived remediation remains **220/223 (98.7%)** complete; its three open records are
 real-environment validation, not missing implementation.
 
 ## Current focus
 
-P1.1 and P1.2 are complete. Continue with the playback-history contract and migration foundation
-in P1.3. The rest of P1 builds on the source-scoped identity already present in the runtime, the
-now-bounded shuffle navigation semantics, and an honest local-only playlist interaction boundary.
+P1.1, P1.2, and the P1.3 playback-history contract/schema foundation are complete. Continue with
+authoritative per-occurrence persistence and live UI invalidation in the second P1.3 record. The
+rest of P1 builds on the source-scoped identity already present in the runtime, the now-bounded
+shuffle navigation semantics, and an honest local-only playlist interaction boundary.
 
 ## P1 — Correctness and shared feature foundations
 
@@ -86,16 +87,25 @@ now-bounded shuffle navigation semantics, and an honest local-only playlist inte
 
 ### P1.3 — Record trustworthy local playback history
 
-- [ ] Define and migrate the durable playback-history contract: counted-play threshold,
-  `last_played`, repeat/seek/restart semantics, clock representation, and legacy-row behavior.
+- [x] Define and migrate the durable playback-history contract: counted-play threshold,
+  `last_played`, repeat/seek/restart semantics, clock representation, and legacy-row behavior
+  ([contract](playback-history.md); implementing PR pending).
 - [ ] Persist play-count and last-played updates from authoritative playback events exactly once,
   without counting rejected loads, stale generations, or retries, and refresh affected UI state.
 - [ ] Make Recently Played and Top 25 reflect the new history contract deterministically, including
   live refresh, ordering, empty-state, migration, and regression coverage.
 
-  Today the schema and Plays column expose `play_count`, but production playback does not increment
-  it and there is no `last_played` field. The seeded playlists therefore exist but ordinarily stay
-  empty for local tracks.
+  Implemented foundation: local tracks now have a nullable UTC epoch-millisecond `last_played`
+  field, negative legacy counts are repaired without inventing timestamps, and a pure one-shot
+  occurrence state accounts only for observed forward playback. A positive duration counts at half
+  duration rounded up and capped at four minutes; missing/zero duration uses four minutes or an
+  unskipped authoritative natural end. Pause, buffering, seek jumps, restarts, and retries cannot
+  manufacture credit, while Repeat One creates a new occurrence. The complete contract and future
+  persistence/smart-playlist boundaries are recorded in [`playback-history.md`](playback-history.md).
+
+  Production playback still does not increment `play_count` or write `last_played`; that is the
+  second record. Recently Played and Top 25 therefore remain ordinarily empty until the second and
+  third records complete.
 
 ### P1.4 — Add ratings as a real library field
 
@@ -229,3 +239,4 @@ now-bounded shuffle navigation semantics, and an honest local-only playlist inte
 | 2026-07-18 | Backlog reset | — | Archived the holistic-review tracker and established the audited feature backlog; no implementation record completed. |
 | 2026-07-18 | P1.1 bounded shuffle history | [#132](https://github.com/jm2/tributary/pull/132) | Retained ten real prior occurrences, fixed forward traversal and complete Repeat All cycles, unified Previous dispatch, made toggle/reset semantics explicit, and added lifecycle/rollback regressions. |
 | 2026-07-18 | P1.2 honest unsupported playlist actions | [#133](https://github.com/jm2/tributary/pull/133) | Refused non-local Add to Playlist actions with an all-or-none localized dialog before database work, localized the existing context-menu labels, and regressed the fail-closed source policy plus every shipped catalog. |
+| 2026-07-18 | P1.3 playback-history contract and schema | Pending | Defined occurrence, threshold, duration, seek/retry/restart, clock, and legacy contracts; added migration 10 plus safe model conversion and a pure one-shot progress state. Production event writes and smart-playlist consumers remain the next two records. |

--- a/src/architecture/models.rs
+++ b/src/architecture/models.rs
@@ -100,6 +100,12 @@ pub struct Track {
 
     /// Number of times this track has been played.
     pub play_count: Option<u32>,
+
+    /// UTC instant when this track most recently crossed Tributary's
+    /// counted-play threshold. Legacy and unplayed tracks leave this unset;
+    /// file metadata timestamps are never substituted for listening history.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_played: Option<DateTime<Utc>>,
 }
 
 /// An album — a logical grouping of tracks.

--- a/src/daap/backend.rs
+++ b/src/daap/backend.rs
@@ -176,6 +176,7 @@ impl DaapBackend {
                 sample_rate_hz: sample_rate,
                 format: Some(format.clone()),
                 play_count: None,
+                last_played: None,
             };
 
             let idx = all_tracks.len();

--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -165,6 +165,7 @@ mod tests {
             artist_name: Set("Artist".to_string()),
             album_title: Set("Album".to_string()),
             play_count: Set(0),
+            last_played_at_ms: Set(None),
             date_added: Set("2026-07-13T00:00:00+00:00".to_string()),
             date_modified: Set("2026-07-13T00:00:00+00:00".to_string()),
             ..Default::default()

--- a/src/db/entities/track.rs
+++ b/src/db/entities/track.rs
@@ -26,6 +26,7 @@ pub struct Model {
     pub sample_rate_hz: Option<i32>,
     pub format: Option<String>,
     pub play_count: i32,
+    pub last_played_at_ms: Option<i64>,
     pub date_added: String,
     pub date_modified: String,
     pub file_size_bytes: Option<i64>,

--- a/src/db/migration/m20260718_000010_add_playback_history.rs
+++ b/src/db/migration/m20260718_000010_add_playback_history.rs
@@ -1,0 +1,318 @@
+//! Migration: add persisted playback-history metadata to local tracks.
+
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::Statement;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if !manager.has_column("tracks", "last_played_at_ms").await? {
+            manager
+                .alter_table(
+                    Table::alter()
+                        .table(Tracks::Table)
+                        .add_column(ColumnDef::new(Tracks::LastPlayedAtMs).big_integer().null())
+                        .to_owned(),
+                )
+                .await?;
+        }
+
+        // SQLite can commit the ALTER before SeaORM records the migration.
+        // Validate an already-present column before accepting it on retry.
+        validate_last_played_column(manager).await?;
+
+        // Older code could persist a signed count even though the public model
+        // exposes an unsigned value. Repair only the invalid part of that
+        // legacy range; all existing nonnegative counts remain untouched.
+        manager
+            .get_connection()
+            .execute(Statement::from_string(
+                manager.get_database_backend(),
+                "UPDATE tracks SET play_count = 0 WHERE play_count < 0".to_string(),
+            ))
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if !manager.has_column("tracks", "last_played_at_ms").await? {
+            return Ok(());
+        }
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Tracks::Table)
+                    .drop_column(Tracks::LastPlayedAtMs)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+/// Reject a same-named legacy or partially-created column with an incompatible
+/// shape instead of silently treating it as the playback-history field.
+async fn validate_last_played_column(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    let rows = manager
+        .get_connection()
+        .query_all(Statement::from_string(
+            manager.get_database_backend(),
+            "PRAGMA table_info('tracks')".to_string(),
+        ))
+        .await?;
+
+    let Some(row) = rows.into_iter().find(|row| {
+        row.try_get::<String>("", "name")
+            .is_ok_and(|name| name == "last_played_at_ms")
+    }) else {
+        return Err(DbErr::Migration(
+            "tracks.last_played_at_ms was not created".to_string(),
+        ));
+    };
+
+    let column_type: String = row.try_get("", "type")?;
+    let not_null: i32 = row.try_get("", "notnull")?;
+    let default: Option<String> = row.try_get("", "dflt_value")?;
+    let primary_key: i32 = row.try_get("", "pk")?;
+    if !column_type.eq_ignore_ascii_case("bigint")
+        || not_null != 0
+        || default.is_some()
+        || primary_key != 0
+    {
+        return Err(DbErr::Migration(format!(
+            "tracks.last_played_at_ms has an unexpected schema: \
+             type={column_type:?}, not_null={not_null}, default={default:?}, \
+             primary_key={primary_key}"
+        )));
+    }
+
+    Ok(())
+}
+
+#[derive(DeriveIden)]
+enum Tracks {
+    Table,
+    LastPlayedAtMs,
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm_migration::sea_orm::{
+        ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement,
+    };
+
+    use super::*;
+    use crate::db::migration::Migrator;
+
+    async fn database_before_playback_history_migration() -> DatabaseConnection {
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("open in-memory database");
+        Migrator::up(&db, Some(9))
+            .await
+            .expect("apply migrations preceding playback history");
+        db
+    }
+
+    async fn insert_track(db: &DatabaseConnection, id: &str, play_count: i32) {
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO tracks (
+                 id, file_path, title, artist_name, album_title, play_count,
+                 date_added, date_modified
+             ) VALUES (?, ?, 'Title', 'Artist', 'Album', ?, 'added', 'modified')",
+            [
+                id.into(),
+                format!("/music/{id}.flac").into(),
+                play_count.into(),
+            ],
+        ))
+        .await
+        .expect("insert pre-migration track");
+    }
+
+    async fn playback_column(db: &DatabaseConnection) -> Option<(String, i32, Option<String>)> {
+        db.query_all(Statement::from_string(
+            DbBackend::Sqlite,
+            "PRAGMA table_info('tracks')".to_string(),
+        ))
+        .await
+        .expect("inspect track columns")
+        .into_iter()
+        .find_map(|row| {
+            let name: String = row.try_get("", "name").ok()?;
+            (name == "last_played_at_ms").then(|| {
+                (
+                    row.try_get("", "type").expect("playback timestamp type"),
+                    row.try_get("", "notnull")
+                        .expect("playback timestamp nullability"),
+                    row.try_get("", "dflt_value")
+                        .expect("playback timestamp default"),
+                )
+            })
+        })
+    }
+
+    async fn track_history(db: &DatabaseConnection, id: &str) -> (i32, Option<i64>) {
+        let row = db
+            .query_one(Statement::from_sql_and_values(
+                DbBackend::Sqlite,
+                "SELECT play_count, last_played_at_ms FROM tracks WHERE id = ?",
+                [id.into()],
+            ))
+            .await
+            .expect("query migrated track")
+            .expect("migrated track exists");
+        (
+            row.try_get("", "play_count").expect("play count"),
+            row.try_get("", "last_played_at_ms")
+                .expect("last-played timestamp"),
+        )
+    }
+
+    async fn migration_is_applied(db: &DatabaseConnection) -> bool {
+        let migration_name = Migration.name().to_string();
+        Migrator::get_migration_models(db)
+            .await
+            .expect("query migration ledger")
+            .iter()
+            .any(|migration| migration.version == migration_name)
+    }
+
+    #[tokio::test]
+    async fn up_adds_nullable_bigint_and_repairs_only_negative_counts() {
+        let db = database_before_playback_history_migration().await;
+        insert_track(&db, "positive", 27).await;
+        insert_track(&db, "zero", 0).await;
+        insert_track(&db, "negative", -4).await;
+
+        Migrator::up(&db, Some(1))
+            .await
+            .expect("apply playback-history migration");
+
+        assert_eq!(
+            playback_column(&db).await,
+            Some(("bigint".to_string(), 0, None))
+        );
+        assert_eq!(track_history(&db, "positive").await, (27, None));
+        assert_eq!(track_history(&db, "zero").await, (0, None));
+        assert_eq!(track_history(&db, "negative").await, (0, None));
+    }
+
+    #[tokio::test]
+    async fn up_rejects_an_incompatible_existing_column_without_repairing_counts() {
+        let db = database_before_playback_history_migration().await;
+        insert_track(&db, "negative", -4).await;
+        db.execute_unprepared(
+            "ALTER TABLE tracks ADD COLUMN last_played_at_ms TEXT NOT NULL DEFAULT 'unknown'",
+        )
+        .await
+        .expect("install incompatible legacy column");
+
+        let error = Migrator::up(&db, Some(1))
+            .await
+            .expect_err("incompatible playback-history column must fail closed");
+        assert!(
+            error.to_string().contains("unexpected schema"),
+            "unexpected migration error: {error}"
+        );
+        assert!(!migration_is_applied(&db).await);
+
+        let count: i32 = db
+            .query_one(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT play_count FROM tracks WHERE id = 'negative'".to_string(),
+            ))
+            .await
+            .expect("query track after rejected migration")
+            .expect("legacy track remains")
+            .try_get("", "play_count")
+            .expect("read unchanged play count");
+        assert_eq!(count, -4, "validation must precede legacy repair");
+    }
+
+    #[tokio::test]
+    async fn migrator_finishes_an_already_applied_schema_change() {
+        let db = database_before_playback_history_migration().await;
+        insert_track(&db, "legacy", -8).await;
+        let manager = SchemaManager::new(&db);
+
+        Migration
+            .up(&manager)
+            .await
+            .expect("apply schema without migration ledger update");
+        assert!(!migration_is_applied(&db).await);
+        assert_eq!(track_history(&db, "legacy").await, (0, None));
+
+        db.execute_unprepared("UPDATE tracks SET play_count = -2 WHERE id = 'legacy'")
+            .await
+            .expect("simulate another legacy write before retry");
+        Migration
+            .up(&manager)
+            .await
+            .expect("repeat direct migration");
+        Migrator::up(&db, Some(1))
+            .await
+            .expect("finish playback-history migration");
+
+        assert!(migration_is_applied(&db).await);
+        assert_eq!(track_history(&db, "legacy").await, (0, None));
+    }
+
+    #[tokio::test]
+    async fn down_and_up_round_trip_preserves_tracks_and_resets_timestamp_to_null() {
+        let db = database_before_playback_history_migration().await;
+        insert_track(&db, "round-trip", 11).await;
+        Migrator::up(&db, Some(1))
+            .await
+            .expect("apply playback-history migration");
+        db.execute_unprepared(
+            "UPDATE tracks SET last_played_at_ms = 1721234567890 \
+             WHERE id = 'round-trip'",
+        )
+        .await
+        .expect("record playback timestamp");
+
+        Migrator::down(&db, Some(1))
+            .await
+            .expect("roll back playback-history migration");
+        assert_eq!(playback_column(&db).await, None);
+
+        let count: i32 = db
+            .query_one(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT play_count FROM tracks WHERE id = 'round-trip'".to_string(),
+            ))
+            .await
+            .expect("query track after rollback")
+            .expect("track survives rollback")
+            .try_get("", "play_count")
+            .expect("play count survives rollback");
+        assert_eq!(count, 11);
+
+        Migrator::up(&db, Some(1))
+            .await
+            .expect("reapply playback-history migration");
+        assert_eq!(track_history(&db, "round-trip").await, (11, None));
+
+        Migration
+            .down(&SchemaManager::new(&db))
+            .await
+            .expect("drop playback-history column before ledger update");
+        assert!(migration_is_applied(&db).await);
+
+        Migrator::down(&db, Some(1))
+            .await
+            .expect("finish partially applied playback-history teardown");
+        assert!(!migration_is_applied(&db).await);
+        Migration
+            .down(&SchemaManager::new(&db))
+            .await
+            .expect("repeat playback-history teardown");
+        assert_eq!(playback_column(&db).await, None);
+    }
+}

--- a/src/db/migration/m20260718_000010_add_playback_history.rs
+++ b/src/db/migration/m20260718_000010_add_playback_history.rs
@@ -78,11 +78,13 @@ async fn validate_last_played_column(manager: &SchemaManager<'_>) -> Result<(), 
     let not_null: i32 = row.try_get("", "notnull")?;
     let default: Option<String> = row.try_get("", "dflt_value")?;
     let primary_key: i32 = row.try_get("", "pk")?;
-    if !column_type.eq_ignore_ascii_case("bigint")
-        || not_null != 0
-        || default.is_some()
-        || primary_key != 0
-    {
+    // SQLite gives BIGINT and INTEGER the same signed 64-bit integer
+    // affinity. Fresh Tributary migrations declare BIGINT, but accepting the
+    // equivalent INTEGER spelling keeps an interrupted/manual compatible
+    // schema usable across SeaQuery declaration changes.
+    let compatible_integer =
+        column_type.eq_ignore_ascii_case("bigint") || column_type.eq_ignore_ascii_case("integer");
+    if !compatible_integer || not_null != 0 || default.is_some() || primary_key != 0 {
         return Err(DbErr::Migration(format!(
             "tracks.last_played_at_ms has an unexpected schema: \
              type={column_type:?}, not_null={not_null}, default={default:?}, \
@@ -233,6 +235,26 @@ mod tests {
             .try_get("", "play_count")
             .expect("read unchanged play count");
         assert_eq!(count, -4, "validation must precede legacy repair");
+    }
+
+    #[tokio::test]
+    async fn up_accepts_sqlites_equivalent_nullable_integer_spelling() {
+        let db = database_before_playback_history_migration().await;
+        insert_track(&db, "negative", -4).await;
+        db.execute_unprepared("ALTER TABLE tracks ADD COLUMN last_played_at_ms INTEGER")
+            .await
+            .expect("install compatible SQLite integer column");
+
+        Migrator::up(&db, Some(1))
+            .await
+            .expect("accept equivalent SQLite integer declaration");
+
+        assert!(migration_is_applied(&db).await);
+        let (column_type, not_null, default) =
+            playback_column(&db).await.expect("playback column exists");
+        assert!(column_type.eq_ignore_ascii_case("integer"));
+        assert_eq!((not_null, default), (0, None));
+        assert_eq!(track_history(&db, "negative").await, (0, None));
     }
 
     #[tokio::test]

--- a/src/db/migration/mod.rs
+++ b/src/db/migration/mod.rs
@@ -11,6 +11,7 @@ mod m20260712_000006_playlist_track_fk;
 mod m20260714_000007_add_composer;
 mod m20260715_000008_playlist_entry_match_path;
 mod m20260715_000009_create_root_reauthorization_receipts;
+mod m20260718_000010_add_playback_history;
 
 pub struct Migrator;
 
@@ -27,6 +28,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260714_000007_add_composer::Migration),
             Box::new(m20260715_000008_playlist_entry_match_path::Migration),
             Box::new(m20260715_000009_create_root_reauthorization_receipts::Migration),
+            Box::new(m20260718_000010_add_playback_history::Migration),
         ]
     }
 }

--- a/src/external_file.rs
+++ b/src/external_file.rs
@@ -154,6 +154,7 @@ impl ExternalFileCandidate {
             sample_rate_hz: parsed.sample_rate_hz,
             format: Some(parsed.format),
             play_count: None,
+            last_played: None,
         };
 
         ExternalFileAdapter {

--- a/src/jellyfin/backend.rs
+++ b/src/jellyfin/backend.rs
@@ -642,6 +642,7 @@ fn jellyfin_item_to_track(
         sample_rate_hz,
         format: item.container.clone(),
         play_count: item.user_data.as_ref().and_then(|ud| ud.play_count),
+        last_played: None,
     }
 }
 

--- a/src/local/backend.rs
+++ b/src/local/backend.rs
@@ -425,6 +425,7 @@ mod tests {
             sample_rate_hz: Set(None),
             format: Set(Some("FLAC".to_owned())),
             play_count: Set(0),
+            last_played_at_ms: Set(None),
             date_added: Set("2026-07-17T00:00:00Z".to_owned()),
             date_modified: Set("2026-07-17T00:00:00Z".to_owned()),
             file_size_bytes: Set(None),

--- a/src/local/engine.rs
+++ b/src/local/engine.rs
@@ -5793,6 +5793,7 @@ where
             sample_rate_hz: Set(parsed.sample_rate_hz.map(|s| s as i32)),
             format: Set(Some(parsed.format.clone())),
             play_count: Set(0),
+            last_played_at_ms: Set(None),
             date_added: Set(now),
             date_modified: Set(mtime),
             file_size_bytes: Set(parsed.file_size_bytes.map(|s| s as i64)),
@@ -6191,7 +6192,12 @@ pub fn db_model_to_track(model: &track::Model) -> Track {
         bitrate_kbps: model.bitrate_kbps.map(|b| b as u32),
         sample_rate_hz: model.sample_rate_hz.map(|s| s as u32),
         format: model.format.clone(),
-        play_count: Some(model.play_count as u32),
+        // Legacy/corrupt negative counts must never wrap into enormous UI
+        // values while the repair migration is pending or being inspected.
+        play_count: Some(u32::try_from(model.play_count).unwrap_or_default()),
+        last_played: model
+            .last_played_at_ms
+            .and_then(chrono::DateTime::<Utc>::from_timestamp_millis),
     }
 }
 
@@ -7423,6 +7429,7 @@ mod tests {
             sample_rate_hz: Some(44_100),
             format: Some("FLAC".to_string()),
             play_count,
+            last_played_at_ms: Some(1_748_776_400_123),
             date_added: "2025-01-02T03:04:05Z".to_string(),
             date_modified: "2025-01-02T03:04:05Z".to_string(),
             file_size_bytes: Some(1_000),
@@ -7701,6 +7708,7 @@ mod tests {
         assert_eq!(renamed.title, "Updated Title");
         assert_eq!(renamed.artist_name, "Updated Artist");
         assert_eq!(renamed.play_count, 17);
+        assert_eq!(renamed.last_played_at_ms, Some(1_748_776_400_123));
         assert_eq!(renamed.date_added, "2025-01-02T03:04:05Z");
 
         let entry_after = playlist_entry::Entity::find_by_id(&entry_before.id)
@@ -8463,6 +8471,7 @@ mod tests {
             directory_fixture_key("/music/Renamed/01.flac")
         );
         assert_eq!(renamed.play_count, 11, "history survives the move");
+        assert_eq!(renamed.last_played_at_ms, Some(1_748_776_400_123));
         assert_eq!(renamed.date_added, "2025-01-02T03:04:05Z");
         assert_eq!(
             renamed.date_modified, "2025-01-02T03:04:05Z",
@@ -10958,6 +10967,7 @@ mod tests {
             sample_rate_hz: None,
             format: Some("MP3".to_string()),
             play_count: 0,
+            last_played_at_ms: None,
             date_added: "2026-07-10T00:00:00Z".to_string(),
             date_modified: "2026-07-10T00:00:00Z".to_string(),
             file_size_bytes: None,
@@ -11050,6 +11060,7 @@ mod tests {
             sample_rate_hz: Some(44100),
             format: Some("FLAC".to_string()),
             play_count: 5,
+            last_played_at_ms: Some(1_748_776_400_123),
             date_added: "2025-01-15T10:30:00+00:00".to_string(),
             date_modified: "2025-06-01T14:00:00+00:00".to_string(),
             file_size_bytes: Some(30_000_000),
@@ -11073,6 +11084,10 @@ mod tests {
         assert_eq!(track.sample_rate_hz, Some(44100));
         assert_eq!(track.format, Some("FLAC".to_string()));
         assert_eq!(track.play_count, Some(5));
+        assert_eq!(
+            track.last_played.map(|instant| instant.timestamp_millis()),
+            Some(1_748_776_400_123)
+        );
         assert_eq!(track.file_path, Some("/music/song.flac".to_string()));
         assert!(track.stream_url.is_none());
         assert!(track.cover_art_url.is_none());
@@ -11099,6 +11114,7 @@ mod tests {
             sample_rate_hz: None,
             format: None,
             play_count: 0,
+            last_played_at_ms: None,
             date_added: "2025-01-01T00:00:00+00:00".to_string(),
             date_modified: "2025-01-01T00:00:00+00:00".to_string(),
             file_size_bytes: None,
@@ -11115,6 +11131,7 @@ mod tests {
         assert_eq!(track.sample_rate_hz, None);
         assert_eq!(track.format, None);
         assert_eq!(track.play_count, Some(0));
+        assert_eq!(track.last_played, None);
     }
 
     #[test]
@@ -11136,6 +11153,7 @@ mod tests {
             sample_rate_hz: None,
             format: None,
             play_count: 0,
+            last_played_at_ms: None,
             date_added: "2025-01-01T00:00:00+00:00".to_string(),
             date_modified: "2025-01-01T00:00:00+00:00".to_string(),
             file_size_bytes: None,
@@ -11177,6 +11195,7 @@ mod tests {
             sample_rate_hz: None,
             format: None,
             play_count: 0,
+            last_played_at_ms: Some(i64::MAX),
             date_added: "not-a-date".to_string(),
             date_modified: "also-not-a-date".to_string(),
             file_size_bytes: None,
@@ -11186,6 +11205,35 @@ mod tests {
         // Invalid dates should result in None, not a panic.
         assert!(track.date_added.is_none());
         assert!(track.date_modified.is_none());
+        assert!(track.last_played.is_none());
+    }
+
+    #[test]
+    fn test_db_model_to_track_repairs_negative_play_count_at_the_read_boundary() {
+        let model = track::Model {
+            id: "legacy-negative-play-count".to_string(),
+            file_path: "/music/legacy.flac".to_string(),
+            title: "Legacy".to_string(),
+            artist_name: "Artist".to_string(),
+            album_artist_name: None,
+            album_title: "Album".to_string(),
+            genre: None,
+            composer: None,
+            year: None,
+            track_number: None,
+            disc_number: None,
+            duration_secs: None,
+            bitrate_kbps: None,
+            sample_rate_hz: None,
+            format: Some("FLAC".to_string()),
+            play_count: -1,
+            last_played_at_ms: None,
+            date_added: "2025-01-01T00:00:00Z".to_string(),
+            date_modified: "2025-01-01T00:00:00Z".to_string(),
+            file_size_bytes: None,
+        };
+
+        assert_eq!(db_model_to_track(&model).play_count, Some(0));
     }
 
     #[test]

--- a/src/local/mod.rs
+++ b/src/local/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod backend;
 pub mod engine;
+pub mod playback_history;
 pub mod playlist_io;
 pub mod playlist_manager;
 pub mod resolver;

--- a/src/local/playback_history.rs
+++ b/src/local/playback_history.rs
@@ -1,0 +1,488 @@
+//! Pure progress accounting for durable local playback history.
+//!
+//! A [`PlaybackHistoryProgress`] belongs to one playback occurrence. It does
+//! not read a clock or perform persistence: the playback coordinator feeds it
+//! advancing position samples, reports user seeks explicitly, and neutrally
+//! re-anchors it for retries or resumes. The single `true` returned by an
+//! observation is the point at which the coordinator may persist one counted
+//! play.
+
+/// The longest listening time required to count one playback occurrence.
+pub const MAX_COUNT_THRESHOLD_MS: u64 = 4 * 60 * 1_000;
+
+/// Progress toward counting one local playback occurrence.
+///
+/// Consecutive position samples are assumed to represent uninterrupted,
+/// forward playback. A caller must use [`Self::observe_seek`] before the next
+/// sample after a seek or restart and [`Self::observe_reanchor`] after a retry
+/// or resume. Paused and buffering pipelines must not provide advancing
+/// samples.
+///
+/// A positive known duration uses half the duration, rounded up to the next
+/// millisecond and capped at four minutes. A missing or zero duration begins
+/// with the four-minute fallback and may accept the first positive duration
+/// later. Once a positive duration is accepted, its threshold is frozen.
+/// Create a new value only for a genuinely new queue occurrence; retrying,
+/// resuming, restarting, or seeking the current occurrence must retain this
+/// value.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PlaybackHistoryProgress {
+    positive_duration_is_frozen: bool,
+    threshold_ms: u64,
+    credited_ms: u64,
+    position_ms: u64,
+    observed_forward_skip: bool,
+    counted: bool,
+}
+
+impl PlaybackHistoryProgress {
+    /// Start accounting for an occurrence at position zero.
+    ///
+    /// A positive `duration_ms` freezes the threshold immediately. `None` and
+    /// zero use the unknown-duration fallback until
+    /// [`Self::observe_duration`] receives the first positive duration.
+    #[must_use]
+    pub fn new(duration_ms: Option<u64>) -> Self {
+        let positive_duration = duration_ms.filter(|duration_ms| *duration_ms > 0);
+        let threshold_ms = positive_duration.map_or(MAX_COUNT_THRESHOLD_MS, count_threshold_ms);
+
+        Self {
+            positive_duration_is_frozen: positive_duration.is_some(),
+            threshold_ms,
+            credited_ms: 0,
+            position_ms: 0,
+            observed_forward_skip: false,
+            counted: false,
+        }
+    }
+
+    /// Supply duration discovered by the playback output.
+    ///
+    /// For an occurrence that began with a missing or zero duration, the
+    /// first positive value replaces the four-minute fallback and freezes the
+    /// threshold. Zero and all later values are ignored. Returns `true`
+    /// exactly once if already accumulated credit reaches the newly reduced
+    /// threshold.
+    #[must_use]
+    pub fn observe_duration(&mut self, duration_ms: u64) -> bool {
+        if !self.positive_duration_is_frozen && duration_ms > 0 {
+            self.threshold_ms = count_threshold_ms(duration_ms);
+            self.credited_ms = self.credited_ms.min(self.threshold_ms);
+            self.positive_duration_is_frozen = true;
+            return self.latch_threshold();
+        }
+
+        false
+    }
+
+    /// Observe an uninterrupted playback position.
+    ///
+    /// Only a strictly advancing sample earns credit. Duplicate and regressed
+    /// samples are ignored as stale or implausible; a real backward seek or
+    /// restart must first be reported with [`Self::observe_seek`]. A retry or
+    /// resume must similarly use [`Self::observe_reanchor`].
+    /// Returns `true` exactly once, when accumulated credit first reaches the
+    /// effective threshold.
+    #[must_use]
+    pub fn observe_position(&mut self, position_ms: u64) -> bool {
+        if position_ms > self.position_ms {
+            let advance_ms = position_ms - self.position_ms;
+            self.credited_ms = self
+                .credited_ms
+                .saturating_add(advance_ms)
+                .min(self.threshold_ms);
+            self.position_ms = position_ms;
+        }
+
+        self.latch_threshold()
+    }
+
+    /// Re-anchor after a seek or restart without earning jump credit.
+    ///
+    /// A forward seek records that content may have been skipped. That
+    /// evidence prevents an unknown-duration natural end from taking its
+    /// otherwise permitted early-count path. Backward and equal seeks do not
+    /// erase credit or prior forward-skip evidence. This operation can never
+    /// itself count the occurrence.
+    pub fn observe_seek(&mut self, position_ms: u64) {
+        if position_ms > self.position_ms {
+            self.observed_forward_skip = true;
+        }
+        self.position_ms = position_ms;
+    }
+
+    /// Re-anchor after a retry, resume, or same-occurrence output handoff.
+    ///
+    /// The position jump earns no credit, but it is not user skip evidence and
+    /// therefore does not suppress the unknown-duration natural-end rule.
+    /// Existing credit and prior forward-seek evidence remain unchanged.
+    pub fn observe_reanchor(&mut self, position_ms: u64) {
+        self.position_ms = position_ms;
+    }
+
+    /// Observe a natural end of stream.
+    ///
+    /// Known-duration media receive no tail credit at end of stream and can
+    /// count only when the normal threshold has already been observed.
+    /// Unknown-duration media may count early at a natural end only when no
+    /// forward seek has ever provided evidence of skipped content.
+    /// Returns `true` only for the occurrence's first count decision.
+    #[must_use]
+    pub fn observe_natural_end(&mut self) -> bool {
+        if self.positive_duration_is_frozen {
+            return self.latch_threshold();
+        }
+
+        if !self.counted && !self.observed_forward_skip {
+            self.counted = true;
+            return true;
+        }
+
+        false
+    }
+
+    /// The current listening threshold for this occurrence.
+    ///
+    /// It becomes immutable when the first positive duration is accepted.
+    #[must_use]
+    pub const fn threshold_ms(&self) -> u64 {
+        self.threshold_ms
+    }
+
+    /// Credited forward playback, capped at the threshold.
+    #[must_use]
+    pub const fn credited_ms(&self) -> u64 {
+        self.credited_ms
+    }
+
+    /// Whether a forward seek has supplied skip evidence.
+    #[must_use]
+    pub const fn observed_forward_skip(&self) -> bool {
+        self.observed_forward_skip
+    }
+
+    /// Whether this occurrence has already produced its one count signal.
+    #[must_use]
+    pub const fn is_counted(&self) -> bool {
+        self.counted
+    }
+
+    fn latch_threshold(&mut self) -> bool {
+        if !self.counted && self.credited_ms >= self.threshold_ms {
+            self.counted = true;
+            return true;
+        }
+
+        false
+    }
+}
+
+const fn ceil_half(value: u64) -> u64 {
+    value / 2 + value % 2
+}
+
+const fn count_threshold_ms(duration_ms: u64) -> u64 {
+    let half_duration_ms = ceil_half(duration_ms);
+    if half_duration_ms < MAX_COUNT_THRESHOLD_MS {
+        half_duration_ms
+    } else {
+        MAX_COUNT_THRESHOLD_MS
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_duration_threshold_is_half_rounded_up() {
+        assert_eq!(PlaybackHistoryProgress::new(Some(10)).threshold_ms(), 5);
+        assert_eq!(PlaybackHistoryProgress::new(Some(9)).threshold_ms(), 5);
+        assert_eq!(PlaybackHistoryProgress::new(Some(1)).threshold_ms(), 1);
+    }
+
+    #[test]
+    fn known_duration_threshold_is_capped_at_four_minutes() {
+        assert_eq!(
+            PlaybackHistoryProgress::new(Some(479_999)).threshold_ms(),
+            240_000
+        );
+        assert_eq!(
+            PlaybackHistoryProgress::new(Some(480_000)).threshold_ms(),
+            240_000
+        );
+        assert_eq!(
+            PlaybackHistoryProgress::new(Some(480_001)).threshold_ms(),
+            240_000
+        );
+        assert_eq!(
+            PlaybackHistoryProgress::new(Some(u64::MAX)).threshold_ms(),
+            240_000
+        );
+    }
+
+    #[test]
+    fn unknown_duration_uses_four_minute_threshold() {
+        assert_eq!(
+            PlaybackHistoryProgress::new(None).threshold_ms(),
+            MAX_COUNT_THRESHOLD_MS
+        );
+        assert_eq!(
+            PlaybackHistoryProgress::new(Some(0)).threshold_ms(),
+            MAX_COUNT_THRESHOLD_MS
+        );
+    }
+
+    #[test]
+    fn initial_positive_duration_freezes_threshold_against_disagreement() {
+        let mut progress = PlaybackHistoryProgress::new(Some(20_000));
+
+        assert!(!progress.observe_duration(2_000));
+        assert_eq!(progress.threshold_ms(), 10_000);
+        assert!(!progress.observe_duration(80_000));
+        assert_eq!(progress.threshold_ms(), 10_000);
+    }
+
+    #[test]
+    fn first_later_positive_duration_replaces_unknown_fallback_and_freezes() {
+        let mut progress = PlaybackHistoryProgress::new(None);
+
+        assert!(!progress.observe_duration(0));
+        assert_eq!(progress.threshold_ms(), MAX_COUNT_THRESHOLD_MS);
+        assert!(!progress.observe_duration(20_001));
+        assert_eq!(progress.threshold_ms(), 10_001);
+        assert!(!progress.observe_duration(2_000));
+        assert_eq!(progress.threshold_ms(), 10_001);
+    }
+
+    #[test]
+    fn later_positive_duration_can_latch_already_accumulated_credit() {
+        let mut progress = PlaybackHistoryProgress::new(Some(0));
+
+        assert!(!progress.observe_position(12_000));
+        assert!(progress.observe_duration(20_000));
+        assert_eq!(progress.threshold_ms(), 10_000);
+        assert_eq!(progress.credited_ms(), 10_000);
+        assert!(!progress.observe_duration(1));
+        assert!(!progress.observe_position(13_000));
+    }
+
+    #[test]
+    fn later_positive_duration_does_not_latch_before_reduced_threshold() {
+        let mut progress = PlaybackHistoryProgress::new(None);
+
+        assert!(!progress.observe_position(9_999));
+        assert!(!progress.observe_duration(20_000));
+        assert_eq!(progress.threshold_ms(), 10_000);
+        assert!(progress.observe_position(10_000));
+    }
+
+    #[test]
+    fn short_track_counts_at_exact_threshold_not_before() {
+        let mut progress = PlaybackHistoryProgress::new(Some(3_001));
+        assert_eq!(progress.threshold_ms(), 1_501);
+
+        assert!(!progress.observe_position(1_500));
+        assert_eq!(progress.credited_ms(), 1_500);
+        assert!(progress.observe_position(1_501));
+        assert_eq!(progress.credited_ms(), 1_501);
+        assert!(progress.is_counted());
+    }
+
+    #[test]
+    fn multiple_samples_accumulate_observed_forward_playback() {
+        let mut progress = PlaybackHistoryProgress::new(Some(20_000));
+
+        assert!(!progress.observe_position(2_000));
+        assert!(!progress.observe_position(6_000));
+        assert_eq!(progress.credited_ms(), 6_000);
+        assert!(progress.observe_position(10_000));
+    }
+
+    #[test]
+    fn duplicate_samples_provide_no_credit() {
+        let mut progress = PlaybackHistoryProgress::new(Some(20_000));
+
+        assert!(!progress.observe_position(4_000));
+        assert!(!progress.observe_position(4_000));
+        assert!(!progress.observe_position(4_000));
+        assert_eq!(progress.credited_ms(), 4_000);
+    }
+
+    #[test]
+    fn regressed_sample_is_ignored_without_manufacturing_replay_credit() {
+        let mut progress = PlaybackHistoryProgress::new(Some(20_000));
+
+        assert!(!progress.observe_position(7_000));
+        assert!(!progress.observe_position(2_000));
+        assert_eq!(progress.credited_ms(), 7_000);
+        assert!(!progress.observe_position(8_000));
+        assert_eq!(progress.credited_ms(), 8_000);
+        assert!(progress.observe_position(10_000));
+    }
+
+    #[test]
+    fn forward_seek_provides_no_credit_and_records_skip_evidence() {
+        let mut progress = PlaybackHistoryProgress::new(Some(30_000));
+
+        assert!(!progress.observe_position(4_000));
+        progress.observe_seek(13_000);
+        assert_eq!(progress.credited_ms(), 4_000);
+        assert!(progress.observed_forward_skip());
+
+        assert!(!progress.observe_position(14_000));
+        assert_eq!(progress.credited_ms(), 5_000);
+    }
+
+    #[test]
+    fn backward_seek_does_not_erase_credit_or_create_skip_evidence() {
+        let mut progress = PlaybackHistoryProgress::new(Some(20_000));
+
+        assert!(!progress.observe_position(7_000));
+        progress.observe_seek(2_000);
+        assert_eq!(progress.credited_ms(), 7_000);
+        assert!(!progress.observed_forward_skip());
+
+        assert!(progress.observe_position(5_000));
+        assert_eq!(progress.credited_ms(), 10_000);
+    }
+
+    #[test]
+    fn restart_at_zero_preserves_credit_for_same_occurrence() {
+        let mut progress = PlaybackHistoryProgress::new(Some(20_000));
+
+        assert!(!progress.observe_position(6_000));
+        progress.observe_seek(0);
+        assert!(!progress.observe_position(3_999));
+        assert!(progress.observe_position(4_000));
+        assert_eq!(progress.credited_ms(), 10_000);
+    }
+
+    #[test]
+    fn retry_and_resume_reanchor_without_resetting_occurrence() {
+        let mut progress = PlaybackHistoryProgress::new(Some(20_000));
+
+        assert!(!progress.observe_position(4_000));
+        // A retry resumes from the last reported position.
+        progress.observe_reanchor(4_000);
+        assert!(!progress.observe_position(7_000));
+        // Another retry restarts decoding from an earlier point.
+        progress.observe_reanchor(5_000);
+        assert!(progress.observe_position(8_000));
+        assert_eq!(progress.credited_ms(), 10_000);
+    }
+
+    #[test]
+    fn forward_retry_reanchor_is_not_user_skip_evidence() {
+        let mut progress = PlaybackHistoryProgress::new(None);
+
+        assert!(!progress.observe_position(10_000));
+        progress.observe_reanchor(12_000);
+
+        assert_eq!(progress.credited_ms(), 10_000);
+        assert!(!progress.observed_forward_skip());
+        assert!(progress.observe_natural_end());
+    }
+
+    #[test]
+    fn counted_signal_is_latched_exactly_once() {
+        let mut progress = PlaybackHistoryProgress::new(Some(10_000));
+
+        assert!(progress.observe_position(5_000));
+        assert!(!progress.observe_position(6_000));
+        assert!(!progress.observe_position(10_000));
+        assert!(!progress.observe_natural_end());
+        assert!(progress.is_counted());
+    }
+
+    #[test]
+    fn repeat_one_replay_uses_a_fresh_count_latch() {
+        let mut first_occurrence = PlaybackHistoryProgress::new(Some(10_000));
+        assert!(first_occurrence.observe_position(5_000));
+        assert!(!first_occurrence.observe_natural_end());
+
+        let mut replay_occurrence = PlaybackHistoryProgress::new(Some(10_000));
+        assert!(!replay_occurrence.is_counted());
+        assert!(replay_occurrence.observe_position(5_000));
+    }
+
+    #[test]
+    fn credit_is_capped_at_threshold_even_for_large_samples() {
+        let mut progress = PlaybackHistoryProgress::new(None);
+
+        assert!(progress.observe_position(u64::MAX));
+        assert_eq!(progress.credited_ms(), MAX_COUNT_THRESHOLD_MS);
+    }
+
+    #[test]
+    fn known_duration_natural_end_does_not_credit_unobserved_tail() {
+        let mut progress = PlaybackHistoryProgress::new(Some(20_000));
+
+        assert!(!progress.observe_position(9_999));
+        assert!(!progress.observe_natural_end());
+        assert!(!progress.is_counted());
+    }
+
+    #[test]
+    fn known_duration_natural_end_cannot_hide_a_forward_skip() {
+        let mut progress = PlaybackHistoryProgress::new(Some(20_000));
+
+        assert!(!progress.observe_position(4_000));
+        progress.observe_seek(19_000);
+        assert!(!progress.observe_natural_end());
+        assert!(!progress.is_counted());
+    }
+
+    #[test]
+    fn zero_duration_is_unknown_and_can_count_at_unskipped_natural_end() {
+        let mut progress = PlaybackHistoryProgress::new(Some(0));
+
+        assert!(progress.observe_natural_end());
+        assert_eq!(progress.credited_ms(), 0);
+        assert!(!progress.observe_natural_end());
+    }
+
+    #[test]
+    fn unknown_duration_natural_end_counts_without_forward_skip() {
+        let mut progress = PlaybackHistoryProgress::new(None);
+
+        assert!(!progress.observe_position(12_000));
+        assert!(progress.observe_natural_end());
+        assert!(!progress.observe_natural_end());
+    }
+
+    #[test]
+    fn unknown_duration_natural_end_allows_backward_seek() {
+        let mut progress = PlaybackHistoryProgress::new(None);
+
+        assert!(!progress.observe_position(12_000));
+        progress.observe_seek(1_000);
+        assert!(!progress.observed_forward_skip());
+        assert!(progress.observe_natural_end());
+    }
+
+    #[test]
+    fn unknown_duration_natural_end_rejects_any_prior_forward_skip() {
+        let mut progress = PlaybackHistoryProgress::new(None);
+
+        assert!(!progress.observe_position(12_000));
+        progress.observe_seek(20_000);
+        progress.observe_seek(0);
+        assert!(!progress.observe_position(30_000));
+        assert!(progress.observed_forward_skip());
+        assert!(!progress.observe_natural_end());
+    }
+
+    #[test]
+    fn unknown_duration_can_reach_normal_threshold_despite_forward_skip() {
+        let mut progress = PlaybackHistoryProgress::new(None);
+
+        assert!(!progress.observe_position(120_000));
+        progress.observe_seek(180_000);
+        assert!(!progress.observe_position(239_999));
+        progress.observe_seek(0);
+        assert!(progress.observe_position(60_001));
+        assert_eq!(progress.credited_ms(), MAX_COUNT_THRESHOLD_MS);
+        assert!(!progress.observe_natural_end());
+    }
+}

--- a/src/local/playlist_io.rs
+++ b/src/local/playlist_io.rs
@@ -831,6 +831,7 @@ mod tests {
             sample_rate_hz: None,
             format: None,
             play_count: 0,
+            last_played_at_ms: None,
             date_added: "2026-01-01T00:00:00Z".to_string(),
             date_modified: "2026-01-01T00:00:00Z".to_string(),
             file_size_bytes: None,

--- a/src/local/playlist_manager.rs
+++ b/src/local/playlist_manager.rs
@@ -717,6 +717,7 @@ mod tests {
             sample_rate_hz: None,
             format: None,
             play_count: 0,
+            last_played_at_ms: None,
             date_added: "2026-07-12T00:00:00Z".to_string(),
             date_modified: "2026-07-12T00:00:00Z".to_string(),
             file_size_bytes: None,

--- a/src/local/resolver.rs
+++ b/src/local/resolver.rs
@@ -452,6 +452,7 @@ mod tests {
             artist_name: Set("Artist".to_string()),
             album_title: Set("Album".to_string()),
             play_count: Set(0),
+            last_played_at_ms: Set(None),
             date_added: Set("2026-07-17T00:00:00+00:00".to_string()),
             date_modified: Set("2026-07-17T00:00:00+00:00".to_string()),
             ..Default::default()

--- a/src/local/smart_rules.rs
+++ b/src/local/smart_rules.rs
@@ -155,9 +155,10 @@ pub enum LimitUnit {
 
 /// How to select items when limiting.
 ///
-/// Recently-played sort variants are intentionally absent: tracks have
-/// no `last_played` column yet, so those modes would silently no-op.
-/// Re-add them once playback statistics are persisted.
+/// Recently-played sort variants remain intentionally absent: the durable
+/// field exists, but production playback does not populate it and smart-rule
+/// evaluation does not expose it yet. P1.3c adds both pieces together so the
+/// modes cannot silently no-op.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum LimitSort {
     Random,

--- a/src/plex/backend.rs
+++ b/src/plex/backend.rs
@@ -647,6 +647,7 @@ fn plex_track_to_track(
         sample_rate_hz: None, // Not available in Plex track metadata.
         format,
         play_count: plex.view_count,
+        last_played: None,
     }
 }
 

--- a/src/radio/adapter.rs
+++ b/src/radio/adapter.rs
@@ -345,6 +345,7 @@ fn station_track(station: &RadioStation, track_id: TrackId) -> Track {
         sample_rate_hz: None,
         format: nonempty(&station.codec),
         play_count: None,
+        last_played: None,
     }
 }
 

--- a/src/removable.rs
+++ b/src/removable.rs
@@ -272,6 +272,7 @@ fn pathless_track(
         sample_rate_hz: parsed.sample_rate_hz,
         format: Some(parsed.format),
         play_count: None,
+        last_played: None,
     }
 }
 

--- a/src/source_registry.rs
+++ b/src/source_registry.rs
@@ -1448,6 +1448,7 @@ mod tests {
             sample_rate_hz: None,
             format: None,
             play_count: None,
+            last_played: None,
         }
     }
 

--- a/src/subsonic/backend.rs
+++ b/src/subsonic/backend.rs
@@ -583,6 +583,7 @@ fn song_to_track(
         sample_rate_hz: None,
         format: song.suffix.clone(),
         play_count: song.play_count,
+        last_played: None,
     }
 }
 


### PR DESCRIPTION
## Summary

- define the authoritative local playback-occurrence, threshold, duration, seek/retry/restart,
  clock, and legacy-history contract
- add migration 10 with nullable UTC epoch-millisecond `last_played`, negative-count repair,
  interrupted-upgrade validation, and safe model conversion
- add pure one-shot playback progress accounting with separate user-seek and neutral retry/resume
  anchors, plus preservation coverage across rename and root reauthorization paths
- update the backlog to 3/35 (8.6%), roadmap, README, changelog, and canonical contract document

This foundation deliberately does not write production playback events or change Recently Played
and Top 25. Those remain the next two P1.3 records.

## Validation

- `cargo test --target-dir /home/jmulesa/tributary/target --all-targets --all-features --locked`
  - 20 library, 968 application, 10 packaging tests
- `cargo test --release --target-dir /home/jmulesa/tributary/target --all-targets --all-features --locked`
  - 20 library, 968 application, 10 packaging tests
- `cargo clippy --target-dir /home/jmulesa/tributary/target --all-targets --all-features --locked -- -D warnings`
- `cargo clippy --release --target-dir /home/jmulesa/tributary/target --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Independent review found and verified fixes for neutral retry/resume re-anchoring, non-null history
preservation, incompatible migration-column rejection, and deferred smart-rule wording. No
substantive findings remain. Gemini's review additionally prompted acceptance and regression of
SQLite's semantically equivalent nullable `INTEGER` declaration while incompatible shapes still
fail closed.
