### PR TITLE
Add live playlist catalogue authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,12 +35,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and root-reauthorization paths retain their prior behavior through the new schema. The shipping UI
   remains intentionally local-only in this slice: it still refuses non-local Add before database
   work and does not render or play stored non-local
-  fixtures. Live `SourceRegistry` resolution, capability-gated authenticated-source Add/Remove/Play,
-  disconnected states, lifecycle/epoch handling, and mixed-source export follow separately;
-  Radio-Browser, removable, external, and unknown sources remain unsupported. Subsonic
-  server-native playlist import or synchronization is a third, separately designed capability.
+  fixtures. The internal live-catalogue authority foundation is described below;
+  capability-gated authenticated-source Add/Remove/Play, disconnected presentation, and
+  mixed-source export remain a later UI record. Subsonic server-native playlist import or
+  synchronization is another separately designed capability.
   The complete boundary and validation matrix are in
   [`docs/source-scoped-playlists.md`](docs/source-scoped-playlists.md).
+- **Regular playlists now have default-deny live-catalogue authority**
+  ([#141](https://github.com/jm2/tributary/pull/141)) —
+  `ManagedSourceAdapter` exposes one explicit `Unsupported` or `SourceScopedEntries` capability. The
+  default, Radio-Browser, removable-media, ephemeral external-file, and unknown adapters remain
+  unsupported; only retained authenticated Subsonic, Jellyfin, Plex, and DAAP catalogues opt in.
+  Each accepted source payload freezes that capability with its complete catalogue. Authority
+  lookup returns one ordered resolution per occurrence against the exact current `SourceId`,
+  non-secret session epoch, accepted catalogue generation, capability, and native-track membership.
+  An otherwise accepted catalogue with a missing or duplicate native ID receives an `Invalid`
+  playlist-authority index, so every playlist occurrence for it fails closed without choosing a
+  duplicate while existing non-playlist UI may continue using the catalogue. Repeated requested IDs
+  remain repeated ordered occurrences. Missing exact tracks, unsupported sources, and unavailable
+  sessions receive fixed unavailable results independently; revalidation denies guards made stale
+  by replacement, refresh, retirement, release, or shutdown.
+  Returned track metadata uses a dedicated display/sort/rating/history whitelist rather than a
+  `Track` clone, so file paths, file/network URLs, stream and artwork locators, credentials, leases,
+  routes, raw backend failures, and future unreviewed fields cannot cross implicitly. Its closed
+  authority guard may carry the non-secret session epoch and catalogue generation transiently, but
+  neither is written into playlist storage. Guarded stream and artwork resolution rechecks exact
+  membership, capability, epoch, and generation before adapter work and after the asynchronous
+  result returns, then maps raw adapter errors to fixed categories. A lifecycle-owned generation
+  lease is explicitly revoked on snapshot replacement/removal and every teardown path, so retained
+  snapshot clones cannot keep an already returned request active.
+  Connecting or a failed replacement preserves the accepted predecessor; successful replacement
+  or same-session catalogue refresh invalidates old guards. Disconnect, shutdown, and final source
+  release synchronously deny new authority before asynchronous teardown completes.
+  This is an internal authority foundation only: the shipping UI still refuses non-local Add and
+  does not remove, render, or play remote playlist entries. Those interactions, explicit
+  unavailable states, mixed-source export, and Subsonic-native playlist synchronization remain
+  separately tracked.
 - **Ratings now have a durable ownership, capability, and persistence foundation**
   ([#138](https://github.com/jm2/tributary/pull/138)) — A canonical
   rating is one validated whole integer from 1 through 100, while `None` alone means unrated.
@@ -162,8 +192,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an unexpected subset. The existing Add to Playlist, Remove from Playlist, and Properties context
   labels now use their shipped translations as well, and the refusal copy is covered across all 13
   locale catalogs. Local-library playlist behavior is unchanged. The source-scoped storage
-  foundation is now described above, while live non-local playlist interaction remains a later
-  P1.5 slice.
+  and default-deny live-catalogue authority foundations are now described above, while live
+  non-local playlist interaction remains P1.5 Record B.
 - **Shuffled Previous and Next now follow a bounded real playback timeline** — Tributary retains
   the current queue occurrence plus ten actual predecessors, walks backward without fabricating a
   random track at the oldest boundary, and replays fixed forward history before drawing again.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,10 +59,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Track` clone, so file paths, file/network URLs, stream and artwork locators, credentials, leases,
   routes, raw backend failures, and future unreviewed fields cannot cross implicitly. Its closed
   authority guard may carry the non-secret session epoch and catalogue generation transiently, but
-  neither is written into playlist storage. Guarded stream and artwork resolution rechecks exact
-  membership, capability, epoch, and generation before adapter work and after the asynchronous
-  result returns, then maps raw adapter errors to fixed categories. A lifecycle-owned generation
-  lease is explicitly revoked on snapshot replacement/removal and every teardown path, so retained
+  neither is written into playlist storage. Immutable catalogue projection runs outside the
+  lifecycle mutex, then exact snapshot identity and both leases are rechecked before adapter work;
+  this keeps a selector from re-entering or extending the critical section without widening stale
+  authority. Guarded stream and artwork resolution rechecks exact membership, capability, epoch,
+  and generation again after the asynchronous result returns, then maps raw adapter errors to fixed
+  categories. A lifecycle-owned generation lease is explicitly revoked on snapshot
+  replacement/removal and every teardown path, so retained
   snapshot clones cannot keep an already returned request active.
   Connecting or a failed replacement preserves the accepted predecessor; successful replacement
   or same-session catalogue refresh invalidates old guards. Disconnect, shutdown, and final source

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Tributary provides a unified interface for managing and streaming music from mul
 | Internet Radio (Top Clicked, Top Voted, Stations Near Me) | ✅ |
 | Tiered geo-location (geo-distance → state → country) | ✅ |
 | Column drag-and-drop reordering with persistence | ✅ |
-| Regular & smart playlists (iTunes-style rules engine) | ✅ Local-library UI; regular-entry storage now has a source-scoped identity foundation, while mixed-source UI/playback remains planned ([#47](https://github.com/jm2/tributary/issues/47)) |
+| Regular & smart playlists (iTunes-style rules engine) | ✅ Local-library UI; source-scoped storage and default-deny live-catalogue authority are implemented, while mixed-source UI/playback remains planned ([#47](https://github.com/jm2/tributary/issues/47)) |
 | Realtime text search filter (title, artist, album, genre) | ✅ |
 | Song metadata editing (Properties dialog with Save/Cancel) | ✅ |
 | Batch metadata editing (multi-select) | ✅ |
@@ -449,7 +449,7 @@ src/
 │   ├── identity.rs         # Stable source/media/view identity types
 │   ├── media.rs            # Retained resolved-media capabilities
 │   └── error.rs            # BackendError (thiserror)
-├── source_registry.rs      # Source lifecycle, provenance, epochs, at-use resolution
+├── source_registry.rs      # Source lifecycle, provenance, playlist authority, at-use resolution
 ├── removable.rs            # Retained removable-mount catalogue/media adapter
 ├── external_file.rs        # Ephemeral retained OS-open file adapter
 ├── audio/
@@ -679,16 +679,36 @@ boundaries.
 
 Tributary supports regular and smart playlists for the local library:
 
-- **Regular playlists** — Right-click the Playlists header in the sidebar to create a new playlist. Right-click tracks in the tracklist to add them. Playlists survive library folder changes via fingerprint-based track matching. Their migrated storage identity is the source-scoped `(SourceId, TrackId)` pair, with a separate nullable local-track foreign-key cache for local deletion and reconciliation; the current UI still projects only local entries.
+- **Regular playlists** — Right-click the Playlists header in the sidebar to create a new playlist. Right-click tracks in the tracklist to add them. Playlists survive library folder changes via fingerprint-based track matching. Their migrated storage identity is the source-scoped `(SourceId, TrackId)` pair, with a separate nullable local-track foreign-key cache for local deletion and reconciliation. Internal live-catalogue lookup now has an explicit default-deny authority boundary, but the current UI still creates and projects only local entries.
 - **Smart playlists** — iTunes-style rules engine with filterable metadata fields, text/numeric/date operators, sorting, and result limiting. Smart playlists are evaluated against the current local library whenever they are opened or exported; they are not stored snapshots. Create them via the sidebar context menu.
 
 **Add to Playlist** currently accepts tracks only from the built-in local library. Invoking it from
 an authenticated remote, internet-radio, removable-media, or other unsupported source shows a
 localized explanation and adds nothing; it never silently writes only a subset. Migration 13 and
 the storage API can represent a non-local occurrence without a URL, credential, lease, or session
-epoch, but that capability is not UI authorization. Live `SourceRegistry` resolution,
-mixed-source Add/Remove/Play behavior, disconnected states, and Subsonic-native playlist
-import/synchronization remain follow-on work under
+epoch, but that capability is not UI authorization.
+
+Inside `SourceRegistry`, regular-playlist catalogue authority defaults to Unsupported. Only the
+retained authenticated Subsonic, Jellyfin, Plex, and DAAP adapters explicitly advertise
+source-scoped entries; Radio-Browser, removable media, ephemeral external files, and unknown
+adapters remain unsupported. An internal lookup accepts an ordered set only from the exact current
+source, session epoch, and accepted catalogue generation, and returns a dedicated metadata
+whitelist without paths, URLs, locators, credentials, leases, routes, or raw backend errors. Its
+closed guard carries the non-secret epoch and generation transiently; neither is written to the
+playlist. Guarded media maps backend failures to fixed categories and carries a lifecycle-owned
+generation lease that is explicitly revoked even if an observer still holds an old snapshot clone.
+Malformed or duplicate catalogue-native IDs make that catalogue's playlist-authority index
+`Invalid`, while the catalogue can remain available to existing non-playlist UI and repeated
+requested IDs remain repeated ordered occurrences. A missing exact track, unavailable session, or
+unsupported source receives an explicit unavailable result without erasing valid neighbors. Stream
+and artwork resolutions revalidate the transient guard around asynchronous adapter work so
+replacement, refresh, disconnect, shutdown, or final source release cannot revive an old result.
+
+This foundation does not change Add, Remove, rendering, or Play behavior by itself. Connecting or
+a failed replacement may continue using its already accepted predecessor; a successful
+replacement or same-session catalogue refresh invalidates old guards, and disconnect/shutdown deny
+new use synchronously. Mixed-source playlist UI, explicit unavailable states, and
+Subsonic-native playlist import/synchronization remain follow-on work under
 [P1.5](docs/task.md#p15--persist-source-scoped-playlists). See the
 [source-scoped playlist storage contract](docs/source-scoped-playlists.md) for the exact boundary.
 

--- a/docs/architecture/source-lifecycle.md
+++ b/docs/architecture/source-lifecycle.md
@@ -3,8 +3,9 @@
 - Status: Accepted in PR #113 and fully implemented through the mounted removable-media adapter;
   P3.1 is complete. Physical removable-hardware, installed Flatpak portal/USB/custom-library, and
   packaged Windows DAAP/Subsonic playback validation remain tracked field work outside this
-  decision. P1.5 migration 13 extends the same identity boundary into regular-playlist storage;
-  mixed-source rendering/playback remains a follow-up and does not reopen P3.1.
+  decision. P1.5 migration 13 extends the same identity boundary into regular-playlist storage,
+  and Record A adds a default-deny live-catalogue authority boundary; mixed-source UI integration
+  remains a follow-up and does not reopen P3.1.
 - Decision date: 2026-07-17
 - Historical tracker:
   [P3.1](../task-remediation-2026-07.md#p31-introduce-a-sourcesession-registry)
@@ -41,8 +42,9 @@ Regular-playlist storage now follows the same identity rule. Migration 13 assign
 entry to the built-in local source and stores its canonical `(source_id, track_id)` separately from
 the nullable local-track foreign-key cache. This foundation can represent another source without
 persisting its locator, credentials, lease, or session epoch. The shipping playlist projection is
-still deliberately local-only until the next P1.5 slice resolves those identities through the live
-registry. The full storage boundary is specified in
+still deliberately local-only. P1.5 Record A now gives the live registry an internal, exact
+source/session/catalogue authority query, while Record B remains responsible for consuming it in
+Add/Remove/render/Play behavior. The full boundary is specified in
 [`source-scoped-playlists.md`](../source-scoped-playlists.md).
 
 The implementation has now converged on this boundary. PR #120 implements stable identity, PR #121
@@ -172,7 +174,7 @@ Backend-native `TrackId` values are represented as follows:
 | Adapter | Native track identity |
 |---|---|
 | Local library | Exact SQLite `tracks.id` string |
-| Regular-playlist occurrence | The exact `TrackId` of its owning source; currently rendered playlist rows remain local-only pending the mixed-source P1.5 slice |
+| Regular-playlist occurrence | The exact `TrackId` of its owning source; internal authority lookup exists, but rendered playlist rows remain local-only pending P1.5 Record B |
 | Subsonic | Exact song `id` returned by the server |
 | Jellyfin | Exact audio item `Id` returned by the server |
 | Plex | Exact track `ratingKey`; the media-part key remains a locator |
@@ -327,8 +329,8 @@ acquires retained root/marker/ancestor/file authority, and keeps that authority 
 or file server has finished consuming it. It rechecks database bindings after acquisition and
 rechecks current root configuration before output handoff. The current playlist navigation path
 queries entries by playlist ID and resolves their nullable `local_track_id` cache from the same
-current snapshot. Stored non-local identities remain outside that projection until live-registry
-resolution is implemented.
+current snapshot. Stored non-local identities remain outside that projection until Record B wires
+the live-registry authority foundation into the UI.
 
 Fingerprint/path fallback is only a local reconciliation operation. It is restricted to the exact
 built-in local `source_id` and updates both canonical `track_id` and `local_track_id` only after a
@@ -341,9 +343,10 @@ receives or reopens the playback-time path.
 A playlist is a `ViewOrigin`, not a source session. Each durable regular-playlist occurrence now
 names its actual media owner with `(source_id, track_id)` while keeping the playlist ID, entry ID,
 and position as view/occurrence state. The current regular- and smart-playlist queue path still
-publishes only local rows; mixed-source GTK rows, current-epoch adoption, playback, and source-
-retirement behavior are the next P1.5 record. Deleting or rebuilding a playlist retires that view's
-pending navigation without pretending that the view owns any contributing source session.
+publishes only local rows. Record A can validate exact current remote catalogue identity internally;
+mixed-source GTK rows, current-epoch adoption, unavailable presentation, and playback are Record B.
+Deleting or rebuilding a playlist retires that view's pending navigation without pretending that
+the view owns any contributing source session.
 
 #### Remote libraries, including DAAP
 
@@ -533,8 +536,28 @@ queue can extend the same ephemeral-source rule explicitly.
   typed source/native identity plus optional non-secret normalized fingerprints and rejects file-
   path evidence. Those fingerprints are neither display fields, identity, nor matching authority;
   migration 13 adds no source-label snapshot. It persists no source epoch, locator, route, lease, or
-  credential. Mixed-source publication and playback remain deliberately unwired in this storage
-  slice.
+  credential.
+- Regular-playlist authority is separately default-deny on `ManagedSourceAdapter`. Only retained
+  authenticated Subsonic, Jellyfin, Plex, and DAAP catalogues opt into source-scoped entries;
+  Radio-Browser, removable, external-file, default, and unknown adapters remain `Unsupported`. Each
+  accepted payload freezes that capability with its complete catalogue. Ordered lookup requires
+  the exact current `SourceId`, session epoch, accepted catalogue generation, capability, and
+  native-track membership, and returns a dedicated display/sort/rating/history metadata whitelist
+  without any path, URL, locator, credential, lease, route, or raw adapter error. Its closed guard
+  carries the non-secret epoch and generation transiently; neither is persisted. An otherwise
+  accepted catalogue with a missing or duplicate native identity receives an `Invalid`
+  playlist-authority index, making every playlist
+  occurrence for that source unavailable without discarding its non-playlist catalogue. Repeated
+  requested IDs remain repeated ordered results; missing exact tracks, unavailable sessions, and
+  unsupported sources receive fixed unavailable results without erasing valid neighbors. Stream
+  and artwork resolution repeat the membership/capability/epoch/generation checks before and after
+  asynchronous adapter work and reduce raw failures to closed media categories. Each accepted
+  lifecycle snapshot owns a generation lease that is explicitly revoked before replacement,
+  removal, teardown, or pruning; retained observer `Arc` clones therefore cannot keep returned
+  media active. Connecting or failed replacement preserves an accepted predecessor;
+  successful replacement or same-session refresh invalidates old guards, while disconnect,
+  shutdown, and final release deny synchronously. None of these internal APIs enables
+  Add/Remove/render/Play UI behavior.
 - `PlaybackSession` captures immutable source/track identity, queue order, duplicate occurrence,
   and playback event generation independently of GTK sorting/filtering. Queue identity is a
   `MediaKey`; playlists and radio queries retain a separate `ViewOrigin`, so local invalidation
@@ -571,8 +594,9 @@ queue can extend the same ephemeral-source rule explicitly.
   future lookups. Shared Chromecast cleanup retains legacy explicit-file routes while revoking
   credential and retained-authority routes. The currently shipping playlist queue identity uses
   the local source plus a separate `ViewOrigin`, so generic local retirement also retires a
-  playlist-origin queue without losing view navigation. A later P1.5 slice will select the source
-  per stored occurrence and retain that same separation between media owner and playlist view.
+  playlist-origin queue without losing view navigation. P1.5 Record B will select the source per
+  stored occurrence through Record A's authority result and retain that same separation between
+  media owner and playlist view.
 - Removable sources derive `SourceId` from the best-available logical key and exact `TrackId` from
   the losslessly encoded mount-relative native path. Their registry-owned adapter publishes a
   pathless, epoch-bound accepted catalogue; retained mounted-root authority, an exact membership
@@ -694,8 +718,9 @@ persist credentials. Exact lifecycle trait names and event-channel shapes remain
 implementation details so long as one registry enforces this contract. A typed retained mutation
 authority for pathless removable Properties editing is deliberately deferred; the UI omits that
 action instead of reconstructing a path or weakening playback authority. Source-scoped regular-
-playlist storage is specified separately, while mixed-source row resolution, playback, lifecycle
-refresh, and Subsonic-native playlist synchronization remain explicitly deferred P1.5 work.
+playlist storage and its default-deny live-catalogue authority are specified separately. Their
+Add/Remove/render/Play UI integration and Subsonic-native playlist synchronization remain
+explicitly deferred P1.5 work.
 
 ## Implementation sequence
 
@@ -728,6 +753,12 @@ refresh, and Subsonic-native playlist synchronization remain explicitly deferred
    `ResolvedLocalMedia` into a generation-checked art worker. It revalidates and retains the exact
    file capability through bounded, cursor-safe parsing without reopening a pathname. External art
    and removable art follow the same post-accept retained-capability rule.
+8. **Regular-playlist catalogue authority complete
+   ([#141](https://github.com/jm2/tributary/pull/141)):** an explicit default-deny adapter
+   capability and exact current source/session/catalogue lookup now bridge durable source-scoped
+   identity to sanitized accepted metadata. Authenticated remote adapters opt in; radio,
+   removable, external, and default adapters do not. Guarded stream/artwork resolution revalidates
+   before and after asynchronous work. This step deliberately adds no mixed-source playlist UI.
 
 The authenticated-remote cutover's locked debug and release suites each passed 20 library, 865
 application, and 10 repository-metadata tests (895 total), with locked all-target/all-feature
@@ -789,8 +820,10 @@ independent lifecycle systems must not become the permanent architecture.
   key can collide for cloned filesystems, a relative file key does not survive rename, and an
   unsaved remote endpoint that changes URL is a new source until explicitly rebound.
 - Regular-playlist persistence can retain a source-scoped occurrence while its source is offline,
-  but storage alone does not make it playable. Only the same live source and exact native track can
-  restore authority; metadata and endpoint similarity are never substitutes.
+  but storage and internal catalogue authority alone do not make it visible or playable in a
+  playlist. Only the same live source, accepted session/catalogue generation, explicit adapter
+  capability, and exact native track can restore authority; metadata and endpoint similarity are
+  never substitutes.
 
 ## Rejected alternatives
 

--- a/docs/architecture/source-lifecycle.md
+++ b/docs/architecture/source-lifecycle.md
@@ -558,6 +558,10 @@ queue can extend the same ephemeral-source rule explicitly.
   successful replacement or same-session refresh invalidates old guards, while disconnect,
   shutdown, and final release deny synchronously. None of these internal APIs enables
   Add/Remove/render/Play UI behavior.
+  Catalogue selectors run against a captured immutable `Arc` outside the lifecycle mutex, followed
+  by an exact pointer/source/epoch/generation/lease recheck before a value returns or adapter work
+  starts. Selector-time refresh or teardown therefore denies stale work without making registry
+  re-entry part of the critical section.
 - `PlaybackSession` captures immutable source/track identity, queue order, duplicate occurrence,
   and playback event generation independently of GTK sorting/filtering. Queue identity is a
   `MediaKey`; playlists and radio queries retain a separate `ViewOrigin`, so local invalidation

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,9 +6,9 @@ This document explains the product and engineering work that remains **after** t
 remediation. [`task.md`](task.md) is the countable active implementation backlog; the completed
 remediation record is preserved separately in
 [`task-remediation-2026-07.md`](task-remediation-2026-07.md) at **220/223 (98.7%)**, with only three
-real-environment validation records left. The feature backlog is now **8/35 (22.9%)** complete. Neither
-percentage estimates equal engineering effort, and the historical percentage is not a claim that
-Tributary has implemented every requested product feature.
+real-environment validation records left. The feature backlog is now **9/36 (25.0%)** complete.
+Neither percentage estimates equal engineering effort, and the historical percentage is not a
+claim that Tributary has implemented every requested product feature.
 
 The entries below are candidates, not release promises. As of this audit, all 10 remaining open GitHub
 issues are unlabeled, unassigned, have no milestone, and have no discussion establishing product
@@ -30,6 +30,11 @@ starts. Historical holistic-review documents are point-in-time findings, not act
   shipping UI remains a local-library projection, so it does not yet create, render, or play the
   non-local rows. An Add to Playlist attempt from any unsupported source still explains that
   boundary in the user's language and performs no database work instead of silently skipping rows.
+  The internal live-catalogue authority layer now defaults every adapter to unsupported and permits
+  source-scoped entry lookup only for explicitly opted-in authenticated Subsonic, Jellyfin, Plex,
+  and DAAP sessions. Exact source, epoch, accepted catalogue generation, membership, and capability
+  are revalidated around asynchronous media resolution; sanitized results expose no locator,
+  credential, lease, route, or raw backend failure. This foundation does not enable UI actions.
   Subsonic server-side playlists are not imported. See the
   [storage contract](source-scoped-playlists.md).
 - XSPF v1 import/export is implemented with exact path and deterministic normalized-metadata
@@ -84,8 +89,9 @@ before starting large protocol or transfer subsystems.
 2. **Completed: make remote-to-playlist behavior explicit ([#47]).** Add to Playlist now snapshots
    the active source and refuses every non-local selection with a localized, all-or-none dialog
    before database work. Full support remains separate: the source-scoped `(SourceId, TrackId)`
-   storage foundation is complete, while disconnected-source semantics and playback-time
-   resolution are current; Subsonic server-native playlist import/sync is another slice.
+   storage and internal live-catalogue authority foundations are complete, and user-facing
+   disconnected/Add/Remove/render/Play behavior is the current record. Subsonic server-native
+   playlist import/sync is another slice.
 3. **Completed: implement trustworthy local playback history.** The durable schema,
    [counted-play contract](playback-history.md), production persistence pipeline, and seeded
    consumers are complete.
@@ -121,9 +127,30 @@ before starting large protocol or transfer subsystems.
    deterministically converts every valid existing entry to the local source, preserves entry
    identity, ordering, duplicates, fingerprints, and local `ON DELETE SET NULL` behavior through a
    separate cache, rejects non-local path evidence, and passed exact up/down/rollback, compatibility,
-   debug/release, and strict-lint validation. Live registry resolution and mixed-source UI/playback
-   are now the current P1.5 record; native Subsonic playlist semantics remain the following record
-   rather than being implied by the schema.
+   debug/release, and strict-lint validation.
+6. **Completed: publish default-deny live-catalogue playlist authority ([#141]).**
+   `ManagedSourceAdapter` exposes an explicit `Unsupported` or `SourceScopedEntries` capability, with
+   only authenticated Subsonic, Jellyfin, Plex, and DAAP adapters opting in. Lookup returns one
+   ordered resolution per requested occurrence against the exact current source, session epoch,
+   and accepted catalogue generation; repeated requested IDs preserve occurrence order. Missing
+   exact tracks, unavailable sessions, and unsupported sources return fixed unavailable results
+   independently. An otherwise accepted catalogue with a missing or duplicate native identity
+   receives an `Invalid` playlist-authority index, so every playlist occurrence for it is
+   unavailable without discarding the catalogue from existing non-playlist UI. Accepted metadata
+   crosses a dedicated display/sort/rating/history whitelist rather than a `Track` clone; its closed
+   guard carries the non-secret epoch and generation transiently, and neither is persisted.
+   Stream/artwork resolution rechecks capability, membership, epoch, and generation before and
+   after asynchronous adapter work, closes raw failures to fixed categories, and carries an
+   explicitly revoked lifecycle generation lease through consumption even if an old snapshot clone
+   remains alive. Connecting or failed replacement may
+   retain an accepted predecessor; successful replacement, same-session refresh, disconnect,
+   shutdown, and final release invalidate or deny old guards at their defined boundaries. This
+   internal foundation is not an Add/Remove/Play feature.
+7. **Current: integrate mixed-source regular-playlist UI.** Add, Remove, rendering, unavailable-row
+   presentation, and Play must consume Record A's exact registry authority without deriving support
+   from backend labels, cached GTK rows, metadata, or persisted locators. Radio-Browser, removable,
+   external-file, and unknown sources stay unsupported. Native Subsonic playlist semantics remain a
+   separate later record rather than being implied by either foundation.
 
 These foundations make Rhythmbox migration and Last.fm behavior much less ambiguous.
 
@@ -192,7 +219,7 @@ mistaken for work already underway.
 | [#57 — Rhythmbox playlists, play counts, and ratings](https://github.com/jm2/tributary/issues/57) | No direct importer. XSPF conversion plus completed playback-history and rating contracts are foundations; XSPF deliberately transfers neither history nor ratings. | Build a separate transactional, idempotent migration with explicit metadata consent and conflict reporting. |
 | [#50 — Last.fm scrobbling](https://github.com/jm2/tributary/issues/50) | No Last.fm client or scrobble pipeline. | Authorization, secret storage, authoritative thresholds, retry/offline queue, and privacy UX. |
 | [#49 — Equalizer](https://github.com/jm2/tributary/issues/49) | No equalizer or audio-filter configuration. | GStreamer DSP design plus explicit behavior for every output backend. |
-| [#47 — Remote/Subsonic tracks in playlists](https://github.com/jm2/tributary/issues/47) | Non-local Add to Playlist attempts are refused visibly and atomically. The source-scoped storage contract and migration-13 foundation are complete, but no user-facing capability policy yet admits, renders, resolves, or plays remote rows; server-native playlist sync is absent. | Implement live registry-backed mixed-source interaction; design server playlist import/sync separately. |
+| [#47 — Remote/Subsonic tracks in playlists](https://github.com/jm2/tributary/issues/47) | Non-local Add to Playlist attempts are refused visibly and atomically. Source-scoped storage is complete, and a default-deny registry authority foundation now validates exact current authenticated catalogues without exposing locators; no user-facing action yet admits, renders, or plays remote rows, and server-native playlist sync is absent. | Publish the authority foundation, integrate mixed-source UI against it, then design server playlist import/sync separately. |
 | [#46 — Drag and drop](https://github.com/jm2/tributary/issues/46) | Column-header reordering exists; track/file drag-and-drop does not. | Local playlist DnD first; file export, remote rows, and device copies as distinct policies. |
 | [#39 — Album art in browser](https://github.com/jm2/tributary/issues/39) | Artwork is shown for now-playing, not in the Genre/Artist/Album browser. | Virtualized art UI with bounded async cache, cancellation, accessibility, and authenticated art. |
 | [#29 — UI refinement](https://github.com/jm2/tributary/issues/29) | Requested separators/alignment changes are not implemented. | Split into independently reviewable visual changes after current-theme design review. |
@@ -269,3 +296,4 @@ When an item becomes active:
 [#50]: https://github.com/jm2/tributary/issues/50
 [#57]: https://github.com/jm2/tributary/issues/57
 [#140]: https://github.com/jm2/tributary/pull/140
+[#141]: https://github.com/jm2/tributary/pull/141

--- a/docs/source-scoped-playlists.md
+++ b/docs/source-scoped-playlists.md
@@ -1,8 +1,8 @@
-# Source-scoped regular playlist storage contract
+# Source-scoped regular playlist storage and authority contract
 
-This document defines the durable-storage foundation for the first record in
-[P1.5](task.md#p15--persist-source-scoped-playlists). It changes how regular-playlist membership is
-represented without yet changing which source rows the shipping UI can add, display, or play.
+This document defines the durable-storage contract and the following live-catalogue authority
+foundation for [P1.5](task.md#p15--persist-source-scoped-playlists). Neither foundation changes
+which source rows the shipping UI can add, display, or play.
 
 The central rule is:
 
@@ -29,10 +29,11 @@ This storage slice covers:
   rename, and deletion paths.
 
 It deliberately does **not** enable remote Add to Playlist, mixed-source playlist rendering or
-playback, disconnected-row presentation, lifecycle refresh, or remote XSPF export. Those behaviors
-need the live `SourceRegistry` and remain the second P1.5 record. Subsonic server-native playlist
-listing, import, synchronization, conflict handling, and deletion semantics remain the separate
-third record and require their own design before implementation.
+playback, disconnected-row presentation, playlist-UI lifecycle refresh, or remote XSPF export.
+P1.5 Record A adds the internal live-registry authority described below; Record B must integrate it
+into those user-facing behaviors. Subsonic server-native playlist listing, import, synchronization,
+conflict handling, and deletion semantics remain a separate record and require their own design
+before implementation.
 
 Smart playlists are unaffected. They remain live queries over the local library rather than stored
 regular-playlist occurrences.
@@ -140,26 +141,91 @@ The user-visible behavior in this slice stays local-only:
   an explicit metadata-only policy and is part of the later presentation/integration work; it may
   not obtain or serialize a protected remote locator.
 
-The existing P1.2 refusal remains correct until the second record lands: selecting Add to Playlist
+The existing P1.2 refusal remains correct until Record B lands: selecting Add to Playlist
 from a remote, radio, removable, external, or malformed source still presents localized all-or-none
-copy before opening the database. The new storage capability is not itself UI authorization.
-That follow-up will initially admit only retained authenticated catalogues through an explicit
-capability check. Radio-Browser, removable media, ephemeral external files, and unknown sources
-remain unsupported until their persistence and lifecycle semantics are separately designed.
+copy before opening the database. Neither the storage capability nor Record A's internal lookup is
+itself UI authorization. Record B will initially admit only retained authenticated catalogues
+through the explicit registry capability. Radio-Browser, removable media, ephemeral external
+files, and unknown sources remain unsupported until their persistence and lifecycle semantics are
+separately designed.
+
+## Live registry and accepted-catalogue authority
+
+P1.5 Record A establishes an internal authority boundary between durable source-scoped identity
+and later playlist UI integration ([#141](https://github.com/jm2/tributary/pull/141)).
+`ManagedSourceAdapter` exposes a closed
+`RegularPlaylistCapability`: its default is `Unsupported`, and only the retained authenticated
+Subsonic, Jellyfin, Plex, and DAAP catalogue adapters explicitly opt into
+`SourceScopedEntries`. Radio-Browser, removable media, ephemeral external files, the trait default,
+and unknown source kinds remain unsupported. Backend names, source provenance, persisted row shape,
+and the mere existence of a catalogue never imply support.
+
+One accepted source payload freezes the advertised capability with its complete catalogue.
+`resolve_regular_playlist_tracks(&[MediaKey])` returns exactly one ordered
+`RegularPlaylistTrackResolution` for each requested occurrence. An authority lookup must match all
+of the following exactly:
+
+1. the requested `SourceId` is the current registered source;
+2. the non-secret session epoch is still the accepted session;
+3. the accepted catalogue generation is still current;
+4. the adapter capability is `SourceScopedEntries`; and
+5. for each requested occurrence, its native `TrackId` is canonical and present in the accepted
+   catalogue's unique native-ID mapping.
+
+An otherwise accepted catalogue with a missing or duplicate catalogue-native identity receives an
+`Invalid` regular-playlist authority index. Every requested occurrence for that source then fails
+closed as `InvalidCatalogue`, while the catalogue can remain available to existing non-playlist UI
+and no duplicate is chosen. Repeated requested IDs remain valid ordered duplicate occurrences and
+produce repeated ordered results when the index is valid. Lookup returns exactly one Available or
+fixed-reason Unavailable result per requested occurrence: a missing member fails only that
+occurrence, while an unsupported source or unavailable session marks its affected occurrences
+without erasing valid neighbors from another source. Revalidation separately rejects results made
+stale by retirement, replacement, refresh, release, or shutdown.
+
+An Available result exposes only its exact `media_key()`, transient `guard()`, and sanitized
+`metadata()`. An Unavailable result exposes its `media_key()` plus one closed reason:
+`SourceUnavailable`, `UnsupportedSource`, `InvalidCatalogue`, or `TrackMissing`—never a backend
+error. `are_regular_playlist_tracks_current` rechecks a previously returned ordered result against
+the current authority state without trusting its metadata copy.
+
+Successful lookup returns a dedicated, whitelisted `RegularPlaylistTrackMetadata` value rather
+than cloning `Track`. Only the display, sort, rating, and history fields named by that DTO cross the
+boundary; paths, file and network URLs, stream/artwork locators, credentials, leases, routes, and
+raw backend errors cannot be inherited accidentally when `Track` grows a field. The closed guard
+also carries its non-secret session epoch and accepted catalogue generation transiently; neither
+value is persisted in `playlist_entries`. Lookup does not write those entries, mint playback
+authority, or authorize a source-native playlist operation.
+
+`resolve_regular_playlist_stream(guard, TrackId)` and
+`resolve_regular_playlist_artwork(guard, TrackId)` independently revalidate exact source
+membership, capability, session epoch, and catalogue generation before adapter work and again after
+the asynchronous result returns. They discard raw adapter failures at the registry seam and expose
+only `RegularPlaylistMediaError::Unavailable` or a closed `BackendFailure(FailureCategory)`.
+Every lifecycle `AcceptedSnapshot` owns a separate generation lease. Replacement, view removal,
+disconnect, shutdown, final-handle teardown, and defensive pruning revoke that lease explicitly
+before clearing the snapshot, so a parked `Arc` snapshot cannot delay invalidation; a returned
+guarded stream or artwork request carries that same authority through consumption. Connecting or a
+failed replacement can retain the already accepted predecessor and its authority. A successful
+replacement or same-session catalogue refresh invalidates guards minted from the previous accepted
+payload. Disconnect, shutdown, and final source release synchronously deny new authority before
+asynchronous teardown can finish.
+
+These APIs are an authority foundation only. The shipping Add/Remove/render/Play paths do not call
+them yet, do not show stored non-local rows, and retain the localized all-or-none refusal from P1.2.
 
 ## Source lifecycle and unavailable identity
 
 Persistent membership does not imply a live source session. Only `source_id` and `track_id` survive
 restart; a session epoch is deliberately transient.
 
-The second P1.5 record will resolve a non-local entry by asking the live `SourceRegistry` for the
-exact source and track, adopting only the current non-secret session epoch at publication and
-playback time. Disconnect, source retirement, a missing server-side track, or an epoch replacement
-must leave the database row intact and make it visibly unavailable. Reconnection may restore it
+Record A can now validate a non-local identity internally against the exact current
+`SourceRegistry` source, epoch, accepted catalogue generation, and native track. Record B must use
+that result to make disconnect, source retirement, a missing server-side track, refresh, or session
+replacement visibly unavailable while leaving the database row intact. Reconnection may restore it
 only when the same `SourceId` publishes the same `TrackId`; endpoint similarity and metadata are
 not identity evidence.
 
-Until that slice exists, stored non-local fixtures remain intentionally outside the regular-
+Until Record B exists, stored non-local fixtures remain intentionally outside the regular-
 playlist UI projection. This prevents the storage migration from accidentally treating durable
 identity as a locator or presenting a row that the current queue still assigns to the local source.
 
@@ -197,5 +263,14 @@ The storage record is complete only when automated coverage demonstrates:
   deletion/retirement cannot cascade into playlist storage, and no remote locator or credential is
   accepted or serialized.
 
-Mixed-source rendering, interaction, playback, lifecycle, and native Subsonic playlist tests belong
-to their explicitly deferred records rather than being claimed by this storage foundation.
+Mixed-source rendering, interaction, playback, unavailable-state presentation, and native
+Subsonic playlist tests belong to their explicitly deferred records rather than being claimed by
+the storage or authority foundations.
+
+Record A additionally requires automated coverage for default-deny adapters, the four explicit
+authenticated opt-ins, Invalid playlist indexing for missing/duplicate catalogue-native identity,
+sanitized metadata, stale epoch/generation rejection, predecessor retention during connecting or a
+failed replacement, invalidation after replacement/refresh, synchronous disconnect/shutdown/final-
+release denial, and pre/post-async stream and artwork revalidation. Ordered lookup must preserve
+duplicate requested occurrences and isolate one missing track's Unavailable result from valid
+neighbors. Passing those tests does not claim Add/Remove/render/Play UI integration.

--- a/docs/source-scoped-playlists.md
+++ b/docs/source-scoped-playlists.md
@@ -196,6 +196,13 @@ also carries its non-secret session epoch and accepted catalogue generation tran
 value is persisted in `playlist_entries`. Lookup does not write those entries, mint playback
 authority, or authorize a source-native playlist operation.
 
+Projection from the captured immutable catalogue `Arc` runs outside the lifecycle mutex. Before a
+lookup returns or guarded adapter work begins, the registry reacquires the mutex and requires the
+same exact `Arc` identity, source, epoch, generation, catalogue authority, and active session
+lease. A selector can therefore re-enter registry code without deadlock, while a refresh,
+replacement, or disconnect completed during selection makes the result unavailable and prevents
+stale adapter work.
+
 `resolve_regular_playlist_stream(guard, TrackId)` and
 `resolve_regular_playlist_artwork(guard, TrackId)` independently revalidate exact source
 membership, capability, session epoch, and catalogue generation before adapter work and again after

--- a/docs/task.md
+++ b/docs/task.md
@@ -21,7 +21,7 @@ state.
 - Do not treat the order below as a release promise. It is a dependency-aware starting order and
   can change as issues receive product decisions and milestones.
 
-Current status: **8/35 (22.9%)** active implementation records complete. This percentage measures
+Current status: **9/36 (25.0%)** active implementation records complete. This percentage measures
 checklist completion, not equal engineering effort: several P3 records are deliberately large
 epics. The archived remediation remains **220/223 (98.7%)** complete; its three open records are
 real-environment validation, not missing implementation.
@@ -29,20 +29,21 @@ real-environment validation, not missing implementation.
 ## Current focus
 
 P1.1, P1.2, all three P1.3 playback-history records, both P1.4 rating records, and P1.5's
-source-scoped regular-playlist storage foundation are complete. Continue with P1.5's live-registry
-resolution and mixed-source Add/Remove/Play interaction record. That slice must retain the storage
-contract's no-locator/no-credential boundary while making disconnected, retired, and stale-epoch
-states honest. The rest of P1 builds on the source-scoped identity already present in the runtime,
-the now-bounded shuffle navigation semantics, authoritative local playback history with
-deterministic live consumers, and an exact capability-aware rating field.
+source-scoped regular-playlist storage and live-catalogue authority foundations are complete.
+Continue with P1.5 Record B, which will use that default-deny authority in Add/Remove/render/Play UI
+and make disconnected, retired, stale-epoch, and missing-track states visible without weakening the
+storage contract's no-locator/no-credential boundary. The rest of P1 builds on the source-scoped
+identity already present in the runtime, the now-bounded shuffle navigation semantics,
+authoritative local playback history with deterministic live consumers, and an exact
+capability-aware rating field.
 
 The independent Linux watcher correctness fix tracked in
-[#103](https://github.com/jm2/tributary/pull/103) does not change the **8/35** feature total.
+[#103](https://github.com/jm2/tributary/pull/103) does not change the **9/36** feature total.
 The salvaged scope rejects explicitly classified access/access-time noise before the bounded watcher
 queue without filtering real bootstrap mutations or backend errors, while retaining overflow
 evidence for authoritative reconciliation. It intentionally omits the original persistent
 unparseable-file cache so transient parser and I/O failures remain retryable. It is tracked outside
-the 35-record feature backlog.
+the 36-record feature backlog.
 
 ## P1 — Correctness and shared feature foundations
 
@@ -229,20 +230,55 @@ the 35-record feature backlog.
   non-local path evidence and persists no URL, credential, lease, or session epoch; existing local
   Add/load, XSPF import/export, reconciliation, rename, root-reauthorization, and deletion behaviors
   remain the compatibility boundary for this slice.
-- [ ] Resolve remote playlist entries only through the live `SourceRegistry` session; implement
-  Add/Remove/Play UI, disconnected states, source retirement, stale-epoch rejection, and mixed-source
-  playlist tests without persisting locators or credentials.
 
-  Explicitly deferred from migration 13: the current UI still refuses every non-local Add before
-  database work and projects only local entries. This record will admit only retained authenticated
-  catalogues through an explicit capability check. Radio-Browser, removable media, ephemeral
-  external files, and unknown sources remain unsupported until separately designed; a generic
-  storage shape alone does not authorize them.
+- [x] **Record A — Live catalogue authority:** establish the live-registry and accepted-catalogue
+  authority foundation for source-scoped regular-playlist entries. Capability must default to
+  unsupported and opt in only authenticated Subsonic, Jellyfin, Plex, and DAAP adapters. Ordered
+  lookup must accept only the exact current source session, catalogue generation, and native-track
+  identities, returning no locator, credential, lease, or route. Its closed result may carry the
+  non-secret session epoch and catalogue generation transiently; neither becomes playlist storage.
+  Guarded media resolution remains a separate at-use operation with retained private authority
+  ([#141](https://github.com/jm2/tributary/pull/141)).
+
+  Implemented contract: `ManagedSourceAdapter` exposes an
+  explicit `Unsupported` or `SourceScopedEntries` capability. The default and Radio-Browser,
+  removable-media, and ephemeral external-file adapters remain unsupported; only the four retained
+  authenticated catalogue adapters opt in. Registry lookup returns one ordered resolution per
+  requested occurrence. Unsupported sources, unavailable sessions, and missing exact tracks return
+  fixed unavailable results independently without erasing valid neighbors. If an otherwise
+  accepted catalogue contains a missing or duplicate native identity, its frozen regular-playlist
+  authority index is `Invalid` and every requested occurrence for that source fails closed; the
+  catalogue may remain available to existing non-playlist UI. Repeated requested IDs remain ordered
+  duplicate occurrences. Available rows use a dedicated display/sort/rating/history metadata
+  whitelist rather than a `Track` clone. The lifecycle snapshot owns a separately revocable
+  generation lease, so replacement or teardown invalidates guarded media even while an observer
+  retains an old snapshot clone; raw adapter failures become fixed media-error categories.
+  Revalidation denies a guard made stale by refresh, replacement, retirement, release, or shutdown.
+  The capability does not authorize a database write, UI row, playback request, or source-native
+  playlist mutation.
+
+  Coverage pins the default-deny and four-opt-in matrix, `Invalid` indexing, ordered
+  duplicate requests, all four closed unavailable reasons, locator-free metadata, current-result
+  rechecks, predecessor retention, refresh/replacement invalidation, synchronous lifecycle denial,
+  and membership/capability/epoch/generation checks before and after stream or artwork resolution.
+
+- [ ] **Record B — Mixed-source UI integration:** integrate the registry authority foundation into
+  regular-playlist Add, Remove, rendering, and Play behavior, with explicit disconnected/missing
+  states, source retirement, stale-epoch rejection, occurrence ordering, duplicates, and all-or-none
+  multi-selection tests.
+
+  Explicitly deferred from Record A: the current UI still refuses every non-local Add before
+  database work and projects only local entries. Record B must consume the registry result rather
+  than infer support from a source key, backend label, cached GTK row, or persisted fingerprint.
+  Radio-Browser, removable media, ephemeral external files, and unknown sources remain unsupported
+  until separately designed; neither a generic storage shape nor a registry lookup API authorizes
+  them.
+
 - [ ] Treat Subsonic server-native playlist import/synchronization as a separate capability slice,
   with direction, conflict, offline, deletion, and server-feature semantics documented first.
 
   No Subsonic playlist endpoint, origin mapping, import, or synchronization behavior is part of the
-  storage migration or the mixed-source interaction record.
+  storage migration, authority foundation, or mixed-source interaction record.
 
 ## P2 — User-facing integrations and bounded enhancements
 
@@ -358,5 +394,6 @@ the 35-record feature backlog.
 | 2026-07-18 | P1.3 deterministic history smart playlists | [#137](https://github.com/jm2/tributary/pull/137) | Made Recently Played and Top 25 deterministic over authoritative history, including intentional empty states, stable ordering and Top 25 membership, committed-event live refresh, exact untouched-default migration from both released historical signatures, and lossless editor round trips for Last Played fields, limits, and relative units. This completed P1.3. |
 | 2026-07-19 | P1.4 rating ownership and persistence foundation | [#138](https://github.com/jm2/tributary/pull/138) | Defined the canonical 1–100 value and coherent Writable/ReadOnly/Unsupported capabilities; added constrained nullable migration 12, transactional exact-local-ID set/clear, scan preservation, validated read-only Subsonic/Jellyfin/Plex conversion, fail-closed catalogue invariants and remote writes, and an explicit rating-neutral XSPF/import policy. Accessible editing, display, sorting, and smart rules were tracked in the following P1.4 record. |
 | 2026-07-19 | P1.4 rating UI and smart-playlist rules | [#139](https://github.com/jm2/tributary/pull/139) | Added the exact Rating column with localized cell/editor states, keyboard-operable local set/clear, honest read-only/unavailable states, serialized post-commit exact-ID refresh, failure-safe feedback, versioned column-config exposure, null-last deterministic sorting, and capability-aware numeric/presence smart rules plus Highest/Lowest Rated selection. This completed P1.4. |
-| 2026-07-19 | P1.5 source-scoped regular-playlist storage | [#140](https://github.com/jm2/tributary/pull/140) | Added migration 13 and typed atomic storage around exact `(SourceId, TrackId)` occurrence identity, a separate nullable local foreign-key cache, exact schema/index recognition, lossless-or-refused downgrade, local compatibility, and explicit no-locator/no-credential boundaries. Mixed-source live resolution and Subsonic-native synchronization remain the next two records. |
+| 2026-07-19 | P1.5 source-scoped regular-playlist storage | [#140](https://github.com/jm2/tributary/pull/140) | Added migration 13 and typed atomic storage around exact `(SourceId, TrackId)` occurrence identity, a separate nullable local foreign-key cache, exact schema/index recognition, lossless-or-refused downgrade, local compatibility, and explicit no-locator/no-credential boundaries. Default-deny live-catalogue authority, mixed-source UI integration, and Subsonic-native synchronization remain the next three records. |
+| 2026-07-19 | P1.5 live-catalogue playlist authority | [#141](https://github.com/jm2/tributary/pull/141) | Added default-deny adapter capability, exact ordered catalogue lookup with invalid-catalogue rejection and sanitized metadata, transient epoch/generation guards, closed media errors, and lifecycle-owned generation leases revoked independently of retained snapshots. Mixed-source Add/Remove/render/Play remains the next record. |
 | 2026-07-18 | Linux watcher feedback-loop fix | [#103](https://github.com/jm2/tributary/pull/103) | Narrowed the external proposal to filter self-generated access events before queue admission without filtering genuine startup events or backend errors; bounded overflow still drives authoritative reconciliation. Persistent negative parse caching is deliberately excluded so failures remain retryable; this separate correctness fix does not advance the feature numerator. |

--- a/docs/task.md
+++ b/docs/task.md
@@ -253,14 +253,17 @@ the 36-record feature backlog.
   whitelist rather than a `Track` clone. The lifecycle snapshot owns a separately revocable
   generation lease, so replacement or teardown invalidates guarded media even while an observer
   retains an old snapshot clone; raw adapter failures become fixed media-error categories.
-  Revalidation denies a guard made stale by refresh, replacement, retirement, release, or shutdown.
+  Catalogue projection runs on the captured immutable snapshot outside the lifecycle mutex, then
+  exact pointer identity and both leases are rechecked before return or adapter work. Revalidation
+  denies a guard made stale by refresh, replacement, retirement, release, or shutdown.
   The capability does not authorize a database write, UI row, playback request, or source-native
   playlist mutation.
 
   Coverage pins the default-deny and four-opt-in matrix, `Invalid` indexing, ordered
   duplicate requests, all four closed unavailable reasons, locator-free metadata, current-result
-  rechecks, predecessor retention, refresh/replacement invalidation, synchronous lifecycle denial,
-  and membership/capability/epoch/generation checks before and after stream or artwork resolution.
+  rechecks, predecessor retention, refresh/replacement invalidation, unlocked selector re-entry,
+  selector-time stale-work denial, synchronous lifecycle denial, and
+  membership/capability/epoch/generation checks before and after stream or artwork resolution.
 
 - [ ] **Record B — Mixed-source UI integration:** integrate the registry authority foundation into
   regular-playlist Add, Remove, rendering, and Play behavior, with explicit disconnected/missing

--- a/src/source_lifecycle.rs
+++ b/src/source_lifecycle.rs
@@ -570,10 +570,10 @@ pub struct LatestAcceptedView<T> {
 
 /// Value selected from the one currently accepted source-wide catalogue.
 ///
-/// The selector that creates this value runs while the lifecycle state is
-/// locked, so the value, catalogue generation, active session epoch, and
-/// source lease are observed atomically. The selected value must not retain
-/// the catalogue payload itself.
+/// The immutable catalogue snapshot, generation, active session epoch, and
+/// authority are captured atomically. The selector then runs outside the
+/// lifecycle lock. The selected value must not retain the catalogue payload
+/// itself.
 pub struct CurrentAcceptedCatalogue<T> {
     pub generation: u64,
     pub session_epoch: u64,
@@ -2032,24 +2032,44 @@ impl<A: LifecycleAdapter + ?Sized, S> SourceLifecycleRegistry<A, S> {
     where
         Select: FnOnce(&S) -> Option<T>,
     {
-        let state = lock(&self.inner.state);
-        if state.gate != RegistryGate::Running {
+        let (generation, session_epoch, session_lease, authority, catalogue_value) = {
+            let state = lock(&self.inner.state);
+            if state.gate != RegistryGate::Running {
+                return None;
+            }
+            let entry = state.entries.get(&source_id)?;
+            let active = entry.active.as_ref()?;
+            if !active.lease.is_active() {
+                return None;
+            }
+            let catalogue = entry.catalogue.as_ref()?;
+            if catalogue.session_epoch != active.epoch || !catalogue.authority.is_active() {
+                return None;
+            }
+            (
+                catalogue.generation,
+                catalogue.session_epoch,
+                active.lease.clone(),
+                catalogue.authority.clone(),
+                Arc::clone(&catalogue.value),
+            )
+        };
+        let value = select(catalogue_value.as_ref())?;
+        if !session_lease.is_active()
+            || !authority.is_active()
+            || !self.is_exact_catalogue_snapshot_current(
+                source_id,
+                generation,
+                session_epoch,
+                &catalogue_value,
+            )
+        {
             return None;
         }
-        let entry = state.entries.get(&source_id)?;
-        let active = entry.active.as_ref()?;
-        if !active.lease.is_active() {
-            return None;
-        }
-        let catalogue = entry.catalogue.as_ref()?;
-        if catalogue.session_epoch != active.epoch || !catalogue.authority.is_active() {
-            return None;
-        }
-        let value = select(catalogue.value.as_ref())?;
         Some(CurrentAcceptedCatalogue {
-            generation: catalogue.generation,
-            session_epoch: catalogue.session_epoch,
-            authority: catalogue.authority.clone(),
+            generation,
+            session_epoch,
+            authority,
             value,
         })
     }
@@ -2065,22 +2085,62 @@ impl<A: LifecycleAdapter + ?Sized, S> SourceLifecycleRegistry<A, S> {
     where
         Select: FnOnce(&S) -> Option<T>,
     {
+        let (session_lease, authority, catalogue_value) = {
+            let state = lock(&self.inner.state);
+            if state.gate != RegistryGate::Running {
+                return None;
+            }
+            let entry = state.entries.get(&source_id)?;
+            let active = entry.active.as_ref()?;
+            let catalogue = entry.catalogue.as_ref()?;
+            if !active.lease.is_active()
+                || active.epoch != expected_session_epoch
+                || catalogue.session_epoch != expected_session_epoch
+                || catalogue.generation != expected_generation
+                || !catalogue.authority.is_active()
+            {
+                return None;
+            }
+            (
+                active.lease.clone(),
+                catalogue.authority.clone(),
+                Arc::clone(&catalogue.value),
+            )
+        };
+        let selected = select(catalogue_value.as_ref())?;
+        (session_lease.is_active()
+            && authority.is_active()
+            && self.is_exact_catalogue_snapshot_current(
+                source_id,
+                expected_generation,
+                expected_session_epoch,
+                &catalogue_value,
+            ))
+        .then_some(selected)
+    }
+
+    /// Recheck the exact immutable catalogue captured before an unlocked
+    /// selector ran. Generation and epoch are necessary but the pointer check
+    /// also proves that no replacement reused the expected metadata.
+    fn is_exact_catalogue_snapshot_current(
+        &self,
+        source_id: SourceId,
+        expected_generation: u64,
+        expected_session_epoch: u64,
+        expected_value: &Arc<S>,
+    ) -> bool {
         let state = lock(&self.inner.state);
-        if state.gate != RegistryGate::Running {
-            return None;
-        }
-        let entry = state.entries.get(&source_id)?;
-        let active = entry.active.as_ref()?;
-        let catalogue = entry.catalogue.as_ref()?;
-        if !active.lease.is_active()
-            || active.epoch != expected_session_epoch
-            || catalogue.session_epoch != expected_session_epoch
-            || catalogue.generation != expected_generation
-            || !catalogue.authority.is_active()
-        {
-            return None;
-        }
-        select(catalogue.value.as_ref())
+        state.gate == RegistryGate::Running
+            && state.entries.get(&source_id).is_some_and(|entry| {
+                entry.active.as_ref().is_some_and(|active| {
+                    active.epoch == expected_session_epoch && active.lease.is_active()
+                }) && entry.catalogue.as_ref().is_some_and(|catalogue| {
+                    catalogue.generation == expected_generation
+                        && catalogue.session_epoch == expected_session_epoch
+                        && catalogue.authority.is_active()
+                        && Arc::ptr_eq(&catalogue.value, expected_value)
+                })
+            })
     }
 
     /// Validate one accepted catalogue identity without cloning its value.
@@ -2130,9 +2190,10 @@ impl<A: LifecycleAdapter + ?Sized, S> SourceLifecycleRegistry<A, S> {
 
     /// Resolve through one exact accepted catalogue and active adapter.
     ///
-    /// The catalogue selector is checked while atomically capturing the
-    /// adapter, epoch, and session lease, then checked again after the async
-    /// adapter call. This is intentionally separate from exact-session media
+    /// The catalogue snapshot is captured atomically with the adapter, epoch,
+    /// and leases. Its selector runs outside the lifecycle lock, and exact
+    /// identity and authority are checked again after the async adapter call.
+    /// This is intentionally separate from exact-session media
     /// resolution: a same-session catalogue replacement must revoke a
     /// persisted playlist reference even though the adapter epoch is stable.
     async fn resolve_exact_catalogue_session<R, T, Select, F, Fut>(
@@ -2150,7 +2211,7 @@ impl<A: LifecycleAdapter + ?Sized, S> SourceLifecycleRegistry<A, S> {
         F: FnOnce(Arc<A>) -> Fut + Send,
         Fut: Future<Output = BackendResult<R>> + Send,
     {
-        let (session, catalogue_authority, selected) = {
+        let (session, catalogue_authority, catalogue_value) = {
             let state = lock(&self.inner.state);
             if state.gate != RegistryGate::Running {
                 return Err(CatalogueMediaResolveError::Unavailable);
@@ -2172,8 +2233,6 @@ impl<A: LifecycleAdapter + ?Sized, S> SourceLifecycleRegistry<A, S> {
             {
                 return Err(CatalogueMediaResolveError::Unavailable);
             }
-            let selected =
-                select(catalogue.value.as_ref()).ok_or(CatalogueMediaResolveError::Unavailable)?;
             (
                 SessionHandle {
                     session_epoch: active.epoch,
@@ -2181,32 +2240,38 @@ impl<A: LifecycleAdapter + ?Sized, S> SourceLifecycleRegistry<A, S> {
                     lease: active.lease.clone(),
                 },
                 catalogue.authority.clone(),
-                selected,
+                Arc::clone(&catalogue.value),
             )
         };
 
+        let selected =
+            select(catalogue_value.as_ref()).ok_or(CatalogueMediaResolveError::Unavailable)?;
+        if !session.lease.is_active()
+            || !catalogue_authority.is_active()
+            || !self.is_exact_catalogue_snapshot_current(
+                source_id,
+                expected_generation,
+                expected_session_epoch,
+                &catalogue_value,
+            )
+        {
+            return Err(CatalogueMediaResolveError::Unavailable);
+        }
+
         let lease = session.lease.clone();
-        let resolved = resolve(session.adapter)
-            .await
-            .map_err(CatalogueMediaResolveError::Backend)?;
-        let state = lock(&self.inner.state);
-        let remains_current = state.gate == RegistryGate::Running
-            && lease.is_active()
+        let resolved = resolve(session.adapter).await;
+        let remains_current = lease.is_active()
             && catalogue_authority.is_active()
-            && state.entries.get(&source_id).is_some_and(|entry| {
-                entry.active.as_ref().is_some_and(|active| {
-                    active.epoch == expected_session_epoch && active.lease.is_active()
-                }) && entry.catalogue.as_ref().is_some_and(|catalogue| {
-                    catalogue.generation == expected_generation
-                        && catalogue.session_epoch == expected_session_epoch
-                        && catalogue.authority.is_active()
-                        && select(catalogue.value.as_ref()).is_some()
-                })
-            });
-        drop(state);
+            && self.is_exact_catalogue_snapshot_current(
+                source_id,
+                expected_generation,
+                expected_session_epoch,
+                &catalogue_value,
+            );
         if !remains_current {
             return Err(CatalogueMediaResolveError::Unavailable);
         }
+        let resolved = resolved.map_err(CatalogueMediaResolveError::Backend)?;
         Ok((resolved, lease, catalogue_authority, selected))
     }
 
@@ -5590,6 +5655,87 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn catalogue_selectors_run_unlocked_and_revalidate_before_return_or_adapter_work() {
+        let registry = registry();
+        let source_id = SourceId::random();
+        claim(&registry, source_id, SourceProvenance::Saved);
+        let mut adapter = AdapterFixture::immediate();
+        let (epoch, _) = adopt(&registry, source_id, &mut adapter, vec!["initial"]);
+
+        let selector_registry = registry.clone();
+        let current = registry.resolve_current_accepted_catalogue(source_id, move |catalogue| {
+            assert!(selector_registry.inner.state.try_lock().is_ok());
+            let refresh = selector_registry
+                .begin_refresh(source_id, RefreshLane::Catalogue)
+                .expect("refresh from current selector");
+            assert!(refresh.submit(vec!["after-current"]));
+            catalogue.first().copied()
+        });
+        assert!(
+            current.is_none(),
+            "selector-time refresh must stale the result"
+        );
+
+        let after_current = registry
+            .snapshot(source_id)
+            .and_then(|snapshot| snapshot.catalogue)
+            .expect("catalogue after current-selector refresh");
+        let selector_registry = registry.clone();
+        let exact = registry.resolve_exact_accepted_catalogue(
+            source_id,
+            after_current.generation,
+            epoch,
+            move |catalogue| {
+                assert!(selector_registry.inner.state.try_lock().is_ok());
+                let refresh = selector_registry
+                    .begin_refresh(source_id, RefreshLane::Catalogue)
+                    .expect("refresh from exact selector");
+                assert!(refresh.submit(vec!["after-exact"]));
+                catalogue.first().copied()
+            },
+        );
+        assert!(
+            exact.is_none(),
+            "exact selector must recheck after selection"
+        );
+
+        let after_exact = registry
+            .snapshot(source_id)
+            .and_then(|snapshot| snapshot.catalogue)
+            .expect("catalogue after exact-selector refresh");
+        let adapter_calls = Arc::new(AtomicUsize::new(0));
+        let calls = Arc::clone(&adapter_calls);
+        let selector_registry = registry.clone();
+        let result = registry
+            .resolve_catalogue_optional_http(
+                source_id,
+                after_exact.generation,
+                epoch,
+                move |catalogue| {
+                    assert!(selector_registry.inner.state.try_lock().is_ok());
+                    let refresh = selector_registry
+                        .begin_refresh(source_id, RefreshLane::Catalogue)
+                        .expect("refresh from media selector");
+                    assert!(refresh.submit(vec!["after-media"]));
+                    catalogue.contains(&"after-exact").then_some(())
+                },
+                move |_| {
+                    calls.fetch_add(1, Ordering::AcqRel);
+                    async { Ok(None) }
+                },
+            )
+            .await;
+        assert!(result.is_err());
+        assert_eq!(
+            adapter_calls.load(Ordering::Acquire),
+            0,
+            "a selector-time refresh must prevent stale adapter work"
+        );
+
+        shutdown_immediate(&registry).await;
+    }
+
+    #[tokio::test]
     async fn guarded_catalogue_resolution_closes_pre_call_and_in_flight_refresh_races() {
         let registry = registry();
         let source_id = SourceId::random();
@@ -5674,15 +5820,48 @@ mod tests {
             .and_then(|snapshot| snapshot.catalogue)
             .expect("refreshed catalogue");
         let delayed_registry = registry.clone();
+        let (error_started, error_started_rx) = oneshot::channel();
+        let (release_error, release_error_rx) = oneshot::channel();
+        let delayed_error = tokio::spawn(async move {
+            delayed_registry
+                .resolve_catalogue_stream(
+                    source_id,
+                    after_stream_refresh.generation,
+                    epoch,
+                    |catalogue| catalogue.contains(&"other").then_some(()),
+                    move |_| async move {
+                        let _ = error_started.send(());
+                        let _ = release_error_rx.await;
+                        Err(BackendError::Timeout { duration_secs: 1 })
+                    },
+                )
+                .await
+        });
+        error_started_rx.await.expect("error resolver entered");
+        let refresh = registry
+            .begin_refresh(source_id, RefreshLane::Catalogue)
+            .expect("backend-error-racing refresh");
+        assert!(refresh.submit(vec!["after-error"]));
+        release_error.send(()).expect("release error resolver");
+        assert!(matches!(
+            delayed_error.await.expect("error resolution task"),
+            Err(CatalogueMediaResolveError::Unavailable)
+        ));
+
+        let after_error_refresh = registry
+            .snapshot(source_id)
+            .and_then(|snapshot| snapshot.catalogue)
+            .expect("catalogue after backend-error race");
+        let delayed_registry = registry.clone();
         let (art_started, art_started_rx) = oneshot::channel();
         let (release_art, release_art_rx) = oneshot::channel();
         let delayed_art = tokio::spawn(async move {
             delayed_registry
                 .resolve_catalogue_optional_http(
                     source_id,
-                    after_stream_refresh.generation,
+                    after_error_refresh.generation,
                     epoch,
-                    |catalogue| catalogue.contains(&"other").then_some(()),
+                    |catalogue| catalogue.contains(&"after-error").then_some(()),
                     move |_| async move {
                         let _ = art_started.send(());
                         let _ = release_art_rx.await;
@@ -5705,12 +5884,17 @@ mod tests {
             .snapshot(source_id)
             .and_then(|snapshot| snapshot.catalogue)
             .expect("twice-refreshed catalogue");
+        let selector_calls = Arc::new(AtomicUsize::new(0));
+        let calls = Arc::clone(&selector_calls);
         let resolved = registry
             .resolve_catalogue_optional_http(
                 source_id,
                 refreshed.generation,
                 epoch,
-                |catalogue| catalogue.contains(&"third").then_some("selected"),
+                move |catalogue| {
+                    calls.fetch_add(1, Ordering::AcqRel);
+                    catalogue.contains(&"third").then_some("selected")
+                },
                 |_| async { Ok(None) },
             )
             .await;
@@ -5720,6 +5904,7 @@ mod tests {
         assert!(none.is_none());
         assert!(authority.is_active());
         assert_eq!(selected, "selected");
+        assert_eq!(selector_calls.load(Ordering::Acquire), 1);
         shutdown_immediate(&registry).await;
         assert!(!authority.is_active());
     }

--- a/src/source_lifecycle.rs
+++ b/src/source_lifecycle.rs
@@ -25,6 +25,7 @@ use tokio::task::AbortHandle;
 use uuid::Uuid;
 
 use crate::architecture::backend::BackendResult;
+use crate::architecture::error::BackendError;
 use crate::architecture::media::MediaLease;
 use crate::architecture::media::ResolvedHttpRequest;
 use crate::architecture::{SourceId, ViewOrigin};
@@ -35,6 +36,13 @@ use crate::local::resolver::ResolvedFileMedia;
 pub enum AdapterStream {
     ProtectedHttp(Box<ResolvedHttpRequest>),
     File(ResolvedFileMedia),
+}
+
+/// Internal distinction used to close raw adapter errors at the public
+/// regular-playlist registry boundary.
+pub enum CatalogueMediaResolveError {
+    Unavailable,
+    Backend(BackendError),
 }
 
 impl AdapterStream {
@@ -545,6 +553,7 @@ pub struct AcceptedSnapshot<S> {
     pub generation: u64,
     pub session_epoch: u64,
     pub value: Arc<S>,
+    authority: MediaLease,
 }
 
 /// Value selected from the newest accepted view that contributes it.
@@ -555,7 +564,46 @@ pub struct AcceptedSnapshot<S> {
 pub struct LatestAcceptedView<T> {
     pub generation: u64,
     pub session_epoch: u64,
+    pub(crate) authority: MediaLease,
     pub value: T,
+}
+
+/// Value selected from the one currently accepted source-wide catalogue.
+///
+/// The selector that creates this value runs while the lifecycle state is
+/// locked, so the value, catalogue generation, active session epoch, and
+/// source lease are observed atomically. The selected value must not retain
+/// the catalogue payload itself.
+pub struct CurrentAcceptedCatalogue<T> {
+    pub generation: u64,
+    pub session_epoch: u64,
+    pub authority: MediaLease,
+    pub value: T,
+}
+
+impl<S> AcceptedSnapshot<S> {
+    fn new(generation: u64, session_epoch: u64, value: S) -> Self {
+        Self {
+            generation,
+            session_epoch,
+            value: Arc::new(value),
+            authority: MediaLease::new(),
+        }
+    }
+
+    fn revoke(&self) {
+        self.authority.revoke();
+    }
+
+    pub(crate) fn map<T>(self, project: impl FnOnce(&S) -> T) -> AcceptedSnapshot<T> {
+        let value = project(self.value.as_ref());
+        AcceptedSnapshot {
+            generation: self.generation,
+            session_epoch: self.session_epoch,
+            value: Arc::new(value),
+            authority: self.authority,
+        }
+    }
 }
 
 impl<S> Clone for AcceptedSnapshot<S> {
@@ -564,6 +612,7 @@ impl<S> Clone for AcceptedSnapshot<S> {
             generation: self.generation,
             session_epoch: self.session_epoch,
             value: Arc::clone(&self.value),
+            authority: self.authority.clone(),
         }
     }
 }
@@ -679,6 +728,42 @@ impl<A: ?Sized, S> Entry<A, S> {
 
     fn session_epoch(&self) -> Option<u64> {
         self.active.as_ref().map(|session| session.epoch)
+    }
+
+    fn replace_catalogue(&mut self, accepted: AcceptedSnapshot<S>) {
+        if let Some(previous) = self.catalogue.as_ref() {
+            previous.revoke();
+        }
+        self.catalogue = Some(accepted);
+    }
+
+    fn replace_view(&mut self, view: ViewOrigin, accepted: AcceptedSnapshot<S>) {
+        if let Some(previous) = self.views.get(&view) {
+            previous.revoke();
+        }
+        self.views.insert(view, accepted);
+    }
+
+    fn remove_view(&mut self, view: &ViewOrigin) -> bool {
+        let Some(removed) = self.views.get(view) else {
+            return false;
+        };
+        removed.revoke();
+        self.views.remove(view);
+        true
+    }
+
+    fn revoke_snapshots(&mut self) -> bool {
+        let had_snapshots = self.catalogue.is_some() || !self.views.is_empty();
+        if let Some(catalogue) = self.catalogue.as_ref() {
+            catalogue.revoke();
+        }
+        for view in self.views.values() {
+            view.revoke();
+        }
+        self.catalogue = None;
+        self.views.clear();
+        had_snapshots
     }
 
     fn active_state(&self) -> SourceState {
@@ -955,8 +1040,7 @@ impl<A: LifecycleAdapter + ?Sized, S> RegistryInner<A, S> {
                     active.lease.revoke();
                     retirements.push((active.adapter, self.tracker.participate()));
                 }
-                entry.catalogue = None;
-                entry.views.clear();
+                entry.revoke_snapshots();
                 entry.failure = None;
                 entry.refresh_failures.clear();
                 entry.disconnect_retirement = None;
@@ -1044,6 +1128,9 @@ impl<A: LifecycleAdapter + ?Sized, S> RegistryInner<A, S> {
             return false;
         }
         self.publish_locked(state, source_id, LifecycleChange::Pruned);
+        if let Some(entry) = state.entries.get_mut(&source_id) {
+            entry.revoke_snapshots();
+        }
         state.entries.remove(&source_id);
         true
     }
@@ -1547,20 +1634,16 @@ impl<A: LifecycleAdapter + ?Sized, S> RegistryInner<A, S> {
         ) {
             return false;
         }
-        let accepted = AcceptedSnapshot {
-            generation,
-            session_epoch,
-            value: Arc::new(snapshot),
-        };
+        let accepted = AcceptedSnapshot::new(generation, session_epoch, snapshot);
         let entry = state
             .entries
             .get_mut(&source_id)
             .expect("current source exists");
         entry.refreshes.remove(lane);
         match lane {
-            RefreshLane::Catalogue => entry.catalogue = Some(accepted),
+            RefreshLane::Catalogue => entry.replace_catalogue(accepted),
             RefreshLane::View(view) => {
-                entry.views.insert(view.clone(), accepted);
+                entry.replace_view(view.clone(), accepted);
             }
         }
         self.set_refresh_failure_locked(
@@ -1905,11 +1988,14 @@ impl<A: LifecycleAdapter + ?Sized, S> SourceLifecycleRegistry<A, S> {
         entry
             .views
             .values()
-            .filter(|accepted| accepted.session_epoch == expected_session_epoch)
+            .filter(|accepted| {
+                accepted.session_epoch == expected_session_epoch && accepted.authority.is_active()
+            })
             .filter_map(|accepted| {
                 select(accepted.value.as_ref()).map(|value| LatestAcceptedView {
                     generation: accepted.generation,
                     session_epoch: accepted.session_epoch,
+                    authority: accepted.authority.clone(),
                     value,
                 })
             })
@@ -1931,6 +2017,72 @@ impl<A: LifecycleAdapter + ?Sized, S> SourceLifecycleRegistry<A, S> {
             .is_some_and(|accepted| accepted.generation == winner_generation)
     }
 
+    /// Select a bounded value from the currently accepted source-wide
+    /// catalogue and its exact active session in one locked observation.
+    ///
+    /// This deliberately does not inspect [`SourceState`]. A predecessor
+    /// catalogue remains authoritative while a replacement is connecting or
+    /// after that replacement fails. Conversely, a catalogue without its
+    /// exact active, unrevoked session is never selectable.
+    pub(crate) fn resolve_current_accepted_catalogue<T, Select>(
+        &self,
+        source_id: SourceId,
+        select: Select,
+    ) -> Option<CurrentAcceptedCatalogue<T>>
+    where
+        Select: FnOnce(&S) -> Option<T>,
+    {
+        let state = lock(&self.inner.state);
+        if state.gate != RegistryGate::Running {
+            return None;
+        }
+        let entry = state.entries.get(&source_id)?;
+        let active = entry.active.as_ref()?;
+        if !active.lease.is_active() {
+            return None;
+        }
+        let catalogue = entry.catalogue.as_ref()?;
+        if catalogue.session_epoch != active.epoch || !catalogue.authority.is_active() {
+            return None;
+        }
+        let value = select(catalogue.value.as_ref())?;
+        Some(CurrentAcceptedCatalogue {
+            generation: catalogue.generation,
+            session_epoch: catalogue.session_epoch,
+            authority: catalogue.authority.clone(),
+            value,
+        })
+    }
+
+    /// Select from one exact accepted catalogue identity.
+    pub(crate) fn resolve_exact_accepted_catalogue<T, Select>(
+        &self,
+        source_id: SourceId,
+        expected_generation: u64,
+        expected_session_epoch: u64,
+        select: Select,
+    ) -> Option<T>
+    where
+        Select: FnOnce(&S) -> Option<T>,
+    {
+        let state = lock(&self.inner.state);
+        if state.gate != RegistryGate::Running {
+            return None;
+        }
+        let entry = state.entries.get(&source_id)?;
+        let active = entry.active.as_ref()?;
+        let catalogue = entry.catalogue.as_ref()?;
+        if !active.lease.is_active()
+            || active.epoch != expected_session_epoch
+            || catalogue.session_epoch != expected_session_epoch
+            || catalogue.generation != expected_generation
+            || !catalogue.authority.is_active()
+        {
+            return None;
+        }
+        select(catalogue.value.as_ref())
+    }
+
     /// Validate one accepted catalogue identity without cloning its value.
     pub fn is_current_catalogue(
         &self,
@@ -1938,15 +2090,8 @@ impl<A: LifecycleAdapter + ?Sized, S> SourceLifecycleRegistry<A, S> {
         generation: u64,
         session_epoch: u64,
     ) -> bool {
-        let state = lock(&self.inner.state);
-        state.gate == RegistryGate::Running
-            && state
-                .entries
-                .get(&source_id)
-                .and_then(|entry| entry.catalogue.as_ref())
-                .is_some_and(|catalogue| {
-                    catalogue.generation == generation && catalogue.session_epoch == session_epoch
-                })
+        self.resolve_exact_accepted_catalogue(source_id, generation, session_epoch, |_| Some(()))
+            .is_some()
     }
 
     /// Atomically capture the global revision and every logical source.
@@ -1981,6 +2126,149 @@ impl<A: LifecycleAdapter + ?Sized, S> SourceLifecycleRegistry<A, S> {
             adapter: session.adapter.operational(),
             lease: session.lease.clone(),
         })
+    }
+
+    /// Resolve through one exact accepted catalogue and active adapter.
+    ///
+    /// The catalogue selector is checked while atomically capturing the
+    /// adapter, epoch, and session lease, then checked again after the async
+    /// adapter call. This is intentionally separate from exact-session media
+    /// resolution: a same-session catalogue replacement must revoke a
+    /// persisted playlist reference even though the adapter epoch is stable.
+    async fn resolve_exact_catalogue_session<R, T, Select, F, Fut>(
+        &self,
+        source_id: SourceId,
+        expected_generation: u64,
+        expected_session_epoch: u64,
+        select: Select,
+        resolve: F,
+    ) -> Result<(R, MediaLease, MediaLease, T), CatalogueMediaResolveError>
+    where
+        S: Send + Sync,
+        T: Send,
+        Select: Fn(&S) -> Option<T> + Send + Sync,
+        F: FnOnce(Arc<A>) -> Fut + Send,
+        Fut: Future<Output = BackendResult<R>> + Send,
+    {
+        let (session, catalogue_authority, selected) = {
+            let state = lock(&self.inner.state);
+            if state.gate != RegistryGate::Running {
+                return Err(CatalogueMediaResolveError::Unavailable);
+            }
+            let Some(entry) = state.entries.get(&source_id) else {
+                return Err(CatalogueMediaResolveError::Unavailable);
+            };
+            let Some(active) = entry.active.as_ref() else {
+                return Err(CatalogueMediaResolveError::Unavailable);
+            };
+            let Some(catalogue) = entry.catalogue.as_ref() else {
+                return Err(CatalogueMediaResolveError::Unavailable);
+            };
+            if !active.lease.is_active()
+                || active.epoch != expected_session_epoch
+                || catalogue.session_epoch != expected_session_epoch
+                || catalogue.generation != expected_generation
+                || !catalogue.authority.is_active()
+            {
+                return Err(CatalogueMediaResolveError::Unavailable);
+            }
+            let selected =
+                select(catalogue.value.as_ref()).ok_or(CatalogueMediaResolveError::Unavailable)?;
+            (
+                SessionHandle {
+                    session_epoch: active.epoch,
+                    adapter: active.adapter.operational(),
+                    lease: active.lease.clone(),
+                },
+                catalogue.authority.clone(),
+                selected,
+            )
+        };
+
+        let lease = session.lease.clone();
+        let resolved = resolve(session.adapter)
+            .await
+            .map_err(CatalogueMediaResolveError::Backend)?;
+        let state = lock(&self.inner.state);
+        let remains_current = state.gate == RegistryGate::Running
+            && lease.is_active()
+            && catalogue_authority.is_active()
+            && state.entries.get(&source_id).is_some_and(|entry| {
+                entry.active.as_ref().is_some_and(|active| {
+                    active.epoch == expected_session_epoch && active.lease.is_active()
+                }) && entry.catalogue.as_ref().is_some_and(|catalogue| {
+                    catalogue.generation == expected_generation
+                        && catalogue.session_epoch == expected_session_epoch
+                        && catalogue.authority.is_active()
+                        && select(catalogue.value.as_ref()).is_some()
+                })
+            });
+        drop(state);
+        if !remains_current {
+            return Err(CatalogueMediaResolveError::Unavailable);
+        }
+        Ok((resolved, lease, catalogue_authority, selected))
+    }
+
+    /// Resolve one stream through exact catalogue membership and attach the
+    /// captured session lease before returning it with the selector value.
+    pub(crate) async fn resolve_catalogue_stream<T, Select, F, Fut>(
+        &self,
+        source_id: SourceId,
+        expected_generation: u64,
+        expected_session_epoch: u64,
+        select: Select,
+        resolve: F,
+    ) -> Result<(AdapterStream, MediaLease, T), CatalogueMediaResolveError>
+    where
+        S: Send + Sync,
+        T: Send,
+        Select: Fn(&S) -> Option<T> + Send + Sync,
+        F: FnOnce(Arc<A>) -> Fut + Send,
+        Fut: Future<Output = BackendResult<AdapterStream>> + Send,
+    {
+        let (stream, lease, catalogue_authority, selected) = self
+            .resolve_exact_catalogue_session(
+                source_id,
+                expected_generation,
+                expected_session_epoch,
+                select,
+                resolve,
+            )
+            .await?;
+        Ok((stream.with_lease(lease), catalogue_authority, selected))
+    }
+
+    /// Optional-artwork counterpart of [`Self::resolve_catalogue_stream`].
+    pub(crate) async fn resolve_catalogue_optional_http<T, Select, F, Fut>(
+        &self,
+        source_id: SourceId,
+        expected_generation: u64,
+        expected_session_epoch: u64,
+        select: Select,
+        resolve: F,
+    ) -> Result<(Option<ResolvedHttpRequest>, MediaLease, T), CatalogueMediaResolveError>
+    where
+        S: Send + Sync,
+        T: Send,
+        Select: Fn(&S) -> Option<T> + Send + Sync,
+        F: FnOnce(Arc<A>) -> Fut + Send,
+        Fut: Future<Output = BackendResult<Option<ResolvedHttpRequest>>> + Send,
+    {
+        let (request, lease, catalogue_authority, selected) = self
+            .resolve_exact_catalogue_session(
+                source_id,
+                expected_generation,
+                expected_session_epoch,
+                select,
+                resolve,
+            )
+            .await?;
+        Ok((
+            request.map(|request| request.with_lease(lease)),
+            catalogue_authority,
+            selected,
+        ))
     }
 
     /// Resolve an adapter-owned capability through one exact session and
@@ -2390,7 +2678,7 @@ impl<A: LifecycleAdapter + ?Sized, S> SourceLifecycleRegistry<A, S> {
             return false;
         };
         let pending = entry.refreshes.remove(&lane);
-        let removed_snapshot = entry.views.remove(view).is_some();
+        let removed_snapshot = entry.remove_view(view);
         let removed_failure = entry.refresh_failures.get(&lane).copied();
         let had_pending = pending.is_some();
         if let Some(operation) = pending {
@@ -2564,9 +2852,7 @@ impl<A: LifecycleAdapter + ?Sized, S> SourceLifecycleRegistry<A, S> {
             RegistryInner::<A, S>::cancel_pending(refresh);
         }
         let active = entry.active.take();
-        let had_snapshots = entry.catalogue.is_some() || !entry.views.is_empty();
-        entry.catalogue = None;
-        entry.views.clear();
+        let had_snapshots = entry.revoke_snapshots();
         let session_failure = entry.failure;
         let refresh_failure_lanes: Vec<_> = entry
             .refresh_failures
@@ -2688,15 +2974,13 @@ impl<A: LifecycleAdapter + ?Sized, S> SourceLifecycleRegistry<A, S> {
                 for refresh in entry.refreshes.drain().map(|(_, operation)| operation) {
                     RegistryInner::<A, S>::cancel_pending(refresh);
                 }
-                let had_snapshots = entry.catalogue.is_some() || !entry.views.is_empty();
+                let had_snapshots = entry.revoke_snapshots();
                 let session_failure = entry.failure;
                 let refresh_failure_lanes: Vec<_> = entry
                     .refresh_failures
                     .iter()
                     .map(|(lane, failure)| (lane.clone(), failure.correlation))
                     .collect();
-                entry.catalogue = None;
-                entry.views.clear();
                 (
                     entry.active.take(),
                     entry.disconnect_retirement.is_some(),
@@ -2911,24 +3195,26 @@ impl<A: LifecycleAdapter + ?Sized, S> ConnectOwner<A, S> {
                 RegistryInner::<A, S>::cancel_pending(refresh);
             }
             let replaced_epoch = predecessor.as_ref().map(|session| session.epoch);
+            if let Some(predecessor) = predecessor.as_ref() {
+                // Lock-free consumers must lose predecessor authority before
+                // any successor state is installed. Retirement repeats this
+                // idempotent revocation when it takes close ownership.
+                predecessor.lease.revoke();
+            }
             let lease = MediaLease::new();
-            let accepted_snapshot = AcceptedSnapshot {
-                generation: self.generation,
-                session_epoch,
-                value: Arc::new(snapshot),
-            };
+            let accepted_snapshot = AcceptedSnapshot::new(self.generation, session_epoch, snapshot);
             {
                 let entry = state
                     .entries
                     .get_mut(&self.source_id)
                     .expect("accepted source exists");
+                entry.revoke_snapshots();
                 entry.active = Some(ActiveSession {
                     epoch: session_epoch,
                     adapter,
                     lease: lease.clone(),
                 });
                 entry.catalogue = Some(accepted_snapshot);
-                entry.views.clear();
             }
             if let Some(predecessor) = predecessor {
                 jobs.push(self.inner.prepare_retirement_locked(
@@ -5196,6 +5482,246 @@ mod tests {
         predecessor.allow_close();
         predecessor.probe.wait_for_completions(1).await;
         shutdown_immediate(&registry).await;
+    }
+
+    #[tokio::test]
+    async fn accepted_catalogue_selector_preserves_predecessor_and_rejects_exact_staleness() {
+        let registry = registry();
+        let source_id = SourceId::random();
+        claim(&registry, source_id, SourceProvenance::Saved);
+        let mut predecessor = AdapterFixture::immediate();
+        let (epoch, _) = adopt(&registry, source_id, &mut predecessor, vec!["predecessor"]);
+        let initial = registry
+            .resolve_current_accepted_catalogue(source_id, |catalogue| catalogue.first().copied())
+            .expect("accepted predecessor catalogue");
+        assert_eq!(initial.session_epoch, epoch);
+        assert_eq!(initial.value, "predecessor");
+        assert!(initial.authority.is_active());
+
+        let replacement = registry
+            .begin_connect(source_id)
+            .expect("replacement pending");
+        let during_connect = registry
+            .resolve_current_accepted_catalogue(source_id, |catalogue| catalogue.first().copied())
+            .expect("predecessor remains accepted while connecting");
+        assert_eq!(during_connect.generation, initial.generation);
+        assert!(replacement.fail(FailureCategory::Timeout));
+        assert_eq!(
+            registry
+                .resolve_current_accepted_catalogue(source_id, |catalogue| {
+                    catalogue.first().copied()
+                })
+                .expect("failed replacement preserves predecessor")
+                .generation,
+            initial.generation
+        );
+
+        let stale_selector_calls = Arc::new(AtomicUsize::new(0));
+        let calls = Arc::clone(&stale_selector_calls);
+        assert!(registry
+            .resolve_exact_accepted_catalogue(
+                source_id,
+                initial.generation.wrapping_add(1),
+                epoch,
+                move |_| {
+                    calls.fetch_add(1, Ordering::AcqRel);
+                    Some(())
+                },
+            )
+            .is_none());
+        assert_eq!(stale_selector_calls.load(Ordering::Acquire), 0);
+
+        let refresh = registry
+            .begin_refresh(source_id, RefreshLane::Catalogue)
+            .expect("catalogue refresh");
+        let refreshed_generation = refresh.generation();
+        assert!(refresh.submit(vec!["refreshed"]));
+        assert!(!initial.authority.is_active());
+        assert!(registry
+            .resolve_exact_accepted_catalogue(source_id, initial.generation, epoch, |_| Some(()),)
+            .is_none());
+        assert_eq!(
+            registry
+                .resolve_current_accepted_catalogue(source_id, |catalogue| {
+                    catalogue.first().copied()
+                })
+                .expect("refreshed catalogue")
+                .generation,
+            refreshed_generation
+        );
+        shutdown_immediate(&registry).await;
+    }
+
+    #[tokio::test]
+    async fn accepted_snapshot_authority_revokes_while_parked_clone_remains_alive() {
+        let registry = registry();
+        let source_id = SourceId::random();
+        claim(&registry, source_id, SourceProvenance::Saved);
+        let mut adapter = AdapterFixture::immediate();
+        adopt(&registry, source_id, &mut adapter, vec!["initial"]);
+
+        let parked_refresh = registry
+            .snapshot(source_id)
+            .and_then(|snapshot| snapshot.catalogue)
+            .expect("parked accepted snapshot");
+        assert!(parked_refresh.authority.is_active());
+        let refresh = registry
+            .begin_refresh(source_id, RefreshLane::Catalogue)
+            .expect("refresh");
+        assert!(refresh.submit(vec!["replacement"]));
+        assert!(
+            !parked_refresh.authority.is_active(),
+            "replacement revokes authority independently of payload Arc lifetime"
+        );
+        assert_eq!(parked_refresh.value.as_slice(), &["initial"]);
+
+        let parked_disconnect = registry
+            .snapshot(source_id)
+            .and_then(|snapshot| snapshot.catalogue)
+            .expect("parked replacement snapshot");
+        assert!(parked_disconnect.authority.is_active());
+        let waiter = registry.disconnect(source_id).expect("disconnect");
+        assert!(
+            !parked_disconnect.authority.is_active(),
+            "disconnect revokes authority synchronously while clone is parked"
+        );
+        waiter.wait().await;
+        assert!(registry.shutdown().is_complete());
+    }
+
+    #[tokio::test]
+    async fn guarded_catalogue_resolution_closes_pre_call_and_in_flight_refresh_races() {
+        let registry = registry();
+        let source_id = SourceId::random();
+        claim(&registry, source_id, SourceProvenance::Saved);
+        let mut adapter = AdapterFixture::immediate();
+        let (epoch, _) = adopt(&registry, source_id, &mut adapter, vec!["track"]);
+        let generation = registry
+            .snapshot(source_id)
+            .and_then(|snapshot| snapshot.catalogue)
+            .expect("catalogue")
+            .generation;
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let stale_calls = Arc::clone(&calls);
+        assert!(registry
+            .resolve_catalogue_stream(
+                source_id,
+                generation.wrapping_add(1),
+                epoch,
+                |_| Some(()),
+                move |_| async move {
+                    stale_calls.fetch_add(1, Ordering::AcqRel);
+                    Ok(AdapterStream::ProtectedHttp(Box::new(
+                        ResolvedHttpRequest::new(
+                            url::Url::parse("http://example.test/stale").expect("URL"),
+                        )?,
+                    )))
+                },
+            )
+            .await
+            .is_err());
+        assert_eq!(calls.load(Ordering::Acquire), 0);
+
+        let missing_calls = Arc::clone(&calls);
+        assert!(registry
+            .resolve_catalogue_optional_http(
+                source_id,
+                generation,
+                epoch,
+                |_| None::<()>,
+                move |_| async move {
+                    missing_calls.fetch_add(1, Ordering::AcqRel);
+                    Ok(None)
+                },
+            )
+            .await
+            .is_err());
+        assert_eq!(calls.load(Ordering::Acquire), 0);
+
+        let delayed_registry = registry.clone();
+        let (started, started_rx) = oneshot::channel();
+        let (release, release_rx) = oneshot::channel();
+        let delayed = tokio::spawn(async move {
+            delayed_registry
+                .resolve_catalogue_stream(
+                    source_id,
+                    generation,
+                    epoch,
+                    |catalogue| catalogue.contains(&"track").then_some(()),
+                    move |_| async move {
+                        let _ = started.send(());
+                        let _ = release_rx.await;
+                        Ok(AdapterStream::ProtectedHttp(Box::new(
+                            ResolvedHttpRequest::new(
+                                url::Url::parse("http://example.test/delayed").expect("URL"),
+                            )?,
+                        )))
+                    },
+                )
+                .await
+        });
+        started_rx.await.expect("resolver entered");
+        let refresh = registry
+            .begin_refresh(source_id, RefreshLane::Catalogue)
+            .expect("same-session refresh");
+        assert!(refresh.submit(vec!["other"]));
+        release.send(()).expect("release resolver");
+        assert!(delayed.await.expect("resolution task").is_err());
+
+        let after_stream_refresh = registry
+            .snapshot(source_id)
+            .and_then(|snapshot| snapshot.catalogue)
+            .expect("refreshed catalogue");
+        let delayed_registry = registry.clone();
+        let (art_started, art_started_rx) = oneshot::channel();
+        let (release_art, release_art_rx) = oneshot::channel();
+        let delayed_art = tokio::spawn(async move {
+            delayed_registry
+                .resolve_catalogue_optional_http(
+                    source_id,
+                    after_stream_refresh.generation,
+                    epoch,
+                    |catalogue| catalogue.contains(&"other").then_some(()),
+                    move |_| async move {
+                        let _ = art_started.send(());
+                        let _ = release_art_rx.await;
+                        Ok(Some(ResolvedHttpRequest::new(
+                            url::Url::parse("http://example.test/delayed-art").expect("URL"),
+                        )?))
+                    },
+                )
+                .await
+        });
+        art_started_rx.await.expect("artwork resolver entered");
+        let refresh = registry
+            .begin_refresh(source_id, RefreshLane::Catalogue)
+            .expect("artwork-racing refresh");
+        assert!(refresh.submit(vec!["third"]));
+        release_art.send(()).expect("release artwork resolver");
+        assert!(delayed_art.await.expect("artwork task").is_err());
+
+        let refreshed = registry
+            .snapshot(source_id)
+            .and_then(|snapshot| snapshot.catalogue)
+            .expect("twice-refreshed catalogue");
+        let resolved = registry
+            .resolve_catalogue_optional_http(
+                source_id,
+                refreshed.generation,
+                epoch,
+                |catalogue| catalogue.contains(&"third").then_some("selected"),
+                |_| async { Ok(None) },
+            )
+            .await;
+        let Ok((none, authority, selected)) = resolved else {
+            panic!("authorized absent artwork must resolve");
+        };
+        assert!(none.is_none());
+        assert!(authority.is_active());
+        assert_eq!(selected, "selected");
+        shutdown_immediate(&registry).await;
+        assert!(!authority.is_active());
     }
 
     #[tokio::test]

--- a/src/source_registry.rs
+++ b/src/source_registry.rs
@@ -21,11 +21,11 @@ use crate::architecture::backend::{
 };
 use crate::architecture::error::BackendError;
 use crate::architecture::media::{
-    MediaLease, MediaRequest, PublicHttpAuthority, PublicHttpEndpoint, RemoteMediaResolver,
+    MediaRequest, PublicHttpAuthority, PublicHttpEndpoint, RemoteMediaResolver,
     ResolvedHttpRequest, ResolvedPublicHttpRequest,
 };
 use crate::architecture::models::{RatingCapability, Track};
-use crate::architecture::{SourceId, TrackId, ViewOrigin};
+use crate::architecture::{MediaKey, SourceId, TrackId, ViewOrigin};
 use crate::external_file::{ExternalFileCandidate, ExternalFileHint};
 use crate::local::resolver::ResolvedFileMedia;
 use crate::source_lifecycle::{
@@ -52,6 +52,262 @@ type ArtworkFuture =
 pub enum ResolvedSourceStream {
     Http(MediaRequest),
     File(ResolvedFileMedia),
+}
+
+/// Whether one managed adapter permits Tributary-owned regular-playlist
+/// membership over its accepted source-wide catalogue.
+///
+/// This capability does not represent server-native playlist synchronization
+/// and is never sufficient authority by itself. Registry operations also
+/// require an exact active catalogue, session, generation, and track identity.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum RegularPlaylistCapability {
+    #[default]
+    Unsupported,
+    SourceScopedEntries,
+}
+
+/// Transient identity of one exact accepted catalogue.
+///
+/// Guards are minted only by a successful registry lookup and must never be
+/// persisted. A session replacement changes `session_epoch`; a same-session
+/// catalogue replacement changes `catalogue_generation`.
+// Record A intentionally lands this authority surface before Record B wires UI consumers.
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RegularPlaylistCatalogueGuard {
+    source_id: SourceId,
+    session_epoch: u64,
+    catalogue_generation: u64,
+}
+
+#[allow(dead_code)]
+impl RegularPlaylistCatalogueGuard {
+    pub const fn source_id(self) -> SourceId {
+        self.source_id
+    }
+
+    pub const fn session_epoch(self) -> u64 {
+        self.session_epoch
+    }
+
+    pub const fn catalogue_generation(self) -> u64 {
+        self.catalogue_generation
+    }
+}
+
+/// Fixed, non-sensitive reason that a persisted source-scoped identity cannot
+/// currently be projected from a regular playlist.
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RegularPlaylistUnavailableReason {
+    SourceUnavailable,
+    UnsupportedSource,
+    InvalidCatalogue,
+    TrackMissing,
+}
+
+/// Closed failure returned by guarded regular-playlist media resolution.
+/// Raw adapter errors, URLs, credentials, and native IDs never cross this
+/// boundary.
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum RegularPlaylistMediaError {
+    #[error("regular playlist media authority is unavailable")]
+    Unavailable,
+    #[error("regular playlist media backend failed")]
+    BackendFailure(FailureCategory),
+}
+
+/// One available regular-playlist track resolved from an exact live catalogue.
+#[allow(dead_code)]
+#[derive(Clone)]
+pub struct RegularPlaylistTrack {
+    media_key: MediaKey,
+    guard: RegularPlaylistCatalogueGuard,
+    metadata: RegularPlaylistTrackMetadata,
+}
+
+#[allow(dead_code)]
+impl RegularPlaylistTrack {
+    pub fn media_key(&self) -> &MediaKey {
+        &self.media_key
+    }
+
+    pub const fn guard(&self) -> RegularPlaylistCatalogueGuard {
+        self.guard
+    }
+
+    pub fn metadata(&self) -> &RegularPlaylistTrackMetadata {
+        &self.metadata
+    }
+}
+
+/// Whitelisted display, sorting, rating, and history metadata for a regular
+/// playlist row.
+///
+/// This is deliberately not a `Track` clone. Adding a new field to `Track`
+/// cannot silently expose a locator, credential, or future private adapter
+/// detail across the playlist authority boundary.
+#[allow(dead_code)]
+#[derive(Clone, Debug, PartialEq)]
+pub struct RegularPlaylistTrackMetadata {
+    title: String,
+    artist_name: String,
+    album_artist_name: Option<String>,
+    album_title: String,
+    track_number: Option<u32>,
+    disc_number: Option<u32>,
+    duration_secs: Option<u64>,
+    composer: Option<String>,
+    genre: Option<String>,
+    year: Option<i32>,
+    date_added: Option<chrono::DateTime<chrono::Utc>>,
+    date_modified: Option<chrono::DateTime<chrono::Utc>>,
+    bitrate_kbps: Option<u32>,
+    sample_rate_hz: Option<u32>,
+    format: Option<String>,
+    play_count: Option<u32>,
+    rating: crate::architecture::models::TrackRating,
+    last_played: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+#[allow(dead_code)]
+impl RegularPlaylistTrackMetadata {
+    fn from_track(track: &Track) -> Self {
+        Self {
+            title: track.title.clone(),
+            artist_name: track.artist_name.clone(),
+            album_artist_name: track.album_artist_name.clone(),
+            album_title: track.album_title.clone(),
+            track_number: track.track_number,
+            disc_number: track.disc_number,
+            duration_secs: track.duration_secs,
+            composer: track.composer.clone(),
+            genre: track.genre.clone(),
+            year: track.year,
+            date_added: track.date_added,
+            date_modified: track.date_modified,
+            bitrate_kbps: track.bitrate_kbps,
+            sample_rate_hz: track.sample_rate_hz,
+            format: track.format.clone(),
+            play_count: track.play_count,
+            rating: track.rating,
+            last_played: track.last_played,
+        }
+    }
+
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+
+    pub fn artist_name(&self) -> &str {
+        &self.artist_name
+    }
+
+    pub fn album_artist_name(&self) -> Option<&str> {
+        self.album_artist_name.as_deref()
+    }
+
+    pub fn album_title(&self) -> &str {
+        &self.album_title
+    }
+
+    pub const fn track_number(&self) -> Option<u32> {
+        self.track_number
+    }
+
+    pub const fn disc_number(&self) -> Option<u32> {
+        self.disc_number
+    }
+
+    pub const fn duration_secs(&self) -> Option<u64> {
+        self.duration_secs
+    }
+
+    pub fn composer(&self) -> Option<&str> {
+        self.composer.as_deref()
+    }
+
+    pub fn genre(&self) -> Option<&str> {
+        self.genre.as_deref()
+    }
+
+    pub const fn year(&self) -> Option<i32> {
+        self.year
+    }
+
+    pub fn date_added(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+        self.date_added
+    }
+
+    pub fn date_modified(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+        self.date_modified
+    }
+
+    pub const fn bitrate_kbps(&self) -> Option<u32> {
+        self.bitrate_kbps
+    }
+
+    pub const fn sample_rate_hz(&self) -> Option<u32> {
+        self.sample_rate_hz
+    }
+
+    pub fn format(&self) -> Option<&str> {
+        self.format.as_deref()
+    }
+
+    pub const fn play_count(&self) -> Option<u32> {
+        self.play_count
+    }
+
+    pub const fn rating(&self) -> crate::architecture::models::TrackRating {
+        self.rating
+    }
+
+    pub fn last_played(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+        self.last_played
+    }
+}
+
+/// One unavailable regular-playlist identity. Its optional private guard lets
+/// the registry distinguish a still-current missing/unsupported catalogue
+/// observation from a replacement without exposing lifecycle internals.
+#[allow(dead_code)]
+#[derive(Clone)]
+pub struct RegularPlaylistUnavailable {
+    media_key: MediaKey,
+    reason: RegularPlaylistUnavailableReason,
+    observed_guard: Option<RegularPlaylistCatalogueGuard>,
+}
+
+#[allow(dead_code)]
+impl RegularPlaylistUnavailable {
+    pub fn media_key(&self) -> &MediaKey {
+        &self.media_key
+    }
+
+    pub const fn reason(&self) -> RegularPlaylistUnavailableReason {
+        self.reason
+    }
+}
+
+/// Ordered result of resolving one persisted source-scoped playlist identity.
+#[allow(dead_code)]
+#[derive(Clone)]
+pub enum RegularPlaylistTrackResolution {
+    Available(Box<RegularPlaylistTrack>),
+    Unavailable(RegularPlaylistUnavailable),
+}
+
+#[allow(dead_code)]
+impl RegularPlaylistTrackResolution {
+    pub fn media_key(&self) -> &MediaKey {
+        match self {
+            Self::Available(track) => track.media_key(),
+            Self::Unavailable(track) => track.media_key(),
+        }
+    }
 }
 
 impl ResolvedSourceStream {
@@ -143,13 +399,6 @@ impl AcceptedView {
         })
     }
 
-    fn catalogue(tracks: Vec<Track>) -> Self {
-        Self {
-            tracks: Arc::new(tracks),
-            public_streams: HashMap::new(),
-        }
-    }
-
     fn published(tracks: Arc<Vec<Track>>) -> Self {
         Self {
             tracks,
@@ -177,7 +426,18 @@ pub enum ViewLoadResult {
 struct AcceptedSourcePayload {
     tracks: Arc<Vec<Track>>,
     public_streams: HashMap<TrackId, PublicHttpEndpoint>,
-    view_lease: MediaLease,
+    #[allow(dead_code)]
+    regular_playlist_capability: RegularPlaylistCapability,
+    #[allow(dead_code)]
+    regular_playlist_index: RegularPlaylistTrackIndex,
+}
+
+#[allow(dead_code)]
+#[derive(Clone)]
+enum RegularPlaylistTrackIndex {
+    Unsupported,
+    Invalid,
+    Exact(Arc<HashMap<TrackId, usize>>),
 }
 
 impl AcceptedSourcePayload {
@@ -185,27 +445,64 @@ impl AcceptedSourcePayload {
         Self {
             tracks: view.tracks,
             public_streams: view.public_streams,
-            view_lease: MediaLease::new(),
+            regular_playlist_capability: RegularPlaylistCapability::Unsupported,
+            regular_playlist_index: RegularPlaylistTrackIndex::Unsupported,
         }
     }
 
-    fn catalogue(tracks: Vec<Track>) -> Self {
-        Self::from_view(AcceptedView::catalogue(tracks))
+    fn catalogue(tracks: Vec<Track>, capability: RegularPlaylistCapability) -> Self {
+        let regular_playlist_index = match capability {
+            RegularPlaylistCapability::Unsupported => RegularPlaylistTrackIndex::Unsupported,
+            RegularPlaylistCapability::SourceScopedEntries => {
+                let mut exact = HashMap::with_capacity(tracks.len());
+                let valid = tracks.iter().enumerate().all(|(index, track)| {
+                    track
+                        .native_track_id
+                        .as_ref()
+                        .is_some_and(|track_id| exact.insert(track_id.clone(), index).is_none())
+                });
+                if valid {
+                    RegularPlaylistTrackIndex::Exact(Arc::new(exact))
+                } else {
+                    RegularPlaylistTrackIndex::Invalid
+                }
+            }
+        };
+        Self {
+            tracks: Arc::new(tracks),
+            public_streams: HashMap::new(),
+            regular_playlist_capability: capability,
+            regular_playlist_index,
+        }
     }
 
     fn published(&self) -> AcceptedView {
         AcceptedView::published(Arc::clone(&self.tracks))
     }
-}
 
-impl Drop for AcceptedSourcePayload {
-    fn drop(&mut self) {
-        self.view_lease.revoke();
+    #[allow(dead_code)]
+    fn regular_playlist_track(&self, track_id: &TrackId) -> Option<&Track> {
+        if self.regular_playlist_capability != RegularPlaylistCapability::SourceScopedEntries {
+            return None;
+        }
+        let RegularPlaylistTrackIndex::Exact(index) = &self.regular_playlist_index else {
+            return None;
+        };
+        index
+            .get(track_id)
+            .and_then(|index| self.tracks.get(*index))
     }
 }
 
 /// Heterogeneous operational contract stored by one lifecycle registry.
 pub trait ManagedSourceAdapter: LifecycleAdapter + Send + Sync {
+    /// Explicit opt-in for Tributary-owned source-scoped regular playlists.
+    /// Future adapters remain denied until their accepted catalogue and media
+    /// resolver satisfy the same exact-ID authority contract.
+    fn regular_playlist_capability(&self) -> RegularPlaylistCapability {
+        RegularPlaylistCapability::Unsupported
+    }
+
     /// Load the first complete catalogue after construction is staged.
     fn load_initial_catalogue(self: Arc<Self>) -> CatalogueFuture;
 
@@ -231,8 +528,19 @@ pub trait ManagedSourceAdapter: LifecycleAdapter + Send + Sync {
     }
 }
 
+mod source_scoped_playlist_sealed {
+    pub trait Adapter {}
+}
+
+fn source_scoped_playlist_capability<A>() -> RegularPlaylistCapability
+where
+    A: source_scoped_playlist_sealed::Adapter,
+{
+    RegularPlaylistCapability::SourceScopedEntries
+}
+
 macro_rules! standard_remote_adapter {
-    ($adapter:ty) => {
+    ($adapter:ty, $regular_playlist_capability:expr) => {
         impl LifecycleAdapter for $adapter {
             fn close(self: Arc<Self>, _authority: CloseAuthority) -> AdapterCloseFuture {
                 Box::pin(async { Ok(()) })
@@ -240,6 +548,10 @@ macro_rules! standard_remote_adapter {
         }
 
         impl ManagedSourceAdapter for $adapter {
+            fn regular_playlist_capability(&self) -> RegularPlaylistCapability {
+                $regular_playlist_capability
+            }
+
             fn load_initial_catalogue(self: Arc<Self>) -> CatalogueFuture {
                 Box::pin(
                     async move { crate::architecture::load_track_catalog(self.as_ref()).await },
@@ -263,12 +575,20 @@ macro_rules! standard_remote_adapter {
     };
 }
 
-standard_remote_adapter!(crate::subsonic::SubsonicBackend);
+impl source_scoped_playlist_sealed::Adapter for crate::subsonic::SubsonicBackend {}
+standard_remote_adapter!(
+    crate::subsonic::SubsonicBackend,
+    source_scoped_playlist_capability::<crate::subsonic::SubsonicBackend>()
+);
 // Plex's legacy auth token is a durable credential, not a revocable server
 // session: its documented revocation mechanisms are account/device-wide, so
 // Tributary has no safe per-adapter close authority. Constructors may therefore
 // be aborted, while disconnect only revokes local media/session authority.
-standard_remote_adapter!(crate::plex::PlexBackend);
+impl source_scoped_playlist_sealed::Adapter for crate::plex::PlexBackend {}
+standard_remote_adapter!(
+    crate::plex::PlexBackend,
+    source_scoped_playlist_capability::<crate::plex::PlexBackend>()
+);
 
 impl LifecycleAdapter for crate::jellyfin::JellyfinBackend {
     fn close(self: Arc<Self>, _authority: CloseAuthority) -> AdapterCloseFuture {
@@ -281,6 +601,10 @@ impl LifecycleAdapter for crate::jellyfin::JellyfinBackend {
 }
 
 impl ManagedSourceAdapter for crate::jellyfin::JellyfinBackend {
+    fn regular_playlist_capability(&self) -> RegularPlaylistCapability {
+        source_scoped_playlist_capability::<Self>()
+    }
+
     fn load_initial_catalogue(self: Arc<Self>) -> CatalogueFuture {
         Box::pin(async move {
             self.ensure_initialized().await?;
@@ -302,6 +626,8 @@ impl ManagedSourceAdapter for crate::jellyfin::JellyfinBackend {
         )
     }
 }
+
+impl source_scoped_playlist_sealed::Adapter for crate::jellyfin::JellyfinBackend {}
 
 mod sealed {
     pub trait AbortableSourceAdapter {}
@@ -334,6 +660,10 @@ fn validate_daap_initial_catalogue(
 }
 
 impl ManagedSourceAdapter for crate::daap::DaapBackend {
+    fn regular_playlist_capability(&self) -> RegularPlaylistCapability {
+        source_scoped_playlist_capability::<Self>()
+    }
+
     fn load_initial_catalogue(self: Arc<Self>) -> CatalogueFuture {
         Box::pin(async move {
             let tracks = self.load_catalogue().await?;
@@ -355,6 +685,8 @@ impl ManagedSourceAdapter for crate::daap::DaapBackend {
         )
     }
 }
+
+impl source_scoped_playlist_sealed::Adapter for crate::daap::DaapBackend {}
 
 struct BuiltInInstallation {
     _claim_id: ProvenanceClaimId,
@@ -524,6 +856,7 @@ impl SourceRegistry {
         let source_id = adapter.source_id();
         let track_id = adapter.track_id().clone();
         let track = adapter.track().clone();
+        let regular_playlist_capability = adapter.regular_playlist_capability();
         #[cfg(test)]
         let close_probe = adapter.close_probe();
         let claim_id = self
@@ -534,7 +867,7 @@ impl SourceRegistry {
         let adopted = self.inner.lifecycle.adopt_stateless_session(
             source_id,
             Box::new(adapter),
-            AcceptedSourcePayload::catalogue(vec![track.clone()]),
+            AcceptedSourcePayload::catalogue(vec![track.clone()], regular_playlist_capability),
         );
         let Some((_, session_epoch)) = adopted else {
             let _ = self.inner.lifecycle.release_provenance(source_id, claim_id);
@@ -769,10 +1102,12 @@ impl SourceRegistry {
                 if cancellation.is_cancelled() {
                     return RefreshTaskResult::Cancelled;
                 }
+                let regular_playlist_capability = adapter.regular_playlist_capability();
                 match adapter.load_initial_catalogue().await {
-                    Ok(tracks) => {
-                        RefreshTaskResult::Refreshed(AcceptedSourcePayload::catalogue(tracks))
-                    }
+                    Ok(tracks) => RefreshTaskResult::Refreshed(AcceptedSourcePayload::catalogue(
+                        tracks,
+                        regular_playlist_capability,
+                    )),
                     Err(error) => RefreshTaskResult::Failed(failure_category(&error)),
                 }
             },
@@ -814,10 +1149,12 @@ impl SourceRegistry {
                 if cancellation.is_cancelled() {
                     return RefreshTaskResult::Cancelled;
                 }
+                let regular_playlist_capability = adapter.regular_playlist_capability();
                 match adapter.load_initial_catalogue().await {
-                    Ok(tracks) => {
-                        RefreshTaskResult::Refreshed(AcceptedSourcePayload::catalogue(tracks))
-                    }
+                    Ok(tracks) => RefreshTaskResult::Refreshed(AcceptedSourcePayload::catalogue(
+                        tracks,
+                        regular_playlist_capability,
+                    )),
                     Err(error) => RefreshTaskResult::Failed(failure_category(&error)),
                 }
             },
@@ -878,10 +1215,11 @@ impl SourceRegistry {
                 return None;
             }
         };
+        let regular_playlist_capability = adapter.regular_playlist_capability();
         let (_, session_epoch) = self.inner.lifecycle.adopt_stateless_session(
             source_id,
             adapter,
-            AcceptedSourcePayload::catalogue(Vec::new()),
+            AcceptedSourcePayload::catalogue(Vec::new(), regular_playlist_capability),
         )?;
         installation.session_epoch = Some(session_epoch);
         Some(session_epoch)
@@ -962,6 +1300,204 @@ impl SourceRegistry {
         }
     }
 
+    /// Resolve persisted source-scoped identities in their input order.
+    ///
+    /// Every requested occurrence receives exactly one result. Sources are
+    /// observed independently under the lifecycle lock, while metadata copies
+    /// and ordering work happen outside it. Similar metadata, another source's
+    /// matching native ID, and endpoint identity are never considered.
+    #[allow(dead_code)]
+    pub fn resolve_regular_playlist_tracks(
+        &self,
+        media_keys: &[MediaKey],
+    ) -> Vec<RegularPlaylistTrackResolution> {
+        let mut by_source: HashMap<SourceId, Vec<(usize, TrackId)>> = HashMap::new();
+        for (position, media_key) in media_keys.iter().enumerate() {
+            by_source
+                .entry(media_key.source_id)
+                .or_default()
+                .push((position, media_key.track_id.clone()));
+        }
+
+        let mut results: Vec<Option<RegularPlaylistTrackResolution>> =
+            std::iter::repeat_with(|| None)
+                .take(media_keys.len())
+                .collect();
+        for (source_id, occurrences) in by_source {
+            let accepted =
+                self.inner
+                    .lifecycle
+                    .resolve_current_accepted_catalogue(source_id, |payload| {
+                        Some((
+                            payload.regular_playlist_capability,
+                            payload.regular_playlist_index.clone(),
+                            Arc::clone(&payload.tracks),
+                        ))
+                    });
+
+            let Some(accepted) = accepted else {
+                for (position, track_id) in occurrences {
+                    results[position] = Some(RegularPlaylistTrackResolution::Unavailable(
+                        RegularPlaylistUnavailable {
+                            media_key: MediaKey::new(source_id, track_id),
+                            reason: RegularPlaylistUnavailableReason::SourceUnavailable,
+                            observed_guard: None,
+                        },
+                    ));
+                }
+                continue;
+            };
+
+            let guard = RegularPlaylistCatalogueGuard {
+                source_id,
+                session_epoch: accepted.session_epoch,
+                catalogue_generation: accepted.generation,
+            };
+            let (capability, index, tracks) = accepted.value;
+            for (position, track_id) in occurrences {
+                let media_key = MediaKey::new(source_id, track_id.clone());
+                let resolution = match (&capability, &index) {
+                    (RegularPlaylistCapability::Unsupported, _) => {
+                        RegularPlaylistTrackResolution::Unavailable(RegularPlaylistUnavailable {
+                            media_key,
+                            reason: RegularPlaylistUnavailableReason::UnsupportedSource,
+                            observed_guard: Some(guard),
+                        })
+                    }
+                    (
+                        RegularPlaylistCapability::SourceScopedEntries,
+                        RegularPlaylistTrackIndex::Invalid,
+                    ) => RegularPlaylistTrackResolution::Unavailable(RegularPlaylistUnavailable {
+                        media_key,
+                        reason: RegularPlaylistUnavailableReason::InvalidCatalogue,
+                        observed_guard: Some(guard),
+                    }),
+                    (
+                        RegularPlaylistCapability::SourceScopedEntries,
+                        RegularPlaylistTrackIndex::Exact(index),
+                    ) => {
+                        if let Some(track) = index
+                            .get(&track_id)
+                            .and_then(|track_index| tracks.get(*track_index))
+                        {
+                            RegularPlaylistTrackResolution::Available(Box::new(
+                                RegularPlaylistTrack {
+                                    media_key,
+                                    guard,
+                                    metadata: RegularPlaylistTrackMetadata::from_track(track),
+                                },
+                            ))
+                        } else {
+                            RegularPlaylistTrackResolution::Unavailable(
+                                RegularPlaylistUnavailable {
+                                    media_key,
+                                    reason: RegularPlaylistUnavailableReason::TrackMissing,
+                                    observed_guard: Some(guard),
+                                },
+                            )
+                        }
+                    }
+                    // Constructor invariants keep these combinations
+                    // unreachable. Treat any future drift as invalid rather
+                    // than granting playlist authority.
+                    _ => RegularPlaylistTrackResolution::Unavailable(RegularPlaylistUnavailable {
+                        media_key,
+                        reason: RegularPlaylistUnavailableReason::InvalidCatalogue,
+                        observed_guard: Some(guard),
+                    }),
+                };
+                results[position] = Some(resolution);
+            }
+        }
+
+        results
+            .into_iter()
+            .map(|result| result.expect("every playlist occurrence is resolved exactly once"))
+            .collect()
+    }
+
+    /// Recheck that an ordered lookup result still describes the current
+    /// source/catalogue authority. Metadata is immutable within a guard, so
+    /// only exact identity, guard, and closed availability state are compared.
+    #[allow(dead_code)]
+    pub fn are_regular_playlist_tracks_current(
+        &self,
+        resolutions: &[RegularPlaylistTrackResolution],
+    ) -> bool {
+        let media_keys: Vec<_> = resolutions
+            .iter()
+            .map(|resolution| resolution.media_key().clone())
+            .collect();
+        let current = self.resolve_regular_playlist_tracks(&media_keys);
+        resolutions
+            .iter()
+            .zip(current.iter())
+            .all(|(observed, current)| regular_playlist_authority_eq(observed, current))
+    }
+
+    /// Resolve one stream only through the exact catalogue guard that minted
+    /// the playlist row. The returned protected request carries the accepted
+    /// catalogue's revocable lease, so a same-session catalogue replacement
+    /// also invalidates a request after resolution but before consumption.
+    #[allow(dead_code)]
+    pub async fn resolve_regular_playlist_stream(
+        &self,
+        guard: RegularPlaylistCatalogueGuard,
+        track_id: TrackId,
+    ) -> Result<ResolvedSourceStream, RegularPlaylistMediaError> {
+        let selected_track_id = track_id.clone();
+        let (stream, accepted_authority, ()) = self
+            .inner
+            .lifecycle
+            .resolve_catalogue_stream(
+                guard.source_id,
+                guard.catalogue_generation,
+                guard.session_epoch,
+                move |payload| {
+                    payload
+                        .regular_playlist_track(&selected_track_id)
+                        .map(|_| ())
+                },
+                move |adapter| async move { adapter.resolve_stream(track_id).await },
+            )
+            .await
+            .map_err(regular_playlist_media_error)?;
+        match stream {
+            AdapterStream::ProtectedHttp(request) => Ok(ResolvedSourceStream::Http(
+                MediaRequest::ProtectedHttp(Box::new((*request).with_lease(accepted_authority))),
+            )),
+            AdapterStream::File(_) => Err(RegularPlaylistMediaError::Unavailable),
+        }
+    }
+
+    /// Artwork counterpart of [`Self::resolve_regular_playlist_stream`] with
+    /// the same exact pre/post guard checks and catalogue-generation lease.
+    #[allow(dead_code)]
+    pub async fn resolve_regular_playlist_artwork(
+        &self,
+        guard: RegularPlaylistCatalogueGuard,
+        track_id: TrackId,
+    ) -> Result<Option<ResolvedHttpRequest>, RegularPlaylistMediaError> {
+        let selected_track_id = track_id.clone();
+        let (request, accepted_authority, ()) = self
+            .inner
+            .lifecycle
+            .resolve_catalogue_optional_http(
+                guard.source_id,
+                guard.catalogue_generation,
+                guard.session_epoch,
+                move |payload| {
+                    payload
+                        .regular_playlist_track(&selected_track_id)
+                        .map(|_| ())
+                },
+                move |adapter| async move { adapter.resolve_artwork(track_id).await },
+            )
+            .await
+            .map_err(regular_playlist_media_error)?;
+        Ok(request.map(|request| request.with_lease(accepted_authority)))
+    }
+
     pub async fn resolve_stream(
         &self,
         source_id: SourceId,
@@ -971,21 +1507,14 @@ impl SourceRegistry {
         if let Some(resolved) = self.inner.lifecycle.resolve_latest_accepted_view(
             source_id,
             expected_session_epoch,
-            |payload| {
-                payload
-                    .public_streams
-                    .get(&track_id)
-                    .cloned()
-                    .map(|endpoint| (endpoint, payload.view_lease.clone()))
-            },
+            |payload| payload.public_streams.get(&track_id).cloned(),
         ) {
             let authority: Arc<dyn PublicHttpAuthority> = self.inner.clone();
             let authority = Arc::downgrade(&authority);
-            let (endpoint, lease) = resolved.value;
             return Ok(ResolvedSourceStream::Http(MediaRequest::PublicHttp(
                 ResolvedPublicHttpRequest::new(
-                    endpoint,
-                    lease,
+                    resolved.value,
+                    resolved.authority,
                     authority,
                     source_id,
                     track_id,
@@ -1026,6 +1555,42 @@ impl SourceRegistry {
                 move |adapter| async move { adapter.resolve_artwork(track_id).await },
             )
             .await
+    }
+}
+
+#[allow(dead_code)]
+fn regular_playlist_authority_eq(
+    observed: &RegularPlaylistTrackResolution,
+    current: &RegularPlaylistTrackResolution,
+) -> bool {
+    match (observed, current) {
+        (
+            RegularPlaylistTrackResolution::Available(observed),
+            RegularPlaylistTrackResolution::Available(current),
+        ) => observed.media_key == current.media_key && observed.guard == current.guard,
+        (
+            RegularPlaylistTrackResolution::Unavailable(observed),
+            RegularPlaylistTrackResolution::Unavailable(current),
+        ) => {
+            observed.media_key == current.media_key
+                && observed.reason == current.reason
+                && observed.observed_guard == current.observed_guard
+        }
+        _ => false,
+    }
+}
+
+#[allow(dead_code)]
+fn regular_playlist_media_error(
+    error: crate::source_lifecycle::CatalogueMediaResolveError,
+) -> RegularPlaylistMediaError {
+    match error {
+        crate::source_lifecycle::CatalogueMediaResolveError::Unavailable => {
+            RegularPlaylistMediaError::Unavailable
+        }
+        crate::source_lifecycle::CatalogueMediaResolveError::Backend(error) => {
+            RegularPlaylistMediaError::BackendFailure(failure_category(&error))
+        }
     }
 }
 
@@ -1079,11 +1644,7 @@ fn public_snapshot(
 fn public_accepted_snapshot(
     snapshot: crate::source_lifecycle::AcceptedSnapshot<AcceptedSourcePayload>,
 ) -> crate::source_lifecycle::AcceptedSnapshot<AcceptedView> {
-    crate::source_lifecycle::AcceptedSnapshot {
-        generation: snapshot.generation,
-        session_epoch: snapshot.session_epoch,
-        value: Arc::new(snapshot.value.published()),
-    }
+    snapshot.map(AcceptedSourcePayload::published)
 }
 
 fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
@@ -1198,7 +1759,9 @@ mod tests {
     struct FakeProbe {
         close_calls: AtomicUsize,
         stream_calls: AtomicUsize,
+        artwork_calls: AtomicUsize,
         close_release: watch::Sender<bool>,
+        stream_release: watch::Sender<bool>,
         view_specs: Mutex<HashMap<ViewOrigin, VecDeque<ViewSpec>>>,
     }
 
@@ -1210,10 +1773,13 @@ mod tests {
     impl FakeProbe {
         fn new(close_released: bool) -> Arc<Self> {
             let (close_release, _receiver) = watch::channel(close_released);
+            let (stream_release, _receiver) = watch::channel(true);
             Arc::new(Self {
                 close_calls: AtomicUsize::new(0),
                 stream_calls: AtomicUsize::new(0),
+                artwork_calls: AtomicUsize::new(0),
                 close_release,
+                stream_release,
                 view_specs: Mutex::new(HashMap::new()),
             })
         }
@@ -1233,6 +1799,26 @@ mod tests {
                 label,
                 probe: Arc::clone(self),
                 close_release: self.close_release.subscribe(),
+                catalogue: Vec::new(),
+                regular_playlist_capability: RegularPlaylistCapability::Unsupported,
+                stream_failure: None,
+                artwork_available: false,
+            }
+        }
+
+        fn playlist_adapter(
+            self: &Arc<Self>,
+            label: &'static str,
+            catalogue: Vec<Track>,
+        ) -> FakeAdapter {
+            FakeAdapter {
+                label,
+                probe: Arc::clone(self),
+                close_release: self.close_release.subscribe(),
+                catalogue,
+                regular_playlist_capability: RegularPlaylistCapability::SourceScopedEntries,
+                stream_failure: None,
+                artwork_available: true,
             }
         }
 
@@ -1251,6 +1837,10 @@ mod tests {
         label: &'static str,
         probe: Arc<FakeProbe>,
         close_release: watch::Receiver<bool>,
+        catalogue: Vec<Track>,
+        regular_playlist_capability: RegularPlaylistCapability,
+        stream_failure: Option<String>,
+        artwork_available: bool,
     }
 
     #[async_trait]
@@ -1304,6 +1894,18 @@ mod tests {
     impl RemoteMediaResolver for FakeAdapter {
         async fn resolve_stream(&self, track_id: &TrackId) -> BackendResult<ResolvedHttpRequest> {
             self.probe.stream_calls.fetch_add(1, Ordering::AcqRel);
+            let mut release = self.probe.stream_release.subscribe();
+            while !*release.borrow_and_update() {
+                if release.changed().await.is_err() {
+                    break;
+                }
+            }
+            if let Some(message) = &self.stream_failure {
+                return Err(BackendError::ConnectionFailed {
+                    message: message.clone(),
+                    source: None,
+                });
+            }
             ResolvedHttpRequest::new(
                 Url::parse(&format!(
                     "https://media.invalid/{}/{}",
@@ -1316,9 +1918,22 @@ mod tests {
 
         async fn resolve_artwork(
             &self,
-            _track_id: &TrackId,
+            track_id: &TrackId,
         ) -> BackendResult<Option<ResolvedHttpRequest>> {
-            Ok(None)
+            self.probe.artwork_calls.fetch_add(1, Ordering::AcqRel);
+            if self.artwork_available {
+                ResolvedHttpRequest::new(
+                    Url::parse(&format!(
+                        "https://art.invalid/{}/{}",
+                        self.label,
+                        track_id.as_str()
+                    ))
+                    .expect("fixture URL"),
+                )
+                .map(Some)
+            } else {
+                Ok(None)
+            }
         }
     }
 
@@ -1338,8 +1953,12 @@ mod tests {
     }
 
     impl ManagedSourceAdapter for FakeAdapter {
+        fn regular_playlist_capability(&self) -> RegularPlaylistCapability {
+            self.regular_playlist_capability
+        }
+
         fn load_initial_catalogue(self: Arc<Self>) -> CatalogueFuture {
-            Box::pin(async { Ok(Vec::new()) })
+            Box::pin(async move { Ok(self.catalogue.clone()) })
         }
 
         fn resolve_stream(self: Arc<Self>, track_id: TrackId) -> StreamFuture {
@@ -1480,6 +2099,24 @@ mod tests {
         assert!(matches!(error, BackendError::Internal(_)));
     }
 
+    #[test]
+    fn authenticated_adapter_playlist_capability_declarations_are_explicit() {
+        fn assert_source_scoped<A>()
+        where
+            A: source_scoped_playlist_sealed::Adapter,
+        {
+            assert_eq!(
+                source_scoped_playlist_capability::<A>(),
+                RegularPlaylistCapability::SourceScopedEntries
+            );
+        }
+
+        assert_source_scoped::<crate::subsonic::SubsonicBackend>();
+        assert_source_scoped::<crate::jellyfin::JellyfinBackend>();
+        assert_source_scoped::<crate::plex::PlexBackend>();
+        assert_source_scoped::<crate::daap::DaapBackend>();
+    }
+
     async fn wait_for_catalogue(registry: &SourceRegistry, source_id: SourceId) -> (u64, u64) {
         timeout(Duration::from_secs(2), async {
             loop {
@@ -1536,6 +2173,74 @@ mod tests {
             .expect("fixture connection admitted");
         let (_, session_epoch) = wait_for_catalogue(registry, source_id).await;
         (source_id, session_epoch)
+    }
+
+    async fn connect_playlist_fixture(
+        registry: &SourceRegistry,
+        source_id: SourceId,
+        adapter: FakeAdapter,
+    ) -> (u64, u64) {
+        registry
+            .claim_provenance(source_id, SourceProvenance::Saved)
+            .expect("saved claim");
+        registry
+            .connect_standard::<FakeAdapter, _, _, _>(
+                source_id,
+                |_| {},
+                move || async move { Ok(adapter) },
+            )
+            .expect("playlist fixture admitted");
+        wait_for_catalogue(registry, source_id).await
+    }
+
+    fn available(resolution: &RegularPlaylistTrackResolution) -> &RegularPlaylistTrack {
+        let RegularPlaylistTrackResolution::Available(track) = resolution else {
+            panic!("expected available regular-playlist track");
+        };
+        track
+    }
+
+    fn unavailable_reason(
+        resolution: &RegularPlaylistTrackResolution,
+    ) -> RegularPlaylistUnavailableReason {
+        let RegularPlaylistTrackResolution::Unavailable(track) = resolution else {
+            panic!("expected unavailable regular-playlist track");
+        };
+        track.reason()
+    }
+
+    async fn refresh_playlist_catalogue(
+        registry: &SourceRegistry,
+        source_id: SourceId,
+        tracks: Vec<Track>,
+        capability: RegularPlaylistCapability,
+    ) -> u64 {
+        let owner = registry
+            .inner
+            .lifecycle
+            .begin_refresh(source_id, RefreshLane::Catalogue)
+            .expect("catalogue refresh admitted");
+        let generation = owner.generation();
+        owner.spawn(move |_session, _cancellation| async move {
+            RefreshTaskResult::Refreshed(AcceptedSourcePayload::catalogue(tracks, capability))
+        });
+        timeout(Duration::from_secs(2), async {
+            loop {
+                if registry
+                    .inner
+                    .lifecycle
+                    .snapshot(source_id)
+                    .and_then(|snapshot| snapshot.catalogue)
+                    .is_some_and(|catalogue| catalogue.generation == generation)
+                {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("catalogue refresh accepted");
+        generation
     }
 
     fn consume_public(request: ResolvedSourceStream) -> BackendResult<Url> {
@@ -1675,6 +2380,441 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn regular_playlist_lookup_is_ordered_source_scoped_and_metadata_is_whitelisted() {
+        let registry = registry();
+        let shared_id = TrackId::remote("shared-native-id").expect("track ID");
+        let other_id = TrackId::remote("other-native-id").expect("track ID");
+        let missing_id = TrackId::remote("missing-native-id").expect("track ID");
+        let secret = format!("secret-locator-{}", Uuid::new_v4());
+
+        let mut first = fixture_track(shared_id.clone());
+        first.title = "First source".to_string();
+        first.file_path = Some(format!("/private/{secret}"));
+        first.stream_url = Some(
+            Url::parse(&format!("https://stream.invalid/audio?token={secret}"))
+                .expect("fixture URL"),
+        );
+        first.cover_art_url = Some(
+            Url::parse(&format!("https://art.invalid/cover?token={secret}")).expect("fixture URL"),
+        );
+        let mut other = fixture_track(other_id.clone());
+        other.title = "Other track".to_string();
+        let first_source = SourceId::random();
+        let first_probe = FakeProbe::new(true);
+        connect_playlist_fixture(
+            &registry,
+            first_source,
+            first_probe.playlist_adapter("first", vec![first, other]),
+        )
+        .await;
+
+        let mut second = fixture_track(shared_id.clone());
+        second.title = "Second source".to_string();
+        let second_source = SourceId::random();
+        let second_probe = FakeProbe::new(true);
+        connect_playlist_fixture(
+            &registry,
+            second_source,
+            second_probe.playlist_adapter("second", vec![second]),
+        )
+        .await;
+
+        let keys = vec![
+            MediaKey::new(first_source, other_id),
+            MediaKey::new(second_source, shared_id.clone()),
+            MediaKey::new(first_source, shared_id.clone()),
+            MediaKey::new(first_source, shared_id),
+            MediaKey::new(first_source, missing_id),
+        ];
+        let resolved = registry.resolve_regular_playlist_tracks(&keys);
+        assert_eq!(resolved.len(), keys.len());
+        assert_eq!(available(&resolved[0]).metadata().title(), "Other track");
+        assert_eq!(available(&resolved[1]).metadata().title(), "Second source");
+        assert_eq!(available(&resolved[2]).metadata().title(), "First source");
+        assert_eq!(available(&resolved[3]).metadata().title(), "First source");
+        assert_eq!(available(&resolved[2]).media_key(), &keys[2]);
+        assert_eq!(available(&resolved[3]).media_key(), &keys[3]);
+        assert_eq!(
+            unavailable_reason(&resolved[4]),
+            RegularPlaylistUnavailableReason::TrackMissing
+        );
+        assert!(registry.are_regular_playlist_tracks_current(&resolved));
+
+        let metadata_debug = format!("{:?}", available(&resolved[2]).metadata());
+        assert!(!metadata_debug.contains(&secret));
+        assert!(!metadata_debug.contains("stream_url"));
+        assert!(!metadata_debug.contains("cover_art_url"));
+        assert!(!metadata_debug.contains("file_path"));
+
+        registry.shutdown().wait().await;
+    }
+
+    #[tokio::test]
+    async fn regular_playlist_default_deny_and_invalid_catalogues_fail_closed() {
+        let registry = registry();
+        let track_id = TrackId::remote("track").expect("track ID");
+
+        let unsupported_source = SourceId::random();
+        let unsupported_probe = FakeProbe::new(true);
+        let mut unsupported = unsupported_probe.adapter("unsupported");
+        unsupported.catalogue = vec![fixture_track(track_id.clone())];
+        connect_playlist_fixture(&registry, unsupported_source, unsupported).await;
+        let unsupported = registry.resolve_regular_playlist_tracks(&[MediaKey::new(
+            unsupported_source,
+            track_id.clone(),
+        )]);
+        assert_eq!(
+            unavailable_reason(&unsupported[0]),
+            RegularPlaylistUnavailableReason::UnsupportedSource
+        );
+        assert_eq!(unsupported_probe.stream_calls.load(Ordering::Acquire), 0);
+
+        let duplicate_source = SourceId::random();
+        let duplicate_probe = FakeProbe::new(true);
+        connect_playlist_fixture(
+            &registry,
+            duplicate_source,
+            duplicate_probe.playlist_adapter(
+                "duplicate",
+                vec![
+                    fixture_track(track_id.clone()),
+                    fixture_track(track_id.clone()),
+                ],
+            ),
+        )
+        .await;
+        assert_eq!(
+            registry
+                .snapshot(duplicate_source)
+                .and_then(|snapshot| snapshot.catalogue)
+                .expect("general duplicate catalogue remains published")
+                .value
+                .tracks()
+                .len(),
+            2
+        );
+        let duplicate = registry
+            .resolve_regular_playlist_tracks(&[MediaKey::new(duplicate_source, track_id.clone())]);
+        assert_eq!(
+            unavailable_reason(&duplicate[0]),
+            RegularPlaylistUnavailableReason::InvalidCatalogue
+        );
+
+        let missing_identity_source = SourceId::random();
+        let missing_identity_probe = FakeProbe::new(true);
+        let mut missing_identity = fixture_track(track_id.clone());
+        missing_identity.native_track_id = None;
+        connect_playlist_fixture(
+            &registry,
+            missing_identity_source,
+            missing_identity_probe.playlist_adapter("missing", vec![missing_identity]),
+        )
+        .await;
+        let invalid = registry
+            .resolve_regular_playlist_tracks(&[MediaKey::new(missing_identity_source, track_id)]);
+        assert_eq!(
+            unavailable_reason(&invalid[0]),
+            RegularPlaylistUnavailableReason::InvalidCatalogue
+        );
+
+        registry.shutdown().wait().await;
+    }
+
+    #[tokio::test]
+    async fn guarded_playlist_media_rechecks_generation_and_retains_exact_authority() {
+        let registry = registry();
+        let source_id = SourceId::random();
+        let track_id = TrackId::remote("guarded-track").expect("track ID");
+        let probe = FakeProbe::new(true);
+        connect_playlist_fixture(
+            &registry,
+            source_id,
+            probe.playlist_adapter("guarded", vec![fixture_track(track_id.clone())]),
+        )
+        .await;
+        let initial =
+            registry.resolve_regular_playlist_tracks(&[MediaKey::new(source_id, track_id.clone())]);
+        let guard = available(&initial[0]).guard();
+        assert_eq!(guard.source_id(), source_id);
+
+        let stream = registry
+            .resolve_regular_playlist_stream(guard, track_id.clone())
+            .await
+            .expect("guarded stream");
+        assert!(protected_request_is_active(&stream));
+        let artwork = registry
+            .resolve_regular_playlist_artwork(guard, track_id.clone())
+            .await
+            .expect("guarded artwork")
+            .expect("fixture artwork");
+        assert!(artwork.is_active());
+        let parked = registry
+            .inner
+            .lifecycle
+            .snapshot(source_id)
+            .and_then(|snapshot| snapshot.catalogue)
+            .expect("parked payload snapshot");
+
+        let mut refreshed_track = fixture_track(track_id.clone());
+        refreshed_track.title = "Refreshed".to_string();
+        let refreshed_generation = refresh_playlist_catalogue(
+            &registry,
+            source_id,
+            vec![refreshed_track],
+            RegularPlaylistCapability::SourceScopedEntries,
+        )
+        .await;
+        assert_ne!(refreshed_generation, guard.catalogue_generation());
+        assert!(!protected_request_is_active(&stream));
+        assert!(!artwork.is_active());
+        assert_eq!(parked.value.tracks[0].title, "Station");
+
+        let calls_before_stale = probe.stream_calls.load(Ordering::Acquire);
+        let stale = registry
+            .resolve_regular_playlist_stream(guard, track_id.clone())
+            .await;
+        assert!(matches!(stale, Err(RegularPlaylistMediaError::Unavailable)));
+        assert_eq!(
+            probe.stream_calls.load(Ordering::Acquire),
+            calls_before_stale
+        );
+        assert!(!registry.are_regular_playlist_tracks_current(&initial));
+
+        let current =
+            registry.resolve_regular_playlist_tracks(&[MediaKey::new(source_id, track_id.clone())]);
+        assert_eq!(available(&current[0]).metadata().title(), "Refreshed");
+        assert!(registry.are_regular_playlist_tracks_current(&current));
+
+        probe.stream_release.send_replace(false);
+        let current_guard = available(&current[0]).guard();
+        let delayed_registry = registry.clone();
+        let delayed_track = track_id.clone();
+        let calls_before_delayed = probe.stream_calls.load(Ordering::Acquire);
+        let delayed = tokio::spawn(async move {
+            delayed_registry
+                .resolve_regular_playlist_stream(current_guard, delayed_track)
+                .await
+        });
+        timeout(Duration::from_secs(2), async {
+            while probe.stream_calls.load(Ordering::Acquire) == calls_before_delayed {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("adapter resolution started");
+        refresh_playlist_catalogue(
+            &registry,
+            source_id,
+            vec![fixture_track(track_id)],
+            RegularPlaylistCapability::SourceScopedEntries,
+        )
+        .await;
+        probe.stream_release.send_replace(true);
+        assert!(matches!(
+            delayed.await.expect("resolution task"),
+            Err(RegularPlaylistMediaError::Unavailable)
+        ));
+
+        let before_disconnect = registry.resolve_regular_playlist_tracks(&[MediaKey::new(
+            source_id,
+            TrackId::remote("guarded-track").expect("track ID"),
+        )]);
+        let disconnect_guard = available(&before_disconnect[0]).guard();
+        let disconnect_track = available(&before_disconnect[0])
+            .media_key()
+            .track_id
+            .clone();
+        let disconnect_stream = registry
+            .resolve_regular_playlist_stream(disconnect_guard, disconnect_track.clone())
+            .await
+            .expect("pre-disconnect stream");
+        let disconnect_art = registry
+            .resolve_regular_playlist_artwork(disconnect_guard, disconnect_track.clone())
+            .await
+            .expect("pre-disconnect artwork")
+            .expect("fixture artwork");
+        let parked_disconnect = registry
+            .inner
+            .lifecycle
+            .snapshot(source_id)
+            .and_then(|snapshot| snapshot.catalogue)
+            .expect("parked disconnect snapshot");
+        let calls_before_disconnect = probe.stream_calls.load(Ordering::Acquire);
+        let waiter = registry.disconnect(source_id).expect("disconnect source");
+        assert!(!protected_request_is_active(&disconnect_stream));
+        assert!(!disconnect_art.is_active());
+        assert_eq!(parked_disconnect.value.tracks.len(), 1);
+        let disconnected = registry
+            .resolve_regular_playlist_tracks(&[MediaKey::new(source_id, disconnect_track.clone())]);
+        assert_eq!(disconnected.len(), 1);
+        assert_eq!(
+            unavailable_reason(&disconnected[0]),
+            RegularPlaylistUnavailableReason::SourceUnavailable
+        );
+        assert!(matches!(
+            registry
+                .resolve_regular_playlist_stream(disconnect_guard, disconnect_track)
+                .await,
+            Err(RegularPlaylistMediaError::Unavailable)
+        ));
+        assert_eq!(
+            probe.stream_calls.load(Ordering::Acquire),
+            calls_before_disconnect
+        );
+        waiter.wait().await;
+
+        registry.shutdown().wait().await;
+    }
+
+    #[tokio::test]
+    async fn guarded_playlist_media_rejects_replacement_without_calling_successor() {
+        let registry = registry();
+        let source_id = SourceId::random();
+        let track_id = TrackId::remote("replacement-track").expect("track ID");
+        let predecessor = FakeProbe::new(true);
+        connect_playlist_fixture(
+            &registry,
+            source_id,
+            predecessor.playlist_adapter("predecessor", vec![fixture_track(track_id.clone())]),
+        )
+        .await;
+        let initial =
+            registry.resolve_regular_playlist_tracks(&[MediaKey::new(source_id, track_id.clone())]);
+        let old_guard = available(&initial[0]).guard();
+        let old_stream = registry
+            .resolve_regular_playlist_stream(old_guard, track_id.clone())
+            .await
+            .expect("predecessor stream");
+        let old_art = registry
+            .resolve_regular_playlist_artwork(old_guard, track_id.clone())
+            .await
+            .expect("predecessor artwork")
+            .expect("fixture artwork");
+        let parked = registry
+            .inner
+            .lifecycle
+            .snapshot(source_id)
+            .and_then(|snapshot| snapshot.catalogue)
+            .expect("parked predecessor snapshot");
+
+        let successor = FakeProbe::new(true);
+        let successor_for_connect = Arc::clone(&successor);
+        let successor_track = track_id.clone();
+        registry
+            .connect_standard::<FakeAdapter, _, _, _>(
+                source_id,
+                |_| {},
+                move || async move {
+                    Ok(successor_for_connect
+                        .playlist_adapter("successor", vec![fixture_track(successor_track)]))
+                },
+            )
+            .expect("replacement admitted");
+        timeout(Duration::from_secs(2), async {
+            loop {
+                let current = registry
+                    .resolve_regular_playlist_tracks(&[MediaKey::new(source_id, track_id.clone())]);
+                if matches!(&current[0], RegularPlaylistTrackResolution::Available(track)
+                    if track.guard().session_epoch() != old_guard.session_epoch())
+                {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("successor catalogue accepted");
+        assert!(!protected_request_is_active(&old_stream));
+        assert!(!old_art.is_active());
+        assert_eq!(parked.value.tracks.len(), 1);
+        assert!(matches!(
+            registry
+                .resolve_regular_playlist_stream(old_guard, track_id.clone())
+                .await,
+            Err(RegularPlaylistMediaError::Unavailable)
+        ));
+        assert_eq!(successor.stream_calls.load(Ordering::Acquire), 0);
+
+        let fresh =
+            registry.resolve_regular_playlist_tracks(&[MediaKey::new(source_id, track_id.clone())]);
+        registry
+            .resolve_regular_playlist_stream(available(&fresh[0]).guard(), track_id)
+            .await
+            .expect("fresh successor guard");
+        assert_eq!(successor.stream_calls.load(Ordering::Acquire), 1);
+        registry.shutdown().wait().await;
+    }
+
+    #[tokio::test]
+    async fn guarded_playlist_media_does_not_retain_final_registry_authority() {
+        let registry = registry();
+        let source_id = SourceId::random();
+        let track_id = TrackId::remote("last-handle-track").expect("track ID");
+        let probe = FakeProbe::new(true);
+        connect_playlist_fixture(
+            &registry,
+            source_id,
+            probe.playlist_adapter("last-handle", vec![fixture_track(track_id.clone())]),
+        )
+        .await;
+        let resolved =
+            registry.resolve_regular_playlist_tracks(&[MediaKey::new(source_id, track_id.clone())]);
+        let guard = available(&resolved[0]).guard();
+        let stream = registry
+            .resolve_regular_playlist_stream(guard, track_id.clone())
+            .await
+            .expect("guarded stream");
+        let artwork = registry
+            .resolve_regular_playlist_artwork(guard, track_id)
+            .await
+            .expect("guarded artwork")
+            .expect("fixture artwork");
+        let parked = registry
+            .inner
+            .lifecycle
+            .snapshot(source_id)
+            .and_then(|snapshot| snapshot.catalogue)
+            .expect("parked catalogue snapshot");
+        assert!(protected_request_is_active(&stream));
+        assert!(artwork.is_active());
+
+        drop(registry);
+
+        assert!(!protected_request_is_active(&stream));
+        assert!(!artwork.is_active());
+        assert_eq!(parked.value.tracks.len(), 1);
+        probe.wait_for_close_calls(1).await;
+    }
+
+    #[tokio::test]
+    async fn guarded_playlist_media_closes_raw_adapter_errors() {
+        let registry = registry();
+        let source_id = SourceId::random();
+        let track_id = TrackId::remote("secret-track-id").expect("track ID");
+        let probe = FakeProbe::new(true);
+        let secret = format!("https://user:password@private.invalid/{}", Uuid::new_v4());
+        let mut adapter = probe.playlist_adapter("failure", vec![fixture_track(track_id.clone())]);
+        adapter.stream_failure = Some(secret.clone());
+        connect_playlist_fixture(&registry, source_id, adapter).await;
+        let resolution =
+            registry.resolve_regular_playlist_tracks(&[MediaKey::new(source_id, track_id.clone())]);
+        let result = registry
+            .resolve_regular_playlist_stream(available(&resolution[0]).guard(), track_id)
+            .await;
+        let Err(error) = result else {
+            panic!("adapter failure must be closed");
+        };
+        assert_eq!(
+            error,
+            RegularPlaylistMediaError::BackendFailure(FailureCategory::Connection)
+        );
+        let rendered = format!("{error:?} {error}");
+        assert!(!rendered.contains(&secret));
+        assert!(!rendered.contains("password"));
+        registry.shutdown().wait().await;
+    }
+
+    #[tokio::test]
     async fn repeated_concurrent_builtin_refreshes_share_one_session_epoch() {
         let registry = registry();
         let source_id = SourceId::radio_browser();
@@ -1693,6 +2833,14 @@ mod tests {
             )
             .expect("existing built-in retained");
         assert_eq!(first_epoch, repeated_epoch);
+        let radio_playlist = registry.resolve_regular_playlist_tracks(&[MediaKey::new(
+            source_id,
+            TrackId::remote("shared-station").expect("track ID"),
+        )]);
+        assert_eq!(
+            unavailable_reason(&radio_playlist[0]),
+            RegularPlaylistUnavailableReason::UnsupportedSource
+        );
 
         let top_clicked = ViewOrigin::radio("top-clicked").expect("view");
         let top_voted = ViewOrigin::radio("top-voted").expect("view");
@@ -2287,6 +3435,12 @@ mod tests {
                 .expect("decode accepted identity"),
             std::path::PathBuf::from("accepted.wav")
         );
+        let playlist =
+            registry.resolve_regular_playlist_tracks(&[MediaKey::new(source_id, track_id.clone())]);
+        assert_eq!(
+            unavailable_reason(&playlist[0]),
+            RegularPlaylistUnavailableReason::UnsupportedSource
+        );
 
         let appeared_later = mount.path().join("appeared-later.wav");
         std::fs::write(&appeared_later, minimal_wav_bytes(0x40))
@@ -2520,6 +3674,14 @@ mod tests {
         assert!(published.file_path.is_none());
         assert!(published.stream_url.is_none());
         assert!(published.cover_art_url.is_none());
+        let playlist = registry.resolve_regular_playlist_tracks(&[MediaKey::new(
+            session.source_id(),
+            session.track_id().clone(),
+        )]);
+        assert_eq!(
+            unavailable_reason(&playlist[0]),
+            RegularPlaylistUnavailableReason::UnsupportedSource
+        );
 
         let wrong_track = TrackId::external();
         assert!(registry

--- a/src/source_registry.rs
+++ b/src/source_registry.rs
@@ -1319,10 +1319,7 @@ impl SourceRegistry {
                 .push((position, media_key.track_id.clone()));
         }
 
-        let mut results: Vec<Option<RegularPlaylistTrackResolution>> =
-            std::iter::repeat_with(|| None)
-                .take(media_keys.len())
-                .collect();
+        let mut results: Vec<Option<RegularPlaylistTrackResolution>> = vec![None; media_keys.len()];
         for (source_id, occurrences) in by_source {
             let accepted =
                 self.inner


### PR DESCRIPTION
## Summary

- add a default-deny regular-playlist capability to managed sources, with explicit opt-in only for authenticated Subsonic, Jellyfin, Plex, and DAAP catalogues
- resolve source-scoped playlist occurrences against the exact current source, session epoch, accepted catalogue generation, capability, and unique native track identity
- return ordered per-occurrence results with a dedicated metadata whitelist and closed unavailable reasons, preserving duplicates without exposing locators, credentials, leases, routes, or raw backend errors
- guard stream and artwork resolution before and after asynchronous adapter work, and revoke lifecycle-owned generation leases independently of retained snapshot clones
- run immutable catalogue selectors outside the lifecycle mutex, then revalidate exact snapshot identity and both leases before return or adapter work; selector-time refresh cannot start stale work
- update README, changelog, roadmap, architecture, the playlist contract, and task tracking; P1.5 Record A becomes 9/36 complete and mixed-source UI integration remains Record B

## Safety boundaries

- malformed catalogues with missing or duplicate native IDs remain usable by existing non-playlist views but fail closed for every playlist lookup
- Radio-Browser, removable media, external files, default adapters, and unknown sources remain unsupported
- this PR does not enable remote Add, Remove, rendering, Play, persisted locators, or source-native playlist mutation

## Validation

- `cargo test --all-targets --no-fail-fast` (20 library + 1082 application + 10 packaging tests)
- `cargo test --release --all-targets --no-fail-fast` (20 library + 1082 application + 10 packaging tests)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --release --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

An independent read-only audit found no merge-blocking implementation or documentation issues.
