### PR TITLE
Add source-scoped playlist storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Regular playlists now have a source-scoped storage foundation**
+  ([#140](https://github.com/jm2/tributary/pull/140)) — Migration 13 makes the exact
+  `(source_id, track_id)` pair canonical for each durable regular-playlist occurrence while keeping
+  the playlist itself a view rather than a media source. Every valid existing row is
+  deterministically assigned to the built-in local `SourceId`; entry and playlist IDs, order,
+  duplicate occurrences, nullable track identity, normalized match metadata, and imported local
+  path evidence are preserved byte-for-byte. A separate nullable
+  `local_track_id -> tracks(id) ON DELETE SET NULL`
+  cache retains local deletion and reconciliation integrity without requiring a remote native ID
+  to reference the unrelated local table. `track_id` may be absent only for an unmatched local
+  import with usable path or normalized title-and-artist evidence, populated local caches must agree
+  with canonical identity, and non-local entries must have an exact bounded native ID with neither
+  a local cache nor file-path evidence.
+  The SQLite table rebuild, data copy, index/constraint restoration, and foreign-key validation are
+  one transaction; an interrupted or forced failure restores the complete predecessor definition
+  and remains retryable. The migrator distinguishes the exact predecessor and target definitions
+  instead of accepting a partial lookalike. Downgrade round-trips representable local rows but
+  transactionally refuses any non-local or otherwise inexpressible state rather than dropping it,
+  converting it to local, or guessing by metadata.
+  Typed source-generic storage accepts only stable source/native identity plus optional non-secret
+  normalized fingerprints, adds no display/source-label snapshots, rejects non-local path evidence,
+  preserves same-ID tracks from different sources as distinct media, and stores no server
+  URL, stream/artwork locator, credential, lease, route, or session epoch. Existing manual local
+  Add/load, XSPF import/export, duplicate ordering, local reconciliation, track deletion, rename,
+  and root-reauthorization paths retain their prior behavior through the new schema. The shipping UI
+  remains intentionally local-only in this slice: it still refuses non-local Add before database
+  work and does not render or play stored non-local
+  fixtures. Live `SourceRegistry` resolution, capability-gated authenticated-source Add/Remove/Play,
+  disconnected states, lifecycle/epoch handling, and mixed-source export follow separately;
+  Radio-Browser, removable, external, and unknown sources remain unsupported. Subsonic
+  server-native playlist import or synchronization is a third, separately designed capability.
+  The complete boundary and validation matrix are in
+  [`docs/source-scoped-playlists.md`](docs/source-scoped-playlists.md).
 - **Ratings now have a durable ownership, capability, and persistence foundation**
   ([#138](https://github.com/jm2/tributary/pull/138)) — A canonical
   rating is one validated whole integer from 1 through 100, while `None` alone means unrated.
@@ -128,8 +161,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Tributary therefore adds nothing instead of silently skipping unsupported rows or modifying only
   an unexpected subset. The existing Add to Playlist, Remove from Playlist, and Properties context
   labels now use their shipped translations as well, and the refusal copy is covered across all 13
-  locale catalogs. Local-library playlist behavior is unchanged; durable source-scoped remote
-  playlist entries remain planned separately.
+  locale catalogs. Local-library playlist behavior is unchanged. The source-scoped storage
+  foundation is now described above, while live non-local playlist interaction remains a later
+  P1.5 slice.
 - **Shuffled Previous and Next now follow a bounded real playback timeline** — Tributary retains
   the current queue occurrence plus ten actual predecessors, walks backward without fabricating a
   random track at the oldest boundary, and replays fixed forward history before drawing again.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Tributary provides a unified interface for managing and streaming music from mul
 | Internet Radio (Top Clicked, Top Voted, Stations Near Me) | ✅ |
 | Tiered geo-location (geo-distance → state → country) | ✅ |
 | Column drag-and-drop reordering with persistence | ✅ |
-| Regular & smart playlists (iTunes-style rules engine) | ✅ Local-library playlists; unsupported source additions are explicitly refused, and remote persistence is planned ([#47](https://github.com/jm2/tributary/issues/47)) |
+| Regular & smart playlists (iTunes-style rules engine) | ✅ Local-library UI; regular-entry storage now has a source-scoped identity foundation, while mixed-source UI/playback remains planned ([#47](https://github.com/jm2/tributary/issues/47)) |
 | Realtime text search filter (title, artist, album, genre) | ✅ |
 | Song metadata editing (Properties dialog with Save/Cancel) | ✅ |
 | Batch metadata editing (multi-select) | ✅ |
@@ -679,14 +679,18 @@ boundaries.
 
 Tributary supports regular and smart playlists for the local library:
 
-- **Regular playlists** — Right-click the Playlists header in the sidebar to create a new playlist. Right-click tracks in the tracklist to add them. Playlists survive library folder changes via fingerprint-based track matching.
+- **Regular playlists** — Right-click the Playlists header in the sidebar to create a new playlist. Right-click tracks in the tracklist to add them. Playlists survive library folder changes via fingerprint-based track matching. Their migrated storage identity is the source-scoped `(SourceId, TrackId)` pair, with a separate nullable local-track foreign-key cache for local deletion and reconciliation; the current UI still projects only local entries.
 - **Smart playlists** — iTunes-style rules engine with filterable metadata fields, text/numeric/date operators, sorting, and result limiting. Smart playlists are evaluated against the current local library whenever they are opened or exported; they are not stored snapshots. Create them via the sidebar context menu.
 
 **Add to Playlist** currently accepts tracks only from the built-in local library. Invoking it from
 an authenticated remote, internet-radio, removable-media, or other unsupported source shows a
-localized explanation and adds nothing; it never silently writes only a subset. Persisting
-source-scoped remote tracks and importing or synchronizing server-native playlists remain planned
-under [P1.5](docs/task.md#p15--persist-source-scoped-playlists).
+localized explanation and adds nothing; it never silently writes only a subset. Migration 13 and
+the storage API can represent a non-local occurrence without a URL, credential, lease, or session
+epoch, but that capability is not UI authorization. Live `SourceRegistry` resolution,
+mixed-source Add/Remove/Play behavior, disconnected states, and Subsonic-native playlist
+import/synchronization remain follow-on work under
+[P1.5](docs/task.md#p15--persist-source-scoped-playlists). See the
+[source-scoped playlist storage contract](docs/source-scoped-playlists.md) for the exact boundary.
 
 #### Importing and exporting playlists
 
@@ -736,6 +740,11 @@ playlist schema). A database or write failure rolls the import back and does not
 An XSPF `<duration>` that is not a valid unsigned millisecond value rejects the document before a
 database transaction begins; a syntactically valid value that exceeds the playlist database range
 instead counts that individual row as failed.
+
+XSPF import continues to create entries owned by the built-in local source. The source-scoped
+storage migration does not make an HTTP(S) location or service identifier a remote playlist
+authority, and current export remains a local-track export. A future mixed-source export must use
+safe metadata without requesting or serializing a protected remote locator.
 
 Apple Music and iTunes can export playlist metadata as XML, but their XML is an Apple property-list
 format, not XSPF. Follow Apple's official export steps for

--- a/docs/architecture/source-lifecycle.md
+++ b/docs/architecture/source-lifecycle.md
@@ -3,7 +3,8 @@
 - Status: Accepted in PR #113 and fully implemented through the mounted removable-media adapter;
   P3.1 is complete. Physical removable-hardware, installed Flatpak portal/USB/custom-library, and
   packaged Windows DAAP/Subsonic playback validation remain tracked field work outside this
-  decision.
+  decision. P1.5 migration 13 extends the same identity boundary into regular-playlist storage;
+  mixed-source rendering/playback remains a follow-up and does not reopen P3.1.
 - Decision date: 2026-07-17
 - Historical tracker:
   [P3.1](../task-remediation-2026-07.md#p31-introduce-a-sourcesession-registry)
@@ -35,6 +36,14 @@ IDs; local playback and local/playlist embedded-art reads retain exact root/file
 consumption. Mounted removable sources now publish pathless registry catalogues and resolve only an
 accepted mount-relative identity through retained mount and exact-file authority. Their scans are
 generation-owned and cancelled on relocation, pre-unmount, removal, or shutdown.
+
+Regular-playlist storage now follows the same identity rule. Migration 13 assigns every existing
+entry to the built-in local source and stores its canonical `(source_id, track_id)` separately from
+the nullable local-track foreign-key cache. This foundation can represent another source without
+persisting its locator, credentials, lease, or session epoch. The shipping playlist projection is
+still deliberately local-only until the next P1.5 slice resolves those identities through the live
+registry. The full storage boundary is specified in
+[`source-scoped-playlists.md`](../source-scoped-playlists.md).
 
 The implementation has now converged on this boundary. PR #120 implements stable identity, PR #121
 adds retained local file authority through output consumption, and PR #122 introduces the generic
@@ -146,18 +155,24 @@ The existing local `tracks.id` value is already the local backend's native `Trac
 byte-for-byte, including a legacy non-UUID string. The random fallback in `db_model_to_track` has
 been removed: exact local identity uses the original string, while still-unmigrated UUID APIs see
 a frozen deterministic compatibility projection. New local tracks may continue to receive UUIDv4
-strings, and playlist foreign keys remain unchanged.
+strings. Migration 13 makes `(source_id, track_id)` the canonical regular-playlist identity and
+retains a separate nullable `local_track_id -> tracks(id) ON DELETE SET NULL` cache so existing
+local deletion and reconciliation integrity does not constrain a remote native ID to the local
+table.
 
-No remote catalogue or playback queue is persisted today. Therefore remote migration discards and
-refetches process-local catalogues; it never attempts to reverse the current one-way UUIDv5 mapping
-back into a server ID. If a future persisted format contains only that derived UUID and not the
-native locator, the row is invalidated and resynchronized rather than guessed.
+No complete remote catalogue or playback queue is persisted. A source-scoped regular-playlist row
+may retain only the exact `SourceId`, exact native `TrackId`, and safe non-secret match metadata;
+it stores no session epoch or media locator. Remote catalogue migration therefore still discards
+and refetches process-local catalogues, and never attempts to reverse a one-way UUIDv5 compatibility
+projection back into a server ID. If persisted state lacks the exact native identity, the row is
+unavailable rather than guessed.
 
 Backend-native `TrackId` values are represented as follows:
 
 | Adapter | Native track identity |
 |---|---|
-| Local and playlist projection | Exact SQLite `tracks.id` string |
+| Local library | Exact SQLite `tracks.id` string |
+| Regular-playlist occurrence | The exact `TrackId` of its owning source; currently rendered playlist rows remain local-only pending the mixed-source P1.5 slice |
 | Subsonic | Exact song `id` returned by the server |
 | Jellyfin | Exact audio item `Id` returned by the server |
 | Plex | Exact track `ratingKey`; the media-part key remains a locator |
@@ -310,19 +325,25 @@ The local playback adapter resolves the exact database `TrackId` at use, obtains
 path, proves it is contained by the most-specific currently configured authoritative root,
 acquires retained root/marker/ancestor/file authority, and keeps that authority until the output
 or file server has finished consuming it. It rechecks database bindings after acquisition and
-rechecks current root configuration before output handoff. Playlist navigation queries entries by
-playlist ID and resolves their linked local track IDs from the same current snapshot.
-Fingerprint/path fallback is only a reconciliation operation that updates
-`playlist_entries.track_id`; playback never performs fuzzy or path fallback on its own. An orphan
-remains visibly unavailable until reconciliation commits a unique match. Embedded-art display
+rechecks current root configuration before output handoff. The current playlist navigation path
+queries entries by playlist ID and resolves their nullable `local_track_id` cache from the same
+current snapshot. Stored non-local identities remain outside that projection until live-registry
+resolution is implemented.
+
+Fingerprint/path fallback is only a local reconciliation operation. It is restricted to the exact
+built-in local `source_id` and updates both canonical `track_id` and `local_track_id` only after a
+unique match commits; playback never performs fuzzy or path fallback on its own. An unmatched
+occurrence remains unavailable until reconciliation commits. Embedded-art display
 clones the exact accepted `ResolvedLocalMedia`, revalidates its physical authority when cloning the
 file, and owns that handle through generation-checked parsing. No local/playlist artwork helper
 receives or reopens the playback-time path.
 
-A playlist is a `ViewOrigin`, not a source session. Regular and smart playlist queue items carry
-the local `SourceId` and local `TrackId`, plus the playlist ID and occurrence for ordering. Deleting
-or rebuilding a playlist retires that view's pending navigation while local-source invalidation
-still retires its media.
+A playlist is a `ViewOrigin`, not a source session. Each durable regular-playlist occurrence now
+names its actual media owner with `(source_id, track_id)` while keeping the playlist ID, entry ID,
+and position as view/occurrence state. The current regular- and smart-playlist queue path still
+publishes only local rows; mixed-source GTK rows, current-epoch adoption, playback, and source-
+retirement behavior are the next P1.5 record. Deleting or rebuilding a playlist retires that view's
+pending navigation without pretending that the view owns any contributing source session.
 
 #### Remote libraries, including DAAP
 
@@ -505,6 +526,15 @@ queue can extend the same ephemeral-source rule explicitly.
   carry only pathless `SourceId`, exact `TrackId`, and the non-secret session epoch that published
   the catalogue. Resolution uses the exact native ID without a derived UUID compatibility
   projection or a generic authenticated/lease-bearing URI.
+- Regular-playlist migration 13 brings durable membership under the same identity namespace.
+  Existing entry IDs, order, duplicate occurrences, local links, and reconciliation evidence are
+  preserved while each row gains the exact built-in local `source_id`; canonical `track_id` is
+  separated from a nullable `local_track_id` foreign-key cache. New non-local storage accepts only
+  typed source/native identity plus optional non-secret normalized fingerprints and rejects file-
+  path evidence. Those fingerprints are neither display fields, identity, nor matching authority;
+  migration 13 adds no source-label snapshot. It persists no source epoch, locator, route, lease, or
+  credential. Mixed-source publication and playback remain deliberately unwired in this storage
+  slice.
 - `PlaybackSession` captures immutable source/track identity, queue order, duplicate occurrence,
   and playback event generation independently of GTK sorting/filtering. Queue identity is a
   `MediaKey`; playlists and radio queries retain a separate `ViewOrigin`, so local invalidation
@@ -527,7 +557,8 @@ queue can extend the same ephemeral-source rule explicitly.
   source loss restores Local's configured music-column and browser presentation.
 - Source navigation rejects stale same-key and cross-source publications and preserves the newest
   cache independently of rendering.
-- Local database IDs and playlist foreign keys survive authoritative file/directory renames.
+- Local database IDs and the playlist entry's canonical/local-cache pair survive authoritative
+  file/directory renames.
   Architecture rows preserve the exact SQLite ID—including a legacy non-UUID value—and local or
   playlist queues no longer retain a file locator. Every queue load resolves that ID against the
   current row and the most-specific currently configured authoritative root under a five-second
@@ -538,9 +569,10 @@ queue can extend the same ephemeral-source rule explicitly.
   full and Range requests independent even when cloned OS handles share a cursor. Every
   replacement, Stop, error, terminal queue completion, ticket drop, or output teardown retires
   future lookups. Shared Chromecast cleanup retains legacy explicit-file routes while revoking
-  credential and retained-authority routes. Playlist queue identity uses the local source plus a
-  separate `ViewOrigin`, so generic local retirement also retires a playlist-origin queue without
-  losing view navigation.
+  credential and retained-authority routes. The currently shipping playlist queue identity uses
+  the local source plus a separate `ViewOrigin`, so generic local retirement also retires a
+  playlist-origin queue without losing view navigation. A later P1.5 slice will select the source
+  per stored occurrence and retain that same separation between media owner and playlist view.
 - Removable sources derive `SourceId` from the best-available logical key and exact `TrackId` from
   the losslessly encoded mount-relative native path. Their registry-owned adapter publishes a
   pathless, epoch-bound accepted catalogue; retained mounted-root authority, an exact membership
@@ -661,7 +693,9 @@ conflict quarantine are also implemented; they do not introduce a second saved-s
 persist credentials. Exact lifecycle trait names and event-channel shapes remain internal
 implementation details so long as one registry enforces this contract. A typed retained mutation
 authority for pathless removable Properties editing is deliberately deferred; the UI omits that
-action instead of reconstructing a path or weakening playback authority.
+action instead of reconstructing a path or weakening playback authority. Source-scoped regular-
+playlist storage is specified separately, while mixed-source row resolution, playback, lifecycle
+refresh, and Subsonic-native playlist synchronization remain explicitly deferred P1.5 work.
 
 ## Implementation sequence
 
@@ -754,6 +788,9 @@ independent lifecycle systems must not become the permanent architecture.
 - Stable IDs do not claim more than their evidence supports. In particular, a removable logical
   key can collide for cloned filesystems, a relative file key does not survive rename, and an
   unsaved remote endpoint that changes URL is a new source until explicitly rebound.
+- Regular-playlist persistence can retain a source-scoped occurrence while its source is offline,
+  but storage alone does not make it playable. Only the same live source and exact native track can
+  restore authority; metadata and endpoint similarity are never substitutes.
 
 ## Rejected alternatives
 
@@ -761,8 +798,9 @@ independent lifecycle systems must not become the permanent architecture.
   material, and make relocation indistinguishable from replacement.
 - **Hash every native ID into a global UUID.** Hashing loses the backend value needed for lookup,
   hides namespace mistakes, and cannot migrate a stored hash back to the native ID.
-- **Make playlists independent sources.** They are ordered projections of local tracks; duplicating
-  source identity would weaken local invalidation and reconciliation.
+- **Make playlists independent sources.** They are ordered projections over media owned by their
+  contributing sources; duplicating source identity would weaken lifecycle invalidation and
+  reconciliation.
 - **Resolve a playlist fingerprint during playback.** Ambiguous matching belongs in transactional
   reconciliation, not an output path that must choose exactly one track.
 - **Perform DAAP logout from `Drop`.** Destructors cannot await, cannot establish exactly-once

--- a/docs/playback-history.md
+++ b/docs/playback-history.md
@@ -15,6 +15,12 @@ events, retries, seeks, and wall-clock changes must not manufacture listening hi
   files do not write into the local `tracks` table. Any source-owned remote count remains remote
   metadata and remote `last_played` remains unknown to this schema. Source-specific history or
   synchronization requires a separate ownership and privacy decision.
+- Regular-playlist migration 13 stores membership by `(source_id, track_id)` but does not broaden
+  this boundary. Only an occurrence whose `source_id` is exactly the built-in local source and
+  whose nullable local foreign-key cache resolves to that row can contribute local history. A
+  future mixed playlist may place remote and local occurrences beside each other without letting a
+  remote native ID update a coincidentally equal local ID. See the
+  [playlist storage contract](source-scoped-playlists.md).
 - `PlaybackSession` owns one `PlaybackHistoryProgress` value per queue occurrence, independently
   of replaceable output-event generations. A retry may bind a new accepted delivery to the same
   occurrence without opening another count opportunity; duplicate queue entries are distinct

--- a/docs/ratings.md
+++ b/docs/ratings.md
@@ -30,6 +30,13 @@ entire result if any track's capability disagrees with its backend, preventing U
 silently drifting from adapter policy. The default backend capability and mutation implementation
 are `Unsupported`, so a new or incomplete remote adapter fails closed.
 
+Regular-playlist migration 13 does not change that ownership. Its durable `(source_id, track_id)`
+pair records membership only; neither the entry nor its safe match fingerprint stores a rating or
+grants mutation authority. Current local playlist projections continue to edit the exact linked
+local row. A later mixed-source projection must obtain a remote row's ReadOnly or Unsupported value
+from the current live source catalogue rather than treating persisted membership as metadata
+authority. See the [playlist storage contract](source-scoped-playlists.md).
+
 ## Local persistence
 
 Migration 12 adds `tracks.rating` as a nullable SQLite `INTEGER` with a constraint requiring either
@@ -171,6 +178,8 @@ or conflict-resolution step for modifying library metadata. Therefore:
 - XSPF export intentionally omits app-owned and read-only ratings.
 - Import ignores rating-like generic `<meta>` elements and extension content.
 - Matching an imported playlist row never changes the matched local track's rating.
+- Source-scoped playlist storage persists no rating snapshot; a disconnected remote occurrence
+  cannot manufacture a readable value from its membership fingerprint.
 
 This asymmetry is intentional: an XSPF file describes playlist membership, not catalogue
 authority. A future rating-transfer feature would need an explicitly versioned scalar plus a

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,7 +6,7 @@ This document explains the product and engineering work that remains **after** t
 remediation. [`task.md`](task.md) is the countable active implementation backlog; the completed
 remediation record is preserved separately in
 [`task-remediation-2026-07.md`](task-remediation-2026-07.md) at **220/223 (98.7%)**, with only three
-real-environment validation records left. The feature backlog is now **7/35 (20.0%)** complete. Neither
+real-environment validation records left. The feature backlog is now **8/35 (22.9%)** complete. Neither
 percentage estimates equal engineering effort, and the historical percentage is not a claim that
 Tributary has implemented every requested product feature.
 
@@ -24,10 +24,14 @@ starts. Historical holistic-review documents are point-in-time findings, not act
   `MediaBackend` seam. Connected remotes, Radio-Browser, removable media, and operating-system-opened
   files use the common `SourceRegistry` lifecycle and playback-time authority model.
 - AirPlay 1/RAOP, Chromecast, MPD, and local playback are implemented. AirPlay 2/HomeKit is not.
-- Regular playlists are local-library projections. Remote tracks cannot currently be persisted in
-  them, and Subsonic server-side playlists are not imported. An Add to Playlist attempt from any
-  unsupported source now explains that boundary in the user's language and performs no database
-  work instead of silently skipping rows.
+- Regular-playlist storage now has a source-scoped foundation: migration 13 gives every valid
+  existing entry the built-in local `SourceId`, makes `(source_id, track_id)` canonical, and
+  retains a separate nullable local-track foreign-key cache for deletion and reconciliation. The
+  shipping UI remains a local-library projection, so it does not yet create, render, or play the
+  non-local rows. An Add to Playlist attempt from any unsupported source still explains that
+  boundary in the user's language and performs no database work instead of silently skipping rows.
+  Subsonic server-side playlists are not imported. See the
+  [storage contract](source-scoped-playlists.md).
 - XSPF v1 import/export is implemented with exact path and deterministic normalized-metadata
   matching. Apple/iTunes XML, Google Takeout CSV, M3U, service URLs, and fuzzy matching are not
   direct input modes. Ratings are intentionally omitted on export and rating-like extension data
@@ -79,9 +83,9 @@ before starting large protocol or transfer subsystems.
    header/OS Previous dispatcher are covered by regressions.
 2. **Completed: make remote-to-playlist behavior explicit ([#47]).** Add to Playlist now snapshots
    the active source and refuses every non-local selection with a localized, all-or-none dialog
-   before database work. Full support remains separate: regular playlist entries need persistent
-   source-scoped `(SourceId, TrackId)` identity, disconnected-source semantics, and playback-time
-   resolution; Subsonic server-native playlist import/sync is another slice.
+   before database work. Full support remains separate: the source-scoped `(SourceId, TrackId)`
+   storage foundation is complete, while disconnected-source semantics and playback-time
+   resolution are current; Subsonic server-native playlist import/sync is another slice.
 3. **Completed: implement trustworthy local playback history.** The durable schema,
    [counted-play contract](playback-history.md), production persistence pipeline, and seeded
    consumers are complete.
@@ -111,6 +115,15 @@ before starting large protocol or transfer subsystems.
    Subsonic/Jellyfin/Plex conversion, rating-neutral XSPF boundary, accessible capability-aware
    column/editor, committed live refresh, deterministic null-last sorting, and validated smart
    filters/sorts/limits are complete.
+5. **Completed: establish source-scoped regular-playlist storage ([#47], [#140]).** The
+   [storage contract](source-scoped-playlists.md) defines one durable occurrence as the exact
+   `(SourceId, TrackId)` of its owning source while keeping playlists as `ViewOrigin`s. Migration 13
+   deterministically converts every valid existing entry to the local source, preserves entry
+   identity, ordering, duplicates, fingerprints, and local `ON DELETE SET NULL` behavior through a
+   separate cache, rejects non-local path evidence, and passed exact up/down/rollback, compatibility,
+   debug/release, and strict-lint validation. Live registry resolution and mixed-source UI/playback
+   are now the current P1.5 record; native Subsonic playlist semantics remain the following record
+   rather than being implied by the schema.
 
 These foundations make Rhythmbox migration and Last.fm behavior much less ambiguous.
 
@@ -179,7 +192,7 @@ mistaken for work already underway.
 | [#57 — Rhythmbox playlists, play counts, and ratings](https://github.com/jm2/tributary/issues/57) | No direct importer. XSPF conversion plus completed playback-history and rating contracts are foundations; XSPF deliberately transfers neither history nor ratings. | Build a separate transactional, idempotent migration with explicit metadata consent and conflict reporting. |
 | [#50 — Last.fm scrobbling](https://github.com/jm2/tributary/issues/50) | No Last.fm client or scrobble pipeline. | Authorization, secret storage, authoritative thresholds, retry/offline queue, and privacy UX. |
 | [#49 — Equalizer](https://github.com/jm2/tributary/issues/49) | No equalizer or audio-filter configuration. | GStreamer DSP design plus explicit behavior for every output backend. |
-| [#47 — Remote/Subsonic tracks in playlists](https://github.com/jm2/tributary/issues/47) | Non-local Add to Playlist attempts are now refused visibly and atomically; durable remote entries and server-native playlist sync are not implemented. | Source-scoped playlist schema/resolution first; server playlist sync separately. |
+| [#47 — Remote/Subsonic tracks in playlists](https://github.com/jm2/tributary/issues/47) | Non-local Add to Playlist attempts are refused visibly and atomically. The source-scoped storage contract and migration-13 foundation are complete, but no user-facing capability policy yet admits, renders, resolves, or plays remote rows; server-native playlist sync is absent. | Implement live registry-backed mixed-source interaction; design server playlist import/sync separately. |
 | [#46 — Drag and drop](https://github.com/jm2/tributary/issues/46) | Column-header reordering exists; track/file drag-and-drop does not. | Local playlist DnD first; file export, remote rows, and device copies as distinct policies. |
 | [#39 — Album art in browser](https://github.com/jm2/tributary/issues/39) | Artwork is shown for now-playing, not in the Genre/Artist/Album browser. | Virtualized art UI with bounded async cache, cancellation, accessibility, and authenticated art. |
 | [#29 — UI refinement](https://github.com/jm2/tributary/issues/29) | Requested separators/alignment changes are not implemented. | Split into independently reviewable visual changes after current-theme design review. |
@@ -255,3 +268,4 @@ When an item becomes active:
 [#49]: https://github.com/jm2/tributary/issues/49
 [#50]: https://github.com/jm2/tributary/issues/50
 [#57]: https://github.com/jm2/tributary/issues/57
+[#140]: https://github.com/jm2/tributary/pull/140

--- a/docs/source-scoped-playlists.md
+++ b/docs/source-scoped-playlists.md
@@ -1,0 +1,201 @@
+# Source-scoped regular playlist storage contract
+
+This document defines the durable-storage foundation for the first record in
+[P1.5](task.md#p15--persist-source-scoped-playlists). It changes how regular-playlist membership is
+represented without yet changing which source rows the shipping UI can add, display, or play.
+
+The central rule is:
+
+> A regular-playlist occurrence identifies media by the stable pair `(SourceId, TrackId)`. A
+> playlist is an ordered view over media owned by those sources; it is not itself a media source.
+
+That pair is identity, not location. A server URL, stream URL, file URI, filesystem path, access
+token, password, DAAP session ID, media lease, or source session epoch must never be substituted for
+either component or persisted as remote playlist authority.
+
+## Scope and delivery boundary
+
+This storage slice covers:
+
+- migration 13 and the `playlist_entries` entity;
+- deterministic conversion of every valid existing entry to the built-in local `SourceId`;
+- a canonical source-scoped identity plus a separate local foreign-key cache;
+- preservation of playlist order, duplicate occurrences, entry identity, and local reconciliation
+  evidence;
+- typed storage operations for future non-local additions without admitting locators or
+  credentials—the schema is source-generic, but this is an internal capability rather than a
+  promise that every source kind is addable; and
+- compatibility for all currently shipping local regular-playlist, XSPF-import, reconciliation,
+  rename, and deletion paths.
+
+It deliberately does **not** enable remote Add to Playlist, mixed-source playlist rendering or
+playback, disconnected-row presentation, lifecycle refresh, or remote XSPF export. Those behaviors
+need the live `SourceRegistry` and remain the second P1.5 record. Subsonic server-native playlist
+listing, import, synchronization, conflict handling, and deletion semantics remain the separate
+third record and require their own design before implementation.
+
+Smart playlists are unaffected. They remain live queries over the local library rather than stored
+regular-playlist occurrences.
+
+## Durable schema
+
+Each `playlist_entries` row remains one occurrence. Repeating the same song twice therefore creates
+two rows with different entry IDs and positions; media identity is intentionally not unique within
+a playlist.
+
+| Column | Contract |
+|---|---|
+| `id` | Stable identity of this playlist occurrence. |
+| `playlist_id` | Owning playlist; deletion of the playlist cascades to its entries. |
+| `position` | Non-negative ordered occurrence position, unique within the owning playlist. |
+| `source_id` | Canonical textual `SourceId` of the media owner. It is never a URL or display key. |
+| `track_id` | Exact source-native `TrackId`. It is nullable only for an unmatched local XSPF/import legacy occurrence that has not acquired track identity. |
+| `local_track_id` | Nullable local integrity/reconciliation cache with `tracks(id) ON DELETE SET NULL`; it is not a second media identity. |
+| `match_title`, `match_artist`, `match_album`, `match_duration_secs` | Non-secret normalized evidence used only to reconcile unmatched entries owned by the built-in local source. A non-local row may retain optional safe fingerprints as non-authoritative context, but they are not display-quality metadata and never authorize matching a different remote track. |
+| `match_file_path` | Optional exact local path evidence supplied by XSPF import. It is permitted only for the built-in local source and never becomes remote playback authority. |
+
+The following invariants apply:
+
+1. `source_id` is always a canonical lowercase, non-nil UUID. Existing and newly imported local
+   occurrences use `SourceId::local()` exactly.
+2. A populated `local_track_id` is valid only for the local source and equals that entry's
+   `track_id`. Its foreign key preserves the existing automatic orphan transition when a local
+   track disappears.
+3. A non-local entry has a non-empty `track_id` of at most 4,096 UTF-8 bytes, has no
+   `local_track_id`, and has no `match_file_path`. Local identity retains the architecture's larger
+   262,144-byte legacy ceiling.
+4. A missing `track_id` is valid only for an unmatched local entry with usable reconciliation
+   evidence: either a nonblank path or both a nonblank normalized title and artist. It is not an
+   invitation to choose a similarly named track from another source.
+5. `(playlist_id, position)` remains unique, while `(source_id, track_id)` deliberately does not:
+   duplicates are ordered occurrences, not corruption.
+6. Schema constraints and typed storage reads fail closed on inconsistent rows. A malformed source
+   identity, mismatched local cache, or non-local path is never reinterpreted as local media and
+   never passed to a source adapter.
+
+The optional local foreign key is deliberately separate from the canonical pair. Keeping it
+retains SQLite's `ON DELETE SET NULL` integrity for local-library churn without forcing a remote
+track ID to reference the unrelated local `tracks` table. A local deletion can therefore make an
+entry unavailable for reconciliation while preserving the occurrence, its source-scoped identity,
+position, and fingerprint evidence.
+
+## Migration 13
+
+Migration 13 transactionally rebuilds `playlist_entries` because SQLite cannot transform the old
+local-only foreign-key layout in place while preserving its constraints and indexes.
+
+For every valid predecessor row it:
+
+1. preserves `id`, `playlist_id`, `position`, all `match_*` evidence, and the old nullable
+   `track_id` byte-for-byte;
+2. writes the exact built-in local source identity to `source_id`; and
+3. copies the old linked `track_id` into `local_track_id`, leaving both identity fields null for an
+   already-unmatched local entry.
+
+No metadata or path heuristic participates in migration. The migration neither resolves an orphan
+nor invents a new track ID. Existing order and repeated occurrences survive even when multiple rows
+name the same local track. A legacy row with no track identity and no usable path or normalized
+title-and-artist evidence is corrupt rather than an unmatched import, so the migration rejects it.
+All table creation, copying, constraint/index restoration, and foreign-key validation occur in one
+transaction; any error restores the complete predecessor schema and data so the upgrade remains
+retryable.
+
+The reverse migration is exact or it does not run. It can rebuild the predecessor schema while all
+rows are representable as local entries, but it transactionally refuses a non-local or otherwise
+unrepresentable row. It never discards such an occurrence, converts it to an unmatched local row,
+or retargets it by metadata; refusal leaves the target schema and all data intact.
+
+The migrator recognizes only the expected predecessor and target table definitions, foreign keys,
+primary key, and standard index shapes. Existing additional explicit indexes are captured and
+restored, but a partial or near-match standard schema is an error rather than a reason to guess
+which columns or constraints are safe to keep. This protects interrupted upgrades and prevents a
+later appended column from making a valid migrated table look like the legacy definition.
+
+## Storage operations and local compatibility
+
+The storage boundary accepts typed `SourceId` and `TrackId` values. A future non-local insertion
+may retain optional non-secret metadata fingerprints, must not provide a file path, and must commit
+all selected occurrences atomically. Those normalized snapshots are neither display fields,
+identity, nor matching authority. The exact same native track ID from two sources remains two
+different media objects.
+
+The user-visible behavior in this slice stays local-only:
+
+- **Manual local add:** writes `(SourceId::local(), tracks.id)` and the matching
+  `local_track_id`, preserving normalized fingerprint metadata and duplicate occurrences.
+- **Regular-playlist load:** retains the established local projection and ordering. Stored
+  non-local or currently unmatched entries are not yet rendered or sent to playback.
+- **XSPF import:** continues to create local-owned entries only. Exact file-path and deterministic
+  metadata matching are unchanged, and an unmatched usable row remains a local occurrence with no
+  `track_id` or `local_track_id` until reconciliation succeeds.
+- **Local reconciliation:** considers only entries whose `source_id` is exactly the built-in local
+  source and whose `local_track_id` is absent. It may update both local track fields after the
+  existing exact path/fingerprint resolver commits a unique match. It never metadata-matches a
+  remote entry.
+- **Local track deletion:** the foreign key clears `local_track_id` but preserves the playlist
+  occurrence and its reconciliation evidence. Deleting a playlist still cascades its entries.
+- **Rename and root reauthorization:** ID-preserving operations retain both source-scoped identity
+  and the local cache. Existing guarded path-evidence relocation remains local-only.
+- **XSPF export:** remains the existing local-track export in this slice. Mixed-source export needs
+  an explicit metadata-only policy and is part of the later presentation/integration work; it may
+  not obtain or serialize a protected remote locator.
+
+The existing P1.2 refusal remains correct until the second record lands: selecting Add to Playlist
+from a remote, radio, removable, external, or malformed source still presents localized all-or-none
+copy before opening the database. The new storage capability is not itself UI authorization.
+That follow-up will initially admit only retained authenticated catalogues through an explicit
+capability check. Radio-Browser, removable media, ephemeral external files, and unknown sources
+remain unsupported until their persistence and lifecycle semantics are separately designed.
+
+## Source lifecycle and unavailable identity
+
+Persistent membership does not imply a live source session. Only `source_id` and `track_id` survive
+restart; a session epoch is deliberately transient.
+
+The second P1.5 record will resolve a non-local entry by asking the live `SourceRegistry` for the
+exact source and track, adopting only the current non-secret session epoch at publication and
+playback time. Disconnect, source retirement, a missing server-side track, or an epoch replacement
+must leave the database row intact and make it visibly unavailable. Reconnection may restore it
+only when the same `SourceId` publishes the same `TrackId`; endpoint similarity and metadata are
+not identity evidence.
+
+Until that slice exists, stored non-local fixtures remain intentionally outside the regular-
+playlist UI projection. This prevents the storage migration from accidentally treating durable
+identity as a locator or presenting a row that the current queue still assigns to the local source.
+
+## Ratings and playback history
+
+This migration does not transfer ownership of track metadata:
+
+- Tributary ratings remain writable only for tracks owned by the local library. A future remote
+  playlist row will display the live source's read-only or unsupported rating capability; this
+  schema persists no rating snapshot and grants no write authority.
+- Playback history remains local-only. A local occurrence reached through a regular playlist can
+  still contribute to its exact local track. A future remote occurrence must not update the local
+  `tracks` table merely because it appears beside local entries.
+
+See the [rating contract](ratings.md), [playback-history contract](playback-history.md), and
+[source-lifecycle architecture](architecture/source-lifecycle.md) for those independent authority
+boundaries.
+
+## Validation matrix
+
+The storage record is complete only when automated coverage demonstrates:
+
+- fresh migration and exact migration from the released predecessor schema;
+- stable local-source backfill for linked and unmatched entries;
+- exact preservation of entry IDs, positions (including valid gaps), duplicate occurrences, and
+  every fingerprint/path field;
+- restoration of the playlist, unique-position, source/track, local-track, and pre-existing custom
+  explicit indexes plus both foreign keys;
+- transactional rollback and safe retry after a forced rebuild/copy/index failure;
+- rejection of malformed predecessor, partial-target, source/track, local-cache, and non-local-path
+  states;
+- local add, load, XSPF import, reconciliation, deletion, rename, and root-reauthorization behavior
+  unchanged through the new schema; and
+- non-local storage isolation: identical native IDs from different sources never collide, remote
+  deletion/retirement cannot cascade into playlist storage, and no remote locator or credential is
+  accepted or serialized.
+
+Mixed-source rendering, interaction, playback, lifecycle, and native Subsonic playlist tests belong
+to their explicitly deferred records rather than being claimed by this storage foundation.

--- a/docs/task.md
+++ b/docs/task.md
@@ -21,21 +21,23 @@ state.
 - Do not treat the order below as a release promise. It is a dependency-aware starting order and
   can change as issues receive product decisions and milestones.
 
-Current status: **7/35 (20.0%)** active implementation records complete. This percentage measures
+Current status: **8/35 (22.9%)** active implementation records complete. This percentage measures
 checklist completion, not equal engineering effort: several P3 records are deliberately large
 epics. The archived remediation remains **220/223 (98.7%)** complete; its three open records are
 real-environment validation, not missing implementation.
 
 ## Current focus
 
-P1.1, P1.2, all three P1.3 playback-history records, and both P1.4 rating records are complete.
-Continue with P1.5's source-scoped playlist design and migration. The rest of P1 builds on the
-source-scoped identity already present in the runtime, the now-bounded shuffle navigation
-semantics, an honest local-only playlist interaction boundary, authoritative local playback
-history with deterministic live consumers, and an exact capability-aware rating field.
+P1.1, P1.2, all three P1.3 playback-history records, both P1.4 rating records, and P1.5's
+source-scoped regular-playlist storage foundation are complete. Continue with P1.5's live-registry
+resolution and mixed-source Add/Remove/Play interaction record. That slice must retain the storage
+contract's no-locator/no-credential boundary while making disconnected, retired, and stale-epoch
+states honest. The rest of P1 builds on the source-scoped identity already present in the runtime,
+the now-bounded shuffle navigation semantics, authoritative local playback history with
+deterministic live consumers, and an exact capability-aware rating field.
 
 The independent Linux watcher correctness fix tracked in
-[#103](https://github.com/jm2/tributary/pull/103) does not change the **7/35** feature total.
+[#103](https://github.com/jm2/tributary/pull/103) does not change the **8/35** feature total.
 The salvaged scope rejects explicitly classified access/access-time noise before the bounded watcher
 queue without filtering real bootstrap mutations or backend errors, while retaining overflow
 evidence for authoritative reconciliation. It intentionally omits the original persistent
@@ -212,15 +214,35 @@ the 35-record feature backlog.
 
 ### P1.5 — Persist source-scoped playlists
 
-- [ ] Design and migrate regular playlist entries from local track foreign keys to stable
+- [x] Design and migrate regular playlist entries from local track foreign keys to stable
   source-scoped `(SourceId, TrackId)` identity, with deterministic local migration, ordering,
   duplicate-occurrence, unavailable-source, deletion, and rollback behavior
-  ([#47](https://github.com/jm2/tributary/issues/47)).
+  ([contract](source-scoped-playlists.md); [#47](https://github.com/jm2/tributary/issues/47);
+  [#140](https://github.com/jm2/tributary/pull/140)).
+
+  Implemented storage contract: migration 13 preserves every valid predecessor occurrence ID,
+  playlist ID, position, duplicate, fingerprint, and local path-evidence field while assigning the
+  exact built-in local `source_id`. Canonical `(source_id, track_id)` identity is separated from a
+  nullable `local_track_id -> tracks(id) ON DELETE SET NULL` cache, so a remote native ID is never
+  forced through the local table. `track_id` remains nullable only for unmatched local imports with
+  usable path or normalized title-and-artist evidence. Typed source-generic storage rejects
+  non-local path evidence and persists no URL, credential, lease, or session epoch; existing local
+  Add/load, XSPF import/export, reconciliation, rename, root-reauthorization, and deletion behaviors
+  remain the compatibility boundary for this slice.
 - [ ] Resolve remote playlist entries only through the live `SourceRegistry` session; implement
   Add/Remove/Play UI, disconnected states, source retirement, stale-epoch rejection, and mixed-source
   playlist tests without persisting locators or credentials.
+
+  Explicitly deferred from migration 13: the current UI still refuses every non-local Add before
+  database work and projects only local entries. This record will admit only retained authenticated
+  catalogues through an explicit capability check. Radio-Browser, removable media, ephemeral
+  external files, and unknown sources remain unsupported until separately designed; a generic
+  storage shape alone does not authorize them.
 - [ ] Treat Subsonic server-native playlist import/synchronization as a separate capability slice,
   with direction, conflict, offline, deletion, and server-feature semantics documented first.
+
+  No Subsonic playlist endpoint, origin mapping, import, or synchronization behavior is part of the
+  storage migration or the mixed-source interaction record.
 
 ## P2 — User-facing integrations and bounded enhancements
 
@@ -336,4 +358,5 @@ the 35-record feature backlog.
 | 2026-07-18 | P1.3 deterministic history smart playlists | [#137](https://github.com/jm2/tributary/pull/137) | Made Recently Played and Top 25 deterministic over authoritative history, including intentional empty states, stable ordering and Top 25 membership, committed-event live refresh, exact untouched-default migration from both released historical signatures, and lossless editor round trips for Last Played fields, limits, and relative units. This completed P1.3. |
 | 2026-07-19 | P1.4 rating ownership and persistence foundation | [#138](https://github.com/jm2/tributary/pull/138) | Defined the canonical 1–100 value and coherent Writable/ReadOnly/Unsupported capabilities; added constrained nullable migration 12, transactional exact-local-ID set/clear, scan preservation, validated read-only Subsonic/Jellyfin/Plex conversion, fail-closed catalogue invariants and remote writes, and an explicit rating-neutral XSPF/import policy. Accessible editing, display, sorting, and smart rules were tracked in the following P1.4 record. |
 | 2026-07-19 | P1.4 rating UI and smart-playlist rules | [#139](https://github.com/jm2/tributary/pull/139) | Added the exact Rating column with localized cell/editor states, keyboard-operable local set/clear, honest read-only/unavailable states, serialized post-commit exact-ID refresh, failure-safe feedback, versioned column-config exposure, null-last deterministic sorting, and capability-aware numeric/presence smart rules plus Highest/Lowest Rated selection. This completed P1.4. |
+| 2026-07-19 | P1.5 source-scoped regular-playlist storage | [#140](https://github.com/jm2/tributary/pull/140) | Added migration 13 and typed atomic storage around exact `(SourceId, TrackId)` occurrence identity, a separate nullable local foreign-key cache, exact schema/index recognition, lossless-or-refused downgrade, local compatibility, and explicit no-locator/no-credential boundaries. Mixed-source live resolution and Subsonic-native synchronization remain the next two records. |
 | 2026-07-18 | Linux watcher feedback-loop fix | [#103](https://github.com/jm2/tributary/pull/103) | Narrowed the external proposal to filter self-generated access events before queue admission without filtering genuine startup events or backend errors; bounded overflow still drives authoritative reconciliation. Persistent negative parse caching is deliberately excluded so failures remain retryable; this separate correctness fix does not advance the feature numerator. |

--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -26,7 +26,7 @@ static SHARED_DB: OnceCell<DatabaseConnection> = OnceCell::const_new();
 ///
 /// All three are stated explicitly rather than inherited:
 ///
-/// - `foreign_keys` is what makes `playlist_entries.track_id`'s
+/// - `foreign_keys` is what makes `playlist_entries.local_track_id`'s
 ///   `ON DELETE SET NULL` fire when a track row is deleted. SQLite defaults
 ///   this to **off**; sqlx happens to enable it on every connection it opens,
 ///   and SeaORM never touches it either way. Leaving the library's whole
@@ -196,11 +196,11 @@ mod tests {
         }
     }
 
-    /// P1.1's guarantee, asserted end to end against a real pool: deleting a
-    /// track must null the referencing playlist entry rather than orphan it or
-    /// fail the delete.
+    /// P1.5's guarantee, asserted end to end against a real pool: deleting a
+    /// local track nulls only the current local binding. The entry and its
+    /// durable source-scoped identity survive for unavailable presentation.
     #[tokio::test]
-    async fn deleting_a_track_nulls_its_playlist_entry() {
+    async fn deleting_a_track_nulls_only_its_playlist_local_binding() {
         let file = TestDatabase::new("set-null");
         let db = connect_and_migrate(file.path())
             .await
@@ -230,7 +230,9 @@ mod tests {
             id: Set("entry-1".to_string()),
             playlist_id: Set("playlist-1".to_string()),
             position: Set(0),
+            source_id: Set(crate::architecture::SourceId::local().to_string()),
             track_id: Set(Some("track-1".to_string())),
+            local_track_id: Set(Some("track-1".to_string())),
             match_title: Set("Title".to_string()),
             match_artist: Set("Artist".to_string()),
             match_album: Set("Album".to_string()),
@@ -251,7 +253,12 @@ mod tests {
             .await
             .expect("load playlist entry")
             .expect("playlist entry survives the delete");
-        assert_eq!(entry.track_id, None);
+        assert_eq!(entry.track_id.as_deref(), Some("track-1"));
+        assert_eq!(entry.local_track_id, None);
+        assert_eq!(
+            entry.source_id,
+            crate::architecture::SourceId::local().to_string()
+        );
         assert_eq!(entry.position, 0);
         assert_eq!(entry.match_title, "Title");
     }

--- a/src/db/entities/playlist_entry.rs
+++ b/src/db/entities/playlist_entry.rs
@@ -11,7 +11,16 @@ pub struct Model {
 
     pub playlist_id: String,
     pub position: i32,
+    /// Stable owner of `track_id`. Together these two columns are the
+    /// durable media identity; neither is a locator or session credential.
+    pub source_id: String,
+    /// Exact source-native track identity. This is nullable only for an
+    /// unmatched legacy local import that has fingerprint evidence instead.
     pub track_id: Option<String>,
+    /// Current local-table binding for a local entry. This is deliberately
+    /// separate from durable identity so deleting a local track can make the
+    /// occurrence unavailable without discarding its source-scoped key.
+    pub local_track_id: Option<String>,
 
     /// Fingerprint fields for track rediscovery after library rebuild.
     pub match_title: String,
@@ -33,7 +42,7 @@ pub enum Relation {
     Playlist,
     #[sea_orm(
         belongs_to = "super::track::Entity",
-        from = "Column::TrackId",
+        from = "Column::LocalTrackId",
         to = "super::track::Column::Id",
         on_delete = "SetNull"
     )]

--- a/src/db/migration/m20260719_000013_source_scoped_playlist_entries.rs
+++ b/src/db/migration/m20260719_000013_source_scoped_playlist_entries.rs
@@ -1,0 +1,1937 @@
+//! Migration: make regular-playlist identity source scoped.
+//!
+//! `track_id` remains the durable source-native identity and is now paired
+//! with a canonical `source_id`. `local_track_id` is a separate nullable
+//! foreign-key binding used only for the built-in local source. Keeping the
+//! binding separate means a local deletion can make an occurrence unavailable
+//! without erasing its durable identity, while non-local IDs are never
+//! misinterpreted as keys in the local `tracks` table.
+
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::{ConnectionTrait, DbBackend, Statement, TransactionTrait};
+
+/// Frozen value of `SourceId::local()` at the migration boundary.
+///
+/// This is persistent format state. It must not follow a future identity
+/// migration implicitly.
+const LOCAL_SOURCE_ID: &str = "dbae1f16-7921-5209-939e-ce3177ec7b57";
+const NIL_SOURCE_ID: &str = "00000000-0000-0000-0000-000000000000";
+
+/// Frozen Unicode `White_Space` code points used by Rust's `str::trim`.
+///
+/// SQLite's one-argument `trim` only removes ASCII spaces. Listing the same
+/// characters explicitly keeps database constraints aligned with playlist
+/// decoding and import validation, both of which use Rust `trim()`.
+const RUST_TRIM_WHITESPACE: &[u32] = &[
+    9, 10, 11, 12, 13, 32, 133, 160, 5760, 8192, 8193, 8194, 8195, 8196, 8197, 8198, 8199, 8200,
+    8201, 8202, 8232, 8233, 8239, 8287, 12288,
+];
+
+const REBUILD_TABLE: &str = "tributary_playlist_entries_source_scope_rebuild";
+const PLAYLIST_INDEX: &str = "idx_playlist_entries_playlist_id";
+const LEGACY_TRACK_INDEX: &str = "idx_playlist_entries_track_id";
+const SOURCE_TRACK_INDEX: &str = "idx_playlist_entries_source_track_id";
+const LOCAL_TRACK_INDEX: &str = "idx_playlist_entries_local_track_id";
+const UNIQUE_POSITION_INDEX: &str = "idx_playlist_entries_playlist_position_unique";
+
+const SOURCE_ID_CHECK: &str = "ck_playlist_entries_source_id";
+const TRACK_ID_CHECK: &str = "ck_playlist_entries_track_id";
+const LOCAL_BINDING_CHECK: &str = "ck_playlist_entries_local_binding";
+const MATCH_PATH_CHECK: &str = "ck_playlist_entries_match_path";
+const ORPHAN_EVIDENCE_CHECK: &str = "ck_playlist_entries_orphan_evidence";
+const POSITION_CHECK: &str = "ck_playlist_entries_position";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PlaylistEntriesSchema {
+    LegacyLocal,
+    SourceScoped,
+}
+
+#[derive(Clone, Debug)]
+struct ExplicitIndex {
+    name: String,
+    sql: String,
+}
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        migrate_playlist_entries(manager, PlaylistEntriesSchema::SourceScoped).await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        migrate_playlist_entries(manager, PlaylistEntriesSchema::LegacyLocal).await
+    }
+}
+
+/// Own the complete rebuild transaction because SQLite/SeaORM does not wrap
+/// this migration automatically. A failed copy, constraint, index recreation,
+/// or validation therefore restores both the original schema and every row.
+async fn migrate_playlist_entries(
+    manager: &SchemaManager<'_>,
+    target: PlaylistEntriesSchema,
+) -> Result<(), DbErr> {
+    if !manager.has_table("playlist_entries").await? {
+        return Err(DbErr::Migration(
+            "playlist_entries must exist for source-scoped identity migration".to_string(),
+        ));
+    }
+
+    let transaction = manager.get_connection().begin().await?;
+    let result = {
+        let manager = SchemaManager::new(&transaction);
+        let current = inspect_schema(&manager).await?;
+        validate_schema(&manager, current).await?;
+
+        if current == target {
+            Ok(())
+        } else {
+            if target == PlaylistEntriesSchema::LegacyLocal {
+                require_lossless_legacy_downgrade(&manager).await?;
+            }
+            rebuild(&manager, current, target).await
+        }
+    };
+
+    match result {
+        Ok(()) => transaction.commit().await,
+        Err(error) => {
+            let rollback_result = transaction.rollback().await;
+            Err(preserve_original_error(error, rollback_result))
+        }
+    }
+}
+
+/// Never replace the unsafe migration failure with a secondary rollback
+/// failure. If rollback also fails, retain both errors in the returned context.
+fn preserve_original_error(original: DbErr, rollback_result: Result<(), DbErr>) -> DbErr {
+    match rollback_result {
+        Ok(()) => original,
+        Err(rollback_error) => DbErr::Migration(format!(
+            "{original}; additionally failed to roll back source-scoped playlist migration: \
+             {rollback_error}"
+        )),
+    }
+}
+
+async fn rebuild(
+    manager: &SchemaManager<'_>,
+    current: PlaylistEntriesSchema,
+    target: PlaylistEntriesSchema,
+) -> Result<(), DbErr> {
+    let custom_indexes = capture_custom_indexes(manager, current).await?;
+    let connection = manager.get_connection();
+
+    let create_sql = match target {
+        PlaylistEntriesSchema::LegacyLocal => legacy_table_sql(REBUILD_TABLE),
+        PlaylistEntriesSchema::SourceScoped => scoped_table_sql(REBUILD_TABLE),
+    };
+    connection.execute_unprepared(&create_sql).await?;
+
+    match target {
+        PlaylistEntriesSchema::SourceScoped => {
+            connection
+                .execute_unprepared(&format!(
+                    "INSERT INTO {REBUILD_TABLE} (
+                         id, playlist_id, position, source_id, track_id, local_track_id,
+                         match_title, match_artist, match_album, match_duration_secs,
+                         match_file_path
+                     )
+                     SELECT id, playlist_id, position, '{LOCAL_SOURCE_ID}', track_id, track_id,
+                            match_title, match_artist, match_album, match_duration_secs,
+                            match_file_path
+                     FROM playlist_entries"
+                ))
+                .await?;
+        }
+        PlaylistEntriesSchema::LegacyLocal => {
+            connection
+                .execute_unprepared(&format!(
+                    "INSERT INTO {REBUILD_TABLE} (
+                         id, playlist_id, position, track_id,
+                         match_title, match_artist, match_album, match_duration_secs,
+                         match_file_path
+                     )
+                     SELECT id, playlist_id, position, track_id,
+                            match_title, match_artist, match_album, match_duration_secs,
+                            match_file_path
+                     FROM playlist_entries"
+                ))
+                .await?;
+        }
+    }
+
+    connection
+        .execute_unprepared("DROP TABLE playlist_entries")
+        .await?;
+    connection
+        .execute_unprepared(&format!(
+            "ALTER TABLE {REBUILD_TABLE} RENAME TO playlist_entries"
+        ))
+        .await?;
+
+    create_standard_indexes(manager, target).await?;
+    for index in custom_indexes {
+        connection
+            .execute_unprepared(&index.sql)
+            .await
+            .map_err(|error| {
+                DbErr::Migration(format!(
+                    "failed to restore playlist_entries index {}: {error}",
+                    index.name
+                ))
+            })?;
+    }
+
+    validate_schema(manager, target).await
+}
+
+fn legacy_table_sql(table: &str) -> String {
+    format!(
+        "CREATE TABLE {table} (
+             id VARCHAR PRIMARY KEY NOT NULL,
+             playlist_id VARCHAR NOT NULL,
+             position INTEGER NOT NULL,
+             track_id VARCHAR NULL,
+             match_title VARCHAR NOT NULL DEFAULT '',
+             match_artist VARCHAR NOT NULL DEFAULT '',
+             match_album VARCHAR NOT NULL DEFAULT '',
+             match_duration_secs INTEGER NULL,
+             match_file_path VARCHAR NULL,
+             CONSTRAINT fk_entry_playlist
+                 FOREIGN KEY (playlist_id)
+                 REFERENCES playlists (id)
+                 ON DELETE CASCADE,
+             CONSTRAINT fk_entry_track
+                 FOREIGN KEY (track_id)
+                 REFERENCES tracks (id)
+                 ON DELETE SET NULL
+         )"
+    )
+}
+
+fn scoped_table_sql(table: &str) -> String {
+    let trim_characters = RUST_TRIM_WHITESPACE
+        .iter()
+        .map(|code_point| {
+            if *code_point == 32 {
+                "' '".to_string()
+            } else {
+                format!("char({code_point})")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" || ");
+    format!(
+        "CREATE TABLE {table} (
+             id VARCHAR PRIMARY KEY NOT NULL,
+             playlist_id VARCHAR NOT NULL,
+             position INTEGER NOT NULL,
+             source_id VARCHAR NOT NULL,
+             track_id VARCHAR NULL,
+             local_track_id VARCHAR NULL,
+             match_title VARCHAR NOT NULL DEFAULT '',
+             match_artist VARCHAR NOT NULL DEFAULT '',
+             match_album VARCHAR NOT NULL DEFAULT '',
+             match_duration_secs INTEGER NULL,
+             match_file_path VARCHAR NULL,
+             CONSTRAINT {SOURCE_ID_CHECK} CHECK (
+                 length(CAST(source_id AS BLOB)) = 36
+                 AND source_id = lower(source_id)
+                 AND substr(source_id, 9, 1) = '-'
+                 AND substr(source_id, 14, 1) = '-'
+                 AND substr(source_id, 19, 1) = '-'
+                 AND substr(source_id, 24, 1) = '-'
+                 AND length(replace(source_id, '-', '')) = 32
+                 AND replace(source_id, '-', '') NOT GLOB '*[^0-9a-f]*'
+                 AND source_id <> '{NIL_SOURCE_ID}'
+             ),
+             CONSTRAINT {TRACK_ID_CHECK} CHECK (
+                 (source_id = '{LOCAL_SOURCE_ID}' AND (
+                     track_id IS NULL OR length(CAST(track_id AS BLOB)) BETWEEN 1 AND 262144
+                 ))
+                 OR
+                 (source_id <> '{LOCAL_SOURCE_ID}' AND
+                     track_id IS NOT NULL AND
+                     length(CAST(track_id AS BLOB)) BETWEEN 1 AND 4096
+                 )
+             ),
+             CONSTRAINT {LOCAL_BINDING_CHECK} CHECK (
+                 (source_id = '{LOCAL_SOURCE_ID}' AND (
+                     local_track_id IS NULL OR
+                     (track_id IS NOT NULL AND local_track_id = track_id)
+                 ))
+                 OR
+                 (source_id <> '{LOCAL_SOURCE_ID}' AND local_track_id IS NULL)
+             ),
+             CONSTRAINT {MATCH_PATH_CHECK} CHECK (
+                 source_id = '{LOCAL_SOURCE_ID}' OR match_file_path IS NULL
+             ),
+             CONSTRAINT {ORPHAN_EVIDENCE_CHECK} CHECK (
+                 track_id IS NOT NULL OR (
+                     source_id = '{LOCAL_SOURCE_ID}' AND
+                     (
+                         (
+                             match_file_path IS NOT NULL AND
+                             length(CAST(trim(match_file_path, {trim_characters}) AS BLOB)) > 0
+                         )
+                         OR
+                         (
+                             length(CAST(trim(match_title, {trim_characters}) AS BLOB)) > 0 AND
+                             length(CAST(trim(match_artist, {trim_characters}) AS BLOB)) > 0
+                         )
+                     )
+                 )
+             ),
+             CONSTRAINT {POSITION_CHECK} CHECK (position >= 0),
+             CONSTRAINT fk_entry_playlist
+                 FOREIGN KEY (playlist_id)
+                 REFERENCES playlists (id)
+                 ON DELETE CASCADE,
+             CONSTRAINT fk_entry_local_track
+                 FOREIGN KEY (local_track_id)
+                 REFERENCES tracks (id)
+                 ON DELETE SET NULL
+         )"
+    )
+}
+
+async fn inspect_schema(manager: &SchemaManager<'_>) -> Result<PlaylistEntriesSchema, DbErr> {
+    let columns = table_columns(manager).await?;
+    if columns == legacy_columns() {
+        let actual_sql = table_sql(manager).await?;
+        let expected_sql = legacy_table_sql("playlist_entries");
+        if canonical_sql(&actual_sql) != canonical_sql(&expected_sql) {
+            return Err(DbErr::Migration(format!(
+                "legacy playlist_entries does not match the exact migration-12 predecessor: \
+                 {actual_sql}"
+            )));
+        }
+        return Ok(PlaylistEntriesSchema::LegacyLocal);
+    }
+    if columns == scoped_columns() {
+        let actual_sql = table_sql(manager).await?;
+        let expected_sql = scoped_table_sql("playlist_entries");
+        if canonical_sql(&actual_sql) != canonical_sql(&expected_sql) {
+            return Err(DbErr::Migration(format!(
+                "source-scoped playlist_entries has unexpected table SQL: {actual_sql}"
+            )));
+        }
+        return Ok(PlaylistEntriesSchema::SourceScoped);
+    }
+    Err(DbErr::Migration(format!(
+        "playlist_entries has an unexpected column schema: {columns:?}"
+    )))
+}
+
+type ColumnSchema = (String, String, i32, Option<String>, i32);
+
+async fn table_columns(manager: &SchemaManager<'_>) -> Result<Vec<ColumnSchema>, DbErr> {
+    manager
+        .get_connection()
+        .query_all(Statement::from_string(
+            manager.get_database_backend(),
+            "PRAGMA table_info('playlist_entries')".to_string(),
+        ))
+        .await?
+        .into_iter()
+        .map(|row| {
+            Ok((
+                row.try_get("", "name")?,
+                row.try_get::<String>("", "type")?.to_ascii_lowercase(),
+                row.try_get("", "notnull")?,
+                row.try_get("", "dflt_value")?,
+                row.try_get("", "pk")?,
+            ))
+        })
+        .collect()
+}
+
+fn legacy_columns() -> Vec<ColumnSchema> {
+    vec![
+        column("id", "varchar", 1, None, 1),
+        column("playlist_id", "varchar", 1, None, 0),
+        column("position", "integer", 1, None, 0),
+        column("track_id", "varchar", 0, None, 0),
+        column("match_title", "varchar", 1, Some("''"), 0),
+        column("match_artist", "varchar", 1, Some("''"), 0),
+        column("match_album", "varchar", 1, Some("''"), 0),
+        column("match_duration_secs", "integer", 0, None, 0),
+        column("match_file_path", "varchar", 0, None, 0),
+    ]
+}
+
+fn scoped_columns() -> Vec<ColumnSchema> {
+    vec![
+        column("id", "varchar", 1, None, 1),
+        column("playlist_id", "varchar", 1, None, 0),
+        column("position", "integer", 1, None, 0),
+        column("source_id", "varchar", 1, None, 0),
+        column("track_id", "varchar", 0, None, 0),
+        column("local_track_id", "varchar", 0, None, 0),
+        column("match_title", "varchar", 1, Some("''"), 0),
+        column("match_artist", "varchar", 1, Some("''"), 0),
+        column("match_album", "varchar", 1, Some("''"), 0),
+        column("match_duration_secs", "integer", 0, None, 0),
+        column("match_file_path", "varchar", 0, None, 0),
+    ]
+}
+
+fn column(
+    name: &str,
+    sql_type: &str,
+    not_null: i32,
+    default: Option<&str>,
+    primary_key: i32,
+) -> ColumnSchema {
+    (
+        name.to_string(),
+        sql_type.to_string(),
+        not_null,
+        default.map(str::to_string),
+        primary_key,
+    )
+}
+
+async fn table_sql(manager: &SchemaManager<'_>) -> Result<String, DbErr> {
+    let row = manager
+        .get_connection()
+        .query_one(Statement::from_string(
+            manager.get_database_backend(),
+            "SELECT sql FROM sqlite_master
+             WHERE type = 'table' AND name = 'playlist_entries'"
+                .to_string(),
+        ))
+        .await?
+        .ok_or_else(|| DbErr::Migration("playlist_entries SQL is missing".to_string()))?;
+    row.try_get("", "sql")
+}
+
+fn canonical_sql(sql: &str) -> String {
+    let mut canonical = String::with_capacity(sql.len());
+    let mut characters = sql.chars().peekable();
+
+    while let Some(character) = characters.next() {
+        match character {
+            '\'' => {
+                // String contents are semantically significant. Preserve
+                // whitespace, case, delimiters, and doubled-quote escapes.
+                canonical.push('\'');
+                while let Some(literal_character) = characters.next() {
+                    canonical.push(literal_character);
+                    if literal_character == '\'' {
+                        if characters.peek() == Some(&'\'') {
+                            canonical.push(characters.next().expect("peeked quote exists"));
+                        } else {
+                            break;
+                        }
+                    }
+                }
+            }
+            '"' => {
+                // SQLite accepts double-quoted strings when DQS compatibility
+                // is enabled. Only normalize tokens known to be identifiers in
+                // these frozen schemas; preserve every other token literally.
+                let mut token = String::new();
+                let mut raw = String::from("\"");
+                while let Some(quoted_character) = characters.next() {
+                    raw.push(quoted_character);
+                    if quoted_character == '"' {
+                        if characters.peek() == Some(&'"') {
+                            raw.push(characters.next().expect("peeked quote exists"));
+                            token.push('"');
+                        } else {
+                            break;
+                        }
+                    } else {
+                        token.push(quoted_character);
+                    }
+                }
+                if is_known_schema_identifier(&token) {
+                    canonical.extend(token.chars().flat_map(char::to_lowercase));
+                } else {
+                    canonical.push_str(&raw);
+                }
+            }
+            '`' => append_quoted_identifier(&mut canonical, &mut characters, '`'),
+            '[' => append_quoted_identifier(&mut canonical, &mut characters, ']'),
+            character if character.is_ascii_whitespace() => {}
+            character => canonical.extend(character.to_lowercase()),
+        }
+    }
+
+    canonical
+}
+
+fn append_quoted_identifier<I>(
+    canonical: &mut String,
+    characters: &mut std::iter::Peekable<I>,
+    closing_quote: char,
+) where
+    I: Iterator<Item = char>,
+{
+    while let Some(character) = characters.next() {
+        if character == closing_quote {
+            if characters.peek() == Some(&closing_quote) {
+                canonical.extend(character.to_lowercase());
+                characters.next();
+            } else {
+                break;
+            }
+        } else {
+            canonical.extend(character.to_lowercase());
+        }
+    }
+}
+
+fn is_known_schema_identifier(identifier: &str) -> bool {
+    matches!(
+        identifier.to_ascii_lowercase().as_str(),
+        "playlist_entries"
+            | "id"
+            | "playlist_id"
+            | "position"
+            | "source_id"
+            | "track_id"
+            | "local_track_id"
+            | "match_title"
+            | "match_artist"
+            | "match_album"
+            | "match_duration_secs"
+            | "match_file_path"
+            | "playlists"
+            | "tracks"
+            | "fk_entry_playlist"
+            | "fk_entry_track"
+            | "fk_entry_local_track"
+            | SOURCE_ID_CHECK
+            | TRACK_ID_CHECK
+            | LOCAL_BINDING_CHECK
+            | MATCH_PATH_CHECK
+            | ORPHAN_EVIDENCE_CHECK
+            | POSITION_CHECK
+            | PLAYLIST_INDEX
+            | LEGACY_TRACK_INDEX
+            | SOURCE_TRACK_INDEX
+            | LOCAL_TRACK_INDEX
+            | UNIQUE_POSITION_INDEX
+    )
+}
+
+async fn validate_schema(
+    manager: &SchemaManager<'_>,
+    schema: PlaylistEntriesSchema,
+) -> Result<(), DbErr> {
+    validate_foreign_keys(manager, schema).await?;
+    validate_standard_indexes(manager, schema).await?;
+    validate_foreign_key_rows(manager).await
+}
+
+async fn validate_foreign_keys(
+    manager: &SchemaManager<'_>,
+    schema: PlaylistEntriesSchema,
+) -> Result<(), DbErr> {
+    let mut actual = manager
+        .get_connection()
+        .query_all(Statement::from_string(
+            manager.get_database_backend(),
+            "PRAGMA foreign_key_list('playlist_entries')".to_string(),
+        ))
+        .await?
+        .into_iter()
+        .map(|row| {
+            Ok::<_, DbErr>((
+                row.try_get::<String>("", "from")?,
+                row.try_get::<String>("", "table")?,
+                row.try_get::<String>("", "to")?,
+                row.try_get::<String>("", "on_update")?.to_ascii_uppercase(),
+                row.try_get::<String>("", "on_delete")?.to_ascii_uppercase(),
+            ))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    actual.sort();
+
+    let track_column = match schema {
+        PlaylistEntriesSchema::LegacyLocal => "track_id",
+        PlaylistEntriesSchema::SourceScoped => "local_track_id",
+    };
+    let mut expected = vec![
+        (
+            "playlist_id".to_string(),
+            "playlists".to_string(),
+            "id".to_string(),
+            "NO ACTION".to_string(),
+            "CASCADE".to_string(),
+        ),
+        (
+            track_column.to_string(),
+            "tracks".to_string(),
+            "id".to_string(),
+            "NO ACTION".to_string(),
+            "SET NULL".to_string(),
+        ),
+    ];
+    expected.sort();
+    if actual != expected {
+        return Err(DbErr::Migration(format!(
+            "playlist_entries has unexpected foreign keys: {actual:?}"
+        )));
+    }
+    Ok(())
+}
+
+async fn validate_foreign_key_rows(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    let violations = manager
+        .get_connection()
+        .query_all(Statement::from_string(
+            manager.get_database_backend(),
+            "PRAGMA foreign_key_check('playlist_entries')".to_string(),
+        ))
+        .await?;
+    if !violations.is_empty() {
+        return Err(DbErr::Migration(format!(
+            "playlist_entries has {} foreign-key violation(s)",
+            violations.len()
+        )));
+    }
+    Ok(())
+}
+
+async fn capture_custom_indexes(
+    manager: &SchemaManager<'_>,
+    schema: PlaylistEntriesSchema,
+) -> Result<Vec<ExplicitIndex>, DbErr> {
+    validate_standard_indexes(manager, schema).await?;
+    let standard = standard_index_names(schema);
+    manager
+        .get_connection()
+        .query_all(Statement::from_string(
+            manager.get_database_backend(),
+            "SELECT name, sql FROM sqlite_master
+             WHERE type = 'index'
+               AND tbl_name = 'playlist_entries'
+               AND sql IS NOT NULL
+             ORDER BY name"
+                .to_string(),
+        ))
+        .await?
+        .into_iter()
+        .filter_map(|row| {
+            let name = row.try_get::<String>("", "name");
+            let sql = row.try_get::<String>("", "sql");
+            match (name, sql) {
+                (Ok(name), Ok(sql)) if !standard.contains(&name.as_str()) => {
+                    Some(Ok(ExplicitIndex { name, sql }))
+                }
+                (Ok(_), Ok(_)) => None,
+                (Err(error), _) | (_, Err(error)) => Some(Err(error)),
+            }
+        })
+        .collect()
+}
+
+fn standard_index_names(schema: PlaylistEntriesSchema) -> &'static [&'static str] {
+    match schema {
+        PlaylistEntriesSchema::LegacyLocal => {
+            &[PLAYLIST_INDEX, LEGACY_TRACK_INDEX, UNIQUE_POSITION_INDEX]
+        }
+        PlaylistEntriesSchema::SourceScoped => &[
+            PLAYLIST_INDEX,
+            SOURCE_TRACK_INDEX,
+            LOCAL_TRACK_INDEX,
+            UNIQUE_POSITION_INDEX,
+        ],
+    }
+}
+
+async fn create_standard_indexes(
+    manager: &SchemaManager<'_>,
+    schema: PlaylistEntriesSchema,
+) -> Result<(), DbErr> {
+    let connection = manager.get_connection();
+    connection
+        .execute_unprepared(&format!(
+            "CREATE INDEX {PLAYLIST_INDEX} ON playlist_entries (playlist_id)"
+        ))
+        .await?;
+    match schema {
+        PlaylistEntriesSchema::LegacyLocal => {
+            connection
+                .execute_unprepared(&format!(
+                    "CREATE INDEX {LEGACY_TRACK_INDEX} ON playlist_entries (track_id)"
+                ))
+                .await?;
+        }
+        PlaylistEntriesSchema::SourceScoped => {
+            connection
+                .execute_unprepared(&format!(
+                    "CREATE INDEX {SOURCE_TRACK_INDEX}
+                     ON playlist_entries (source_id, track_id)"
+                ))
+                .await?;
+            connection
+                .execute_unprepared(&format!(
+                    "CREATE INDEX {LOCAL_TRACK_INDEX} ON playlist_entries (local_track_id)"
+                ))
+                .await?;
+        }
+    }
+    connection
+        .execute_unprepared(&format!(
+            "CREATE UNIQUE INDEX {UNIQUE_POSITION_INDEX}
+             ON playlist_entries (playlist_id, position)"
+        ))
+        .await?;
+    Ok(())
+}
+
+async fn validate_standard_indexes(
+    manager: &SchemaManager<'_>,
+    schema: PlaylistEntriesSchema,
+) -> Result<(), DbErr> {
+    validate_primary_key_index(manager).await?;
+    validate_index(manager, PLAYLIST_INDEX, false, &["playlist_id"]).await?;
+    validate_index(
+        manager,
+        UNIQUE_POSITION_INDEX,
+        true,
+        &["playlist_id", "position"],
+    )
+    .await?;
+    match schema {
+        PlaylistEntriesSchema::LegacyLocal => {
+            validate_index(manager, LEGACY_TRACK_INDEX, false, &["track_id"]).await?;
+        }
+        PlaylistEntriesSchema::SourceScoped => {
+            validate_index(
+                manager,
+                SOURCE_TRACK_INDEX,
+                false,
+                &["source_id", "track_id"],
+            )
+            .await?;
+            validate_index(manager, LOCAL_TRACK_INDEX, false, &["local_track_id"]).await?;
+        }
+    }
+    Ok(())
+}
+
+async fn validate_index(
+    manager: &SchemaManager<'_>,
+    name: &str,
+    expected_unique: bool,
+    expected_columns: &[&str],
+) -> Result<(), DbErr> {
+    let row = manager
+        .get_connection()
+        .query_all(Statement::from_string(
+            manager.get_database_backend(),
+            "PRAGMA index_list('playlist_entries')".to_string(),
+        ))
+        .await?
+        .into_iter()
+        .find(|row| {
+            row.try_get::<String>("", "name")
+                .is_ok_and(|value| value == name)
+        })
+        .ok_or_else(|| DbErr::Migration(format!("playlist_entries is missing index {name}")))?;
+    let unique = row.try_get::<i32>("", "unique")? == 1;
+    let origin: String = row.try_get("", "origin")?;
+    let partial = row.try_get::<i32>("", "partial")? == 1;
+    if unique != expected_unique || origin != "c" || partial {
+        return Err(DbErr::Migration(format!(
+            "playlist_entries index {name} has unique={unique}, origin={origin}, \
+             partial={partial}"
+        )));
+    }
+
+    let actual_sql = manager
+        .get_connection()
+        .query_one(Statement::from_sql_and_values(
+            manager.get_database_backend(),
+            "SELECT sql FROM sqlite_master
+             WHERE type = 'index' AND name = ? AND tbl_name = 'playlist_entries'",
+            [name.into()],
+        ))
+        .await?
+        .ok_or_else(|| DbErr::Migration(format!("playlist_entries index {name} SQL is missing")))?
+        .try_get::<String>("", "sql")?;
+    let expected_sql = format!(
+        "CREATE {}INDEX {name} ON playlist_entries ({})",
+        if expected_unique { "UNIQUE " } else { "" },
+        expected_columns.join(", ")
+    );
+    if canonical_sql(&actual_sql) != canonical_sql(&expected_sql) {
+        return Err(DbErr::Migration(format!(
+            "playlist_entries index {name} has unexpected SQL: {actual_sql}"
+        )));
+    }
+
+    let quoted = name.replace('\'', "''");
+    let mut columns = manager
+        .get_connection()
+        .query_all(Statement::from_string(
+            manager.get_database_backend(),
+            format!("PRAGMA index_info('{quoted}')"),
+        ))
+        .await?
+        .into_iter()
+        .map(|row| {
+            Ok::<_, DbErr>((
+                row.try_get::<i32>("", "seqno")?,
+                row.try_get::<String>("", "name")?,
+            ))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    columns.sort_by_key(|(sequence, _)| *sequence);
+    let columns: Vec<_> = columns.into_iter().map(|(_, column)| column).collect();
+    let expected: Vec<_> = expected_columns
+        .iter()
+        .map(|column| (*column).to_string())
+        .collect();
+    if columns != expected {
+        return Err(DbErr::Migration(format!(
+            "playlist_entries index {name} has columns {columns:?}, expected {expected:?}"
+        )));
+    }
+    Ok(())
+}
+
+async fn validate_primary_key_index(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    let implicit = manager
+        .get_connection()
+        .query_all(Statement::from_string(
+            manager.get_database_backend(),
+            "PRAGMA index_list('playlist_entries')".to_string(),
+        ))
+        .await?
+        .into_iter()
+        .filter_map(|row| {
+            let origin = row.try_get::<String>("", "origin").ok()?;
+            (origin != "c").then(|| {
+                Ok::<_, DbErr>((
+                    row.try_get::<String>("", "name")?,
+                    row.try_get::<i32>("", "unique")? == 1,
+                    origin,
+                    row.try_get::<i32>("", "partial")? == 1,
+                ))
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let [(name, true, origin, false)] = implicit.as_slice() else {
+        return Err(DbErr::Migration(format!(
+            "playlist_entries has unexpected implicit indexes: {implicit:?}"
+        )));
+    };
+    if origin != "pk" {
+        return Err(DbErr::Migration(format!(
+            "playlist_entries primary-key index {name} has origin {origin}"
+        )));
+    }
+
+    let quoted = name.replace('\'', "''");
+    let columns = manager
+        .get_connection()
+        .query_all(Statement::from_string(
+            manager.get_database_backend(),
+            format!("PRAGMA index_info('{quoted}')"),
+        ))
+        .await?
+        .into_iter()
+        .map(|row| row.try_get::<String>("", "name"))
+        .collect::<Result<Vec<_>, _>>()?;
+    if columns != ["id"] {
+        return Err(DbErr::Migration(format!(
+            "playlist_entries primary-key index has columns {columns:?}"
+        )));
+    }
+    Ok(())
+}
+
+async fn require_lossless_legacy_downgrade(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    let row = manager
+        .get_connection()
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "SELECT COUNT(*) AS count
+             FROM playlist_entries
+             WHERE source_id <> ?
+                OR track_id IS NOT local_track_id",
+            [LOCAL_SOURCE_ID.into()],
+        ))
+        .await?
+        .ok_or_else(|| DbErr::Migration("failed to inspect playlist entries".to_string()))?;
+    let count: i64 = row.try_get("", "count")?;
+    if count != 0 {
+        return Err(DbErr::Migration(format!(
+            "cannot downgrade {count} source-scoped playlist entry row(s) losslessly"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm_migration::sea_orm::{
+        ConnectionTrait, Database, DatabaseConnection, DbBackend, ExecResult, Statement,
+    };
+
+    use super::*;
+    use crate::db::migration::Migrator;
+
+    const REMOTE_SOURCE_ID: &str = "11111111-1111-4111-8111-111111111111";
+    const SECOND_REMOTE_SOURCE_ID: &str = "22222222-2222-4222-8222-222222222222";
+
+    async fn database_before_migration() -> DatabaseConnection {
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("open in-memory sqlite");
+        Migrator::up(&db, Some(12))
+            .await
+            .expect("apply migrations preceding source-scoped playlists");
+        db
+    }
+
+    async fn insert_playlist(db: &DatabaseConnection, id: &str) {
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO playlists (id, name, created_at, updated_at)
+             VALUES (?, ?, '2026-07-19T00:00:00Z', '2026-07-19T00:00:00Z')",
+            [id.into(), format!("Playlist {id}").into()],
+        ))
+        .await
+        .expect("insert playlist");
+    }
+
+    async fn insert_track(db: &DatabaseConnection, id: &str) {
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO tracks (
+                 id, file_path, title, artist_name, album_title,
+                 date_added, date_modified
+             )
+             VALUES (?, ?, ?, 'Artist', 'Album',
+                     '2026-07-19T00:00:00Z', '2026-07-19T00:00:00Z')",
+            [
+                id.into(),
+                format!("/music/{id}.flac").into(),
+                format!("Track {id}").into(),
+            ],
+        ))
+        .await
+        .expect("insert track");
+    }
+
+    async fn insert_legacy_entry(
+        db: &DatabaseConnection,
+        id: &str,
+        playlist_id: &str,
+        position: i32,
+        track_id: Option<&str>,
+        path: Option<&str>,
+    ) {
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO playlist_entries (
+                 id, playlist_id, position, track_id,
+                 match_title, match_artist, match_album, match_duration_secs,
+                 match_file_path
+             )
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                id.into(),
+                playlist_id.into(),
+                position.into(),
+                track_id.into(),
+                format!("title-{id}").into(),
+                format!("artist-{id}").into(),
+                format!("album-{id}").into(),
+                (position + 180).into(),
+                path.into(),
+            ],
+        ))
+        .await
+        .expect("insert legacy playlist entry");
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn insert_scoped_entry(
+        db: &DatabaseConnection,
+        id: &str,
+        playlist_id: &str,
+        position: i32,
+        source_id: &str,
+        track_id: Option<&str>,
+        local_track_id: Option<&str>,
+        path: Option<&str>,
+    ) -> Result<ExecResult, DbErr> {
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO playlist_entries (
+                 id, playlist_id, position, source_id, track_id, local_track_id,
+                 match_title, match_artist, match_album, match_duration_secs,
+                 match_file_path
+             )
+             VALUES (?, ?, ?, ?, ?, ?, 'title', 'artist', 'album', 180, ?)",
+            [
+                id.into(),
+                playlist_id.into(),
+                position.into(),
+                source_id.into(),
+                track_id.into(),
+                local_track_id.into(),
+                path.into(),
+            ],
+        ))
+        .await
+    }
+
+    type ScopedRow = (
+        String,
+        String,
+        i32,
+        String,
+        Option<String>,
+        Option<String>,
+        String,
+        String,
+        String,
+        Option<i32>,
+        Option<String>,
+    );
+
+    async fn scoped_rows(db: &DatabaseConnection) -> Vec<ScopedRow> {
+        db.query_all(Statement::from_string(
+            DbBackend::Sqlite,
+            "SELECT id, playlist_id, position, source_id, track_id, local_track_id,
+                    match_title, match_artist, match_album, match_duration_secs,
+                    match_file_path
+             FROM playlist_entries
+             ORDER BY playlist_id, position"
+                .to_string(),
+        ))
+        .await
+        .expect("query scoped entries")
+        .into_iter()
+        .map(|row| {
+            (
+                row.try_get("", "id").expect("id"),
+                row.try_get("", "playlist_id").expect("playlist"),
+                row.try_get("", "position").expect("position"),
+                row.try_get("", "source_id").expect("source"),
+                row.try_get("", "track_id").expect("track"),
+                row.try_get("", "local_track_id").expect("local track"),
+                row.try_get("", "match_title").expect("title"),
+                row.try_get("", "match_artist").expect("artist"),
+                row.try_get("", "match_album").expect("album"),
+                row.try_get("", "match_duration_secs").expect("duration"),
+                row.try_get("", "match_file_path").expect("path"),
+            )
+        })
+        .collect()
+    }
+
+    async fn row_count(db: &DatabaseConnection, predicate: &str) -> i64 {
+        let row = db
+            .query_one(Statement::from_string(
+                DbBackend::Sqlite,
+                format!("SELECT COUNT(*) AS count FROM playlist_entries WHERE {predicate}"),
+            ))
+            .await
+            .expect("count entries")
+            .expect("count row");
+        row.try_get("", "count").expect("count")
+    }
+
+    async fn has_index(db: &DatabaseConnection, name: &str) -> bool {
+        db.query_one(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "SELECT 1 AS present FROM sqlite_master
+             WHERE type = 'index' AND name = ? AND tbl_name = 'playlist_entries'",
+            [name.into()],
+        ))
+        .await
+        .expect("query index")
+        .is_some()
+    }
+
+    async fn migration_table_exists(db: &DatabaseConnection) -> bool {
+        db.query_one(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = ?",
+            [REBUILD_TABLE.into()],
+        ))
+        .await
+        .expect("query rebuild table")
+        .is_some()
+    }
+
+    async fn install_near_match_legacy_schema(db: &DatabaseConnection) {
+        let near_table = "near_match_playlist_entries";
+        let near_sql = legacy_table_sql(near_table).replace(
+            "position INTEGER NOT NULL,",
+            "position INTEGER NOT NULL CONSTRAINT unexpected_position_check \
+             CHECK (position >= 0),",
+        );
+        db.execute_unprepared(&near_sql)
+            .await
+            .expect("create near-match legacy table");
+        db.execute_unprepared(&format!(
+            "INSERT INTO {near_table} (
+                 id, playlist_id, position, track_id,
+                 match_title, match_artist, match_album, match_duration_secs,
+                 match_file_path
+             )
+             SELECT id, playlist_id, position, track_id,
+                    match_title, match_artist, match_album, match_duration_secs,
+                    match_file_path
+             FROM playlist_entries"
+        ))
+        .await
+        .expect("copy near-match legacy rows");
+        db.execute_unprepared("DROP TABLE playlist_entries")
+            .await
+            .expect("drop exact predecessor");
+        db.execute_unprepared(&format!(
+            "ALTER TABLE {near_table} RENAME TO playlist_entries"
+        ))
+        .await
+        .expect("install near-match legacy table");
+        create_standard_indexes(&SchemaManager::new(db), PlaylistEntriesSchema::LegacyLocal)
+            .await
+            .expect("restore legacy indexes");
+    }
+
+    async fn install_near_match_scoped_schema(db: &DatabaseConnection, near_sql: &str) {
+        let near_table = "near_match_playlist_entries";
+        db.execute_unprepared(near_sql)
+            .await
+            .expect("create near-match scoped table");
+        db.execute_unprepared(&format!(
+            "INSERT INTO {near_table} (
+                 id, playlist_id, position, source_id, track_id, local_track_id,
+                 match_title, match_artist, match_album, match_duration_secs,
+                 match_file_path
+             )
+             SELECT id, playlist_id, position, source_id, track_id, local_track_id,
+                    match_title, match_artist, match_album, match_duration_secs,
+                    match_file_path
+             FROM playlist_entries"
+        ))
+        .await
+        .expect("copy near-match scoped rows");
+        db.execute_unprepared("DROP TABLE playlist_entries")
+            .await
+            .expect("drop exact scoped table");
+        db.execute_unprepared(&format!(
+            "ALTER TABLE {near_table} RENAME TO playlist_entries"
+        ))
+        .await
+        .expect("install near-match scoped table");
+        create_standard_indexes(&SchemaManager::new(db), PlaylistEntriesSchema::SourceScoped)
+            .await
+            .expect("restore scoped indexes");
+    }
+
+    #[test]
+    fn frozen_migration_local_source_id_matches_the_architecture_constant() {
+        assert_eq!(
+            LOCAL_SOURCE_ID,
+            crate::architecture::SourceId::local().to_string()
+        );
+    }
+
+    #[test]
+    fn frozen_sql_trim_set_matches_rust_trim_whitespace() {
+        let rust_whitespace = (0..=char::MAX as u32)
+            .filter_map(char::from_u32)
+            .filter(|character| character.is_whitespace())
+            .map(u32::from)
+            .collect::<Vec<_>>();
+
+        assert_eq!(RUST_TRIM_WHITESPACE, rust_whitespace);
+    }
+
+    #[test]
+    fn canonical_sql_preserves_literals_and_only_normalizes_known_identifier_quotes() {
+        assert_eq!(
+            canonical_sql(r#"CREATE TABLE "playlist_entries" ("source_id" VARCHAR DEFAULT '')"#),
+            canonical_sql("CREATE TABLE playlist_entries (source_id VARCHAR DEFAULT '')")
+        );
+        assert_ne!(
+            canonical_sql(&format!("CHECK (source_id = '{LOCAL_SOURCE_ID}')")),
+            canonical_sql(&format!(
+                "CHECK (source_id = '{}')",
+                LOCAL_SOURCE_ID.to_ascii_uppercase()
+            ))
+        );
+        assert_ne!(
+            canonical_sql(&format!("CHECK (source_id = '{LOCAL_SOURCE_ID}')")),
+            canonical_sql(&format!(r#"CHECK (source_id = "{LOCAL_SOURCE_ID}")"#))
+        );
+        assert_ne!(
+            canonical_sql("CHECK (trim(value, ' ') <> '')"),
+            canonical_sql("CHECK (trim(value, '') <> '')")
+        );
+    }
+
+    #[test]
+    fn rollback_failure_retains_the_original_and_secondary_context() {
+        let original = DbErr::Migration("forced rebuild failure".to_string());
+        let returned = preserve_original_error(
+            original,
+            Err(DbErr::Migration("forced rollback failure".to_string())),
+        );
+        let message = returned.to_string();
+
+        assert!(message.contains("forced rebuild failure"));
+        assert!(message.contains("forced rollback failure"));
+        assert_eq!(
+            preserve_original_error(DbErr::Migration("only original".to_string()), Ok(()))
+                .to_string(),
+            "Migration Error: only original"
+        );
+    }
+
+    #[tokio::test]
+    async fn upgrade_backfills_exact_local_identity_and_preserves_occurrences_and_evidence() {
+        let db = database_before_migration().await;
+        insert_playlist(&db, "a").await;
+        insert_playlist(&db, "b").await;
+        insert_track(&db, "shared").await;
+        insert_track(&db, "other").await;
+        insert_legacy_entry(
+            &db,
+            "entry-a0",
+            "a",
+            0,
+            Some("shared"),
+            Some("/import/shared.flac"),
+        )
+        .await;
+        insert_legacy_entry(&db, "entry-a1", "a", 1, Some("shared"), None).await;
+        insert_legacy_entry(&db, "entry-a2", "a", 2, None, Some("/import/future.flac")).await;
+        insert_legacy_entry(&db, "entry-b0", "b", 0, Some("other"), None).await;
+        db.execute_unprepared(
+            "CREATE INDEX idx_playlist_entries_match_title_custom
+             ON playlist_entries (match_title)
+             WHERE match_title <> ''",
+        )
+        .await
+        .expect("create custom index");
+
+        Migration
+            .up(&SchemaManager::new(&db))
+            .await
+            .expect("upgrade source-scoped entries");
+        Migration
+            .up(&SchemaManager::new(&db))
+            .await
+            .expect("repeat upgrade validates in place");
+
+        assert_eq!(
+            inspect_schema(&SchemaManager::new(&db)).await,
+            Ok(PlaylistEntriesSchema::SourceScoped)
+        );
+        let rows = scoped_rows(&db).await;
+        assert_eq!(rows.len(), 4);
+        assert_eq!(&rows[0].0, "entry-a0");
+        assert_eq!(rows[0].2, 0);
+        assert_eq!(&rows[0].3, LOCAL_SOURCE_ID);
+        assert_eq!(rows[0].4.as_deref(), Some("shared"));
+        assert_eq!(rows[0].5.as_deref(), Some("shared"));
+        assert_eq!(rows[0].6, "title-entry-a0");
+        assert_eq!(rows[0].7, "artist-entry-a0");
+        assert_eq!(rows[0].8, "album-entry-a0");
+        assert_eq!(rows[0].9, Some(180));
+        assert_eq!(rows[0].10.as_deref(), Some("/import/shared.flac"));
+        assert_eq!(&rows[1].0, "entry-a1");
+        assert_eq!(rows[1].4, rows[0].4, "duplicate media pair is retained");
+        assert_eq!(rows[1].5, rows[0].5, "duplicate local binding is legal");
+        assert_eq!(&rows[2].0, "entry-a2");
+        assert_eq!(rows[2].4, None);
+        assert_eq!(rows[2].5, None);
+        assert_eq!(rows[2].10.as_deref(), Some("/import/future.flac"));
+        assert_eq!(&rows[3].0, "entry-b0");
+
+        assert!(has_index(&db, PLAYLIST_INDEX).await);
+        assert!(has_index(&db, SOURCE_TRACK_INDEX).await);
+        assert!(has_index(&db, LOCAL_TRACK_INDEX).await);
+        assert!(has_index(&db, UNIQUE_POSITION_INDEX).await);
+        assert!(has_index(&db, "idx_playlist_entries_match_title_custom").await);
+        assert!(!has_index(&db, LEGACY_TRACK_INDEX).await);
+        assert!(!migration_table_exists(&db).await);
+    }
+
+    #[tokio::test]
+    async fn scoped_constraints_use_byte_bounds_and_keep_remote_rows_locator_free() {
+        let db = database_before_migration().await;
+        insert_playlist(&db, "playlist").await;
+        insert_track(&db, "local").await;
+        insert_track(&db, "other").await;
+        Migration
+            .up(&SchemaManager::new(&db))
+            .await
+            .expect("upgrade source-scoped entries");
+
+        insert_scoped_entry(
+            &db,
+            "local-orphan",
+            "playlist",
+            0,
+            LOCAL_SOURCE_ID,
+            None,
+            None,
+            Some("/import/orphan.flac"),
+        )
+        .await
+        .expect("local fingerprint-only orphan remains representable");
+        insert_scoped_entry(
+            &db,
+            "remote-valid",
+            "playlist",
+            1,
+            REMOTE_SOURCE_ID,
+            Some("native-id"),
+            None,
+            None,
+        )
+        .await
+        .expect("valid remote identity");
+        insert_scoped_entry(
+            &db,
+            "local-stale",
+            "playlist",
+            2,
+            LOCAL_SOURCE_ID,
+            Some("remembered-id"),
+            None,
+            None,
+        )
+        .await
+        .expect("durable local identity may outlive its binding");
+        insert_scoped_entry(
+            &db,
+            "local-fingerprint-orphan",
+            "playlist",
+            3,
+            LOCAL_SOURCE_ID,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("nonblank title and artist retain a local orphan");
+
+        assert!(db
+            .execute(Statement::from_sql_and_values(
+                DbBackend::Sqlite,
+                "INSERT INTO playlist_entries (
+                     id, playlist_id, position, source_id, track_id, local_track_id,
+                     match_title, match_artist, match_album, match_duration_secs,
+                     match_file_path
+                 )
+                 VALUES ('empty-evidence', 'playlist', 10, ?, NULL, NULL,
+                         '  ', char(9) || char(10), '', NULL, '   ')",
+                [LOCAL_SOURCE_ID.into()],
+            ))
+            .await
+            .is_err());
+
+        for (index, code_point) in RUST_TRIM_WHITESPACE.iter().enumerate() {
+            let whitespace = char::from_u32(*code_point)
+                .expect("frozen whitespace code point is valid")
+                .to_string();
+            assert!(whitespace.trim().is_empty());
+
+            for (suffix, title, artist, path) in [
+                (
+                    "path",
+                    String::new(),
+                    String::new(),
+                    Some(whitespace.clone()),
+                ),
+                ("fingerprint", whitespace.clone(), whitespace.clone(), None),
+            ] {
+                let id = format!("unicode-whitespace-{index}-{suffix}");
+                let result = db
+                    .execute(Statement::from_sql_and_values(
+                        DbBackend::Sqlite,
+                        "INSERT INTO playlist_entries (
+                             id, playlist_id, position, source_id, track_id, local_track_id,
+                             match_title, match_artist, match_album, match_duration_secs,
+                             match_file_path
+                         )
+                         VALUES (?, 'playlist', 10, ?, NULL, NULL, ?, ?, '', NULL, ?)",
+                        [
+                            id.clone().into(),
+                            LOCAL_SOURCE_ID.into(),
+                            title.into(),
+                            artist.into(),
+                            path.into(),
+                        ],
+                    ))
+                    .await;
+                assert!(
+                    result.is_err(),
+                    "Rust-trim whitespace U+{code_point:04X} supplied usable {suffix} evidence"
+                );
+            }
+        }
+
+        for (id, source_id, track_id, local_track_id, path) in [
+            (
+                "source-upper",
+                "AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA",
+                Some("id"),
+                None,
+                None,
+            ),
+            ("source-nil", NIL_SOURCE_ID, Some("id"), None, None),
+            (
+                "source-short",
+                "11111111-1111-4111-8111-11111111111",
+                Some("id"),
+                None,
+                None,
+            ),
+            ("remote-null", REMOTE_SOURCE_ID, None, None, None),
+            ("remote-empty", REMOTE_SOURCE_ID, Some(""), None, None),
+            (
+                "remote-binding",
+                REMOTE_SOURCE_ID,
+                Some("local"),
+                Some("local"),
+                None,
+            ),
+            (
+                "remote-path",
+                REMOTE_SOURCE_ID,
+                Some("id"),
+                None,
+                Some("/secret/locator"),
+            ),
+            (
+                "local-mismatch",
+                LOCAL_SOURCE_ID,
+                Some("local"),
+                Some("other"),
+                None,
+            ),
+            (
+                "local-dangling",
+                LOCAL_SOURCE_ID,
+                Some("missing"),
+                Some("missing"),
+                None,
+            ),
+        ] {
+            assert!(
+                insert_scoped_entry(
+                    &db,
+                    id,
+                    "playlist",
+                    10,
+                    source_id,
+                    track_id,
+                    local_track_id,
+                    path,
+                )
+                .await
+                .is_err(),
+                "invalid scoped entry {id} was accepted"
+            );
+        }
+
+        let remote_over_byte_limit = "é".repeat(2_049);
+        assert_eq!(remote_over_byte_limit.chars().count(), 2_049);
+        assert_eq!(remote_over_byte_limit.len(), 4_098);
+        assert!(insert_scoped_entry(
+            &db,
+            "remote-over-bytes",
+            "playlist",
+            10,
+            SECOND_REMOTE_SOURCE_ID,
+            Some(&remote_over_byte_limit),
+            None,
+            None,
+        )
+        .await
+        .is_err());
+
+        let local_over_byte_limit = "é".repeat(131_073);
+        assert_eq!(local_over_byte_limit.len(), 262_146);
+        assert!(insert_scoped_entry(
+            &db,
+            "local-over-bytes",
+            "playlist",
+            10,
+            LOCAL_SOURCE_ID,
+            Some(&local_over_byte_limit),
+            None,
+            None,
+        )
+        .await
+        .is_err());
+
+        assert!(insert_scoped_entry(
+            &db,
+            "negative-position",
+            "playlist",
+            -1,
+            LOCAL_SOURCE_ID,
+            Some("local"),
+            Some("local"),
+            None,
+        )
+        .await
+        .is_err());
+    }
+
+    #[tokio::test]
+    async fn corrupt_predecessor_orphan_fails_atomically_and_can_be_repaired_and_retried() {
+        let db = database_before_migration().await;
+        insert_playlist(&db, "playlist").await;
+        insert_legacy_entry(&db, "empty-orphan", "playlist", 0, None, None).await;
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "UPDATE playlist_entries
+             SET match_title = ?, match_artist = ?, match_file_path = ?
+             WHERE id = 'empty-orphan'",
+            [
+                "\u{00a0}".into(),
+                "\u{000c}".into(),
+                "\u{00a0}\u{000c}".into(),
+            ],
+        ))
+        .await
+        .expect("create Unicode-whitespace-only predecessor orphan");
+
+        Migration
+            .up(&SchemaManager::new(&db))
+            .await
+            .expect_err("orphan without identity or match evidence must fail");
+        assert_eq!(
+            inspect_schema(&SchemaManager::new(&db)).await,
+            Ok(PlaylistEntriesSchema::LegacyLocal)
+        );
+        assert_eq!(
+            row_count(&db, "id = 'empty-orphan' AND track_id IS NULL").await,
+            1
+        );
+        assert!(!migration_table_exists(&db).await);
+
+        db.execute_unprepared(
+            "UPDATE playlist_entries
+             SET match_title = 'Recovered', match_artist = 'Artist'
+             WHERE id = 'empty-orphan'",
+        )
+        .await
+        .expect("repair predecessor evidence");
+        Migration
+            .up(&SchemaManager::new(&db))
+            .await
+            .expect("retry accepts repaired fingerprint evidence");
+    }
+
+    #[tokio::test]
+    async fn near_match_legacy_table_is_rejected_before_rebuild_without_changing_data() {
+        let db = database_before_migration().await;
+        insert_playlist(&db, "playlist").await;
+        insert_track(&db, "track").await;
+        insert_legacy_entry(&db, "entry", "playlist", 0, Some("track"), None).await;
+        install_near_match_legacy_schema(&db).await;
+        let before_sql = table_sql(&SchemaManager::new(&db))
+            .await
+            .expect("near-match table SQL");
+        assert!(before_sql.contains("unexpected_position_check"));
+
+        let error = Migration
+            .up(&SchemaManager::new(&db))
+            .await
+            .expect_err("near-match predecessor must not be adopted");
+        assert!(error.to_string().contains("exact migration-12 predecessor"));
+        assert_eq!(
+            table_sql(&SchemaManager::new(&db)).await.unwrap(),
+            before_sql
+        );
+        assert_eq!(
+            row_count(&db, "id = 'entry' AND track_id = 'track'").await,
+            1
+        );
+        assert!(has_index(&db, LEGACY_TRACK_INDEX).await);
+        assert!(!migration_table_exists(&db).await);
+    }
+
+    #[tokio::test]
+    async fn target_literal_mutations_are_rejected_without_changing_schema() {
+        for mutation in ["uppercase-local-source", "missing-ascii-space-trim"] {
+            let db = database_before_migration().await;
+            insert_playlist(&db, "playlist").await;
+            Migration
+                .up(&SchemaManager::new(&db))
+                .await
+                .expect("install exact scoped schema");
+
+            let exact_sql = scoped_table_sql("near_match_playlist_entries");
+            let near_sql = match mutation {
+                "uppercase-local-source" => {
+                    exact_sql.replacen(LOCAL_SOURCE_ID, &LOCAL_SOURCE_ID.to_ascii_uppercase(), 1)
+                }
+                "missing-ascii-space-trim" => exact_sql.replacen(
+                    "char(13) || ' ' || char(133)",
+                    "char(13) || '' || char(133)",
+                    1,
+                ),
+                _ => unreachable!("fixed mutation list"),
+            };
+            assert_ne!(near_sql, exact_sql, "test mutation must alter table SQL");
+            install_near_match_scoped_schema(&db, &near_sql).await;
+            let before_sql = table_sql(&SchemaManager::new(&db))
+                .await
+                .expect("near-match target SQL");
+
+            let error = Migration
+                .up(&SchemaManager::new(&db))
+                .await
+                .expect_err("literal-mutated target must not be adopted");
+            assert!(error
+                .to_string()
+                .contains("source-scoped playlist_entries has unexpected table SQL"));
+            assert_eq!(
+                table_sql(&SchemaManager::new(&db)).await.unwrap(),
+                before_sql
+            );
+            assert_eq!(row_count(&db, "1 = 1").await, 0);
+            assert!(has_index(&db, SOURCE_TRACK_INDEX).await);
+            assert!(!migration_table_exists(&db).await);
+        }
+    }
+
+    #[tokio::test]
+    async fn partial_standard_index_is_rejected_without_rebuilding_and_retry_is_clean() {
+        let db = database_before_migration().await;
+        insert_playlist(&db, "playlist").await;
+        insert_track(&db, "track").await;
+        insert_legacy_entry(&db, "entry", "playlist", 0, Some("track"), None).await;
+        db.execute_unprepared(&format!("DROP INDEX {LEGACY_TRACK_INDEX}"))
+            .await
+            .expect("drop exact track index");
+        db.execute_unprepared(&format!(
+            "CREATE INDEX {LEGACY_TRACK_INDEX}
+             ON playlist_entries (track_id) WHERE track_id IS NOT NULL"
+        ))
+        .await
+        .expect("install partial lookalike");
+
+        let error = Migration
+            .up(&SchemaManager::new(&db))
+            .await
+            .expect_err("partial standard index must be rejected");
+        assert!(error.to_string().contains("partial=true"));
+        assert_eq!(
+            inspect_schema(&SchemaManager::new(&db)).await,
+            Ok(PlaylistEntriesSchema::LegacyLocal)
+        );
+        assert_eq!(row_count(&db, "id = 'entry'").await, 1);
+        assert!(!migration_table_exists(&db).await);
+
+        db.execute_unprepared(&format!("DROP INDEX {LEGACY_TRACK_INDEX}"))
+            .await
+            .expect("drop partial lookalike");
+        db.execute_unprepared(&format!(
+            "CREATE INDEX {LEGACY_TRACK_INDEX} ON playlist_entries (track_id)"
+        ))
+        .await
+        .expect("restore exact track index");
+        Migration
+            .up(&SchemaManager::new(&db))
+            .await
+            .expect("retry after index repair");
+    }
+
+    #[tokio::test]
+    async fn collation_lookalike_standard_index_is_rejected_and_retry_is_clean() {
+        let db = database_before_migration().await;
+        insert_playlist(&db, "playlist").await;
+        insert_track(&db, "track").await;
+        insert_legacy_entry(&db, "entry", "playlist", 0, Some("track"), None).await;
+        db.execute_unprepared(&format!("DROP INDEX {UNIQUE_POSITION_INDEX}"))
+            .await
+            .expect("drop exact position index");
+        db.execute_unprepared(&format!(
+            "CREATE UNIQUE INDEX {UNIQUE_POSITION_INDEX}
+             ON playlist_entries (playlist_id COLLATE NOCASE, position)"
+        ))
+        .await
+        .expect("install collation lookalike");
+
+        let error = Migration
+            .up(&SchemaManager::new(&db))
+            .await
+            .expect_err("collation lookalike must be rejected");
+        assert!(error.to_string().contains("has unexpected SQL"));
+        assert_eq!(
+            inspect_schema(&SchemaManager::new(&db)).await,
+            Ok(PlaylistEntriesSchema::LegacyLocal)
+        );
+        assert_eq!(row_count(&db, "id = 'entry'").await, 1);
+        assert!(!migration_table_exists(&db).await);
+
+        db.execute_unprepared(&format!("DROP INDEX {UNIQUE_POSITION_INDEX}"))
+            .await
+            .expect("drop collation lookalike");
+        db.execute_unprepared(&format!(
+            "CREATE UNIQUE INDEX {UNIQUE_POSITION_INDEX}
+             ON playlist_entries (playlist_id, position)"
+        ))
+        .await
+        .expect("restore exact position index");
+        Migration
+            .up(&SchemaManager::new(&db))
+            .await
+            .expect("retry after index repair");
+    }
+
+    #[tokio::test]
+    async fn local_deletion_clears_only_the_binding_and_never_collides_with_remote_identity() {
+        let db = database_before_migration().await;
+        insert_playlist(&db, "playlist").await;
+        insert_track(&db, "same-native-id").await;
+        insert_legacy_entry(
+            &db,
+            "local-entry",
+            "playlist",
+            0,
+            Some("same-native-id"),
+            None,
+        )
+        .await;
+        Migration
+            .up(&SchemaManager::new(&db))
+            .await
+            .expect("upgrade source-scoped entries");
+        insert_scoped_entry(
+            &db,
+            "remote-entry",
+            "playlist",
+            1,
+            REMOTE_SOURCE_ID,
+            Some("same-native-id"),
+            None,
+            None,
+        )
+        .await
+        .expect("insert colliding remote-native ID");
+
+        db.execute_unprepared("DELETE FROM tracks WHERE id = 'same-native-id'")
+            .await
+            .expect("delete local track");
+
+        let rows = scoped_rows(&db).await;
+        assert_eq!(rows[0].3, LOCAL_SOURCE_ID);
+        assert_eq!(rows[0].4.as_deref(), Some("same-native-id"));
+        assert_eq!(rows[0].5, None);
+        assert_eq!(rows[1].3, REMOTE_SOURCE_ID);
+        assert_eq!(rows[1].4.as_deref(), Some("same-native-id"));
+        assert_eq!(rows[1].5, None);
+
+        db.execute_unprepared("DELETE FROM playlists WHERE id = 'playlist'")
+            .await
+            .expect("delete playlist");
+        assert_eq!(row_count(&db, "1 = 1").await, 0);
+    }
+
+    #[tokio::test]
+    async fn downgrade_round_trips_only_losslessly_representable_local_rows() {
+        let db = database_before_migration().await;
+        insert_playlist(&db, "playlist").await;
+        insert_track(&db, "linked").await;
+        insert_legacy_entry(&db, "linked-entry", "playlist", 0, Some("linked"), None).await;
+        insert_legacy_entry(
+            &db,
+            "orphan-entry",
+            "playlist",
+            1,
+            None,
+            Some("/import/orphan.flac"),
+        )
+        .await;
+        db.execute_unprepared(
+            "CREATE INDEX idx_playlist_entries_match_artist_custom
+             ON playlist_entries (match_artist)",
+        )
+        .await
+        .expect("create custom index");
+
+        Migration
+            .up(&SchemaManager::new(&db))
+            .await
+            .expect("upgrade source-scoped entries");
+        Migration
+            .down(&SchemaManager::new(&db))
+            .await
+            .expect("lossless local downgrade");
+        Migration
+            .down(&SchemaManager::new(&db))
+            .await
+            .expect("repeat downgrade validates in place");
+
+        assert_eq!(
+            inspect_schema(&SchemaManager::new(&db)).await,
+            Ok(PlaylistEntriesSchema::LegacyLocal)
+        );
+        validate_schema(&SchemaManager::new(&db), PlaylistEntriesSchema::LegacyLocal)
+            .await
+            .expect("validate restored legacy schema");
+        assert!(has_index(&db, LEGACY_TRACK_INDEX).await);
+        assert!(has_index(&db, "idx_playlist_entries_match_artist_custom").await);
+        let rows = db
+            .query_all(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT id, position, track_id, match_file_path
+                 FROM playlist_entries ORDER BY position"
+                    .to_string(),
+            ))
+            .await
+            .expect("query downgraded rows");
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].try_get::<String>("", "id").unwrap(), "linked-entry");
+        assert_eq!(
+            rows[0]
+                .try_get::<Option<String>>("", "track_id")
+                .unwrap()
+                .as_deref(),
+            Some("linked")
+        );
+        assert_eq!(
+            rows[1].try_get::<Option<String>>("", "track_id").unwrap(),
+            None
+        );
+        assert_eq!(
+            rows[1]
+                .try_get::<Option<String>>("", "match_file_path")
+                .unwrap()
+                .as_deref(),
+            Some("/import/orphan.flac")
+        );
+
+        Migration
+            .up(&SchemaManager::new(&db))
+            .await
+            .expect("upgrade succeeds again after downgrade");
+    }
+
+    #[tokio::test]
+    async fn downgrade_refuses_remote_and_deleted_local_identity_without_changing_data() {
+        let db = database_before_migration().await;
+        insert_playlist(&db, "playlist").await;
+        insert_track(&db, "local").await;
+        insert_legacy_entry(&db, "local-entry", "playlist", 0, Some("local"), None).await;
+        Migration
+            .up(&SchemaManager::new(&db))
+            .await
+            .expect("upgrade source-scoped entries");
+        insert_scoped_entry(
+            &db,
+            "remote-entry",
+            "playlist",
+            1,
+            REMOTE_SOURCE_ID,
+            Some("remote-track"),
+            None,
+            None,
+        )
+        .await
+        .expect("insert remote entry");
+        let before = scoped_rows(&db).await;
+
+        let error = Migration
+            .down(&SchemaManager::new(&db))
+            .await
+            .expect_err("remote row cannot be downgraded losslessly");
+        assert!(error.to_string().contains("cannot downgrade 1"));
+        assert_eq!(scoped_rows(&db).await, before);
+        assert_eq!(
+            inspect_schema(&SchemaManager::new(&db)).await,
+            Ok(PlaylistEntriesSchema::SourceScoped)
+        );
+
+        db.execute_unprepared("DELETE FROM playlist_entries WHERE id = 'remote-entry'")
+            .await
+            .expect("remove remote test row");
+        db.execute_unprepared("DELETE FROM tracks WHERE id = 'local'")
+            .await
+            .expect("delete local binding");
+        let deleted_local = scoped_rows(&db).await;
+        assert_eq!(deleted_local[0].4.as_deref(), Some("local"));
+        assert_eq!(deleted_local[0].5, None);
+        let error = Migration
+            .down(&SchemaManager::new(&db))
+            .await
+            .expect_err("deleted-local durable identity cannot be downgraded losslessly");
+        assert!(error.to_string().contains("cannot downgrade 1"));
+        assert_eq!(scoped_rows(&db).await, deleted_local);
+
+        db.execute_unprepared(
+            "UPDATE playlist_entries SET track_id = NULL WHERE id = 'local-entry'",
+        )
+        .await
+        .expect("explicitly discard unrepresentable durable identity");
+        Migration
+            .down(&SchemaManager::new(&db))
+            .await
+            .expect("downgrade becomes lossless and retryable");
+    }
+
+    #[tokio::test]
+    async fn mid_rebuild_index_failure_rolls_back_exactly_and_retry_succeeds() {
+        let db = database_before_migration().await;
+        insert_playlist(&db, "playlist").await;
+        insert_track(&db, "track").await;
+        insert_legacy_entry(&db, "entry", "playlist", 0, Some("track"), None).await;
+        db.execute_unprepared("CREATE TABLE unrelated (id VARCHAR NOT NULL)")
+            .await
+            .expect("create unrelated table");
+        db.execute_unprepared(&format!(
+            "CREATE INDEX {SOURCE_TRACK_INDEX} ON unrelated (id)"
+        ))
+        .await
+        .expect("reserve target index name");
+
+        let error = Migration
+            .up(&SchemaManager::new(&db))
+            .await
+            .expect_err("target index collision must fail after rebuild begins");
+        assert!(error.to_string().contains(SOURCE_TRACK_INDEX));
+        assert_eq!(
+            inspect_schema(&SchemaManager::new(&db)).await,
+            Ok(PlaylistEntriesSchema::LegacyLocal)
+        );
+        assert_eq!(
+            row_count(&db, "id = 'entry' AND track_id = 'track'").await,
+            1
+        );
+        assert!(has_index(&db, LEGACY_TRACK_INDEX).await);
+        assert!(!migration_table_exists(&db).await);
+
+        db.execute_unprepared(&format!("DROP INDEX {SOURCE_TRACK_INDEX}"))
+            .await
+            .expect("remove injected collision");
+        Migration
+            .up(&SchemaManager::new(&db))
+            .await
+            .expect("retry upgrade after rollback");
+        assert_eq!(
+            inspect_schema(&SchemaManager::new(&db)).await,
+            Ok(PlaylistEntriesSchema::SourceScoped)
+        );
+        assert_eq!(
+            row_count(&db, "id = 'entry' AND track_id = 'track'").await,
+            1
+        );
+    }
+}

--- a/src/db/migration/mod.rs
+++ b/src/db/migration/mod.rs
@@ -14,6 +14,7 @@ mod m20260715_000009_create_root_reauthorization_receipts;
 mod m20260718_000010_add_playback_history;
 mod m20260718_000011_migrate_default_history_playlists;
 mod m20260719_000012_add_track_rating;
+mod m20260719_000013_source_scoped_playlist_entries;
 
 pub struct Migrator;
 
@@ -33,6 +34,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260718_000010_add_playback_history::Migration),
             Box::new(m20260718_000011_migrate_default_history_playlists::Migration),
             Box::new(m20260719_000012_add_track_rating::Migration),
+            Box::new(m20260719_000013_source_scoped_playlist_entries::Migration),
         ]
     }
 }

--- a/src/local/engine.rs
+++ b/src/local/engine.rs
@@ -1023,7 +1023,13 @@ where
             active.update(&transaction).await?;
         }
 
-        let entries = playlist_entry::Entity::find().all(&transaction).await?;
+        let entries = playlist_entry::Entity::find()
+            .filter(
+                playlist_entry::Column::SourceId
+                    .eq(crate::architecture::SourceId::local().to_string()),
+            )
+            .all(&transaction)
+            .await?;
         for entry in entries {
             let Some(source_path) = entry.match_file_path.as_deref() else {
                 continue;
@@ -6536,6 +6542,10 @@ mod tests {
         expected_entry.match_file_path = Some(destination_path.to_string_lossy().into_owned());
         assert_eq!(moved_entry, expected_entry);
         assert_eq!(moved_entry.track_id.as_deref(), Some(original.id.as_str()));
+        assert_eq!(
+            moved_entry.local_track_id.as_deref(),
+            Some(original.id.as_str())
+        );
 
         assert!(
             library_root::Entity::find_by_id(old_root.to_string_lossy().as_ref())
@@ -6562,6 +6572,73 @@ mod tests {
         assert_eq!(receipt.old_path, old_root.to_string_lossy());
         assert_eq!(receipt.new_path, new_root.to_string_lossy());
         assert_eq!(receipt.marker_identity, marker);
+    }
+
+    #[tokio::test]
+    async fn root_reauthorization_ignores_non_local_playlist_match_paths_defensively() {
+        let db = rename_test_database().await;
+        let old_root = directory_fixture_path("/legacy/Music");
+        let new_root = directory_fixture_path("/portal/Music");
+        let marker = test_marker_identity();
+        let stored_root = insert_reauthorization_root(&db, &old_root, &marker, true).await;
+        let manager = super::super::playlist_manager::PlaylistManager::new(db.clone());
+        let playlist = manager
+            .create_playlist("Corrupt remote path evidence", false)
+            .await
+            .expect("create playlist");
+        let remote_match_path = old_root.join("Remote").join("song.flac");
+        let remote_entry_id = Uuid::new_v4().to_string();
+
+        // Migration 13 rejects this state. Insert it only to prove the
+        // relocation boundary remains safe if an older or externally modified
+        // database nevertheless contains remote path evidence.
+        db.execute_unprepared("PRAGMA ignore_check_constraints = ON")
+            .await
+            .expect("disable checks for corrupt fixture");
+        playlist_entry::ActiveModel {
+            id: Set(remote_entry_id.clone()),
+            playlist_id: Set(playlist.id),
+            position: Set(0),
+            source_id: Set(crate::architecture::SourceId::random().to_string()),
+            track_id: Set(Some("remote-track".to_string())),
+            local_track_id: Set(None),
+            match_title: Set("Remote song".to_string()),
+            match_artist: Set("Remote artist".to_string()),
+            match_album: Set(String::new()),
+            match_duration_secs: Set(None),
+            match_file_path: Set(Some(remote_match_path.to_string_lossy().into_owned())),
+        }
+        .insert(&db)
+        .await
+        .expect("insert corrupt remote playlist entry");
+        db.execute_unprepared("PRAGMA ignore_check_constraints = OFF")
+            .await
+            .expect("restore playlist checks");
+
+        let request = RootReauthorizationRequest::new(Uuid::new_v4(), old_root, new_root.clone());
+        relocate_library_root_rows(&db, &request, Some(&stored_root), &marker, || async {
+            true
+        })
+        .await
+        .expect("relocate local library root rows");
+
+        let remote_entry = playlist_entry::Entity::find_by_id(remote_entry_id)
+            .one(&db)
+            .await
+            .expect("load remote playlist entry")
+            .expect("remote playlist entry survives");
+        assert_eq!(
+            remote_entry.match_file_path.as_deref(),
+            Some(remote_match_path.to_string_lossy().as_ref()),
+            "root relocation must never rewrite non-local source evidence"
+        );
+        assert!(
+            library_root::Entity::find_by_id(new_root.to_string_lossy().as_ref())
+                .one(&db)
+                .await
+                .expect("query relocated root")
+                .is_some()
+        );
     }
 
     #[tokio::test]
@@ -7044,7 +7121,9 @@ mod tests {
             id: Set(Uuid::new_v4().to_string()),
             playlist_id: Set(playlist.id),
             position: Set(0),
+            source_id: Set(crate::architecture::SourceId::local().to_string()),
             track_id: Set(None),
+            local_track_id: Set(None),
             match_title: Set("Remembered".to_string()),
             match_artist: Set(String::new()),
             match_album: Set(String::new()),
@@ -8296,6 +8375,10 @@ mod tests {
             .expect("playlist entry remains");
         assert_eq!(entry_after, entry_before);
         assert_eq!(entry_after.track_id.as_deref(), Some("stable-track-id"));
+        assert_eq!(
+            entry_after.local_track_id.as_deref(),
+            Some("stable-track-id")
+        );
     }
 
     #[tokio::test]
@@ -8366,7 +8449,13 @@ mod tests {
             .await
             .expect("load overwrite playlist entries");
         assert_eq!(entries[0].track_id.as_deref(), Some("source-track"));
-        assert_eq!(entries[1].track_id, None);
+        assert_eq!(entries[0].local_track_id.as_deref(), Some("source-track"));
+        assert_eq!(
+            entries[1].track_id.as_deref(),
+            Some("destination-track"),
+            "local deletion preserves durable playlist identity"
+        );
+        assert_eq!(entries[1].local_track_id, None);
     }
 
     #[tokio::test]
@@ -8535,16 +8624,17 @@ mod tests {
         )
         .await
         .expect("insert watcher track");
-        db.execute_unprepared(
+        let local_source_id = crate::architecture::SourceId::local();
+        db.execute_unprepared(&format!(
             "INSERT INTO playlist_entries (
-                 id, playlist_id, position, track_id,
+                 id, playlist_id, position, source_id, track_id, local_track_id,
                  match_title, match_artist, match_album, match_duration_secs
              )
              VALUES (
-                 'watcher-entry', 'watcher-playlist', 0, NULL,
+                 'watcher-entry', 'watcher-playlist', 0, '{local_source_id}', NULL, NULL,
                  'watcher song', 'watcher artist', 'watcher album', 180
-             )",
-        )
+             )"
+        ))
         .await
         .expect("insert orphaned playlist entry");
         let (event_tx, event_rx) = async_channel::unbounded();
@@ -8565,6 +8655,7 @@ mod tests {
             .expect("query skipped reconciliation")
             .expect("playlist entry remains");
         assert_eq!(still_orphaned.track_id, None);
+        assert_eq!(still_orphaned.local_track_id, None);
 
         assert_eq!(
             settle_playlist_projections_after_watcher_batch(&db, &event_tx, false, true)
@@ -8582,6 +8673,7 @@ mod tests {
             .expect("query removal-only reconciliation")
             .expect("playlist entry remains");
         assert_eq!(still_orphaned.track_id, None);
+        assert_eq!(still_orphaned.local_track_id, None);
 
         db.execute_unprepared(
             "CREATE TRIGGER fail_watcher_playlist_reconciliation
@@ -8619,6 +8711,7 @@ mod tests {
             .expect("query watcher reconciliation")
             .expect("playlist entry remains");
         assert_eq!(relinked.track_id.as_deref(), Some("watcher-track"));
+        assert_eq!(relinked.local_track_id.as_deref(), Some("watcher-track"));
     }
 
     #[tokio::test]

--- a/src/local/playlist_manager.rs
+++ b/src/local/playlist_manager.rs
@@ -1060,29 +1060,30 @@ async fn assign_contiguous_positions(
 
     // Park every row above the complete current range, then assign 0..N.
     // The unique position index remains valid after every individual update.
+    // Reuse the snapshot already validated above: querying each entry again
+    // in both passes would add 2N database round trips while holding the
+    // write transaction.
+    let mut current_by_id: HashMap<String, playlist_entry::Model> = current
+        .into_iter()
+        .map(|entry| (entry.id.clone(), entry))
+        .collect();
+    let mut parked_entries = Vec::with_capacity(entry_ids.len());
     for (offset, entry_id) in entry_ids.iter().enumerate() {
         let offset = i32::try_from(offset)
             .map_err(|_| DbErr::Custom("Playlist has too many entries".to_string()))?;
-        let mut entry: playlist_entry::ActiveModel =
-            playlist_entry::Entity::find_by_id(entry_id.clone())
-                .filter(playlist_entry::Column::PlaylistId.eq(playlist_id))
-                .one(txn)
-                .await?
-                .ok_or_else(|| DbErr::RecordNotFound(format!("Entry {entry_id} not found")))?
-                .into();
+        let mut entry: playlist_entry::ActiveModel = current_by_id
+            .remove(entry_id)
+            .ok_or_else(|| DbErr::RecordNotFound(format!("Entry {entry_id} not found")))?
+            .into();
         entry.position = Set(parking_start + offset);
-        entry.update(txn).await?;
+        parked_entries.push(entry.update(txn).await?);
     }
-    for (position, entry_id) in entry_ids.iter().enumerate() {
+    debug_assert!(current_by_id.is_empty());
+
+    for (position, entry) in parked_entries.into_iter().enumerate() {
         let position = i32::try_from(position)
             .map_err(|_| DbErr::Custom("Playlist has too many entries".to_string()))?;
-        let mut entry: playlist_entry::ActiveModel =
-            playlist_entry::Entity::find_by_id(entry_id.clone())
-                .filter(playlist_entry::Column::PlaylistId.eq(playlist_id))
-                .one(txn)
-                .await?
-                .ok_or_else(|| DbErr::RecordNotFound(format!("Entry {entry_id} not found")))?
-                .into();
+        let mut entry: playlist_entry::ActiveModel = entry.into();
         entry.position = Set(position);
         entry.update(txn).await?;
     }

--- a/src/local/playlist_manager.rs
+++ b/src/local/playlist_manager.rs
@@ -4,15 +4,16 @@
 //! references with fingerprint data for rediscovery after library rebuilds.
 //! Smart playlists store rule configurations and evaluate dynamically.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use sea_orm::prelude::*;
-use sea_orm::{ActiveValue::Set, QueryOrder, TransactionTrait};
+use sea_orm::{ActiveValue::Set, DatabaseTransaction, QueryOrder, TransactionTrait};
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use super::playlist_io::{ImportedTrack, ImportedTrackMatchIndex};
 use super::smart_rules::{self, SmartRules};
+use crate::architecture::{MediaKey, SourceId, TrackId};
 use crate::db::entities::{playlist, playlist_entry, track};
 
 /// Per-entry outcome counts for one committed playlist import.
@@ -28,6 +29,177 @@ pub struct PlaylistImportCounts {
 pub struct PlaylistImportResult {
     pub playlist: playlist::Model,
     pub counts: PlaylistImportCounts,
+}
+
+/// One exact, source-scoped track to append to a regular playlist.
+///
+/// The identity is deliberately independent of any playable URI. Remote
+/// locators and credentials remain owned by the live source session and are
+/// never accepted by playlist persistence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PlaylistEntryInput {
+    pub media_key: MediaKey,
+    pub title: String,
+    pub artist: String,
+    pub album: String,
+    pub duration_secs: Option<u64>,
+}
+
+impl PlaylistEntryInput {
+    pub fn new(
+        media_key: MediaKey,
+        title: impl Into<String>,
+        artist: impl Into<String>,
+        album: impl Into<String>,
+        duration_secs: Option<u64>,
+    ) -> Self {
+        Self {
+            media_key,
+            title: title.into(),
+            artist: artist.into(),
+            album: album.into(),
+            duration_secs,
+        }
+    }
+
+    fn local(track: &track::Model) -> Result<Self, DbErr> {
+        let track_id = TrackId::new(track.id.clone())
+            .map_err(|error| DbErr::Custom(format!("Local track identity is invalid: {error}")))?;
+        Ok(Self::new(
+            MediaKey::new(SourceId::local(), track_id),
+            track.title.clone(),
+            track.artist_name.clone(),
+            track.album_title.clone(),
+            valid_track_match_duration(track).map(|duration| duration as u64),
+        ))
+    }
+}
+
+/// Durable regular-playlist occurrence returned by the storage boundary.
+///
+/// `track_id` is absent only for an unmatched local import. `local_track_id`
+/// is a resolution cache backed by the local-track foreign key; deleting a
+/// local library row can clear it without erasing the occurrence's canonical
+/// source-scoped identity or match evidence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StoredPlaylistEntry {
+    pub id: String,
+    pub playlist_id: String,
+    pub position: i32,
+    pub source_id: SourceId,
+    pub track_id: Option<TrackId>,
+    pub local_track_id: Option<TrackId>,
+    pub match_title: String,
+    pub match_artist: String,
+    pub match_album: String,
+    pub match_duration_secs: Option<i32>,
+    pub match_file_path: Option<String>,
+}
+
+impl StoredPlaylistEntry {
+    pub fn media_key(&self) -> Option<MediaKey> {
+        self.track_id
+            .clone()
+            .map(|track_id| MediaKey::new(self.source_id, track_id))
+    }
+
+    fn from_model(entry: playlist_entry::Model) -> Result<Self, DbErr> {
+        if entry.position < 0 {
+            return Err(DbErr::Custom(format!(
+                "Playlist entry {} has an invalid position",
+                entry.id
+            )));
+        }
+        let source_id = entry.source_id.parse::<SourceId>().map_err(|error| {
+            DbErr::Custom(format!(
+                "Playlist entry {} has an invalid source identity: {error}",
+                entry.id
+            ))
+        })?;
+        if source_id.to_string() != entry.source_id {
+            return Err(DbErr::Custom(format!(
+                "Playlist entry {} has a non-canonical source identity",
+                entry.id
+            )));
+        }
+        if source_id.as_uuid().is_nil() {
+            return Err(DbErr::Custom(format!(
+                "Playlist entry {} has an unavailable source identity",
+                entry.id
+            )));
+        }
+        let track_id = entry
+            .track_id
+            .as_deref()
+            .map(|track_id| {
+                if source_id == SourceId::local() {
+                    TrackId::new(track_id)
+                } else {
+                    TrackId::remote(track_id)
+                }
+            })
+            .transpose()
+            .map_err(|_| {
+                DbErr::Custom(format!(
+                    "Playlist entry {} has an invalid track identity",
+                    entry.id
+                ))
+            })?;
+        let local_track_id = entry
+            .local_track_id
+            .as_deref()
+            .map(TrackId::new)
+            .transpose()
+            .map_err(|_| {
+                DbErr::Custom(format!(
+                    "Playlist entry {} has an invalid local track identity",
+                    entry.id
+                ))
+            })?;
+
+        if source_id == SourceId::local() {
+            if let Some(local_track_id) = local_track_id.as_ref() {
+                if track_id.as_ref() != Some(local_track_id) {
+                    return Err(DbErr::Custom(format!(
+                        "Playlist entry {} has inconsistent local identities",
+                        entry.id
+                    )));
+                }
+            }
+            let has_path_evidence = entry
+                .match_file_path
+                .as_deref()
+                .is_some_and(|path| !path.trim().is_empty());
+            let has_fingerprint =
+                !entry.match_title.trim().is_empty() && !entry.match_artist.trim().is_empty();
+            if track_id.is_none() && !has_path_evidence && !has_fingerprint {
+                return Err(DbErr::Custom(format!(
+                    "Playlist entry {} has no usable local identity evidence",
+                    entry.id
+                )));
+            }
+        } else if track_id.is_none() || local_track_id.is_some() || entry.match_file_path.is_some()
+        {
+            return Err(DbErr::Custom(format!(
+                "Playlist entry {} has inconsistent remote identity",
+                entry.id
+            )));
+        }
+
+        Ok(Self {
+            id: entry.id,
+            playlist_id: entry.playlist_id,
+            position: entry.position,
+            source_id,
+            track_id,
+            local_track_id,
+            match_title: entry.match_title,
+            match_artist: entry.match_artist,
+            match_album: entry.match_album,
+            match_duration_secs: entry.match_duration_secs,
+            match_file_path: entry.match_file_path,
+        })
+    }
 }
 
 /// Manages playlist persistence and track reconciliation.
@@ -128,6 +300,10 @@ impl PlaylistManager {
             let matched = match_index.find(source);
             let (track_id, match_file_path, title, artist, album, match_duration) =
                 if let Some(track) = matched {
+                    if TrackId::new(track.id.as_str()).is_err() {
+                        counts.failed += 1;
+                        continue;
+                    }
                     counts.matched += 1;
                     (
                         Some(track.id.clone()),
@@ -153,7 +329,9 @@ impl PlaylistManager {
                 id: Set(Uuid::new_v4().to_string()),
                 playlist_id: Set(playlist.id.clone()),
                 position: Set(position),
-                track_id: Set(track_id),
+                source_id: Set(SourceId::local().to_string()),
+                track_id: Set(track_id.clone()),
+                local_track_id: Set(track_id),
                 match_file_path: Set(match_file_path),
                 match_title: Set(title),
                 match_artist: Set(artist),
@@ -226,117 +404,274 @@ impl PlaylistManager {
     /// Stores fingerprint data (title, artist, album, duration) for
     /// rediscovery after a library rebuild.
     pub async fn add_track(&self, playlist_id: &str, track: &track::Model) -> Result<(), DbErr> {
-        // Wrap the next-position read and the insert in a transaction so the
-        // two statements form a single atomic unit. (Fully preventing two
-        // concurrent adds from claiming the same position would additionally
-        // require a UNIQUE(playlist_id, position) index — see migrations.)
-        let txn = self.db.begin().await?;
-
-        // Get next position.
-        let max_pos = playlist_entry::Entity::find()
-            .filter(playlist_entry::Column::PlaylistId.eq(playlist_id))
-            .order_by_desc(playlist_entry::Column::Position)
-            .one(&txn)
-            .await?
-            .map(|e| e.position)
-            .unwrap_or(-1);
-
-        let entry = playlist_entry::ActiveModel {
-            id: Set(Uuid::new_v4().to_string()),
-            playlist_id: Set(playlist_id.to_string()),
-            position: Set(max_pos + 1),
-            track_id: Set(Some(track.id.clone())),
-            // A path is authoritative only when an imported playlist supplied
-            // it as durable location evidence. A manually added entry follows
-            // the song fingerprint after deletion/rename; otherwise a
-            // different file later scanned at the reused path could silently
-            // replace the user's original choice.
-            match_file_path: Set(None),
-            match_title: Set(track.title.to_lowercase().trim().to_string()),
-            match_artist: Set(track.artist_name.to_lowercase().trim().to_string()),
-            match_album: Set(track.album_title.to_lowercase().trim().to_string()),
-            match_duration_secs: Set(valid_track_match_duration(track)),
-        };
-        entry.insert(&txn).await?;
-        txn.commit().await?;
+        let input = PlaylistEntryInput::local(track)?;
+        self.add_entries(playlist_id, &[input]).await?;
         debug!(playlist = %playlist_id, track = %track.title, "Track added to playlist");
         Ok(())
     }
 
-    /// Remove an entry from a playlist.
-    pub async fn remove_entry(&self, entry_id: &str) -> Result<(), DbErr> {
-        playlist_entry::Entity::delete_by_id(entry_id.to_string())
-            .exec(&self.db)
+    /// Append exact source-scoped tracks to one regular playlist atomically.
+    ///
+    /// Duplicate identities are intentionally preserved as distinct
+    /// occurrences in input order. Local identities are resolved against the
+    /// current track table inside the same transaction and receive the local
+    /// foreign-key cache. Non-local identities are persisted without a URI or
+    /// local foreign key; the UI does not expose remote mutations until its
+    /// live-session projection is implemented.
+    pub async fn add_entries(
+        &self,
+        playlist_id: &str,
+        inputs: &[PlaylistEntryInput],
+    ) -> Result<Vec<StoredPlaylistEntry>, DbErr> {
+        let txn = self.db.begin().await?;
+        require_regular_playlist(&txn, playlist_id).await?;
+        if inputs.is_empty() {
+            txn.commit().await?;
+            return Ok(Vec::new());
+        }
+
+        for input in inputs {
+            if input.media_key.source_id.as_uuid().is_nil() {
+                return Err(DbErr::Custom(
+                    "Playlist source identity is unavailable".to_string(),
+                ));
+            }
+            if input.media_key.source_id != SourceId::local() {
+                TrackId::remote(input.media_key.track_id.as_str()).map_err(|_| {
+                    DbErr::Custom("Remote playlist track identity is invalid".to_string())
+                })?;
+            }
+        }
+
+        let max_position = playlist_entry::Entity::find()
+            .filter(playlist_entry::Column::PlaylistId.eq(playlist_id))
+            .order_by_desc(playlist_entry::Column::Position)
+            .one(&txn)
+            .await?
+            .map(|entry| entry.position)
+            .unwrap_or(-1);
+        if max_position < -1 {
+            return Err(DbErr::Custom(format!(
+                "Playlist {playlist_id} has an invalid entry position"
+            )));
+        }
+        let first_position = max_position
+            .checked_add(1)
+            .ok_or_else(|| DbErr::Custom("Playlist has too many entries".to_string()))?;
+
+        let local_ids: HashSet<&str> = inputs
+            .iter()
+            .filter(|input| input.media_key.source_id == SourceId::local())
+            .map(|input| input.media_key.track_id.as_str())
+            .collect();
+        let local_tracks: HashMap<String, track::Model> = if local_ids.is_empty() {
+            HashMap::new()
+        } else {
+            track::Entity::find()
+                .filter(track::Column::Id.is_in(local_ids.iter().copied()))
+                .all(&txn)
+                .await?
+                .into_iter()
+                .map(|track| (track.id.clone(), track))
+                .collect()
+        };
+        if local_ids
+            .iter()
+            .any(|track_id| !local_tracks.contains_key(*track_id))
+        {
+            return Err(DbErr::RecordNotFound(
+                "Local playlist track not found".to_string(),
+            ));
+        }
+
+        let mut inserted = Vec::with_capacity(inputs.len());
+        for (offset, input) in inputs.iter().enumerate() {
+            let offset = i32::try_from(offset)
+                .map_err(|_| DbErr::Custom("Playlist has too many entries".to_string()))?;
+            let position = first_position
+                .checked_add(offset)
+                .ok_or_else(|| DbErr::Custom("Playlist has too many entries".to_string()))?;
+
+            let is_local = input.media_key.source_id == SourceId::local();
+            let local_track = is_local.then(|| {
+                local_tracks
+                    .get(input.media_key.track_id.as_str())
+                    .expect("all local playlist inputs were validated")
+            });
+            let duration = match local_track {
+                Some(track) => valid_track_match_duration(track),
+                None => input
+                    .duration_secs
+                    .map(i32::try_from)
+                    .transpose()
+                    .map_err(|_| {
+                        DbErr::Custom("Playlist entry duration is too large".to_string())
+                    })?,
+            };
+            let (title, artist, album) = match local_track {
+                Some(track) => (&track.title, &track.artist_name, &track.album_title),
+                None => (&input.title, &input.artist, &input.album),
+            };
+            let track_id = input.media_key.track_id.as_str().to_string();
+            let model = playlist_entry::ActiveModel {
+                id: Set(Uuid::new_v4().to_string()),
+                playlist_id: Set(playlist_id.to_string()),
+                position: Set(position),
+                source_id: Set(input.media_key.source_id.to_string()),
+                track_id: Set(Some(track_id.clone())),
+                local_track_id: Set(is_local.then_some(track_id)),
+                // A path is authoritative only when an imported local
+                // playlist supplied it as durable location evidence.
+                match_file_path: Set(None),
+                match_title: Set(normalize_fingerprint(title)),
+                match_artist: Set(normalize_fingerprint(artist)),
+                match_album: Set(normalize_fingerprint(album)),
+                match_duration_secs: Set(duration),
+            }
+            .insert(&txn)
             .await?;
+            inserted.push(StoredPlaylistEntry::from_model(model)?);
+        }
+
+        txn.commit().await?;
+        Ok(inserted)
+    }
+
+    /// Remove an entry from its owning regular playlist and close the gap.
+    pub async fn remove_entry(&self, entry_id: &str) -> Result<(), DbErr> {
+        let entry = playlist_entry::Entity::find_by_id(entry_id.to_string())
+            .one(&self.db)
+            .await?
+            .ok_or_else(|| DbErr::RecordNotFound(format!("Entry {entry_id} not found")))?;
+        self.remove_entries(&entry.playlist_id, &[entry_id.to_string()])
+            .await
+    }
+
+    /// Remove exact durable occurrences atomically and restore contiguous
+    /// positions. Every ID must be unique and belong to `playlist_id`.
+    pub async fn remove_entries(
+        &self,
+        playlist_id: &str,
+        entry_ids: &[String],
+    ) -> Result<(), DbErr> {
+        let txn = self.db.begin().await?;
+        require_regular_playlist(&txn, playlist_id).await?;
+        if entry_ids.is_empty() {
+            txn.commit().await?;
+            return Ok(());
+        }
+        let current = playlist_entry::Entity::find()
+            .filter(playlist_entry::Column::PlaylistId.eq(playlist_id))
+            .order_by_asc(playlist_entry::Column::Position)
+            .all(&txn)
+            .await?;
+        let requested: HashSet<&str> = entry_ids.iter().map(String::as_str).collect();
+        if requested.len() != entry_ids.len() {
+            return Err(DbErr::Custom(
+                "Playlist removal contains duplicate entry IDs".to_string(),
+            ));
+        }
+        let current_ids: HashSet<&str> = current.iter().map(|entry| entry.id.as_str()).collect();
+        if let Some(missing) = requested
+            .iter()
+            .find(|entry_id| !current_ids.contains(**entry_id))
+        {
+            return Err(DbErr::RecordNotFound(format!(
+                "Entry {missing} not found in playlist {playlist_id}"
+            )));
+        }
+
+        if !entry_ids.is_empty() {
+            let deleted = playlist_entry::Entity::delete_many()
+                .filter(playlist_entry::Column::PlaylistId.eq(playlist_id))
+                .filter(playlist_entry::Column::Id.is_in(entry_ids.iter().map(String::as_str)))
+                .exec(&txn)
+                .await?;
+            let expected = u64::try_from(entry_ids.len())
+                .map_err(|_| DbErr::Custom("Too many playlist entries selected".to_string()))?;
+            if deleted.rows_affected != expected {
+                return Err(DbErr::Custom(
+                    "Playlist changed while entries were being removed".to_string(),
+                ));
+            }
+        }
+
+        let remaining_ids: Vec<String> = current
+            .into_iter()
+            .filter(|entry| !requested.contains(entry.id.as_str()))
+            .map(|entry| entry.id)
+            .collect();
+        assign_contiguous_positions(&txn, playlist_id, &remaining_ids).await?;
+        txn.commit().await?;
         Ok(())
     }
 
-    /// Reorder entries in a playlist. `entry_ids` is the new order.
+    /// Reorder every occurrence in a playlist. `entry_ids` must be one exact,
+    /// duplicate-free permutation of the playlist's durable entry IDs.
     pub async fn reorder_entries(
         &self,
         playlist_id: &str,
         entry_ids: &[String],
     ) -> Result<(), DbErr> {
-        // The `UNIQUE(playlist_id, position)` index makes naive sequential
-        // updates collide: assigning an entry its final position while another
-        // entry still holds it is a transient duplicate the index rejects.
-        //
-        // Two phases inside one transaction avoid that. Phase 1 parks every
-        // affected entry in a high, non-overlapping range; phase 2 assigns the
-        // final `0..N` positions. Phase-1 values (>= `TEMP_OFFSET`) never
-        // overlap phase-2 targets, so no statement ever produces a duplicate.
-        // The whole thing is transactional, so a mid-way failure rolls back
-        // cleanly instead of leaving a mix of old and new positions.
-        const TEMP_OFFSET: i32 = 1_000_000;
-
         let txn = self.db.begin().await?;
-
-        // Phase 1: park each entry at `index + TEMP_OFFSET`.
-        for (pos, entry_id) in entry_ids.iter().enumerate() {
-            let mut entry: playlist_entry::ActiveModel =
-                playlist_entry::Entity::find_by_id(entry_id.clone())
-                    .filter(playlist_entry::Column::PlaylistId.eq(playlist_id))
-                    .one(&txn)
-                    .await?
-                    .ok_or(DbErr::RecordNotFound(format!("Entry {entry_id} not found")))?
-                    .into();
-
-            entry.position = Set(pos as i32 + TEMP_OFFSET);
-            entry.update(&txn).await?;
+        require_regular_playlist(&txn, playlist_id).await?;
+        let current = playlist_entry::Entity::find()
+            .filter(playlist_entry::Column::PlaylistId.eq(playlist_id))
+            .all(&txn)
+            .await?;
+        let requested: HashSet<&str> = entry_ids.iter().map(String::as_str).collect();
+        let current_ids: HashSet<&str> = current.iter().map(|entry| entry.id.as_str()).collect();
+        if requested.len() != entry_ids.len()
+            || entry_ids.len() != current.len()
+            || requested != current_ids
+        {
+            return Err(DbErr::Custom(format!(
+                "Playlist {playlist_id} reorder must contain each entry exactly once"
+            )));
         }
 
-        // Phase 2: assign the final 0..N positions.
-        for (pos, entry_id) in entry_ids.iter().enumerate() {
-            let mut entry: playlist_entry::ActiveModel =
-                playlist_entry::Entity::find_by_id(entry_id.clone())
-                    .filter(playlist_entry::Column::PlaylistId.eq(playlist_id))
-                    .one(&txn)
-                    .await?
-                    .ok_or(DbErr::RecordNotFound(format!("Entry {entry_id} not found")))?
-                    .into();
-
-            entry.position = Set(pos as i32);
-            entry.update(&txn).await?;
-        }
-
+        assign_contiguous_positions(&txn, playlist_id, entry_ids).await?;
         txn.commit().await?;
         Ok(())
     }
 
+    /// Load every durable regular-playlist occurrence in stored order.
+    /// Unmatched and currently unavailable entries are retained.
+    pub async fn get_playlist_entries(
+        &self,
+        playlist_id: &str,
+    ) -> Result<Vec<StoredPlaylistEntry>, DbErr> {
+        require_regular_playlist(&self.db, playlist_id).await?;
+        let entries = playlist_entry::Entity::find()
+            .filter(playlist_entry::Column::PlaylistId.eq(playlist_id))
+            .order_by_asc(playlist_entry::Column::Position)
+            .all(&self.db)
+            .await?;
+        entries
+            .into_iter()
+            .map(StoredPlaylistEntry::from_model)
+            .collect()
+    }
+
     /// Get all matched tracks for a regular playlist (ordered by position).
     ///
-    /// Returns only entries that have a valid `track_id` link. Unmatched
-    /// entries (orphans from a library rebuild) are excluded.
+    /// This compatibility projection is deliberately local-only. It returns
+    /// entries with a valid local foreign-key cache and excludes remote or
+    /// unresolved occurrences until mixed-source UI projection lands.
     pub async fn get_playlist_tracks(&self, playlist_id: &str) -> Result<Vec<track::Model>, DbErr> {
         let entries = playlist_entry::Entity::find()
             .filter(playlist_entry::Column::PlaylistId.eq(playlist_id))
-            .filter(playlist_entry::Column::TrackId.is_not_null())
+            .filter(playlist_entry::Column::SourceId.eq(SourceId::local().to_string()))
+            .filter(playlist_entry::Column::LocalTrackId.is_not_null())
             .order_by_asc(playlist_entry::Column::Position)
             .all(&self.db)
             .await?;
 
         // Collect the linked track IDs in playlist order.
-        let track_ids: Vec<String> = entries.iter().filter_map(|e| e.track_id.clone()).collect();
+        let track_ids: Vec<String> = entries
+            .iter()
+            .filter_map(|entry| entry.local_track_id.clone())
+            .collect();
         if track_ids.is_empty() {
             return Ok(Vec::new());
         }
@@ -460,14 +795,17 @@ impl PlaylistManager {
     /// Re-link orphaned playlist entries to newly-discovered tracks.
     ///
     /// Called after a library rebuild (FullSync). Finds entries with
-    /// `track_id IS NULL` and attempts to match them against current
-    /// tracks by exact retained path first, then by a normalized
+    /// the built-in local `source_id` and `local_track_id IS NULL`, then
+    /// attempts to match them against current tracks by exact retained path
+    /// first, then by a normalized
     /// `(title, artist, album)` fingerprint with optional duration tolerance.
+    /// Remote identities are never relinked by local metadata.
     ///
     /// Returns the number of entries re-linked.
     pub async fn reconcile_all(&self) -> Result<u32, DbErr> {
         let orphans = playlist_entry::Entity::find()
-            .filter(playlist_entry::Column::TrackId.is_null())
+            .filter(playlist_entry::Column::SourceId.eq(SourceId::local().to_string()))
+            .filter(playlist_entry::Column::LocalTrackId.is_null())
             .all(&self.db)
             .await?;
 
@@ -511,13 +849,21 @@ impl PlaylistManager {
             let best = match_index.find(&imported);
 
             if let Some(best) = best {
+                if TrackId::new(best.id.as_str()).is_err() {
+                    warn!(
+                        entry = %orphan.id,
+                        "Skipping playlist reconciliation with an invalid local track identity"
+                    );
+                    continue;
+                }
                 let track_id = best.id.clone();
                 let match_title = normalize_fingerprint(&best.title);
                 let match_artist = normalize_fingerprint(&best.artist_name);
                 let match_album = normalize_fingerprint(&best.album_title);
                 let match_duration_secs = valid_track_match_duration(best);
                 let mut entry: playlist_entry::ActiveModel = orphan.into();
-                entry.track_id = Set(Some(track_id));
+                entry.track_id = Set(Some(track_id.clone()));
+                entry.local_track_id = Set(Some(track_id));
                 entry.match_title = Set(match_title);
                 entry.match_artist = Set(match_artist);
                 entry.match_album = Set(match_album);
@@ -641,6 +987,109 @@ fn top_25_most_played_default_rules() -> smart_rules::SmartRules {
     }
 }
 
+async fn require_regular_playlist<C>(db: &C, playlist_id: &str) -> Result<(), DbErr>
+where
+    C: ConnectionTrait,
+{
+    let playlist = playlist::Entity::find_by_id(playlist_id.to_string())
+        .one(db)
+        .await?
+        .ok_or_else(|| DbErr::RecordNotFound(format!("Playlist {playlist_id} not found")))?;
+    if playlist.is_smart {
+        return Err(DbErr::Custom(format!(
+            "Playlist {playlist_id} is smart and cannot store regular entries"
+        )));
+    }
+    Ok(())
+}
+
+/// Assign one exact occurrence order without ever violating the unique
+/// `(playlist_id, position)` index. All arithmetic is checked before the
+/// first write, and the caller owns the surrounding transaction.
+async fn assign_contiguous_positions(
+    txn: &DatabaseTransaction,
+    playlist_id: &str,
+    entry_ids: &[String],
+) -> Result<(), DbErr> {
+    let current = playlist_entry::Entity::find()
+        .filter(playlist_entry::Column::PlaylistId.eq(playlist_id))
+        .order_by_asc(playlist_entry::Column::Position)
+        .all(txn)
+        .await?;
+    let requested: HashSet<&str> = entry_ids.iter().map(String::as_str).collect();
+    let current_ids: HashSet<&str> = current.iter().map(|entry| entry.id.as_str()).collect();
+    if requested.len() != entry_ids.len()
+        || entry_ids.len() != current.len()
+        || requested != current_ids
+    {
+        return Err(DbErr::Custom(format!(
+            "Playlist {playlist_id} changed while positions were being assigned"
+        )));
+    }
+
+    let already_contiguous = current.iter().enumerate().all(|(position, entry)| {
+        i32::try_from(position) == Ok(entry.position) && entry_ids.get(position) == Some(&entry.id)
+    });
+    if already_contiguous {
+        return Ok(());
+    }
+
+    let maximum_position = current
+        .iter()
+        .map(|entry| entry.position)
+        .max()
+        .unwrap_or(-1);
+    if maximum_position < -1 {
+        return Err(DbErr::Custom(format!(
+            "Playlist {playlist_id} has an invalid entry position"
+        )));
+    }
+    let parking_start = maximum_position.checked_add(1).ok_or_else(|| {
+        DbErr::Custom("Playlist positions cannot be reordered safely".to_string())
+    })?;
+    let final_offset = entry_ids
+        .len()
+        .checked_sub(1)
+        .map(i32::try_from)
+        .transpose()
+        .map_err(|_| DbErr::Custom("Playlist has too many entries".to_string()))?
+        .unwrap_or(0);
+    parking_start.checked_add(final_offset).ok_or_else(|| {
+        DbErr::Custom("Playlist positions cannot be reordered safely".to_string())
+    })?;
+
+    // Park every row above the complete current range, then assign 0..N.
+    // The unique position index remains valid after every individual update.
+    for (offset, entry_id) in entry_ids.iter().enumerate() {
+        let offset = i32::try_from(offset)
+            .map_err(|_| DbErr::Custom("Playlist has too many entries".to_string()))?;
+        let mut entry: playlist_entry::ActiveModel =
+            playlist_entry::Entity::find_by_id(entry_id.clone())
+                .filter(playlist_entry::Column::PlaylistId.eq(playlist_id))
+                .one(txn)
+                .await?
+                .ok_or_else(|| DbErr::RecordNotFound(format!("Entry {entry_id} not found")))?
+                .into();
+        entry.position = Set(parking_start + offset);
+        entry.update(txn).await?;
+    }
+    for (position, entry_id) in entry_ids.iter().enumerate() {
+        let position = i32::try_from(position)
+            .map_err(|_| DbErr::Custom("Playlist has too many entries".to_string()))?;
+        let mut entry: playlist_entry::ActiveModel =
+            playlist_entry::Entity::find_by_id(entry_id.clone())
+                .filter(playlist_entry::Column::PlaylistId.eq(playlist_id))
+                .one(txn)
+                .await?
+                .ok_or_else(|| DbErr::RecordNotFound(format!("Entry {entry_id} not found")))?
+                .into();
+        entry.position = Set(position);
+        entry.update(txn).await?;
+    }
+
+    Ok(())
+}
+
 fn normalize_fingerprint(value: &str) -> String {
     value.trim().to_lowercase()
 }
@@ -679,7 +1128,11 @@ mod tests {
     };
     use sea_orm_migration::MigratorTrait;
 
-    use super::{recently_played_default_rules, top_25_most_played_default_rules, PlaylistManager};
+    use super::{
+        recently_played_default_rules, top_25_most_played_default_rules, PlaylistEntryInput,
+        PlaylistManager, StoredPlaylistEntry,
+    };
+    use crate::architecture::{MediaKey, SourceId, TrackId};
     use crate::db::entities::{playlist, playlist_entry, track};
     use crate::db::migration::Migrator;
     use crate::local::playlist_io::ImportedTrack;
@@ -702,10 +1155,12 @@ mod tests {
             id: Set(id.to_string()),
             playlist_id: Set(playlist_id.to_string()),
             position: Set(position),
+            source_id: Set(SourceId::local().to_string()),
             track_id: Set(None),
+            local_track_id: Set(None),
             match_file_path: Set(None),
-            match_title: Set(String::new()),
-            match_artist: Set(String::new()),
+            match_title: Set("placeholder".to_string()),
+            match_artist: Set("placeholder".to_string()),
             match_album: Set(String::new()),
             match_duration_secs: Set(None),
         }
@@ -777,6 +1232,70 @@ mod tests {
             top_25,
             r#"{"match_mode":"All","rules":[{"field":"PlayCount","operator":"GreaterThan","value":{"Number":0}}],"limit":{"value":25,"unit":"Items","selected_by":"MostPlayed"},"sort_order":[{"field":"PlayCount","direction":"Descending"},{"field":"LastPlayed","direction":"Descending"},{"field":"TrackId","direction":"Ascending"}]}"#
         );
+    }
+
+    #[test]
+    fn stored_entry_decode_enforces_remote_byte_bound_without_leaking_identity() {
+        // SQLite's length() reports characters, so the storage boundary still
+        // enforces the architecture's byte ceiling when decoding a row.
+        let oversized_secret = "é".repeat(3_000);
+        let model = playlist_entry::Model {
+            id: "remote-entry".to_string(),
+            playlist_id: "playlist".to_string(),
+            position: 0,
+            source_id: SourceId::random().to_string(),
+            track_id: Some(oversized_secret.clone()),
+            local_track_id: None,
+            match_title: "Title".to_string(),
+            match_artist: "Artist".to_string(),
+            match_album: "Album".to_string(),
+            match_duration_secs: None,
+            match_file_path: None,
+        };
+
+        let error = StoredPlaylistEntry::from_model(model)
+            .expect_err("remote IDs over 4096 bytes must fail closed");
+        assert!(!error.to_string().contains(&oversized_secret));
+    }
+
+    #[test]
+    fn stored_entry_decode_rejects_unidentified_local_orphan() {
+        let model = playlist_entry::Model {
+            id: "unidentified-local-entry".to_string(),
+            playlist_id: "playlist".to_string(),
+            position: 0,
+            source_id: SourceId::local().to_string(),
+            track_id: None,
+            local_track_id: None,
+            match_title: " ".to_string(),
+            match_artist: String::new(),
+            match_album: String::new(),
+            match_duration_secs: None,
+            match_file_path: Some("  ".to_string()),
+        };
+
+        StoredPlaylistEntry::from_model(model)
+            .expect_err("an unmatched local row needs path or title/artist evidence");
+    }
+
+    #[test]
+    fn stored_entry_decode_rejects_negative_position() {
+        let model = playlist_entry::Model {
+            id: "negative-position-entry".to_string(),
+            playlist_id: "playlist".to_string(),
+            position: -1,
+            source_id: SourceId::random().to_string(),
+            track_id: Some("remote-track".to_string()),
+            local_track_id: None,
+            match_title: String::new(),
+            match_artist: String::new(),
+            match_album: String::new(),
+            match_duration_secs: None,
+            match_file_path: None,
+        };
+
+        StoredPlaylistEntry::from_model(model)
+            .expect_err("typed storage must reject a negative occurrence position");
     }
 
     #[tokio::test]
@@ -1056,7 +1575,12 @@ mod tests {
         let before = playlist_entries(&db, &result.playlist.id).await;
         assert_eq!(before.len(), 3);
         assert_eq!(before[0].position, 0);
+        assert_eq!(before[0].source_id, SourceId::local().to_string());
         assert_eq!(before[0].track_id.as_deref(), Some(existing.id.as_str()));
+        assert_eq!(
+            before[0].local_track_id.as_deref(),
+            Some(existing.id.as_str())
+        );
         assert_eq!(
             before[0].match_file_path.as_deref(),
             Some(existing.file_path.as_str())
@@ -1064,9 +1588,14 @@ mod tests {
         assert_eq!(before[0].match_title, "canonical title");
         assert_eq!(before[1].position, 1);
         assert_eq!(before[1].track_id.as_deref(), Some(existing.id.as_str()));
+        assert_eq!(
+            before[1].local_track_id.as_deref(),
+            Some(existing.id.as_str())
+        );
         assert_eq!(before[1].match_file_path, None);
         assert_eq!(before[2].position, 2);
         assert_eq!(before[2].track_id, None);
+        assert_eq!(before[2].local_track_id, None);
         assert_eq!(
             before[2].match_file_path.as_deref(),
             Some("/music/available-later.flac")
@@ -1087,6 +1616,7 @@ mod tests {
         assert_eq!(after[2].id, before[2].id);
         assert_eq!(after[2].position, before[2].position);
         assert_eq!(after[2].track_id.as_deref(), Some(later.id.as_str()));
+        assert_eq!(after[2].local_track_id.as_deref(), Some(later.id.as_str()));
         assert_eq!(after[2].match_title, "metadata can differ");
         assert_eq!(after[2].match_artist, "path wins");
         assert_eq!(after[2].match_album, "album");
@@ -1292,6 +1822,249 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn source_scoped_batch_preserves_order_duplicates_and_local_projection() {
+        let db = in_memory_db().await;
+        let manager = PlaylistManager::new(db.clone());
+        let playlist = manager
+            .create_playlist("Mixed storage fixture", false)
+            .await
+            .expect("create playlist");
+        let local = insert_track(
+            &db,
+            "shared-native-id",
+            "/music/local.flac",
+            "Local title",
+            "Local artist",
+            "Local album",
+            Some(180),
+        )
+        .await;
+        let remote_source = SourceId::random();
+        let other_source = SourceId::random();
+        let shared_remote_id = TrackId::remote("shared-native-id").expect("remote track ID");
+        let inputs = vec![
+            PlaylistEntryInput::new(
+                MediaKey::new(remote_source, shared_remote_id.clone()),
+                " Remote title ",
+                "REMOTE ARTIST",
+                "Remote album",
+                Some(200),
+            ),
+            PlaylistEntryInput::local(&local).expect("local playlist input"),
+            PlaylistEntryInput::new(
+                MediaKey::new(remote_source, shared_remote_id.clone()),
+                "Remote title",
+                "Remote artist",
+                "Remote album",
+                Some(200),
+            ),
+            PlaylistEntryInput::new(
+                MediaKey::new(other_source, shared_remote_id.clone()),
+                "Other source title",
+                "Other source artist",
+                "Other source album",
+                None,
+            ),
+        ];
+
+        let inserted = manager
+            .add_entries(&playlist.id, &inputs)
+            .await
+            .expect("append source-scoped entries");
+        assert_eq!(
+            inserted
+                .iter()
+                .map(|entry| entry.position)
+                .collect::<Vec<_>>(),
+            vec![0, 1, 2, 3]
+        );
+        assert_ne!(inserted[0].id, inserted[2].id);
+        assert_eq!(inserted[0].media_key(), inserted[2].media_key());
+        assert_ne!(inserted[0].media_key(), inserted[3].media_key());
+        assert_eq!(inserted[0].source_id, remote_source);
+        assert_eq!(inserted[0].local_track_id, None);
+        assert_eq!(inserted[0].match_title, "remote title");
+        assert_eq!(inserted[1].source_id, SourceId::local());
+        assert_eq!(
+            inserted[1].local_track_id.as_ref().map(TrackId::as_str),
+            Some(local.id.as_str())
+        );
+
+        let stored = manager
+            .get_playlist_entries(&playlist.id)
+            .await
+            .expect("load typed entries");
+        assert_eq!(stored, inserted);
+        let projected = manager
+            .get_playlist_tracks(&playlist.id)
+            .await
+            .expect("load local compatibility projection");
+        assert_eq!(
+            projected
+                .iter()
+                .map(|track| track.id.as_str())
+                .collect::<Vec<_>>(),
+            vec![local.id.as_str()]
+        );
+
+        // A remote occurrence waiting for live-session projection must never
+        // be fingerprint-reconciled to a similarly named local row.
+        assert_eq!(
+            manager.reconcile_all().await.expect("reconcile local only"),
+            0
+        );
+        let after = manager
+            .get_playlist_entries(&playlist.id)
+            .await
+            .expect("reload source-scoped entries");
+        assert_eq!(after[0].source_id, remote_source);
+        assert_eq!(after[0].track_id.as_ref(), Some(&shared_remote_id));
+        assert_eq!(after[0].local_track_id, None);
+
+        manager
+            .remove_entries(&playlist.id, &[inserted[0].id.clone()])
+            .await
+            .expect("remove one duplicate occurrence");
+        let remaining = manager
+            .get_playlist_entries(&playlist.id)
+            .await
+            .expect("reload after exact removal");
+        assert_eq!(remaining.len(), 3);
+        assert_eq!(
+            remaining
+                .iter()
+                .filter(|entry| entry.media_key() == inserted[2].media_key())
+                .count(),
+            1
+        );
+        assert_eq!(
+            remaining
+                .iter()
+                .map(|entry| entry.position)
+                .collect::<Vec<_>>(),
+            vec![0, 1, 2]
+        );
+    }
+
+    #[tokio::test]
+    async fn source_scoped_batch_rejects_invalid_input_without_partial_writes_or_id_leaks() {
+        let db = in_memory_db().await;
+        let manager = PlaylistManager::new(db.clone());
+        let playlist = manager
+            .create_playlist("Atomic batch", false)
+            .await
+            .expect("create playlist");
+        let oversized_secret = format!("private-track-id-{}", "x".repeat(4096));
+        let remote_input = PlaylistEntryInput::new(
+            MediaKey::new(
+                SourceId::random(),
+                TrackId::new(oversized_secret.clone()).expect("generic bounded track ID"),
+            ),
+            "Remote",
+            "Artist",
+            "Album",
+            None,
+        );
+        let error = manager
+            .add_entries(&playlist.id, &[remote_input])
+            .await
+            .expect_err("server-controlled ID ceiling must be enforced");
+        assert!(!error.to_string().contains(&oversized_secret));
+        assert!(playlist_entries(&db, &playlist.id).await.is_empty());
+
+        let source_id = SourceId::random();
+        let valid_first = PlaylistEntryInput::new(
+            MediaKey::new(
+                source_id,
+                TrackId::remote("first-valid").expect("remote ID"),
+            ),
+            "First",
+            "Artist",
+            "Album",
+            Some(180),
+        );
+        let invalid_second = PlaylistEntryInput::new(
+            MediaKey::new(
+                source_id,
+                TrackId::remote("second-invalid").expect("remote ID"),
+            ),
+            "Second",
+            "Artist",
+            "Album",
+            Some(u64::MAX),
+        );
+        assert!(manager
+            .add_entries(&playlist.id, &[valid_first, invalid_second])
+            .await
+            .is_err());
+        assert!(playlist_entries(&db, &playlist.id).await.is_empty());
+
+        let missing_local = PlaylistEntryInput::new(
+            MediaKey::new(
+                SourceId::local(),
+                TrackId::new("missing-private-local-id").expect("local track ID"),
+            ),
+            "Missing",
+            "Artist",
+            "Album",
+            None,
+        );
+        let error = manager
+            .add_entries(&playlist.id, &[missing_local])
+            .await
+            .expect_err("missing local FK target must reject the batch");
+        assert!(!error.to_string().contains("missing-private-local-id"));
+        assert!(playlist_entries(&db, &playlist.id).await.is_empty());
+
+        let smart = manager
+            .create_playlist("Smart", true)
+            .await
+            .expect("create smart playlist");
+        let valid_remote = PlaylistEntryInput::new(
+            MediaKey::new(
+                SourceId::random(),
+                TrackId::remote("valid-remote").expect("remote ID"),
+            ),
+            "Remote",
+            "Artist",
+            "Album",
+            None,
+        );
+        assert!(manager
+            .add_entries(&smart.id, &[valid_remote])
+            .await
+            .is_err());
+        assert!(playlist_entries(&db, &smart.id).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn add_uses_checked_positions_and_rolls_back_on_overflow() {
+        let db = in_memory_db().await;
+        let manager = PlaylistManager::new(db.clone());
+        let playlist = manager
+            .create_playlist("Position overflow", false)
+            .await
+            .expect("create playlist");
+        insert_entry(&db, &playlist.id, "maximum-position", i32::MAX).await;
+        let track = insert_track(
+            &db,
+            "overflow-candidate",
+            "/music/overflow-candidate.flac",
+            "Candidate",
+            "Artist",
+            "Album",
+            Some(180),
+        )
+        .await;
+
+        assert!(manager.add_track(&playlist.id, &track).await.is_err());
+        let entries = playlist_entries(&db, &playlist.id).await;
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].id, "maximum-position");
+        assert_eq!(entries[0].position, i32::MAX);
+    }
+
+    #[tokio::test]
     async fn reorder_yields_unique_contiguous_positions() {
         let db = in_memory_db().await;
         let manager = PlaylistManager::new(db.clone());
@@ -1339,6 +2112,74 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn reorder_and_remove_require_exact_occurrence_ids_and_rollback_invalid_requests() {
+        let db = in_memory_db().await;
+        let manager = PlaylistManager::new(db.clone());
+        let playlist = manager
+            .create_playlist("Exact mutations", false)
+            .await
+            .expect("create playlist");
+        for (position, id) in ["first", "second", "third"].into_iter().enumerate() {
+            insert_entry(&db, &playlist.id, id, position as i32).await;
+        }
+        let original_ids = vec![
+            "first".to_string(),
+            "second".to_string(),
+            "third".to_string(),
+        ];
+
+        assert!(manager
+            .reorder_entries(
+                &playlist.id,
+                &[
+                    "first".to_string(),
+                    "first".to_string(),
+                    "third".to_string()
+                ],
+            )
+            .await
+            .is_err());
+        assert_eq!(
+            playlist_entries(&db, &playlist.id)
+                .await
+                .into_iter()
+                .map(|entry| entry.id)
+                .collect::<Vec<_>>(),
+            original_ids
+        );
+
+        assert!(manager
+            .remove_entries(&playlist.id, &["second".to_string(), "second".to_string()])
+            .await
+            .is_err());
+        assert!(manager
+            .remove_entries(&playlist.id, &["not-in-this-playlist".to_string()])
+            .await
+            .is_err());
+        assert_eq!(playlist_entries(&db, &playlist.id).await.len(), 3);
+
+        manager
+            .remove_entries(&playlist.id, &["second".to_string()])
+            .await
+            .expect("remove exact occurrence");
+        let remaining = playlist_entries(&db, &playlist.id).await;
+        assert_eq!(
+            remaining
+                .iter()
+                .map(|entry| entry.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["first", "third"]
+        );
+        assert_eq!(
+            remaining
+                .iter()
+                .map(|entry| entry.position)
+                .collect::<Vec<_>>(),
+            vec![0, 1]
+        );
+    }
+
+    #[tokio::test]
     async fn rename_fallback_relinks_without_changing_playlist_entry_identity() {
         let db = in_memory_db().await;
         let manager = PlaylistManager::new(db.clone());
@@ -1375,7 +2216,8 @@ mod tests {
             .await
             .pop()
             .expect("orphaned playlist entry");
-        assert_eq!(orphan.track_id, None);
+        assert_eq!(orphan.track_id.as_deref(), Some(original.id.as_str()));
+        assert_eq!(orphan.local_track_id, None);
 
         let replacement = insert_track(
             &db,
@@ -1401,6 +2243,10 @@ mod tests {
         assert_eq!(after.match_album, before.match_album);
         assert_eq!(after.match_duration_secs, before.match_duration_secs);
         assert_eq!(after.track_id.as_deref(), Some(replacement.id.as_str()));
+        assert_eq!(
+            after.local_track_id.as_deref(),
+            Some(replacement.id.as_str())
+        );
         assert_eq!(
             manager
                 .reconcile_all()
@@ -1475,6 +2321,10 @@ mod tests {
             .pop()
             .expect("relinked playlist entry");
         assert_eq!(relinked.track_id.as_deref(), Some(relocated.id.as_str()));
+        assert_eq!(
+            relinked.local_track_id.as_deref(),
+            Some(relocated.id.as_str())
+        );
         assert_eq!(relinked.match_file_path, None);
 
         track::Entity::delete_by_id(&relocated.id)
@@ -1502,7 +2352,8 @@ mod tests {
             .await
             .pop()
             .expect("preserved orphan");
-        assert_eq!(orphan.track_id, None);
+        assert_eq!(orphan.track_id.as_deref(), Some(relocated.id.as_str()));
+        assert_eq!(orphan.local_track_id, None);
         assert_eq!(orphan.match_title, "original song");
         assert_eq!(orphan.match_artist, "original artist");
         assert_eq!(orphan.match_album, "original album");
@@ -1570,13 +2421,16 @@ mod tests {
             .pop()
             .expect("preserved import with valid source duration");
         assert_eq!(imported_orphan.track_id, None);
+        assert_eq!(imported_orphan.local_track_id, None);
         assert_eq!(imported_orphan.match_duration_secs, Some(i32::MAX));
 
         playlist_entry::ActiveModel {
             id: Set("corrupt-duration-orphan".to_string()),
             playlist_id: Set(playlist.id.clone()),
             position: Set(2),
+            source_id: Set(SourceId::local().to_string()),
             track_id: Set(None),
+            local_track_id: Set(None),
             match_file_path: Set(Some(overflowing.file_path.clone())),
             match_title: Set(String::new()),
             match_artist: Set(String::new()),
@@ -1601,6 +2455,10 @@ mod tests {
             .expect("reconciled corrupt-duration entry");
         assert_eq!(
             reconciled.track_id.as_deref(),
+            Some(overflowing.id.as_str())
+        );
+        assert_eq!(
+            reconciled.local_track_id.as_deref(),
             Some(overflowing.id.as_str())
         );
         assert_eq!(
@@ -1655,7 +2513,7 @@ mod tests {
         assert!(playlist_entries(&db, &playlist.id)
             .await
             .iter()
-            .all(|entry| entry.track_id.is_none()));
+            .all(|entry| entry.local_track_id.is_none()));
 
         // Insert in reverse order to ensure matching is fingerprint-based,
         // not dependent on table or scan order.
@@ -1692,6 +2550,14 @@ mod tests {
         );
         assert_eq!(after[0].track_id.as_deref(), Some(first_new.id.as_str()));
         assert_eq!(after[1].track_id.as_deref(), Some(second_new.id.as_str()));
+        assert_eq!(
+            after[0].local_track_id.as_deref(),
+            Some(first_new.id.as_str())
+        );
+        assert_eq!(
+            after[1].local_track_id.as_deref(),
+            Some(second_new.id.as_str())
+        );
     }
 
     #[tokio::test]
@@ -1748,7 +2614,9 @@ mod tests {
                 .expect("reconcile ambiguous entry"),
             0
         );
-        assert_eq!(playlist_entries(&db, &playlist.id).await[0].track_id, None);
+        let orphan = &playlist_entries(&db, &playlist.id).await[0];
+        assert_eq!(orphan.track_id.as_deref(), Some(original.id.as_str()));
+        assert_eq!(orphan.local_track_id, None);
     }
 
     #[tokio::test]
@@ -1807,7 +2675,7 @@ mod tests {
         );
         assert_eq!(
             playlist_entries(&db, &playlist.id).await[0]
-                .track_id
+                .local_track_id
                 .as_deref(),
             Some(expected.id.as_str())
         );

--- a/src/ui/context_menu.rs
+++ b/src/ui/context_menu.rs
@@ -456,6 +456,17 @@ fn build_remove_from_playlist_action(
                                 &pid,
                             ),
                         )
+                        .filter(
+                            <crate::db::entities::playlist_entry::Column as sea_orm::ColumnTrait>::eq(
+                                &crate::db::entities::playlist_entry::Column::SourceId,
+                                crate::architecture::SourceId::local().to_string(),
+                            ),
+                        )
+                        .filter(
+                            <crate::db::entities::playlist_entry::Column as sea_orm::ColumnTrait>::is_not_null(
+                                &crate::db::entities::playlist_entry::Column::LocalTrackId,
+                            ),
+                        )
                         .all(&db)
                         .await
                     {
@@ -464,7 +475,7 @@ fn build_remove_from_playlist_action(
                         // rows rather than all at once.
                         let mut remaining = selection_counts(&uris);
                         for entry in entries {
-                            if let Some(ref track_id) = entry.track_id {
+                            if let Some(ref track_id) = entry.local_track_id {
                                 // Look up the track to get its file path / URI.
                                 if let Ok(Some(track)) = crate::db::entities::track::Entity::find_by_id(track_id.clone())
                                     .one(&db)


### PR DESCRIPTION
## Summary

- add migration 13, making each regular-playlist occurrence durable by exact `(SourceId, TrackId)` identity while retaining a separate nullable local-track foreign-key cache
- add typed, atomic source-scoped append/read/remove/reorder storage operations with duplicate-occurrence and ordering guarantees
- preserve all existing local Add/load, XSPF import/export, reconciliation, deletion, rename, root-reauthorization, and context-menu compatibility paths
- document the complete storage, migration, downgrade, privacy, lifecycle, and deferred-capability contract; advance `docs/task.md` to 8/35 (22.9%)

## Safety and migration behavior

- existing valid entries are assigned to the frozen built-in local source without changing entry IDs, order, duplicates, canonical local IDs, or match evidence
- local `ON DELETE SET NULL` now clears only `local_track_id`, preserving durable identity and evidence
- remote entries require a bounded native ID and cannot carry a local FK or path evidence; no URL, credential, lease, route, or session epoch field is persisted
- schema and standard indexes are recognized exactly, including literal, collation, direction, partial-index, PK, FK, and Unicode-whitespace orphan-evidence semantics
- upgrade/rebuild/index restoration is transactional and retryable; downgrade succeeds only for exactly representable local rows and otherwise refuses without loss

## Deliberate deferrals

This storage foundation does not enable remote Add/Remove/Play, mixed-source rendering, disconnected-row presentation, source lifecycle resolution, or Subsonic server-native playlist synchronization. The existing localized non-local Add refusal remains in place. Those are the next two P1.5 records.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --release --all-targets -- -D warnings`
- `cargo test --all-targets --no-fail-fast` — 20 library + 1,071 application + 10 packaging tests
- `cargo test --release --all-targets --no-fail-fast` — 20 library + 1,071 application + 10 packaging tests
- focused migration suite — 54/54, including 15 migration-13 tests
- focused playlist-manager suite — 23/23
- `git diff --check`

Closes the first storage-foundation record under #47; #47 remains open for mixed-source interaction and Subsonic-native playlist work.
