### PR TITLE
feat: integrate mixed-source regular playlists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,13 +32,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   preserves same-ID tracks from different sources as distinct media, and stores no server
   URL, stream/artwork locator, credential, lease, route, or session epoch. Existing manual local
   Add/load, XSPF import/export, duplicate ordering, local reconciliation, track deletion, rename,
-  and root-reauthorization paths retain their prior behavior through the new schema. The shipping UI
-  remains intentionally local-only in this slice: it still refuses non-local Add before database
-  work and does not render or play stored non-local
-  fixtures. The internal live-catalogue authority foundation is described below;
-  capability-gated authenticated-source Add/Remove/Play, disconnected presentation, and
-  mixed-source export remain a later UI record. Subsonic server-native playlist import or
-  synchronization is another separately designed capability.
+  and root-reauthorization paths retain their prior behavior through the new schema. At this
+  storage slice's delivery boundary the UI deliberately remained local-only; the live authority
+  and mixed-source UI records below now consume the schema without widening what it may persist.
+  Mixed-source XSPF metadata export and Subsonic server-native playlist synchronization remain
+  separately designed capabilities.
   The complete boundary and validation matrix are in
   [`docs/source-scoped-playlists.md`](docs/source-scoped-playlists.md).
 - **Regular playlists now have default-deny live-catalogue authority**
@@ -70,10 +68,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Connecting or a failed replacement preserves the accepted predecessor; successful replacement
   or same-session catalogue refresh invalidates old guards. Disconnect, shutdown, and final source
   release synchronously deny new authority before asynchronous teardown completes.
-  This is an internal authority foundation only: the shipping UI still refuses non-local Add and
-  does not remove, render, or play remote playlist entries. Those interactions, explicit
-  unavailable states, mixed-source export, and Subsonic-native playlist synchronization remain
-  separately tracked.
+  This PR's delivery boundary was an internal authority foundation rather than a UI authorization;
+  the mixed-source record immediately below is its reviewed consumer. Mixed-source XSPF export and
+  Subsonic-native playlist synchronization remain separately tracked.
+- **Regular playlists now integrate exact mixed-source entries end to end**
+  ([#142](https://github.com/jm2/tributary/pull/142)) — Add to Playlist now accepts exact local
+  tracks plus rows from current authenticated Subsonic, Jellyfin, Plex, and DAAP catalogues. One
+  registry lookup validates every selected remote occurrence against its current source, session
+  epoch, accepted catalogue generation, advertised capability, and native-track membership before
+  one atomic ordered write. If any current selected member is unsupported, disconnected, missing,
+  or in an invalid catalogue, a localized all-or-none result is shown and nothing is written. A
+  result made stale before commit is discarded and also writes nothing. Radio-Browser,
+  removable-media, ephemeral external-file, and unknown sources remain unsupported.
+  Regular-playlist projection now retains every durable entry in position order, including
+  duplicates and unavailable occurrences. Available local rows use the exact current database
+  record; available remote rows use only the registry's sanitized live metadata. Disconnected or
+  retired sources, unsupported owners, invalid catalogues, missing native tracks, and
+  missing/unmatched local identities render explicit localized unavailable rows that remain
+  removable. Stale projected work or results are discarded and the affected playlist is
+  invalidated and projected again from current authority. Persisted fingerprints are neither
+  displayed as stale metadata nor used to choose a similarly named remote track. Remove operates
+  atomically on exact durable occurrence IDs, so repeated media can be removed independently and a
+  failed mutation changes nothing.
+  Playlist queues keep the playlist as `ViewOrigin` while assigning each item to its actual source.
+  Local rows retain exact root/file authority; remote stream and artwork resolution revalidate the
+  row's transient closed guard before and after adapter work. Refresh, replacement, retirement,
+  disconnect, or shutdown therefore denies stale media instead of replaying a cached locator, and
+  reconnect restores a row only when the same `SourceId` publishes the same exact `TrackId`.
+  Playback-history ownership remains local-only. Remote ratings retain their live read-only or
+  unsupported state, and playlist membership grants no mutation authority. Smart playlists and
+  XSPF import/export remain local-only; mixed-source metadata export and Subsonic server-native
+  playlist synchronization remain explicitly deferred.
 - **Ratings now have a durable ownership, capability, and persistence foundation**
   ([#138](https://github.com/jm2/tributary/pull/138)) — A canonical
   rating is one validated whole integer from 1 through 100, while `None` alone means unrated.
@@ -194,9 +219,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Tributary therefore adds nothing instead of silently skipping unsupported rows or modifying only
   an unexpected subset. The existing Add to Playlist, Remove from Playlist, and Properties context
   labels now use their shipped translations as well, and the refusal copy is covered across all 13
-  locale catalogs. Local-library playlist behavior is unchanged. The source-scoped storage
-  and default-deny live-catalogue authority foundations are now described above, while live
-  non-local playlist interaction remains P1.5 Record B.
+  locale catalogs. That refusal remains the fail-closed result for unsupported or unavailable
+  selections; the source-scoped storage, default-deny authority, and capability-gated
+  authenticated mixed-source interaction are now described above.
 - **Shuffled Previous and Next now follow a bounded real playback timeline** — Tributary retains
   the current queue occurrence plus ten actual predecessors, walks backward without fabricating a
   random track at the oldest boundary, and replays fixed forward history before drawing again.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,9 +76,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tracks plus rows from current authenticated Subsonic, Jellyfin, Plex, and DAAP catalogues. One
   registry lookup validates every selected remote occurrence against its current source, session
   epoch, accepted catalogue generation, advertised capability, and native-track membership before
-  one atomic ordered write. If any current selected member is unsupported, disconnected, missing,
-  or in an invalid catalogue, a localized all-or-none result is shown and nothing is written. A
-  result made stale before commit is discarded and also writes nothing. Radio-Browser,
+  one atomic ordered write. After staging its SQL changes and immediately before commit, the
+  transaction revalidates the complete batch and acquires exact commit-scoped session/catalogue
+  authority permits. A result made stale during staging is rejected and the transaction rolls back;
+  once admitted, refresh, replacement, disconnect, or shutdown waits for commit or rollback. The
+  transaction and permits transfer to an independent completion worker, so caller cancellation or
+  a synchronous lifecycle revoker cannot strand authority or starve the commit. If
+  any current selected member is unsupported, disconnected, missing,
+  or in an invalid catalogue, a localized all-or-none result is shown and nothing is written.
+  Radio-Browser,
   removable-media, ephemeral external-file, and unknown sources remain unsupported.
   Regular-playlist projection now retains every durable entry in position order, including
   duplicates and unavailable occurrences. Available local rows use the exact current database
@@ -90,6 +96,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   displayed as stale metadata nor used to choose a similarly named remote track. Remove operates
   atomically on exact durable occurrence IDs, so repeated media can be removed independently and a
   failed mutation changes nothing.
+  XSPF remains a local-only interchange format: exporting a regular playlist with any remote or
+  unresolved occurrence now refuses the whole export with localized copy before touching the
+  destination instead of silently emitting only its local subset.
   Playlist queues keep the playlist as `ViewOrigin` while assigning each item to its actual source.
   Local rows retain exact root/file authority; remote stream and artwork resolution revalidate the
   row's transient closed guard before and after adapter work. Refresh, replacement, retirement,

--- a/README.md
+++ b/README.md
@@ -689,15 +689,17 @@ Tributary supports mixed-source regular playlists and local-library smart playli
 - **Smart playlists** — iTunes-style rules engine with filterable metadata fields, text/numeric/date operators, sorting, and result limiting. Smart playlists are evaluated against the current local library whenever they are opened or exported; they are not stored snapshots. Create them via the sidebar context menu.
 
 **Add to Playlist** accepts built-in local tracks and exact current rows from retained authenticated
-Subsonic, Jellyfin, Plex, and DAAP catalogues. Before opening a database transaction, the registry
-validates every selected remote identity against the same current source session and accepted
-catalogue generation. The complete ordered selection is then added atomically. If one member is
-currently unsupported, disconnected, in an invalid catalogue, or missing, Tributary explains the
-result in the user's language and adds nothing. If the authority result becomes stale, it is
-discarded and nothing is written. Radio-Browser, removable media, ephemeral external files, and
-unknown sources remain unsupported. Removing rows is likewise one atomic operation over their exact
-durable entry IDs, so a duplicate or unavailable occurrence can be removed without affecting its
-neighbors.
+Subsonic, Jellyfin, Plex, and DAAP catalogues. The registry first resolves every selected remote
+identity against the same current source session and accepted catalogue generation. After the
+database transaction stages the complete ordered selection, it repeats that exact validation and
+acquires session/catalogue permits immediately before commit. Authority made stale during staging
+rolls back every insert; after admission, lifecycle invalidation waits for commit or rollback. The
+commit and permits have an independent completion owner, so cancellation cannot strand authority
+or abandon commit completion. If one member is unsupported, disconnected, in an invalid
+catalogue, or missing, Tributary explains the result in the user's language and adds nothing.
+Radio-Browser, removable media, ephemeral external files, and unknown sources remain unsupported.
+Removing rows is likewise one atomic operation over their exact durable entry IDs, so a duplicate
+or unavailable occurrence can be removed without affecting its neighbors.
 
 Opening a regular playlist retains every stored occurrence in position order. Available local rows
 use current database metadata; available authenticated rows use only the registry's sanitized live
@@ -750,6 +752,11 @@ before the temporary file or destination is touched. A corrupt negative stored d
 outside Tributary's supported `u64` millisecond range is omitted rather than blocking the otherwise
 valid playlist, because XSPF duration is optional.
 
+XSPF currently represents only local-library tracks. Exporting a regular playlist that contains
+any remote or unresolved occurrence is therefore refused as a whole with a visible explanation
+before the destination is touched; Tributary never silently exports just the playlist's local
+subset. Mixed-source metadata export remains deferred until it has an explicit no-locator policy.
+
 Ratings are deliberately outside this playlist interchange. XSPF v1 has no standard rating field,
 so export emits none; import treats rating-like `<meta>` and extension content as inert and never
 changes a matched local track's app-owned rating. See the [rating contract](docs/ratings.md) for the
@@ -790,9 +797,10 @@ instead counts that individual row as failed.
 
 XSPF import continues to create entries owned by the built-in local source. The source-scoped
 storage migration does not make an HTTP(S) location or service identifier a remote playlist
-authority. Export emits only resolved local tracks and therefore is not a complete export of a
-mixed regular playlist. Mixed-source metadata export is explicitly deferred until it has a policy
-that cannot request or serialize a protected remote locator.
+authority. Export refuses a regular playlist containing any remote or unresolved occurrence before
+touching the destination; it never emits a truncated local-only subset. Mixed-source metadata export
+is explicitly deferred until it has a policy that cannot request or serialize a protected remote
+locator.
 
 Apple Music and iTunes can export playlist metadata as XML, but their XML is an Apple property-list
 format, not XSPF. Follow Apple's official export steps for

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Tributary provides a unified interface for managing and streaming music from mul
 | Internet Radio (Top Clicked, Top Voted, Stations Near Me) | ✅ |
 | Tiered geo-location (geo-distance → state → country) | ✅ |
 | Column drag-and-drop reordering with persistence | ✅ |
-| Regular & smart playlists (iTunes-style rules engine) | ✅ Local-library UI; source-scoped storage and default-deny live-catalogue authority are implemented, while mixed-source UI/playback remains planned ([#47](https://github.com/jm2/tributary/issues/47)) |
+| Regular & smart playlists (iTunes-style rules engine) | ✅ Regular playlists mix local and authenticated Subsonic/Jellyfin/Plex/DAAP entries; smart playlists remain local-library queries ([#47](https://github.com/jm2/tributary/issues/47)) |
 | Realtime text search filter (title, artist, album, genre) | ✅ |
 | Song metadata editing (Properties dialog with Save/Cancel) | ✅ |
 | Batch metadata editing (multi-select) | ✅ |
@@ -134,8 +134,9 @@ disagree, rather than values from an arbitrary SQLite row. `Album.artist_id` del
 empty because a compilation's album artist is not necessarily any performing-artist entity.
 Identity-bearing metadata edits therefore produce a new aggregate ID. Persisted local track IDs
 are preserved byte-for-byte; malformed legacy IDs use a frozen deterministic compatibility
-projection rather than a random fallback. Local and playlist queues resolve the exact current
-database row beneath retained, revalidated root and file authority at use time.
+projection rather than a random fallback. Local occurrences in local or playlist queues resolve
+the exact current database row beneath retained, revalidated root and file authority at use time;
+authenticated remote playlist occurrences resolve through their exact current registry guard.
 
 The [source identity and lifecycle decision](docs/architecture/source-lifecycle.md) documents that
 implemented seam, including provenance, cancellation, explicit DAAP/Jellyfin session retirement,
@@ -677,23 +678,44 @@ boundaries.
 
 ### Playlists
 
-Tributary supports regular and smart playlists for the local library:
+Tributary supports mixed-source regular playlists and local-library smart playlists:
 
-- **Regular playlists** — Right-click the Playlists header in the sidebar to create a new playlist. Right-click tracks in the tracklist to add them. Playlists survive library folder changes via fingerprint-based track matching. Their migrated storage identity is the source-scoped `(SourceId, TrackId)` pair, with a separate nullable local-track foreign-key cache for local deletion and reconciliation. Internal live-catalogue lookup now has an explicit default-deny authority boundary, but the current UI still creates and projects only local entries.
+- **Regular playlists** — Right-click the Playlists header in the sidebar to create one, then
+  right-click selected tracks to add them. Every ordered occurrence has its own durable entry ID
+  and exact `(SourceId, TrackId)` media identity, so duplicates remain distinct. Local entries
+  survive library-folder changes through the existing exact reconciliation contract; current
+  authenticated Subsonic, Jellyfin, Plex, and DAAP entries use live catalogue authority without
+  persisting a locator, credential, lease, route, session epoch, or display snapshot.
 - **Smart playlists** — iTunes-style rules engine with filterable metadata fields, text/numeric/date operators, sorting, and result limiting. Smart playlists are evaluated against the current local library whenever they are opened or exported; they are not stored snapshots. Create them via the sidebar context menu.
 
-**Add to Playlist** currently accepts tracks only from the built-in local library. Invoking it from
-an authenticated remote, internet-radio, removable-media, or other unsupported source shows a
-localized explanation and adds nothing; it never silently writes only a subset. Migration 13 and
-the storage API can represent a non-local occurrence without a URL, credential, lease, or session
-epoch, but that capability is not UI authorization.
+**Add to Playlist** accepts built-in local tracks and exact current rows from retained authenticated
+Subsonic, Jellyfin, Plex, and DAAP catalogues. Before opening a database transaction, the registry
+validates every selected remote identity against the same current source session and accepted
+catalogue generation. The complete ordered selection is then added atomically. If one member is
+currently unsupported, disconnected, in an invalid catalogue, or missing, Tributary explains the
+result in the user's language and adds nothing. If the authority result becomes stale, it is
+discarded and nothing is written. Radio-Browser, removable media, ephemeral external files, and
+unknown sources remain unsupported. Removing rows is likewise one atomic operation over their exact
+durable entry IDs, so a duplicate or unavailable occurrence can be removed without affecting its
+neighbors.
+
+Opening a regular playlist retains every stored occurrence in position order. Available local rows
+use current database metadata; available authenticated rows use only the registry's sanitized live
+metadata. A disconnected or retired source, unsupported owner, invalid catalogue, missing native
+track, or missing/unmatched local identity produces an explicit localized unavailable row that
+remains visible and removable. Tributary does not display persisted reconciliation fingerprints as
+stale metadata or use them to guess another remote track. Stale projection work and results are
+discarded; the affected playlist is invalidated and projected again from current authority.
+Reconnection restores a row only when the same `SourceId` publishes the same exact native `TrackId`
+again.
 
 Inside `SourceRegistry`, regular-playlist catalogue authority defaults to Unsupported. Only the
 retained authenticated Subsonic, Jellyfin, Plex, and DAAP adapters explicitly advertise
 source-scoped entries; Radio-Browser, removable media, ephemeral external files, and unknown
-adapters remain unsupported. An internal lookup accepts an ordered set only from the exact current
-source, session epoch, and accepted catalogue generation, and returns a dedicated metadata
-whitelist without paths, URLs, locators, credentials, leases, routes, or raw backend errors. Its
+adapters remain unsupported. Playlist Add and rendering consume an ordered lookup that accepts
+only the exact current source, session epoch, and accepted catalogue generation and returns a
+dedicated metadata whitelist without paths, URLs, locators, credentials, leases, routes, or raw
+backend errors. Its
 closed guard carries the non-secret epoch and generation transiently; neither is written to the
 playlist. Guarded media maps backend failures to fixed categories and carries a lifecycle-owned
 generation lease that is explicitly revoked even if an observer still holds an old snapshot clone.
@@ -704,12 +726,17 @@ unsupported source receives an explicit unavailable result without erasing valid
 and artwork resolutions revalidate the transient guard around asynchronous adapter work so
 replacement, refresh, disconnect, shutdown, or final source release cannot revive an old result.
 
-This foundation does not change Add, Remove, rendering, or Play behavior by itself. Connecting or
-a failed replacement may continue using its already accepted predecessor; a successful
-replacement or same-session catalogue refresh invalidates old guards, and disconnect/shutdown deny
-new use synchronously. Mixed-source playlist UI, explicit unavailable states, and
-Subsonic-native playlist import/synchronization remain follow-on work under
-[P1.5](docs/task.md#p15--persist-source-scoped-playlists). See the
+Each playlist queue item keeps the playlist as its view origin while taking media ownership from
+that row's real source. Local items retain exact file authority; remote stream and artwork requests
+must pass guarded at-use resolution again. A refresh, replacement, retirement, disconnect, or
+shutdown therefore denies a stale item instead of replaying a cached URL. Only an exact local
+occurrence can update Tributary's local playback history. Remote ratings keep their live
+read-only/unsupported capability and never gain mutation authority from playlist membership.
+
+Smart playlists and XSPF import/export remain local-only. Mixed-source metadata export requires a
+separate no-locator policy, and Subsonic server-native playlist import/synchronization still needs
+direction, conflict, offline, deletion, and feature semantics. See
+[P1.5](docs/task.md#p15--persist-source-scoped-playlists) and the
 [source-scoped playlist storage contract](docs/source-scoped-playlists.md) for the exact boundary.
 
 #### Importing and exporting playlists
@@ -763,8 +790,9 @@ instead counts that individual row as failed.
 
 XSPF import continues to create entries owned by the built-in local source. The source-scoped
 storage migration does not make an HTTP(S) location or service identifier a remote playlist
-authority, and current export remains a local-track export. A future mixed-source export must use
-safe metadata without requesting or serializing a protected remote locator.
+authority. Export emits only resolved local tracks and therefore is not a complete export of a
+mixed regular playlist. Mixed-source metadata export is explicitly deferred until it has a policy
+that cannot request or serialize a protected remote locator.
 
 Apple Music and iTunes can export playlist metadata as XML, but their XML is an Apple property-list
 format, not XSPF. Follow Apple's official export steps for

--- a/docs/architecture/source-lifecycle.md
+++ b/docs/architecture/source-lifecycle.md
@@ -770,15 +770,23 @@ metadata export remain explicitly deferred P1.5 policies.
    before and after asynchronous work. This step deliberately added no mixed-source playlist UI.
 9. **Mixed-source regular-playlist consumer complete
    ([#142](https://github.com/jm2/tributary/pull/142)):** Add resolves and revalidates the entire
-   selected authenticated batch before one atomic ordered write; Remove addresses exact durable
-   occurrence IDs. Projection preserves positions and duplicates and retains disconnected,
+   selected authenticated batch. After staging SQL and immediately before commit, the transaction
+   performs its final revalidation and acquires exact session/catalogue permits that remain held
+   through commit or rollback. Authority made stale during staging rolls back; refresh, replacement,
+   disconnect, and shutdown after admission wait. The transaction and permits move to an independent
+   completion worker before waiting, so caller cancellation and synchronous revocation cannot
+   strand the permit or starve the database commit. Remove addresses exact durable occurrence IDs.
+   Projection preserves
+   positions and duplicates and retains disconnected,
    retired/unavailable-source, unsupported-source, invalid-catalogue, missing-track, and
    missing/unmatched-local entries as localized removable rows without displaying persisted
    fingerprints. Stale projection work/results are discarded, and the playlist is invalidated and
    reprojected; staleness is not a row reason. Queue items keep per-row media ownership, and remote
    stream/artwork calls deny stale closed guards at use. Local history ownership and remote rating
-   capability remain unchanged. Smart playlists and XSPF import/export remain local-only;
-   mixed-source metadata export and Subsonic-native playlist synchronization remain separate.
+   capability remain unchanged. Smart playlists and XSPF import/export remain local-only; a regular
+   playlist with any remote or unresolved occurrence is refused before XSPF export can touch its
+   destination. Mixed-source metadata export and Subsonic-native playlist synchronization remain
+   separate.
 
 The authenticated-remote cutover's locked debug and release suites each passed 20 library, 865
 application, and 10 repository-metadata tests (895 total), with locked all-target/all-feature

--- a/docs/architecture/source-lifecycle.md
+++ b/docs/architecture/source-lifecycle.md
@@ -4,8 +4,8 @@
   P3.1 is complete. Physical removable-hardware, installed Flatpak portal/USB/custom-library, and
   packaged Windows DAAP/Subsonic playback validation remain tracked field work outside this
   decision. P1.5 migration 13 extends the same identity boundary into regular-playlist storage,
-  and Record A adds a default-deny live-catalogue authority boundary; mixed-source UI integration
-  remains a follow-up and does not reopen P3.1.
+  Record A adds a default-deny live-catalogue authority boundary, and Record B consumes it in
+  mixed-source Add/Remove/render/Play without reopening P3.1.
 - Decision date: 2026-07-17
 - Historical tracker:
   [P3.1](../task-remediation-2026-07.md#p31-introduce-a-sourcesession-registry)
@@ -41,10 +41,11 @@ generation-owned and cancelled on relocation, pre-unmount, removal, or shutdown.
 Regular-playlist storage now follows the same identity rule. Migration 13 assigns every existing
 entry to the built-in local source and stores its canonical `(source_id, track_id)` separately from
 the nullable local-track foreign-key cache. This foundation can represent another source without
-persisting its locator, credentials, lease, or session epoch. The shipping playlist projection is
-still deliberately local-only. P1.5 Record A now gives the live registry an internal, exact
-source/session/catalogue authority query, while Record B remains responsible for consuming it in
-Add/Remove/render/Play behavior. The full boundary is specified in
+persisting its locator, credentials, lease, or session epoch. P1.5 Record A gives the live registry
+an internal, exact source/session/catalogue authority query. Record B now makes that query the only
+non-local authority for regular-playlist Add and rendering, retains exact durable occurrence IDs
+for Remove, and carries each available row's closed guard into at-use stream and artwork
+resolution. The full boundary is specified in
 [`source-scoped-playlists.md`](../source-scoped-playlists.md).
 
 The implementation has now converged on this boundary. PR #120 implements stable identity, PR #121
@@ -174,7 +175,7 @@ Backend-native `TrackId` values are represented as follows:
 | Adapter | Native track identity |
 |---|---|
 | Local library | Exact SQLite `tracks.id` string |
-| Regular-playlist occurrence | The exact `TrackId` of its owning source; internal authority lookup exists, but rendered playlist rows remain local-only pending P1.5 Record B |
+| Regular-playlist occurrence | The exact `TrackId` of its owning source; local rows resolve through current database/file authority, while authenticated remote rows require current Record A catalogue authority and guarded at-use media resolution |
 | Subsonic | Exact song `id` returned by the server |
 | Jellyfin | Exact audio item `Id` returned by the server |
 | Plex | Exact track `ratingKey`; the media-part key remains a locator |
@@ -327,10 +328,12 @@ The local playback adapter resolves the exact database `TrackId` at use, obtains
 path, proves it is contained by the most-specific currently configured authoritative root,
 acquires retained root/marker/ancestor/file authority, and keeps that authority until the output
 or file server has finished consuming it. It rechecks database bindings after acquisition and
-rechecks current root configuration before output handoff. The current playlist navigation path
-queries entries by playlist ID and resolves their nullable `local_track_id` cache from the same
-current snapshot. Stored non-local identities remain outside that projection until Record B wires
-the live-registry authority foundation into the UI.
+rechecks current root configuration before output handoff. Regular-playlist navigation reads every
+durable entry by playlist ID in position order. It resolves a local occurrence's nullable
+`local_track_id` cache against the current database and each eligible non-local occurrence through
+the live-registry authority foundation. Missing local tracks and unavailable remote authority
+remain explicit removable rows rather than being omitted. Smart-playlist projection remains a live
+local-library query.
 
 Fingerprint/path fallback is only a local reconciliation operation. It is restricted to the exact
 built-in local `source_id` and updates both canonical `track_id` and `local_track_id` only after a
@@ -342,9 +345,11 @@ receives or reopens the playback-time path.
 
 A playlist is a `ViewOrigin`, not a source session. Each durable regular-playlist occurrence now
 names its actual media owner with `(source_id, track_id)` while keeping the playlist ID, entry ID,
-and position as view/occurrence state. The current regular- and smart-playlist queue path still
-publishes only local rows. Record A can validate exact current remote catalogue identity internally;
-mixed-source GTK rows, current-epoch adoption, unavailable presentation, and playback are Record B.
+and position as view/occurrence state. A regular-playlist row separately retains that media owner,
+its durable occurrence ID, and any current transient catalogue guard; the queue does not replace
+them with the playlist or local source. Unavailable rows expose fixed localized state without stale
+metadata or persisted fingerprints and cannot enter playback, but they remain removable. Smart
+playlist queues remain local-only.
 Deleting or rebuilding a playlist retires that view's pending navigation without pretending that
 the view owns any contributing source session.
 
@@ -596,11 +601,11 @@ queue can extend the same ephemeral-source rule explicitly.
   full and Range requests independent even when cloned OS handles share a cursor. Every
   replacement, Stop, error, terminal queue completion, ticket drop, or output teardown retires
   future lookups. Shared Chromecast cleanup retains legacy explicit-file routes while revoking
-  credential and retained-authority routes. The currently shipping playlist queue identity uses
-  the local source plus a separate `ViewOrigin`, so generic local retirement also retires a
-  playlist-origin queue without losing view navigation. P1.5 Record B will select the source per
-  stored occurrence through Record A's authority result and retain that same separation between
-  media owner and playlist view.
+  credential and retained-authority routes. A playlist queue retains its separate `ViewOrigin` but
+  selects the media source per stored occurrence. An exact local row takes the local authority path;
+  an authenticated remote row takes Record A's guarded stream/artwork path. Refresh, replacement,
+  retirement, disconnect, shutdown, stale epoch/generation, or missing membership therefore denies
+  a queued remote item at use without conflating source retirement with playlist navigation.
 - Removable sources derive `SourceId` from the best-available logical key and exact `TrackId` from
   the losslessly encoded mount-relative native path. Their registry-owned adapter publishes a
   pathless, epoch-bound accepted catalogue; retained mounted-root authority, an exact membership
@@ -722,9 +727,9 @@ persist credentials. Exact lifecycle trait names and event-channel shapes remain
 implementation details so long as one registry enforces this contract. A typed retained mutation
 authority for pathless removable Properties editing is deliberately deferred; the UI omits that
 action instead of reconstructing a path or weakening playback authority. Source-scoped regular-
-playlist storage and its default-deny live-catalogue authority are specified separately. Their
-Add/Remove/render/Play UI integration and Subsonic-native playlist synchronization remain
-explicitly deferred P1.5 work.
+playlist storage, default-deny live-catalogue authority, and Add/Remove/render/Play consumer are
+specified separately and complete. Subsonic-native playlist synchronization and mixed-source XSPF
+metadata export remain explicitly deferred P1.5 policies.
 
 ## Implementation sequence
 
@@ -762,7 +767,18 @@ explicitly deferred P1.5 work.
    capability and exact current source/session/catalogue lookup now bridge durable source-scoped
    identity to sanitized accepted metadata. Authenticated remote adapters opt in; radio,
    removable, external, and default adapters do not. Guarded stream/artwork resolution revalidates
-   before and after asynchronous work. This step deliberately adds no mixed-source playlist UI.
+   before and after asynchronous work. This step deliberately added no mixed-source playlist UI.
+9. **Mixed-source regular-playlist consumer complete
+   ([#142](https://github.com/jm2/tributary/pull/142)):** Add resolves and revalidates the entire
+   selected authenticated batch before one atomic ordered write; Remove addresses exact durable
+   occurrence IDs. Projection preserves positions and duplicates and retains disconnected,
+   retired/unavailable-source, unsupported-source, invalid-catalogue, missing-track, and
+   missing/unmatched-local entries as localized removable rows without displaying persisted
+   fingerprints. Stale projection work/results are discarded, and the playlist is invalidated and
+   reprojected; staleness is not a row reason. Queue items keep per-row media ownership, and remote
+   stream/artwork calls deny stale closed guards at use. Local history ownership and remote rating
+   capability remain unchanged. Smart playlists and XSPF import/export remain local-only;
+   mixed-source metadata export and Subsonic-native playlist synchronization remain separate.
 
 The authenticated-remote cutover's locked debug and release suites each passed 20 library, 865
 application, and 10 repository-metadata tests (895 total), with locked all-target/all-feature

--- a/docs/playback-history.md
+++ b/docs/playback-history.md
@@ -18,8 +18,9 @@ events, retries, seeks, and wall-clock changes must not manufacture listening hi
 - Regular-playlist migration 13 stores membership by `(source_id, track_id)` but does not broaden
   this boundary. Only an occurrence whose `source_id` is exactly the built-in local source and
   whose nullable local foreign-key cache resolves to that row can contribute local history. A
-  future mixed playlist may place remote and local occurrences beside each other without letting a
-  remote native ID update a coincidentally equal local ID. See the
+  mixed regular playlist may place remote and local occurrences beside each other, but its queue
+  retains each row's real media owner and never lets a remote native ID update a coincidentally
+  equal local ID. An unavailable remote row cannot enter playback. See the
   [playlist storage contract](source-scoped-playlists.md).
 - `PlaybackSession` owns one `PlaybackHistoryProgress` value per queue occurrence, independently
   of replaceable output-event generations. A retry may bind a new accepted delivery to the same

--- a/docs/ratings.md
+++ b/docs/ratings.md
@@ -32,10 +32,11 @@ are `Unsupported`, so a new or incomplete remote adapter fails closed.
 
 Regular-playlist migration 13 does not change that ownership. Its durable `(source_id, track_id)`
 pair records membership only; neither the entry nor its safe match fingerprint stores a rating or
-grants mutation authority. Current local playlist projections continue to edit the exact linked
-local row. A later mixed-source projection must obtain a remote row's ReadOnly or Unsupported value
-from the current live source catalogue rather than treating persisted membership as metadata
-authority. See the [playlist storage contract](source-scoped-playlists.md).
+grants mutation authority. An available local playlist row continues to edit the exact linked
+local track. An available authenticated remote row obtains its ReadOnly or Unsupported value only
+from the current live source catalogue; an unavailable row has no persisted rating snapshot to
+display. Playlist membership, a cached GTK row, or a stored fingerprint never authorizes a remote
+write. See the [playlist storage contract](source-scoped-playlists.md).
 
 ## Local persistence
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,8 +28,9 @@ starts. Historical holistic-review documents are point-in-time findings, not act
   existing entry the built-in local `SourceId`, makes `(source_id, track_id)` canonical, and
   retains a separate nullable local-track foreign-key cache for deletion and reconciliation.
   Regular playlists now mix exact local occurrences with current authenticated Subsonic,
-  Jellyfin, Plex, and DAAP entries. Add validates a complete selection through the default-deny
-  live registry before one atomic ordered write; Remove uses exact durable occurrence IDs, so
+  Jellyfin, Plex, and DAAP entries. Add first resolves a complete selection through the default-deny
+  live registry, then revalidates after staging SQL and retains exact authority permits through its
+  atomic commit or rollback; Remove uses exact durable occurrence IDs, so
   duplicates remain independent. Rendering preserves every position and shows disconnected,
   retired/unavailable-source, unsupported-source, invalid-catalogue, missing-track, or
   missing/unmatched-local entries as localized unavailable rows that stay removable. Stale
@@ -153,14 +154,18 @@ before starting large protocol or transfer subsystems.
    shutdown, and final release invalidate or deny old guards at their defined boundaries. This
    internal foundation was not itself an Add/Remove/Play feature; [#142] is its reviewed consumer.
 7. **Completed: integrate mixed-source regular-playlist UI ([#142]).** Add consumes Record A's exact
-   current authority for authenticated Subsonic, Jellyfin, Plex, and DAAP entries and commits the
-   entire ordered selection or nothing. Remove addresses durable occurrence IDs atomically.
+   current authority for authenticated Subsonic, Jellyfin, Plex, and DAAP entries. Its transaction
+   revalidates after staging SQL and acquires an exact permit immediately before committing the
+   entire ordered selection or nothing. A stale final check rolls back; lifecycle invalidation
+   after admission waits for commit or rollback. Remove addresses durable occurrence IDs atomically.
    Projection preserves ordering and duplicates while retaining explicit removable unavailable
    rows without stale metadata or fingerprint matching. Queue items use each occurrence's real
    source, and guarded remote stream/artwork resolution rejects refresh, replacement, retirement,
    disconnect, stale epoch/generation, or missing membership at use. Local history ownership and
    remote rating capability do not widen. Radio-Browser, removable, external-file, and unknown
-   sources remain unsupported; smart playlists and XSPF import/export remain local-only. Native
+   sources remain unsupported; smart playlists and XSPF import/export remain local-only, and a
+   remote or unresolved regular occurrence makes XSPF export refuse all-or-none rather than emit a
+   local-only subset. Native
    Subsonic playlist semantics and mixed-source metadata export remain separate later policies.
 
 These contracts make Rhythmbox migration and Last.fm behavior much less ambiguous.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,7 +6,7 @@ This document explains the product and engineering work that remains **after** t
 remediation. [`task.md`](task.md) is the countable active implementation backlog; the completed
 remediation record is preserved separately in
 [`task-remediation-2026-07.md`](task-remediation-2026-07.md) at **220/223 (98.7%)**, with only three
-real-environment validation records left. The feature backlog is now **9/36 (25.0%)** complete.
+real-environment validation records left. The feature backlog is now **10/36 (27.8%)** complete.
 Neither percentage estimates equal engineering effort, and the historical percentage is not a
 claim that Tributary has implemented every requested product feature.
 
@@ -26,16 +26,22 @@ starts. Historical holistic-review documents are point-in-time findings, not act
 - AirPlay 1/RAOP, Chromecast, MPD, and local playback are implemented. AirPlay 2/HomeKit is not.
 - Regular-playlist storage now has a source-scoped foundation: migration 13 gives every valid
   existing entry the built-in local `SourceId`, makes `(source_id, track_id)` canonical, and
-  retains a separate nullable local-track foreign-key cache for deletion and reconciliation. The
-  shipping UI remains a local-library projection, so it does not yet create, render, or play the
-  non-local rows. An Add to Playlist attempt from any unsupported source still explains that
-  boundary in the user's language and performs no database work instead of silently skipping rows.
-  The internal live-catalogue authority layer now defaults every adapter to unsupported and permits
-  source-scoped entry lookup only for explicitly opted-in authenticated Subsonic, Jellyfin, Plex,
-  and DAAP sessions. Exact source, epoch, accepted catalogue generation, membership, and capability
-  are revalidated around asynchronous media resolution; sanitized results expose no locator,
-  credential, lease, route, or raw backend failure. This foundation does not enable UI actions.
-  Subsonic server-side playlists are not imported. See the
+  retains a separate nullable local-track foreign-key cache for deletion and reconciliation.
+  Regular playlists now mix exact local occurrences with current authenticated Subsonic,
+  Jellyfin, Plex, and DAAP entries. Add validates a complete selection through the default-deny
+  live registry before one atomic ordered write; Remove uses exact durable occurrence IDs, so
+  duplicates remain independent. Rendering preserves every position and shows disconnected,
+  retired/unavailable-source, unsupported-source, invalid-catalogue, missing-track, or
+  missing/unmatched-local entries as localized unavailable rows that stay removable. Stale
+  projected work/results are discarded and the playlist is invalidated and reprojected. It never
+  displays a persisted fingerprint as stale metadata or uses one to guess a remote replacement.
+  Each queue item keeps its real source owner;
+  remote stream and artwork access revalidates exact epoch, accepted catalogue generation,
+  membership, and capability at use while exposing no locator, credential, lease, route, or raw
+  backend failure. Only local occurrences own local playback history, and remote ratings remain
+  read-only or unsupported. Radio-Browser, removable, external, and unknown sources remain
+  unsupported. Smart playlists and XSPF import/export remain local-only; mixed-source metadata
+  export and Subsonic server-native playlist synchronization remain separate. See the
   [storage contract](source-scoped-playlists.md).
 - XSPF v1 import/export is implemented with exact path and deterministic normalized-metadata
   matching. Apple/iTunes XML, Google Takeout CSV, M3U, service URLs, and fuzzy matching are not
@@ -86,12 +92,12 @@ before starting large protocol or transfer subsystems.
    retained boundary, and starts complete Repeat All cycles without an immediate repeat. Shuffle
    toggles, rollback, lifecycle resets, duplicate occurrences, small queues, and the shared
    header/OS Previous dispatcher are covered by regressions.
-2. **Completed: make remote-to-playlist behavior explicit ([#47]).** Add to Playlist now snapshots
-   the active source and refuses every non-local selection with a localized, all-or-none dialog
-   before database work. Full support remains separate: the source-scoped `(SourceId, TrackId)`
-   storage and internal live-catalogue authority foundations are complete, and user-facing
-   disconnected/Add/Remove/render/Play behavior is the current record. Subsonic server-native
-   playlist import/sync is another slice.
+2. **Completed: make unsupported remote-to-playlist behavior explicit ([#47]).** The initial slice
+   made every then-unsupported non-local selection fail visibly and all-or-none before database
+   work. Source-scoped storage, default-deny authority, and the capability-gated mixed-source
+   integration now admit current authenticated Subsonic, Jellyfin, Plex, and DAAP rows while
+   retaining that refusal for radio, removable, external, unknown, or unavailable selections and
+   discarding stale selection results.
 3. **Completed: implement trustworthy local playback history.** The durable schema,
    [counted-play contract](playback-history.md), production persistence pipeline, and seeded
    consumers are complete.
@@ -145,14 +151,19 @@ before starting large protocol or transfer subsystems.
    remains alive. Connecting or failed replacement may
    retain an accepted predecessor; successful replacement, same-session refresh, disconnect,
    shutdown, and final release invalidate or deny old guards at their defined boundaries. This
-   internal foundation is not an Add/Remove/Play feature.
-7. **Current: integrate mixed-source regular-playlist UI.** Add, Remove, rendering, unavailable-row
-   presentation, and Play must consume Record A's exact registry authority without deriving support
-   from backend labels, cached GTK rows, metadata, or persisted locators. Radio-Browser, removable,
-   external-file, and unknown sources stay unsupported. Native Subsonic playlist semantics remain a
-   separate later record rather than being implied by either foundation.
+   internal foundation was not itself an Add/Remove/Play feature; [#142] is its reviewed consumer.
+7. **Completed: integrate mixed-source regular-playlist UI ([#142]).** Add consumes Record A's exact
+   current authority for authenticated Subsonic, Jellyfin, Plex, and DAAP entries and commits the
+   entire ordered selection or nothing. Remove addresses durable occurrence IDs atomically.
+   Projection preserves ordering and duplicates while retaining explicit removable unavailable
+   rows without stale metadata or fingerprint matching. Queue items use each occurrence's real
+   source, and guarded remote stream/artwork resolution rejects refresh, replacement, retirement,
+   disconnect, stale epoch/generation, or missing membership at use. Local history ownership and
+   remote rating capability do not widen. Radio-Browser, removable, external-file, and unknown
+   sources remain unsupported; smart playlists and XSPF import/export remain local-only. Native
+   Subsonic playlist semantics and mixed-source metadata export remain separate later policies.
 
-These foundations make Rhythmbox migration and Last.fm behavior much less ambiguous.
+These contracts make Rhythmbox migration and Last.fm behavior much less ambiguous.
 
 ### 2. Build migration and listening integrations
 
@@ -219,7 +230,7 @@ mistaken for work already underway.
 | [#57 — Rhythmbox playlists, play counts, and ratings](https://github.com/jm2/tributary/issues/57) | No direct importer. XSPF conversion plus completed playback-history and rating contracts are foundations; XSPF deliberately transfers neither history nor ratings. | Build a separate transactional, idempotent migration with explicit metadata consent and conflict reporting. |
 | [#50 — Last.fm scrobbling](https://github.com/jm2/tributary/issues/50) | No Last.fm client or scrobble pipeline. | Authorization, secret storage, authoritative thresholds, retry/offline queue, and privacy UX. |
 | [#49 — Equalizer](https://github.com/jm2/tributary/issues/49) | No equalizer or audio-filter configuration. | GStreamer DSP design plus explicit behavior for every output backend. |
-| [#47 — Remote/Subsonic tracks in playlists](https://github.com/jm2/tributary/issues/47) | Non-local Add to Playlist attempts are refused visibly and atomically. Source-scoped storage is complete, and a default-deny registry authority foundation now validates exact current authenticated catalogues without exposing locators; no user-facing action yet admits, renders, or plays remote rows, and server-native playlist sync is absent. | Publish the authority foundation, integrate mixed-source UI against it, then design server playlist import/sync separately. |
+| [#47 — Remote/Subsonic tracks in playlists](https://github.com/jm2/tributary/issues/47) | Source-scoped storage, default-deny live authority, and exact mixed-source Add/Remove/render/Play are complete for local plus authenticated Subsonic, Jellyfin, Plex, and DAAP entries. Unavailable rows remain visible/removable; unsupported sources fail all-or-none; no locator or credential is persisted. Smart playlists and XSPF remain local-only, and server-native Subsonic sync is absent. | Design Subsonic server-native direction, conflict, offline, deletion, and feature semantics separately; define a no-locator metadata policy before any mixed-source export. |
 | [#46 — Drag and drop](https://github.com/jm2/tributary/issues/46) | Column-header reordering exists; track/file drag-and-drop does not. | Local playlist DnD first; file export, remote rows, and device copies as distinct policies. |
 | [#39 — Album art in browser](https://github.com/jm2/tributary/issues/39) | Artwork is shown for now-playing, not in the Genre/Artist/Album browser. | Virtualized art UI with bounded async cache, cancellation, accessibility, and authenticated art. |
 | [#29 — UI refinement](https://github.com/jm2/tributary/issues/29) | Requested separators/alignment changes are not implemented. | Split into independently reviewable visual changes after current-theme design review. |
@@ -297,3 +308,4 @@ When an item becomes active:
 [#57]: https://github.com/jm2/tributary/issues/57
 [#140]: https://github.com/jm2/tributary/pull/140
 [#141]: https://github.com/jm2/tributary/pull/141
+[#142]: https://github.com/jm2/tributary/pull/142

--- a/docs/source-scoped-playlists.md
+++ b/docs/source-scoped-playlists.md
@@ -126,10 +126,16 @@ The current user-visible behavior is:
 
 - **All-or-none Add:** a local selection writes `(SourceId::local(), tracks.id)` plus the matching
   `local_track_id`. An authenticated Subsonic, Jellyfin, Plex, or DAAP selection must first resolve
-  every ordered `MediaKey` through Record A and recheck the complete result before one atomic
-  storage operation. A current unsupported, disconnected, missing, or invalid-catalogue selection
-  writes nothing and presents fixed localized copy; a result made stale before commit is discarded
-  and also writes nothing. Duplicate selections create distinct ordered occurrence IDs.
+  every ordered `MediaKey` through Record A. After staging the ordered SQL inserts and immediately
+  before commit, the same transaction revalidates the complete result and atomically acquires exact
+  current session/catalogue permits. A result made stale during staging rolls the transaction back;
+  after admission, refresh, replacement, disconnect, and shutdown wait for commit or rollback.
+  The transaction and permits transfer to an independent completion worker before that final wait,
+  so caller cancellation or a synchronous lifecycle revoker cannot strand authority or starve the
+  commit.
+  A current unsupported, disconnected, missing, or invalid-catalogue selection likewise writes
+  nothing and presents fixed localized copy. Duplicate selections create distinct ordered
+  occurrence IDs.
 - **Regular-playlist load:** reads every stored occurrence in position order. Local identities use
   exact current database rows; eligible non-local identities consume only the registry's current
   sanitized metadata. A missing local track, unavailable or retired source, unsupported owner,
@@ -157,9 +163,10 @@ The current user-visible behavior is:
   occurrence and its reconciliation evidence. Deleting a playlist still cascades its entries.
 - **Rename and root reauthorization:** ID-preserving operations retain both source-scoped identity
   and the local cache. Existing guarded path-evidence relocation remains local-only.
-- **XSPF export:** emits only resolved local tracks and is not a complete export of a mixed regular
-  playlist. Mixed-source metadata export is explicitly deferred until it has a policy that cannot
-  obtain or serialize a protected remote locator.
+- **XSPF export:** refuses a regular playlist containing any remote or unresolved occurrence before
+  touching the destination; it never emits a truncated local-only subset. Mixed-source metadata
+  export is explicitly deferred until it has a policy that cannot obtain or serialize a protected
+  remote locator.
 
 The existing P1.2 refusal remains the correct fail-closed result, but Record B narrows it to a
 selection that Record A does not authorize. Retained authenticated Subsonic, Jellyfin, Plex, and
@@ -300,7 +307,9 @@ The storage record is complete only when automated coverage demonstrates:
 
 The storage and authority foundation records do not retroactively claim their consumer. Native
 Subsonic playlist synchronization and mixed-source XSPF metadata export remain explicitly deferred
-and require their own validation.
+and require their own validation. Until a no-locator mixed-source export policy exists, a regular
+playlist containing any remote or unresolved occurrence is refused all-or-none before XSPF touches
+its destination; the local-only compatibility projection is never exported as a truncated result.
 
 Record A additionally requires automated coverage for default-deny adapters, the four explicit
 authenticated opt-ins, Invalid playlist indexing for missing/duplicate catalogue-native identity,
@@ -311,9 +320,10 @@ duplicate requested occurrences and isolate one missing track's Unavailable resu
 neighbors. Passing those tests alone does not claim Add/Remove/render/Play UI integration.
 
 Record B additionally requires automated coverage that the complete selected Add batch is resolved
-and revalidated all-or-none; local plus each of the four authenticated opt-ins are admitted while
-current radio, removable, external, unknown, unavailable, invalid, and missing cases write nothing,
-and stale Add results are discarded before any write. Projection tests preserve occurrence IDs,
+and admitted under commit-scoped authority all-or-none; local plus each of the four authenticated
+opt-ins are admitted while current radio, removable, external, unknown, unavailable, invalid, and
+missing cases write nothing, stale final acquisition rolls back staged writes, and lifecycle
+invalidation cannot cross an admitted commit. Projection tests preserve occurrence IDs,
 positions, and duplicates; retain every unavailable row without displaying fingerprints; discard
 stale projection work/results before current reprojection; and restore only exact reconnected
 identity. Remove tests address durable entry IDs atomically, including repeated and unavailable

--- a/docs/source-scoped-playlists.md
+++ b/docs/source-scoped-playlists.md
@@ -1,8 +1,10 @@
-# Source-scoped regular playlist storage and authority contract
+# Source-scoped regular playlist storage, authority, and UI contract
 
-This document defines the durable-storage contract and the following live-catalogue authority
-foundation for [P1.5](task.md#p15--persist-source-scoped-playlists). Neither foundation changes
-which source rows the shipping UI can add, display, or play.
+This document defines the durable-storage contract, live-catalogue authority, and mixed-source UI
+integration for [P1.5](task.md#p15--persist-source-scoped-playlists). The storage foundation landed
+in [#140](https://github.com/jm2/tributary/pull/140), Record A's default-deny live authority in
+[#141](https://github.com/jm2/tributary/pull/141), and Record B's Add/Remove/render/Play consumer in
+[#142](https://github.com/jm2/tributary/pull/142).
 
 The central rule is:
 
@@ -15,25 +17,25 @@ either component or persisted as remote playlist authority.
 
 ## Scope and delivery boundary
 
-This storage slice covers:
+The [#140](https://github.com/jm2/tributary/pull/140) storage slice covers:
 
 - migration 13 and the `playlist_entries` entity;
 - deterministic conversion of every valid existing entry to the built-in local `SourceId`;
 - a canonical source-scoped identity plus a separate local foreign-key cache;
 - preservation of playlist order, duplicate occurrences, entry identity, and local reconciliation
   evidence;
-- typed storage operations for future non-local additions without admitting locators or
-  credentials—the schema is source-generic, but this is an internal capability rather than a
-  promise that every source kind is addable; and
+- typed storage operations for non-local additions without admitting locators or credentials—the
+  schema is source-generic, but it is not by itself a promise that every source kind is addable; and
 - compatibility for all currently shipping local regular-playlist, XSPF-import, reconciliation,
   rename, and deletion paths.
 
-It deliberately does **not** enable remote Add to Playlist, mixed-source playlist rendering or
-playback, disconnected-row presentation, playlist-UI lifecycle refresh, or remote XSPF export.
-P1.5 Record A adds the internal live-registry authority described below; Record B must integrate it
-into those user-facing behaviors. Subsonic server-native playlist listing, import, synchronization,
-conflict handling, and deletion semantics remain a separate record and require their own design
-before implementation.
+At that delivery boundary the storage slice deliberately did **not** enable remote Add to Playlist,
+mixed-source rendering or playback, disconnected-row presentation, or playlist-UI lifecycle
+refresh. Record A added the internal live-registry authority described below, and Record B now
+integrates it into those user-facing behaviors without changing the durable schema. Remote XSPF
+metadata export still needs an explicit no-locator policy. Subsonic server-native playlist listing,
+import, synchronization, conflict handling, and deletion semantics remain a separate record and
+require their own design before implementation.
 
 Smart playlists are unaffected. They remain live queries over the local library rather than stored
 regular-playlist occurrences.
@@ -114,18 +116,36 @@ later appended column from making a valid migrated table look like the legacy de
 
 ## Storage operations and local compatibility
 
-The storage boundary accepts typed `SourceId` and `TrackId` values. A future non-local insertion
-may retain optional non-secret metadata fingerprints, must not provide a file path, and must commit
-all selected occurrences atomically. Those normalized snapshots are neither display fields,
-identity, nor matching authority. The exact same native track ID from two sources remains two
-different media objects.
+The storage boundary accepts typed `SourceId` and `TrackId` values. A non-local insertion may retain
+optional non-secret metadata fingerprints, must not provide a file path, and must commit all
+selected occurrences atomically. Those normalized snapshots are neither display fields, identity,
+nor matching authority. The exact same native track ID from two sources remains two different
+media objects.
 
-The user-visible behavior in this slice stays local-only:
+The current user-visible behavior is:
 
-- **Manual local add:** writes `(SourceId::local(), tracks.id)` and the matching
-  `local_track_id`, preserving normalized fingerprint metadata and duplicate occurrences.
-- **Regular-playlist load:** retains the established local projection and ordering. Stored
-  non-local or currently unmatched entries are not yet rendered or sent to playback.
+- **All-or-none Add:** a local selection writes `(SourceId::local(), tracks.id)` plus the matching
+  `local_track_id`. An authenticated Subsonic, Jellyfin, Plex, or DAAP selection must first resolve
+  every ordered `MediaKey` through Record A and recheck the complete result before one atomic
+  storage operation. A current unsupported, disconnected, missing, or invalid-catalogue selection
+  writes nothing and presents fixed localized copy; a result made stale before commit is discarded
+  and also writes nothing. Duplicate selections create distinct ordered occurrence IDs.
+- **Regular-playlist load:** reads every stored occurrence in position order. Local identities use
+  exact current database rows; eligible non-local identities consume only the registry's current
+  sanitized metadata. A missing local track, unavailable or retired source, unsupported owner,
+  invalid catalogue, or missing remote track becomes an explicit localized unavailable row that
+  remains visible and removable. Stale projected work or results are discarded; the playlist is
+  invalidated and projected again from current authority rather than presenting staleness as a row
+  reason. Persisted fingerprints are never displayed as stale metadata or used to choose a
+  replacement.
+- **Exact Remove:** removes the selected durable entry IDs in one transaction. Each repeated
+  occurrence is independently addressable, unavailable rows require no live source authority, and
+  an error leaves every selected occurrence unchanged.
+- **Per-occurrence Play and artwork:** the playlist remains a `ViewOrigin`, while each projected
+  row and queue item retains its actual media-owning source. Local media uses current retained
+  root/file authority. Remote stream and artwork access revalidate the row's exact transient guard
+  before and after adapter work, so refresh, replacement, retirement, disconnect, shutdown, or a
+  stale epoch/generation cannot reuse a cached locator.
 - **XSPF import:** continues to create local-owned entries only. Exact file-path and deterministic
   metadata matching are unchanged, and an unmatched usable row remains a local occurrence with no
   `track_id` or `local_track_id` until reconciliation succeeds.
@@ -137,22 +157,21 @@ The user-visible behavior in this slice stays local-only:
   occurrence and its reconciliation evidence. Deleting a playlist still cascades its entries.
 - **Rename and root reauthorization:** ID-preserving operations retain both source-scoped identity
   and the local cache. Existing guarded path-evidence relocation remains local-only.
-- **XSPF export:** remains the existing local-track export in this slice. Mixed-source export needs
-  an explicit metadata-only policy and is part of the later presentation/integration work; it may
-  not obtain or serialize a protected remote locator.
+- **XSPF export:** emits only resolved local tracks and is not a complete export of a mixed regular
+  playlist. Mixed-source metadata export is explicitly deferred until it has a policy that cannot
+  obtain or serialize a protected remote locator.
 
-The existing P1.2 refusal remains correct until Record B lands: selecting Add to Playlist
-from a remote, radio, removable, external, or malformed source still presents localized all-or-none
-copy before opening the database. Neither the storage capability nor Record A's internal lookup is
-itself UI authorization. Record B will initially admit only retained authenticated catalogues
-through the explicit registry capability. Radio-Browser, removable media, ephemeral external
-files, and unknown sources remain unsupported until their persistence and lifecycle semantics are
-separately designed.
+The existing P1.2 refusal remains the correct fail-closed result, but Record B narrows it to a
+selection that Record A does not authorize. Retained authenticated Subsonic, Jellyfin, Plex, and
+DAAP catalogues may opt in through the explicit capability. Radio-Browser, removable media,
+ephemeral external files, and unknown sources remain unsupported; a generic storage shape, backend
+label, source key, cached GTK row, or persisted fingerprint cannot authorize them.
 
 ## Live registry and accepted-catalogue authority
 
-P1.5 Record A establishes an internal authority boundary between durable source-scoped identity
-and later playlist UI integration ([#141](https://github.com/jm2/tributary/pull/141)).
+P1.5 Record A ([#141](https://github.com/jm2/tributary/pull/141)) establishes the internal
+authority boundary between durable source-scoped identity and Record B's playlist UI integration
+([#142](https://github.com/jm2/tributary/pull/142)).
 `ManagedSourceAdapter` exposes a closed
 `RegularPlaylistCapability`: its default is `Unsupported`, and only the retained authenticated
 Subsonic, Jellyfin, Plex, and DAAP catalogue adapters explicitly opt into
@@ -217,35 +236,44 @@ replacement or same-session catalogue refresh invalidates guards minted from the
 payload. Disconnect, shutdown, and final source release synchronously deny new authority before
 asynchronous teardown can finish.
 
-These APIs are an authority foundation only. The shipping Add/Remove/render/Play paths do not call
-them yet, do not show stored non-local rows, and retain the localized all-or-none refusal from P1.2.
+Record A did not by itself authorize a UI or database operation. Record B now makes these APIs the
+only non-local admission and projection authority: Add and rendering consume their ordered result,
+then guarded Play and artwork independently revalidate it at use. Remove instead consumes the
+durable playlist occurrence ID and therefore remains available even when its media owner is not.
+The localized P1.2 refusal still applies whenever the closed capability or current-state checks do
+not authorize the complete selected batch.
 
 ## Source lifecycle and unavailable identity
 
 Persistent membership does not imply a live source session. Only `source_id` and `track_id` survive
 restart; a session epoch is deliberately transient.
 
-Record A can now validate a non-local identity internally against the exact current
-`SourceRegistry` source, epoch, accepted catalogue generation, and native track. Record B must use
-that result to make disconnect, source retirement, a missing server-side track, refresh, or session
-replacement visibly unavailable while leaving the database row intact. Reconnection may restore it
-only when the same `SourceId` publishes the same `TrackId`; endpoint similarity and metadata are
-not identity evidence.
+Record B validates every non-local identity against the exact current `SourceRegistry` source,
+epoch, accepted catalogue generation, capability, and native track. A currently unavailable or
+retired source, unsupported source, invalid catalogue, or missing server-side track makes the
+occurrence visibly unavailable while leaving its durable row and position intact; a missing or
+unmatched local identity follows the corresponding local unavailable path. The unavailable
+projection uses fixed localized state, not a persisted fingerprint or stale metadata snapshot, and
+remains removable by exact entry ID. Refresh, session replacement, or any other authority change
+instead discards stale projection work/results, invalidates the playlist, and projects it again.
+Reconnection may restore it only when the same `SourceId` publishes the same `TrackId`; endpoint
+similarity and metadata are not identity evidence.
 
-Until Record B exists, stored non-local fixtures remain intentionally outside the regular-
-playlist UI projection. This prevents the storage migration from accidentally treating durable
-identity as a locator or presenting a row that the current queue still assigns to the local source.
+An available row carries its actual media-owning source separately from the playlist view. Its
+queue item adopts only the guard returned for that current projection. Source refresh or retirement
+invalidates active and cached playlist projections, while at-use stream and artwork checks prevent
+an already queued item carrying a stale guard from crossing the lifecycle boundary.
 
 ## Ratings and playback history
 
-This migration does not transfer ownership of track metadata:
+These records do not transfer ownership of track metadata:
 
-- Tributary ratings remain writable only for tracks owned by the local library. A future remote
-  playlist row will display the live source's read-only or unsupported rating capability; this
-  schema persists no rating snapshot and grants no write authority.
+- Tributary ratings remain writable only for tracks owned by the local library. A remote playlist
+  row displays the current live source's read-only or unsupported rating capability; this schema
+  persists no rating snapshot and grants no write authority.
 - Playback history remains local-only. A local occurrence reached through a regular playlist can
-  still contribute to its exact local track. A future remote occurrence must not update the local
-  `tracks` table merely because it appears beside local entries.
+  still contribute to its exact local track. A remote occurrence does not update the local
+  `tracks` table merely because it appears beside local entries or has an equal native ID.
 
 See the [rating contract](ratings.md), [playback-history contract](playback-history.md), and
 [source-lifecycle architecture](architecture/source-lifecycle.md) for those independent authority
@@ -270,9 +298,9 @@ The storage record is complete only when automated coverage demonstrates:
   deletion/retirement cannot cascade into playlist storage, and no remote locator or credential is
   accepted or serialized.
 
-Mixed-source rendering, interaction, playback, unavailable-state presentation, and native
-Subsonic playlist tests belong to their explicitly deferred records rather than being claimed by
-the storage or authority foundations.
+The storage and authority foundation records do not retroactively claim their consumer. Native
+Subsonic playlist synchronization and mixed-source XSPF metadata export remain explicitly deferred
+and require their own validation.
 
 Record A additionally requires automated coverage for default-deny adapters, the four explicit
 authenticated opt-ins, Invalid playlist indexing for missing/duplicate catalogue-native identity,
@@ -280,4 +308,18 @@ sanitized metadata, stale epoch/generation rejection, predecessor retention duri
 failed replacement, invalidation after replacement/refresh, synchronous disconnect/shutdown/final-
 release denial, and pre/post-async stream and artwork revalidation. Ordered lookup must preserve
 duplicate requested occurrences and isolate one missing track's Unavailable result from valid
-neighbors. Passing those tests does not claim Add/Remove/render/Play UI integration.
+neighbors. Passing those tests alone does not claim Add/Remove/render/Play UI integration.
+
+Record B additionally requires automated coverage that the complete selected Add batch is resolved
+and revalidated all-or-none; local plus each of the four authenticated opt-ins are admitted while
+current radio, removable, external, unknown, unavailable, invalid, and missing cases write nothing,
+and stale Add results are discarded before any write. Projection tests preserve occurrence IDs,
+positions, and duplicates; retain every unavailable row without displaying fingerprints; discard
+stale projection work/results before current reprojection; and restore only exact reconnected
+identity. Remove tests address durable entry IDs atomically, including repeated and unavailable
+occurrences. Queue and artwork tests retain per-row media ownership, use the closed guard at use,
+and reject refresh, replacement, retirement, stale epoch/generation, and missing membership. Rating
+and history regressions prove
+that playlist membership grants neither remote rating mutation nor local-history ownership to a
+remote occurrence. Every new unavailable and mutation result is non-fallback localized across all
+13 shipped catalogues.

--- a/docs/task.md
+++ b/docs/task.md
@@ -21,24 +21,24 @@ state.
 - Do not treat the order below as a release promise. It is a dependency-aware starting order and
   can change as issues receive product decisions and milestones.
 
-Current status: **9/36 (25.0%)** active implementation records complete. This percentage measures
+Current status: **10/36 (27.8%)** active implementation records complete. This percentage measures
 checklist completion, not equal engineering effort: several P3 records are deliberately large
 epics. The archived remediation remains **220/223 (98.7%)** complete; its three open records are
 real-environment validation, not missing implementation.
 
 ## Current focus
 
-P1.1, P1.2, all three P1.3 playback-history records, both P1.4 rating records, and P1.5's
-source-scoped regular-playlist storage and live-catalogue authority foundations are complete.
-Continue with P1.5 Record B, which will use that default-deny authority in Add/Remove/render/Play UI
-and make disconnected, retired, stale-epoch, and missing-track states visible without weakening the
-storage contract's no-locator/no-credential boundary. The rest of P1 builds on the source-scoped
-identity already present in the runtime, the now-bounded shuffle navigation semantics,
-authoritative local playback history with deterministic live consumers, and an exact
-capability-aware rating field.
+P1.1, P1.2, all three P1.3 playback-history records, both P1.4 rating records, and P1.5's three
+source-scoped storage, authority, and mixed-source UI records are complete. Continue with
+the remaining P1.5 record: define Subsonic server-native playlist import/synchronization direction,
+conflict, offline, deletion, and feature semantics before implementing it. This native-server slice
+must remain separate from Tributary's regular playlists, whose exact local plus authenticated
+Subsonic/Jellyfin/Plex/DAAP Add/Remove/render/Play path now consumes the default-deny registry
+authority without persisting locators or credentials. Smart playlists and XSPF import/export remain
+local-only, while mixed-source metadata export requires its own no-locator policy.
 
 The independent Linux watcher correctness fix tracked in
-[#103](https://github.com/jm2/tributary/pull/103) does not change the **9/36** feature total.
+[#103](https://github.com/jm2/tributary/pull/103) does not change the **10/36** feature total.
 The salvaged scope rejects explicitly classified access/access-time noise before the bounded watcher
 queue without filtering real bootstrap mutations or backend errors, while retaining overflow
 evidence for authoritative reconciliation. It intentionally omits the original persistent
@@ -88,14 +88,14 @@ the 36-record feature backlog.
   Keep this slice migration-free. It closes the misleading current interaction while P1.5 designs
   full remote playlist persistence.
 
-  Implemented contract: the context menu snapshots the active source together with its selection.
-  Only the exact built-in `local` view may enter the local-playlist database path. Choosing a
-  destination playlist from an authenticated remote, Radio-Browser, removable source, or any
-  unknown/pathless view now presents a localized all-or-none explanation before a runtime task or
-  database connection is created, so no unsupported selection can be partially written. Existing
-  Add/Remove/Properties menu labels now use their shipped translations as well. Policy regressions
-  fail closed across exact remote/radio/removable identities and malformed keys, and all 13 locale
-  catalogs carry non-fallback result copy. Persistent remote playlist entries remain P1.5.
+  Implemented delivery boundary: the context menu snapshots the active source together with its
+  selection. In [#133](https://github.com/jm2/tributary/pull/133), only the exact built-in `local`
+  view could enter the playlist database path; every non-local or malformed view presented a
+  localized all-or-none explanation first. Existing Add/Remove/Properties labels used their
+  shipped translations, and all 13 locale catalogs carried non-fallback result copy. P1.5 Record B
+  now admits current authenticated Subsonic, Jellyfin, Plex, and DAAP selections through exact
+  registry authority while retaining that refusal for unsupported or unavailable selections and
+  discarding stale selection results.
 
 ### P1.3 — Record trustworthy local playback history
 
@@ -265,17 +265,40 @@ the 36-record feature backlog.
   selector-time stale-work denial, synchronous lifecycle denial, and
   membership/capability/epoch/generation checks before and after stream or artwork resolution.
 
-- [ ] **Record B — Mixed-source UI integration:** integrate the registry authority foundation into
+- [x] **Record B — Mixed-source UI integration:** integrate the registry authority foundation into
   regular-playlist Add, Remove, rendering, and Play behavior, with explicit disconnected/missing
   states, source retirement, stale-epoch rejection, occurrence ordering, duplicates, and all-or-none
-  multi-selection tests.
+  multi-selection tests ([#142](https://github.com/jm2/tributary/pull/142)).
 
-  Explicitly deferred from Record A: the current UI still refuses every non-local Add before
-  database work and projects only local entries. Record B must consume the registry result rather
-  than infer support from a source key, backend label, cached GTK row, or persisted fingerprint.
-  Radio-Browser, removable media, ephemeral external files, and unknown sources remain unsupported
-  until separately designed; neither a generic storage shape nor a registry lookup API authorizes
-  them.
+  Implemented contract: Add to Playlist accepts exact local rows plus current authenticated
+  Subsonic, Jellyfin, Plex, and DAAP catalogue rows. It resolves the complete ordered remote
+  selection through Record A, rechecks current epoch/generation immediately before one atomic
+  storage operation, and writes nothing if any current member is unsupported, unavailable, missing,
+  or in an invalid catalogue. A result made stale before commit is discarded and also writes
+  nothing. Support is never inferred from a source key, backend label, cached GTK row, or persisted
+  fingerprint. Radio-Browser, removable media, ephemeral external files, and unknown sources remain
+  unsupported and receive the localized all-or-none refusal.
+
+  Regular rendering retains every durable occurrence in position order, including duplicates and
+  unavailable rows. Local rows use exact current database metadata; authenticated remote rows use
+  only Record A's sanitized current catalogue projection. Disconnected or retired sources,
+  unsupported owners, invalid catalogues, missing native tracks, and missing/unmatched local
+  identities produce explicit localized rows that remain removable. Stale projection work or
+  results are discarded and the playlist is invalidated and projected again from current
+  authority; a stale guard is denied rather than rendered as a row state. No persisted fingerprint
+  is shown as display metadata or used to guess a replacement. Remove uses exact durable entry IDs
+  in one transaction, so duplicate occurrences are independently addressable and a failure changes
+  nothing.
+
+  A playlist remains a `ViewOrigin`; each queue item separately retains its real media-owning
+  source. Local stream and embedded-art access retains exact file authority, while authenticated
+  remote stream and artwork resolution revalidates the closed catalogue guard at use. Source
+  refresh, replacement, retirement, disconnect, or shutdown denies stale work, and reconnection
+  restores availability only for the same exact `(SourceId, TrackId)`. Only exact local occurrences
+  contribute to local playback history. Remote ratings remain live read-only or unsupported and
+  cannot be mutated through playlist membership. Smart playlists and XSPF import/export remain
+  local-only; mixed-source metadata export and Subsonic server-native synchronization remain
+  separate policy records.
 
 - [ ] Treat Subsonic server-native playlist import/synchronization as a separate capability slice,
   with direction, conflict, offline, deletion, and server-feature semantics documented first.
@@ -397,6 +420,7 @@ the 36-record feature backlog.
 | 2026-07-18 | P1.3 deterministic history smart playlists | [#137](https://github.com/jm2/tributary/pull/137) | Made Recently Played and Top 25 deterministic over authoritative history, including intentional empty states, stable ordering and Top 25 membership, committed-event live refresh, exact untouched-default migration from both released historical signatures, and lossless editor round trips for Last Played fields, limits, and relative units. This completed P1.3. |
 | 2026-07-19 | P1.4 rating ownership and persistence foundation | [#138](https://github.com/jm2/tributary/pull/138) | Defined the canonical 1–100 value and coherent Writable/ReadOnly/Unsupported capabilities; added constrained nullable migration 12, transactional exact-local-ID set/clear, scan preservation, validated read-only Subsonic/Jellyfin/Plex conversion, fail-closed catalogue invariants and remote writes, and an explicit rating-neutral XSPF/import policy. Accessible editing, display, sorting, and smart rules were tracked in the following P1.4 record. |
 | 2026-07-19 | P1.4 rating UI and smart-playlist rules | [#139](https://github.com/jm2/tributary/pull/139) | Added the exact Rating column with localized cell/editor states, keyboard-operable local set/clear, honest read-only/unavailable states, serialized post-commit exact-ID refresh, failure-safe feedback, versioned column-config exposure, null-last deterministic sorting, and capability-aware numeric/presence smart rules plus Highest/Lowest Rated selection. This completed P1.4. |
-| 2026-07-19 | P1.5 source-scoped regular-playlist storage | [#140](https://github.com/jm2/tributary/pull/140) | Added migration 13 and typed atomic storage around exact `(SourceId, TrackId)` occurrence identity, a separate nullable local foreign-key cache, exact schema/index recognition, lossless-or-refused downgrade, local compatibility, and explicit no-locator/no-credential boundaries. Default-deny live-catalogue authority, mixed-source UI integration, and Subsonic-native synchronization remain the next three records. |
-| 2026-07-19 | P1.5 live-catalogue playlist authority | [#141](https://github.com/jm2/tributary/pull/141) | Added default-deny adapter capability, exact ordered catalogue lookup with invalid-catalogue rejection and sanitized metadata, transient epoch/generation guards, closed media errors, and lifecycle-owned generation leases revoked independently of retained snapshots. Mixed-source Add/Remove/render/Play remains the next record. |
+| 2026-07-19 | P1.5 source-scoped regular-playlist storage | [#140](https://github.com/jm2/tributary/pull/140) | Added migration 13 and typed atomic storage around exact `(SourceId, TrackId)` occurrence identity, a separate nullable local foreign-key cache, exact schema/index recognition, lossless-or-refused downgrade, local compatibility, and explicit no-locator/no-credential boundaries. It intentionally reserved live authority, mixed-source UI, and Subsonic-native synchronization for separate records. |
+| 2026-07-19 | P1.5 live-catalogue playlist authority | [#141](https://github.com/jm2/tributary/pull/141) | Added default-deny adapter capability, exact ordered catalogue lookup with invalid-catalogue rejection and sanitized metadata, transient epoch/generation guards, closed media errors, and lifecycle-owned generation leases revoked independently of retained snapshots. It intentionally reserved Add/Remove/render/Play consumption for Record B. |
+| 2026-07-19 | P1.5 mixed-source regular-playlist UI | [#142](https://github.com/jm2/tributary/pull/142) | Integrated exact local and authenticated Subsonic/Jellyfin/Plex/DAAP entries through all-or-none Add, durable-occurrence Remove, ordered duplicate-preserving projection with explicit removable unavailable rows, and per-source guarded Play/artwork. Current closed unavailable reasons render honestly; stale projection results are discarded/reprojected and stale guards are denied. Local history and remote rating ownership remain unchanged. Smart playlists, XSPF import/export, mixed-source metadata export, and Subsonic-native synchronization remain separate. |
 | 2026-07-18 | Linux watcher feedback-loop fix | [#103](https://github.com/jm2/tributary/pull/103) | Narrowed the external proposal to filter self-generated access events before queue admission without filtering genuine startup events or backend errors; bounded overflow still drives authoritative reconciliation. Persistent negative parse caching is deliberately excluded so failures remain retryable; this separate correctness fix does not advance the feature numerator. |

--- a/docs/task.md
+++ b/docs/task.md
@@ -272,10 +272,14 @@ the 36-record feature backlog.
 
   Implemented contract: Add to Playlist accepts exact local rows plus current authenticated
   Subsonic, Jellyfin, Plex, and DAAP catalogue rows. It resolves the complete ordered remote
-  selection through Record A, rechecks current epoch/generation immediately before one atomic
-  storage operation, and writes nothing if any current member is unsupported, unavailable, missing,
-  or in an invalid catalogue. A result made stale before commit is discarded and also writes
-  nothing. Support is never inferred from a source key, backend label, cached GTK row, or persisted
+  selection through Record A. After staging its SQL inserts and immediately before commit, that
+  transaction revalidates the complete result and acquires exact session/catalogue permits. A
+  result made stale during staging rolls back; after admission, a concurrent refresh, replacement,
+  disconnect, or shutdown waits for commit or rollback. The transaction and permits transfer to an
+  independent completion worker, so cancellation cannot strand authority or abandon commit
+  completion. Any unsupported, unavailable, missing, or invalid-catalogue member likewise writes
+  nothing. Support is
+  never inferred from a source key, backend label, cached GTK row, or persisted
   fingerprint. Radio-Browser, removable media, ephemeral external files, and unknown sources remain
   unsupported and receive the localized all-or-none refusal.
 
@@ -297,8 +301,9 @@ the 36-record feature backlog.
   restores availability only for the same exact `(SourceId, TrackId)`. Only exact local occurrences
   contribute to local playback history. Remote ratings remain live read-only or unsupported and
   cannot be mutated through playlist membership. Smart playlists and XSPF import/export remain
-  local-only; mixed-source metadata export and Subsonic server-native synchronization remain
-  separate policy records.
+  local-only; attempting to export a regular playlist with any remote or unresolved occurrence is
+  refused all-or-none before the destination is touched. Mixed-source metadata export and
+  Subsonic server-native synchronization remain separate policy records.
 
 - [ ] Treat Subsonic server-native playlist import/synchronization as a separate capability slice,
   with direction, conflict, offline, deletion, and server-feature semantics documented first.
@@ -422,5 +427,5 @@ the 36-record feature backlog.
 | 2026-07-19 | P1.4 rating UI and smart-playlist rules | [#139](https://github.com/jm2/tributary/pull/139) | Added the exact Rating column with localized cell/editor states, keyboard-operable local set/clear, honest read-only/unavailable states, serialized post-commit exact-ID refresh, failure-safe feedback, versioned column-config exposure, null-last deterministic sorting, and capability-aware numeric/presence smart rules plus Highest/Lowest Rated selection. This completed P1.4. |
 | 2026-07-19 | P1.5 source-scoped regular-playlist storage | [#140](https://github.com/jm2/tributary/pull/140) | Added migration 13 and typed atomic storage around exact `(SourceId, TrackId)` occurrence identity, a separate nullable local foreign-key cache, exact schema/index recognition, lossless-or-refused downgrade, local compatibility, and explicit no-locator/no-credential boundaries. It intentionally reserved live authority, mixed-source UI, and Subsonic-native synchronization for separate records. |
 | 2026-07-19 | P1.5 live-catalogue playlist authority | [#141](https://github.com/jm2/tributary/pull/141) | Added default-deny adapter capability, exact ordered catalogue lookup with invalid-catalogue rejection and sanitized metadata, transient epoch/generation guards, closed media errors, and lifecycle-owned generation leases revoked independently of retained snapshots. It intentionally reserved Add/Remove/render/Play consumption for Record B. |
-| 2026-07-19 | P1.5 mixed-source regular-playlist UI | [#142](https://github.com/jm2/tributary/pull/142) | Integrated exact local and authenticated Subsonic/Jellyfin/Plex/DAAP entries through all-or-none Add, durable-occurrence Remove, ordered duplicate-preserving projection with explicit removable unavailable rows, and per-source guarded Play/artwork. Current closed unavailable reasons render honestly; stale projection results are discarded/reprojected and stale guards are denied. Local history and remote rating ownership remain unchanged. Smart playlists, XSPF import/export, mixed-source metadata export, and Subsonic-native synchronization remain separate. |
+| 2026-07-19 | P1.5 mixed-source regular-playlist UI | [#142](https://github.com/jm2/tributary/pull/142) | Integrated exact local and authenticated Subsonic/Jellyfin/Plex/DAAP entries through all-or-none Add, durable-occurrence Remove, ordered duplicate-preserving projection with explicit removable unavailable rows, and per-source guarded Play/artwork. Add revalidates after staging SQL, rolls back a stale result, and retains exact session/catalogue permits through an admitted commit or rollback. Current closed unavailable reasons render honestly; stale projection results are discarded/reprojected and stale guards are denied. Local history and remote rating ownership remain unchanged. Smart playlists and XSPF remain local-only; mixed/unresolved XSPF export refuses all-or-none instead of truncating, while mixed-source metadata export and Subsonic-native synchronization remain separate. |
 | 2026-07-18 | Linux watcher feedback-loop fix | [#103](https://github.com/jm2/tributary/pull/103) | Narrowed the external proposal to filter self-generated access events before queue admission without filtering genuine startup events or backend errors; bounded overflow still drives authoritative reconciliation. Persistent negative parse caching is deliberately excluded so failures remain retryable; this separate correctness fix does not advance the feature numerator. |

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -176,6 +176,7 @@ playlist_io:
   playlist_missing: "Die ausgewählte Wiedergabeliste ist nicht mehr vorhanden."
   smart_playlist_evaluation_failed: "Die intelligente Wiedergabeliste konnte nicht ausgewertet werden: %{error}"
   playlist_tracks_read_failed: "Die Titel der Wiedergabeliste konnten nicht gelesen werden: %{error}"
+  export_local_only_unsupported_body: "Diese Wiedergabeliste enthält entfernte oder nicht verfügbare Einträge. Der XSPF-Export unterstützt derzeit nur Wiedergabelisten, deren Einträge vollständig in der lokalen Mediathek verfügbar sind."
   writer_worker_failed: "Der XSPF-Schreibprozess wurde beendet: %{error}"
   write_failed: "Die XSPF-Datei konnte nicht geschrieben werden: %{error}"
   export_success_heading: "XSPF-Wiedergabeliste exportiert"

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -190,7 +190,17 @@ context:
   add_to_playlist: "Zur Wiedergabeliste hinzufügen"
   remove_from_playlist: "Aus Wiedergabeliste entfernen"
   playlist_add_unsupported_heading: "Titel wurden nicht hinzugefügt"
-  playlist_add_unsupported_body: "Derzeit können nur Titel aus der lokalen Bibliothek von Tributary zu Wiedergabelisten hinzugefügt werden. Aus dieser Quelle wurde nichts hinzugefügt."
+  playlist_add_unsupported_body: "Mindestens ein ausgewählter Titel ist nicht verfügbar oder wird in regulären Wiedergabelisten nicht unterstützt. Es wurde nichts hinzugefügt."
+
+# ── Reguläre Wiedergabelisten ─────────────────────────────────────
+regular_playlist:
+  unavailable_track: "Nicht verfügbarer Titel"
+  source_unavailable: "Quelle getrennt oder nicht verfügbar"
+  source_unsupported: "Diese Quelle kann nicht in regulären Wiedergabelisten verwendet werden"
+  source_catalogue_unavailable: "Medienbibliothek der Quelle nicht verfügbar"
+  track_missing: "Der Titel ist in dieser Quelle nicht mehr vorhanden"
+  mutation_failed_heading: "Wiedergabeliste wurde nicht aktualisiert"
+  mutation_failed_body: "Tributary konnte die Wiedergabeliste nicht aktualisieren. Es wurde nichts geändert."
 
 # ── Properties dialog ──────────────────────────────────────────────
 properties:

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -223,7 +223,17 @@ context:
   add_to_playlist: "Add to Playlist"
   remove_from_playlist: "Remove from Playlist"
   playlist_add_unsupported_heading: "Tracks Weren’t Added"
-  playlist_add_unsupported_body: "Only tracks in Tributary’s local library can be added to playlists right now. Nothing from this source was added."
+  playlist_add_unsupported_body: "At least one selected track is unavailable or is not supported in regular playlists. Nothing was added."
+
+# ── Regular playlists ──────────────────────────────────────────────
+regular_playlist:
+  unavailable_track: "Unavailable track"
+  source_unavailable: "Source disconnected or unavailable"
+  source_unsupported: "This source cannot be used in regular playlists"
+  source_catalogue_unavailable: "Source library unavailable"
+  track_missing: "Track no longer exists in this source"
+  mutation_failed_heading: "Playlist Wasn’t Updated"
+  mutation_failed_body: "Tributary couldn’t update the playlist. Nothing was changed."
 
 # ── Properties dialog ──────────────────────────────────────────────
 properties:

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -181,6 +181,7 @@ playlist_io:
   playlist_missing: "The selected playlist no longer exists."
   smart_playlist_evaluation_failed: "Could not evaluate the smart playlist: %{error}"
   playlist_tracks_read_failed: "Could not read playlist tracks: %{error}"
+  export_local_only_unsupported_body: "This playlist contains remote or unavailable entries. XSPF export currently supports only playlists whose every entry is available in the local library."
   writer_worker_failed: "The XSPF writer worker stopped: %{error}"
   write_failed: "Could not write the XSPF file: %{error}"
   export_success_heading: "XSPF Playlist Exported"

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -176,6 +176,7 @@ playlist_io:
   playlist_missing: "La lista seleccionada ya no existe."
   smart_playlist_evaluation_failed: "No se pudo evaluar la lista inteligente: %{error}"
   playlist_tracks_read_failed: "No se pudieron leer las pistas de la lista: %{error}"
+  export_local_only_unsupported_body: "Esta lista contiene entradas remotas o no disponibles. Actualmente, la exportación XSPF solo admite listas cuyas entradas estén todas disponibles en la biblioteca local."
   writer_worker_failed: "El proceso de escritura XSPF se detuvo: %{error}"
   write_failed: "No se pudo escribir el archivo XSPF: %{error}"
   export_success_heading: "Lista XSPF exportada"

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -190,7 +190,17 @@ context:
   add_to_playlist: "Añadir a lista de reproducción"
   remove_from_playlist: "Quitar de lista de reproducción"
   playlist_add_unsupported_heading: "No se añadieron pistas"
-  playlist_add_unsupported_body: "Por ahora, solo se pueden añadir a las listas de reproducción pistas de la biblioteca local de Tributary. No se añadió nada de esta fuente."
+  playlist_add_unsupported_body: "Al menos una pista seleccionada no está disponible o no es compatible con las listas de reproducción normales. No se añadió nada."
+
+# ── Listas de reproducción normales ───────────────────────────────────
+regular_playlist:
+  unavailable_track: "Pista no disponible"
+  source_unavailable: "Fuente desconectada o no disponible"
+  source_unsupported: "Esta fuente no se puede usar en listas de reproducción normales"
+  source_catalogue_unavailable: "Biblioteca de la fuente no disponible"
+  track_missing: "La pista ya no existe en esta fuente"
+  mutation_failed_heading: "No se actualizó la lista de reproducción"
+  mutation_failed_body: "Tributary no pudo actualizar la lista de reproducción. No se cambió nada."
 
 # ── Properties dialog ──────────────────────────────────────────────
 properties:

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -176,6 +176,7 @@ playlist_io:
   playlist_missing: "La liste sélectionnée n’existe plus."
   smart_playlist_evaluation_failed: "Impossible d’évaluer la liste intelligente : %{error}"
   playlist_tracks_read_failed: "Impossible de lire les pistes de la liste : %{error}"
+  export_local_only_unsupported_body: "Cette liste contient des entrées distantes ou indisponibles. L’exportation XSPF ne prend actuellement en charge que les listes dont toutes les entrées sont disponibles dans la bibliothèque locale."
   writer_worker_failed: "Le processus d’écriture XSPF s’est arrêté : %{error}"
   write_failed: "Impossible d’écrire le fichier XSPF : %{error}"
   export_success_heading: "Liste XSPF exportée"

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -190,7 +190,17 @@ context:
   add_to_playlist: "Ajouter à la liste de lecture"
   remove_from_playlist: "Retirer de la liste de lecture"
   playlist_add_unsupported_heading: "Les pistes n’ont pas été ajoutées"
-  playlist_add_unsupported_body: "Pour le moment, seules les pistes de la bibliothèque locale de Tributary peuvent être ajoutées aux listes de lecture. Aucune piste provenant de cette source n’a été ajoutée."
+  playlist_add_unsupported_body: "Au moins une piste sélectionnée est indisponible ou n’est pas prise en charge dans les listes de lecture normales. Aucune piste n’a été ajoutée."
+
+# ── Listes de lecture normales ───────────────────────────────────────
+regular_playlist:
+  unavailable_track: "Piste indisponible"
+  source_unavailable: "Source déconnectée ou indisponible"
+  source_unsupported: "Cette source ne peut pas être utilisée dans les listes de lecture normales"
+  source_catalogue_unavailable: "Bibliothèque de la source indisponible"
+  track_missing: "La piste n’existe plus dans cette source"
+  mutation_failed_heading: "La liste de lecture n’a pas été mise à jour"
+  mutation_failed_body: "Tributary n’a pas pu mettre à jour la liste de lecture. Aucune modification n’a été effectuée."
 
 # ── Properties dialog ──────────────────────────────────────────────
 properties:

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -190,7 +190,17 @@ context:
   add_to_playlist: "Aggiungi alla playlist"
   remove_from_playlist: "Rimuovi dalla playlist"
   playlist_add_unsupported_heading: "I brani non sono stati aggiunti"
-  playlist_add_unsupported_body: "Al momento, è possibile aggiungere alle playlist solo i brani della libreria locale di Tributary. Non è stato aggiunto nulla da questa sorgente."
+  playlist_add_unsupported_body: "Almeno un brano selezionato non è disponibile o non è supportato nelle playlist normali. Non è stato aggiunto nulla."
+
+# ── Playlist normali ─────────────────────────────────────────────
+regular_playlist:
+  unavailable_track: "Brano non disponibile"
+  source_unavailable: "Sorgente disconnessa o non disponibile"
+  source_unsupported: "Questa sorgente non può essere usata nelle playlist normali"
+  source_catalogue_unavailable: "Libreria della sorgente non disponibile"
+  track_missing: "Il brano non esiste più in questa sorgente"
+  mutation_failed_heading: "La playlist non è stata aggiornata"
+  mutation_failed_body: "Tributary non ha potuto aggiornare la playlist. Non è stato modificato nulla."
 
 # ── Properties dialog ──────────────────────────────────────────────
 properties:

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -176,6 +176,7 @@ playlist_io:
   playlist_missing: "La playlist selezionata non esiste più."
   smart_playlist_evaluation_failed: "Impossibile valutare la playlist intelligente: %{error}"
   playlist_tracks_read_failed: "Impossibile leggere i brani della playlist: %{error}"
+  export_local_only_unsupported_body: "Questa playlist contiene elementi remoti o non disponibili. Attualmente l’esportazione XSPF supporta solo playlist i cui elementi sono tutti disponibili nella libreria locale."
   writer_worker_failed: "Il processo di scrittura XSPF si è interrotto: %{error}"
   write_failed: "Impossibile scrivere il file XSPF: %{error}"
   export_success_heading: "Playlist XSPF esportata"

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -176,6 +176,7 @@ playlist_io:
   playlist_missing: "選択したプレイリストは存在しなくなりました。"
   smart_playlist_evaluation_failed: "スマートプレイリストを評価できませんでした: %{error}"
   playlist_tracks_read_failed: "プレイリストの曲を読み込めませんでした: %{error}"
+  export_local_only_unsupported_body: "このプレイリストにはリモートまたは利用できない項目が含まれています。現在、XSPFにエクスポートできるのは、すべての項目がローカルライブラリで利用できるプレイリストだけです。"
   writer_worker_failed: "XSPF書き込み処理が停止しました: %{error}"
   write_failed: "XSPFファイルを書き込めませんでした: %{error}"
   export_success_heading: "XSPFプレイリストをエクスポートしました"

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -190,7 +190,17 @@ context:
   add_to_playlist: "プレイリストに追加"
   remove_from_playlist: "プレイリストから削除"
   playlist_add_unsupported_heading: "曲は追加されませんでした"
-  playlist_add_unsupported_body: "現在プレイリストに追加できるのは、Tributary のローカルライブラリにある曲だけです。このソースからは何も追加されませんでした。"
+  playlist_add_unsupported_body: "選択した曲のうち少なくとも 1 曲が利用できないか、通常のプレイリストではサポートされていません。曲は追加されませんでした。"
+
+# ── 通常のプレイリスト ─────────────────────────────────────────
+regular_playlist:
+  unavailable_track: "利用できない曲"
+  source_unavailable: "ソースが切断されているか利用できません"
+  source_unsupported: "このソースは通常のプレイリストでは使用できません"
+  source_catalogue_unavailable: "ソースライブラリを利用できません"
+  track_missing: "このソースに曲が存在しなくなりました"
+  mutation_failed_heading: "プレイリストは更新されませんでした"
+  mutation_failed_body: "Tributary はプレイリストを更新できませんでした。変更は行われませんでした。"
 
 # ── Properties dialog ──────────────────────────────────────────────
 properties:

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -190,7 +190,17 @@ context:
   add_to_playlist: "재생목록에 추가"
   remove_from_playlist: "재생목록에서 제거"
   playlist_add_unsupported_heading: "트랙이 추가되지 않았습니다"
-  playlist_add_unsupported_body: "현재는 Tributary의 로컬 라이브러리에 있는 트랙만 재생목록에 추가할 수 있습니다. 이 소스에서는 아무것도 추가되지 않았습니다."
+  playlist_add_unsupported_body: "선택한 트랙 중 하나 이상을 사용할 수 없거나 일반 재생목록에서 지원하지 않습니다. 아무것도 추가되지 않았습니다."
+
+# ── 일반 재생목록 ───────────────────────────────────────────────
+regular_playlist:
+  unavailable_track: "사용할 수 없는 트랙"
+  source_unavailable: "소스 연결이 끊겼거나 사용할 수 없습니다"
+  source_unsupported: "이 소스는 일반 재생목록에서 사용할 수 없습니다"
+  source_catalogue_unavailable: "소스 라이브러리를 사용할 수 없습니다"
+  track_missing: "이 소스에 트랙이 더 이상 없습니다"
+  mutation_failed_heading: "재생목록이 업데이트되지 않았습니다"
+  mutation_failed_body: "Tributary가 재생목록을 업데이트하지 못했습니다. 변경된 내용이 없습니다."
 
 # ── Properties dialog ──────────────────────────────────────────────
 properties:

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -176,6 +176,7 @@ playlist_io:
   playlist_missing: "선택한 재생목록이 더 이상 존재하지 않습니다."
   smart_playlist_evaluation_failed: "스마트 재생목록을 평가할 수 없습니다: %{error}"
   playlist_tracks_read_failed: "재생목록의 트랙을 읽을 수 없습니다: %{error}"
+  export_local_only_unsupported_body: "이 재생목록에는 원격 또는 사용할 수 없는 항목이 있습니다. 현재 XSPF 내보내기는 모든 항목을 로컬 라이브러리에서 사용할 수 있는 재생목록만 지원합니다."
   writer_worker_failed: "XSPF 쓰기 작업이 중지되었습니다: %{error}"
   write_failed: "XSPF 파일을 쓸 수 없습니다: %{error}"
   export_success_heading: "XSPF 재생목록을 내보냄"

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -190,7 +190,17 @@ context:
   add_to_playlist: "Toevoegen aan afspeellijst"
   remove_from_playlist: "Verwijderen uit afspeellijst"
   playlist_add_unsupported_heading: "Nummers zijn niet toegevoegd"
-  playlist_add_unsupported_body: "Op dit moment kunnen alleen nummers uit de lokale bibliotheek van Tributary aan afspeellijsten worden toegevoegd. Er is niets uit deze bron toegevoegd."
+  playlist_add_unsupported_body: "Ten minste één geselecteerd nummer is niet beschikbaar of wordt niet ondersteund in gewone afspeellijsten. Er is niets toegevoegd."
+
+# ── Gewone afspeellijsten ─────────────────────────────────────────
+regular_playlist:
+  unavailable_track: "Nummer niet beschikbaar"
+  source_unavailable: "Bron niet verbonden of niet beschikbaar"
+  source_unsupported: "Deze bron kan niet in gewone afspeellijsten worden gebruikt"
+  source_catalogue_unavailable: "Bronbibliotheek niet beschikbaar"
+  track_missing: "Het nummer bestaat niet meer in deze bron"
+  mutation_failed_heading: "Afspeellijst is niet bijgewerkt"
+  mutation_failed_body: "Tributary kon de afspeellijst niet bijwerken. Er is niets gewijzigd."
 
 # ── Properties dialog ──────────────────────────────────────────────
 properties:

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -176,6 +176,7 @@ playlist_io:
   playlist_missing: "De geselecteerde afspeellijst bestaat niet meer."
   smart_playlist_evaluation_failed: "De slimme afspeellijst kon niet worden geëvalueerd: %{error}"
   playlist_tracks_read_failed: "De nummers van de afspeellijst konden niet worden gelezen: %{error}"
+  export_local_only_unsupported_body: "Deze afspeellijst bevat externe of niet-beschikbare items. XSPF-export ondersteunt momenteel alleen afspeellijsten waarvan elk item beschikbaar is in de lokale bibliotheek."
   writer_worker_failed: "Het XSPF-schrijfproces is gestopt: %{error}"
   write_failed: "Het XSPF-bestand kon niet worden geschreven: %{error}"
   export_success_heading: "XSPF-afspeellijst geëxporteerd"

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -176,6 +176,7 @@ playlist_io:
   playlist_missing: "Wybrana lista już nie istnieje."
   smart_playlist_evaluation_failed: "Nie można obliczyć inteligentnej listy: %{error}"
   playlist_tracks_read_failed: "Nie można odczytać utworów z listy: %{error}"
+  export_local_only_unsupported_body: "Ta lista zawiera zdalne lub niedostępne pozycje. Eksport XSPF obsługuje obecnie tylko listy, których wszystkie pozycje są dostępne w lokalnej bibliotece."
   writer_worker_failed: "Proces zapisu XSPF został zatrzymany: %{error}"
   write_failed: "Nie można zapisać pliku XSPF: %{error}"
   export_success_heading: "Wyeksportowano listę XSPF"

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -190,7 +190,17 @@ context:
   add_to_playlist: "Dodaj do listy odtwarzania"
   remove_from_playlist: "Usuń z listy odtwarzania"
   playlist_add_unsupported_heading: "Utwory nie zostały dodane"
-  playlist_add_unsupported_body: "Obecnie do list odtwarzania można dodawać tylko utwory z lokalnej biblioteki Tributary. Nie dodano niczego z tego źródła."
+  playlist_add_unsupported_body: "Co najmniej jeden wybrany utwór jest niedostępny lub nie jest obsługiwany w zwykłych listach odtwarzania. Nic nie dodano."
+
+# ── Zwykłe listy odtwarzania ───────────────────────────────────────
+regular_playlist:
+  unavailable_track: "Niedostępny utwór"
+  source_unavailable: "Źródło jest rozłączone lub niedostępne"
+  source_unsupported: "Tego źródła nie można używać w zwykłych listach odtwarzania"
+  source_catalogue_unavailable: "Biblioteka źródła jest niedostępna"
+  track_missing: "Utwór nie istnieje już w tym źródle"
+  mutation_failed_heading: "Lista odtwarzania nie została zaktualizowana"
+  mutation_failed_body: "Nie udało się zaktualizować listy odtwarzania w Tributary. Niczego nie zmieniono."
 
 # ── Properties dialog ──────────────────────────────────────────────
 properties:

--- a/locales/pt-BR.yml
+++ b/locales/pt-BR.yml
@@ -176,6 +176,7 @@ playlist_io:
   playlist_missing: "A lista de reprodução selecionada não existe mais."
   smart_playlist_evaluation_failed: "Não foi possível avaliar a lista de reprodução inteligente: %{error}"
   playlist_tracks_read_failed: "Não foi possível ler as faixas da lista de reprodução: %{error}"
+  export_local_only_unsupported_body: "Esta lista de reprodução contém itens remotos ou indisponíveis. No momento, a exportação XSPF aceita apenas listas cujos itens estejam todos disponíveis na biblioteca local."
   writer_worker_failed: "O processo de gravação XSPF foi interrompido: %{error}"
   write_failed: "Não foi possível gravar o arquivo XSPF: %{error}"
   export_success_heading: "Lista de reprodução XSPF exportada"

--- a/locales/pt-BR.yml
+++ b/locales/pt-BR.yml
@@ -190,7 +190,17 @@ context:
   add_to_playlist: "Adicionar à lista de reprodução"
   remove_from_playlist: "Remover da lista de reprodução"
   playlist_add_unsupported_heading: "As faixas não foram adicionadas"
-  playlist_add_unsupported_body: "No momento, somente as faixas da biblioteca local do Tributary podem ser adicionadas às listas de reprodução. Nada desta fonte foi adicionado."
+  playlist_add_unsupported_body: "Pelo menos uma faixa selecionada não está disponível ou não é compatível com listas de reprodução comuns. Nada foi adicionado."
+
+# ── Listas de reprodução comuns ─────────────────────────────────────
+regular_playlist:
+  unavailable_track: "Faixa indisponível"
+  source_unavailable: "Fonte desconectada ou indisponível"
+  source_unsupported: "Esta fonte não pode ser usada em listas de reprodução comuns"
+  source_catalogue_unavailable: "Biblioteca da fonte indisponível"
+  track_missing: "A faixa não existe mais nesta fonte"
+  mutation_failed_heading: "A lista de reprodução não foi atualizada"
+  mutation_failed_body: "O Tributary não conseguiu atualizar a lista de reprodução. Nada foi alterado."
 
 # ── Properties dialog ──────────────────────────────────────────────
 properties:

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -190,7 +190,17 @@ context:
   add_to_playlist: "Добавить в плейлист"
   remove_from_playlist: "Удалить из плейлиста"
   playlist_add_unsupported_heading: "Композиции не добавлены"
-  playlist_add_unsupported_body: "Сейчас в плейлисты можно добавлять только композиции из локальной медиатеки Tributary. Из этого источника ничего не добавлено."
+  playlist_add_unsupported_body: "По крайней мере одна выбранная композиция недоступна или не поддерживается в обычных плейлистах. Ничего не добавлено."
+
+# ── Обычные плейлисты ───────────────────────────────────────────
+regular_playlist:
+  unavailable_track: "Недоступная композиция"
+  source_unavailable: "Источник отключён или недоступен"
+  source_unsupported: "Этот источник нельзя использовать в обычных плейлистах"
+  source_catalogue_unavailable: "Медиатека источника недоступна"
+  track_missing: "Композиции больше нет в этом источнике"
+  mutation_failed_heading: "Плейлист не обновлён"
+  mutation_failed_body: "Tributary не удалось обновить плейлист. Ничего не изменено."
 
 # ── Properties dialog ──────────────────────────────────────────────
 properties:

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -176,6 +176,7 @@ playlist_io:
   playlist_missing: "Выбранный плейлист больше не существует."
   smart_playlist_evaluation_failed: "Не удалось вычислить смарт-плейлист: %{error}"
   playlist_tracks_read_failed: "Не удалось прочитать композиции плейлиста: %{error}"
+  export_local_only_unsupported_body: "Этот плейлист содержит удалённые или недоступные элементы. Сейчас экспорт XSPF поддерживает только плейлисты, все элементы которых доступны в локальной медиатеке."
   writer_worker_failed: "Процесс записи XSPF остановился: %{error}"
   write_failed: "Не удалось записать файл XSPF: %{error}"
   export_success_heading: "Плейлист XSPF экспортирован"

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -190,7 +190,17 @@ context:
   add_to_playlist: "添加到播放列表"
   remove_from_playlist: "从播放列表中移除"
   playlist_add_unsupported_heading: "曲目未添加"
-  playlist_add_unsupported_body: "目前，只有 Tributary 本地音乐库中的曲目才能添加到播放列表。此数据源中的内容均未添加。"
+  playlist_add_unsupported_body: "至少有一个所选曲目不可用，或不支持添加到常规播放列表。未添加任何曲目。"
+
+# ── 常规播放列表 ────────────────────────────────────────────
+regular_playlist:
+  unavailable_track: "不可用的曲目"
+  source_unavailable: "数据源已断开连接或不可用"
+  source_unsupported: "此数据源不能用于常规播放列表"
+  source_catalogue_unavailable: "数据源音乐库不可用"
+  track_missing: "此数据源中已不存在该曲目"
+  mutation_failed_heading: "播放列表未更新"
+  mutation_failed_body: "Tributary 无法更新播放列表。未进行任何更改。"
 
 # ── Properties dialog ──────────────────────────────────────────────
 properties:

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -176,6 +176,7 @@ playlist_io:
   playlist_missing: "所选播放列表已不存在。"
   smart_playlist_evaluation_failed: "无法计算智能播放列表：%{error}"
   playlist_tracks_read_failed: "无法读取播放列表中的曲目：%{error}"
+  export_local_only_unsupported_body: "此播放列表包含远程或不可用的条目。目前，XSPF 导出仅支持所有条目都可在本地媒体库中使用的播放列表。"
   writer_worker_failed: "XSPF 写入进程已停止：%{error}"
   write_failed: "无法写入 XSPF 文件：%{error}"
   export_success_heading: "已导出 XSPF 播放列表"

--- a/locales/zh-TW.yml
+++ b/locales/zh-TW.yml
@@ -176,6 +176,7 @@ playlist_io:
   playlist_missing: "所選播放清單已不存在。"
   smart_playlist_evaluation_failed: "無法計算智慧型播放清單：%{error}"
   playlist_tracks_read_failed: "無法讀取播放清單中的曲目：%{error}"
+  export_local_only_unsupported_body: "此播放清單包含遠端或無法使用的項目。目前，XSPF 匯出僅支援所有項目都可在本機媒體庫中使用的播放清單。"
   writer_worker_failed: "XSPF 寫入程序已停止：%{error}"
   write_failed: "無法寫入 XSPF 檔案：%{error}"
   export_success_heading: "已匯出 XSPF 播放清單"

--- a/locales/zh-TW.yml
+++ b/locales/zh-TW.yml
@@ -190,7 +190,17 @@ context:
   add_to_playlist: "加入播放清單"
   remove_from_playlist: "從播放清單移除"
   playlist_add_unsupported_heading: "曲目未加入"
-  playlist_add_unsupported_body: "目前，只有 Tributary 本機音樂庫中的曲目才能加入播放清單。此資料來源中的內容均未加入。"
+  playlist_add_unsupported_body: "至少有一個所選曲目無法使用，或不支援加入一般播放清單。未加入任何曲目。"
+
+# ── 一般播放清單 ──────────────────────────────────────────────
+regular_playlist:
+  unavailable_track: "無法使用的曲目"
+  source_unavailable: "資料來源已中斷連線或無法使用"
+  source_unsupported: "此資料來源不能用於一般播放清單"
+  source_catalogue_unavailable: "資料來源音樂庫無法使用"
+  track_missing: "此資料來源中已不存在該曲目"
+  mutation_failed_heading: "播放清單未更新"
+  mutation_failed_body: "Tributary 無法更新播放清單。未進行任何變更。"
 
 # ── Properties dialog ──────────────────────────────────────────────
 properties:

--- a/src/architecture/media.rs
+++ b/src/architecture/media.rs
@@ -9,7 +9,7 @@
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
-    Arc, Weak,
+    Arc, Condvar, Mutex, Weak,
 };
 
 use super::identity::{SourceId, TrackId};
@@ -183,7 +183,30 @@ fn canonical_address(address: SocketAddr, port: u16) -> Option<SocketAddr> {
 /// ticket derived from that session to fail closed immediately.
 #[derive(Clone)]
 pub struct MediaLease {
-    active: Arc<AtomicBool>,
+    state: Arc<MediaLeaseState>,
+}
+
+struct MediaLeaseState {
+    active: AtomicBool,
+    in_flight: Mutex<usize>,
+    idle: Condvar,
+}
+
+/// One admitted section that must finish before its media lease can be
+/// revoked.
+///
+/// This is deliberately crate-private and has no operations of its own. Its
+/// lifetime is the authority: dropping it releases the admission count and
+/// wakes a revoker waiting to invalidate the lease.
+pub struct MediaLeasePermit {
+    state: Arc<MediaLeaseState>,
+}
+
+impl MediaLeasePermit {
+    #[cfg(test)]
+    pub(crate) fn revocation_started(&self) -> bool {
+        !self.state.active.load(Ordering::Acquire)
+    }
 }
 
 /// Credential-free HTTP(S) stream locator retained only by a live source view.
@@ -325,16 +348,71 @@ pub type ResolvedStream = MediaRequest;
 impl MediaLease {
     pub(crate) fn new() -> Self {
         Self {
-            active: Arc::new(AtomicBool::new(true)),
+            state: Arc::new(MediaLeaseState {
+                active: AtomicBool::new(true),
+                in_flight: Mutex::new(0),
+                idle: Condvar::new(),
+            }),
         }
     }
 
+    /// Close new admission and wait for every already-admitted section.
+    ///
+    /// The active check and permit count are serialized by the same mutex as
+    /// revocation. Once this returns, no earlier permit remains and no later
+    /// acquisition can succeed.
     pub(crate) fn revoke(&self) {
-        self.active.store(false, Ordering::Release);
+        let mut in_flight = self
+            .state
+            .in_flight
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        self.state.active.store(false, Ordering::Release);
+        while *in_flight != 0 {
+            in_flight = self
+                .state
+                .idle
+                .wait(in_flight)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
     }
 
     pub(crate) fn is_active(&self) -> bool {
-        self.active.load(Ordering::Acquire)
+        self.state.active.load(Ordering::Acquire)
+    }
+
+    /// Atomically acquire one in-flight section if revocation has not begun.
+    pub(crate) fn try_acquire(&self) -> Option<MediaLeasePermit> {
+        let mut in_flight = self
+            .state
+            .in_flight
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if !self.state.active.load(Ordering::Acquire) {
+            return None;
+        }
+        *in_flight = in_flight
+            .checked_add(1)
+            .expect("media lease in-flight permit count overflow");
+        Some(MediaLeasePermit {
+            state: Arc::clone(&self.state),
+        })
+    }
+}
+
+impl Drop for MediaLeasePermit {
+    fn drop(&mut self) {
+        let mut in_flight = self
+            .state
+            .in_flight
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *in_flight = in_flight
+            .checked_sub(1)
+            .expect("media lease in-flight permit count underflow");
+        if *in_flight == 0 {
+            self.state.idle.notify_all();
+        }
     }
 }
 
@@ -552,7 +630,37 @@ fn is_allowed_required_header(name: &HeaderName) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
     use uuid::Uuid;
+
+    #[test]
+    fn lease_revocation_waits_for_admitted_permit_and_closes_new_admission() {
+        let lease = MediaLease::new();
+        let permit = lease.try_acquire().expect("active lease admits work");
+        let revoking = lease.clone();
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            revoking.revoke();
+            done_tx.send(()).expect("test receiver remains alive");
+        });
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while lease.is_active() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "revocation closed admission"
+            );
+            std::thread::yield_now();
+        }
+        assert!(lease.try_acquire().is_none());
+        assert!(done_rx.recv_timeout(Duration::from_millis(50)).is_err());
+
+        drop(permit);
+        done_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("revocation finishes after permit release");
+        worker.join().expect("revocation worker");
+    }
 
     #[test]
     fn endpoint_rejects_embedded_credentials_and_unsafe_schemes() {

--- a/src/local/playlist_manager.rs
+++ b/src/local/playlist_manager.rs
@@ -96,6 +96,19 @@ pub struct StoredPlaylistEntry {
     pub match_file_path: Option<String>,
 }
 
+/// One durable regular-playlist occurrence aligned with its current local
+/// library row, when the occurrence is owned by the built-in local source and
+/// its foreign-key cache still resolves.
+///
+/// Non-local and currently unmatched local occurrences deliberately carry
+/// `None`. The durable entry is retained in every case so callers never lose
+/// playlist order or confuse repeated media identities with one occurrence.
+#[derive(Clone, Debug, PartialEq)]
+pub struct LoadedPlaylistEntry {
+    pub stored: StoredPlaylistEntry,
+    pub local_track: Option<track::Model>,
+}
+
 impl StoredPlaylistEntry {
     pub fn media_key(&self) -> Option<MediaKey> {
         self.track_id
@@ -416,8 +429,8 @@ impl PlaylistManager {
     /// occurrences in input order. Local identities are resolved against the
     /// current track table inside the same transaction and receive the local
     /// foreign-key cache. Non-local identities are persisted without a URI or
-    /// local foreign key; the UI does not expose remote mutations until its
-    /// live-session projection is implemented.
+    /// local foreign key; callers must obtain and recheck live catalogue
+    /// authority before entering this storage boundary.
     pub async fn add_entries(
         &self,
         playlist_id: &str,
@@ -651,6 +664,46 @@ impl PlaylistManager {
             .into_iter()
             .map(StoredPlaylistEntry::from_model)
             .collect()
+    }
+
+    /// Load every durable regular-playlist occurrence in stored order and
+    /// align it with its exact current local row when one exists.
+    ///
+    /// Playlist validation and the ordered left join share one read
+    /// transaction. Remote and unmatched local entries remain present with no
+    /// local model; duplicate occurrences remain separate rows even when they
+    /// resolve to the same local track.
+    pub async fn load_playlist_entries(
+        &self,
+        playlist_id: &str,
+    ) -> Result<Vec<LoadedPlaylistEntry>, DbErr> {
+        let txn = self.db.begin().await?;
+        require_regular_playlist(&txn, playlist_id).await?;
+        let rows = playlist_entry::Entity::find()
+            .filter(playlist_entry::Column::PlaylistId.eq(playlist_id))
+            .order_by_asc(playlist_entry::Column::Position)
+            .find_also_related(track::Entity)
+            .all(&txn)
+            .await?;
+
+        let mut loaded = Vec::with_capacity(rows.len());
+        for (entry, local_track) in rows {
+            let stored = StoredPlaylistEntry::from_model(entry)?;
+            let local_track = if stored.source_id == SourceId::local() {
+                local_track
+            } else {
+                // Typed decoding rejects a non-local foreign-key cache. Keep
+                // the projection fail-closed as well if a future relation or
+                // schema change ever produces an unexpected joined row.
+                None
+            };
+            loaded.push(LoadedPlaylistEntry {
+                stored,
+                local_track,
+            });
+        }
+        txn.commit().await?;
+        Ok(loaded)
     }
 
     /// Get all matched tracks for a regular playlist (ordered by position).
@@ -1945,6 +1998,118 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![0, 1, 2]
         );
+    }
+
+    #[tokio::test]
+    async fn aligned_playlist_load_retains_every_occurrence_and_only_joins_exact_local_rows() {
+        let db = in_memory_db().await;
+        let manager = PlaylistManager::new(db.clone());
+        let playlist = manager
+            .create_playlist("Aligned mixed load", false)
+            .await
+            .expect("create playlist");
+        let local = insert_track(
+            &db,
+            "shared-native-id",
+            "/music/local.flac",
+            "Local title",
+            "Local artist",
+            "Local album",
+            Some(180),
+        )
+        .await;
+        let vanished = insert_track(
+            &db,
+            "vanished-local-id",
+            "/music/vanished.flac",
+            "Vanished title",
+            "Local artist",
+            "Local album",
+            Some(190),
+        )
+        .await;
+        let first_remote_source = SourceId::random();
+        let second_remote_source = SourceId::random();
+        let shared_remote_id = TrackId::remote("shared-native-id").expect("remote track ID");
+        let inserted = manager
+            .add_entries(
+                &playlist.id,
+                &[
+                    PlaylistEntryInput::new(
+                        MediaKey::new(first_remote_source, shared_remote_id.clone()),
+                        "First remote",
+                        "Remote artist",
+                        "Remote album",
+                        Some(200),
+                    ),
+                    PlaylistEntryInput::local(&local).expect("local playlist input"),
+                    PlaylistEntryInput::new(
+                        MediaKey::new(second_remote_source, shared_remote_id),
+                        "Second remote",
+                        "Remote artist",
+                        "Remote album",
+                        Some(210),
+                    ),
+                    PlaylistEntryInput::local(&local).expect("duplicate local playlist input"),
+                    PlaylistEntryInput::local(&vanished).expect("vanishing local playlist input"),
+                ],
+            )
+            .await
+            .expect("append mixed occurrences");
+
+        track::Entity::delete_by_id(vanished.id.clone())
+            .exec(&db)
+            .await
+            .expect("delete local row and clear its foreign-key cache");
+
+        let loaded = manager
+            .load_playlist_entries(&playlist.id)
+            .await
+            .expect("load aligned occurrences");
+        assert_eq!(loaded.len(), inserted.len());
+        assert_eq!(
+            loaded
+                .iter()
+                .map(|entry| entry.stored.id.as_str())
+                .collect::<Vec<_>>(),
+            inserted
+                .iter()
+                .map(|entry| entry.id.as_str())
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            loaded
+                .iter()
+                .map(|entry| entry.stored.position)
+                .collect::<Vec<_>>(),
+            vec![0, 1, 2, 3, 4]
+        );
+        assert_eq!(loaded[0].local_track, None, "remote rows never join local");
+        assert_eq!(loaded[2].local_track, None, "source identity isolates IDs");
+        assert_eq!(
+            loaded[1]
+                .local_track
+                .as_ref()
+                .map(|track| track.id.as_str()),
+            Some(local.id.as_str())
+        );
+        assert_eq!(
+            loaded[3]
+                .local_track
+                .as_ref()
+                .map(|track| track.id.as_str()),
+            Some(local.id.as_str()),
+            "duplicate occurrences remain independently aligned"
+        );
+        assert_ne!(loaded[1].stored.id, loaded[3].stored.id);
+        assert_eq!(loaded[1].stored.media_key(), loaded[3].stored.media_key());
+        assert_eq!(loaded[4].local_track, None);
+        assert_eq!(
+            loaded[4].stored.track_id.as_ref().map(TrackId::as_str),
+            Some(vanished.id.as_str()),
+            "local deletion preserves durable identity"
+        );
+        assert_eq!(loaded[4].stored.local_track_id, None);
     }
 
     #[tokio::test]

--- a/src/local/playlist_manager.rs
+++ b/src/local/playlist_manager.rs
@@ -45,6 +45,38 @@ pub struct PlaylistEntryInput {
     pub duration_secs: Option<u64>,
 }
 
+/// Result of an atomic playlist append with a final commit-time authority
+/// check.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PlaylistEntryAddOutcome {
+    Committed(Vec<StoredPlaylistEntry>),
+    Rejected,
+}
+
+/// Finish an authority-bearing transaction on a dedicated blocking worker.
+///
+/// Lifecycle invalidation is synchronous and may wait for `authority` from a
+/// Tokio worker. The commit therefore needs an independent completion owner:
+/// even if every async worker is waiting in revocation, or the calling future
+/// is cancelled after this task is spawned, this worker drives the commit to
+/// completion and only then releases authority.
+async fn commit_with_authority<Authority>(
+    txn: DatabaseTransaction,
+    authority: Authority,
+) -> Result<(), DbErr>
+where
+    Authority: Send + 'static,
+{
+    let runtime = tokio::runtime::Handle::current();
+    tokio::task::spawn_blocking(move || {
+        let committed = runtime.block_on(txn.commit());
+        drop(authority);
+        committed
+    })
+    .await
+    .map_err(|_| DbErr::Custom("Playlist commit worker failed".to_string()))?
+}
+
 impl PlaylistEntryInput {
     pub fn new(
         media_key: MediaKey,
@@ -107,6 +139,18 @@ pub struct StoredPlaylistEntry {
 pub struct LoadedPlaylistEntry {
     pub stored: StoredPlaylistEntry,
     pub local_track: Option<track::Model>,
+}
+
+/// Complete local-track snapshot required by the current XSPF export format.
+///
+/// XSPF export intentionally remains local-only. Callers must not treat the
+/// local compatibility projection as an export source because that projection
+/// omits remote and unresolved occurrences. This typed result makes the
+/// all-or-none boundary explicit before any destination is written.
+#[derive(Clone, Debug, PartialEq)]
+pub enum LocalPlaylistExport {
+    Ready(Vec<track::Model>),
+    UnsupportedEntries,
 }
 
 impl StoredPlaylistEntry {
@@ -429,18 +473,51 @@ impl PlaylistManager {
     /// occurrences in input order. Local identities are resolved against the
     /// current track table inside the same transaction and receive the local
     /// foreign-key cache. Non-local identities are persisted without a URI or
-    /// local foreign key; callers must obtain and recheck live catalogue
-    /// authority before entering this storage boundary.
+    /// local foreign key. Remote callers use
+    /// [`Self::add_entries_if_authorized`] so live catalogue authority is
+    /// acquired only after these writes are staged and retained through the
+    /// commit.
     pub async fn add_entries(
         &self,
         playlist_id: &str,
         inputs: &[PlaylistEntryInput],
     ) -> Result<Vec<StoredPlaylistEntry>, DbErr> {
+        match self
+            .add_entries_if_authorized(playlist_id, inputs, || Some(()))
+            .await?
+        {
+            PlaylistEntryAddOutcome::Committed(inserted) => Ok(inserted),
+            PlaylistEntryAddOutcome::Rejected => {
+                unreachable!("unconditional playlist storage authority")
+            }
+        }
+    }
+
+    /// Stage exact source-scoped entries, then acquire final authority at the
+    /// transaction's commit boundary.
+    ///
+    /// Returning `None` from `authorize` rejects the whole mutation and drops
+    /// the transaction, including every staged insert. A returned opaque value
+    /// is retained across `commit().await`, allowing its owner to delay source
+    /// invalidation until the durable write has completed.
+    pub async fn add_entries_if_authorized<Authority, Authorize>(
+        &self,
+        playlist_id: &str,
+        inputs: &[PlaylistEntryInput],
+        authorize: Authorize,
+    ) -> Result<PlaylistEntryAddOutcome, DbErr>
+    where
+        Authorize: FnOnce() -> Option<Authority>,
+        Authority: Send + 'static,
+    {
         let txn = self.db.begin().await?;
         require_regular_playlist(&txn, playlist_id).await?;
         if inputs.is_empty() {
-            txn.commit().await?;
-            return Ok(Vec::new());
+            let Some(authority) = authorize() else {
+                return Ok(PlaylistEntryAddOutcome::Rejected);
+            };
+            commit_with_authority(txn, authority).await?;
+            return Ok(PlaylistEntryAddOutcome::Committed(Vec::new()));
         }
 
         for input in inputs {
@@ -546,8 +623,11 @@ impl PlaylistManager {
             inserted.push(StoredPlaylistEntry::from_model(model)?);
         }
 
-        txn.commit().await?;
-        Ok(inserted)
+        let Some(authority) = authorize() else {
+            return Ok(PlaylistEntryAddOutcome::Rejected);
+        };
+        commit_with_authority(txn, authority).await?;
+        Ok(PlaylistEntryAddOutcome::Committed(inserted))
     }
 
     /// Remove an entry from its owning regular playlist and close the gap.
@@ -704,6 +784,36 @@ impl PlaylistManager {
         }
         txn.commit().await?;
         Ok(loaded)
+    }
+
+    /// Prepare an all-or-none local snapshot for XSPF export.
+    ///
+    /// A regular playlist containing even one remote or currently unresolved
+    /// local occurrence is rejected as a whole. This prevents callers from
+    /// silently exporting only the rows returned by the compatibility
+    /// projection and presenting a truncated playlist as successful.
+    pub async fn local_playlist_export(
+        &self,
+        playlist_id: &str,
+    ) -> Result<LocalPlaylistExport, DbErr> {
+        let entries = self.load_playlist_entries(playlist_id).await?;
+        if entries
+            .iter()
+            .any(|entry| entry.stored.source_id != SourceId::local() || entry.local_track.is_none())
+        {
+            return Ok(LocalPlaylistExport::UnsupportedEntries);
+        }
+
+        let mut tracks = Vec::with_capacity(entries.len());
+        for entry in entries {
+            let Some(local_track) = entry.local_track else {
+                // Keep the materialization fail-closed even if the predicate
+                // above is changed independently in a later refactor.
+                return Ok(LocalPlaylistExport::UnsupportedEntries);
+            };
+            tracks.push(local_track);
+        }
+        Ok(LocalPlaylistExport::Ready(tracks))
     }
 
     /// Get all matched tracks for a regular playlist (ordered by position).
@@ -1183,8 +1293,8 @@ mod tests {
     use sea_orm_migration::MigratorTrait;
 
     use super::{
-        recently_played_default_rules, top_25_most_played_default_rules, PlaylistEntryInput,
-        PlaylistManager, StoredPlaylistEntry,
+        recently_played_default_rules, top_25_most_played_default_rules, LocalPlaylistExport,
+        PlaylistEntryAddOutcome, PlaylistEntryInput, PlaylistManager, StoredPlaylistEntry,
     };
     use crate::architecture::{MediaKey, SourceId, TrackId};
     use crate::db::entities::{playlist, playlist_entry, track};
@@ -2001,6 +2111,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn final_authority_rejection_rolls_back_every_staged_entry() {
+        let db = in_memory_db().await;
+        let manager = PlaylistManager::new(db.clone());
+        let playlist = manager
+            .create_playlist("Commit authority rollback", false)
+            .await
+            .expect("create playlist");
+        let input = PlaylistEntryInput::new(
+            MediaKey::new(
+                SourceId::random(),
+                TrackId::remote("staged-remote-track").expect("remote track ID"),
+            ),
+            "Staged title",
+            "Staged artist",
+            "Staged album",
+            Some(180),
+        );
+        let authorize_called = std::sync::atomic::AtomicBool::new(false);
+
+        let outcome = manager
+            .add_entries_if_authorized(&playlist.id, &[input.clone(), input.clone()], || {
+                authorize_called.store(true, std::sync::atomic::Ordering::Release);
+                Option::<()>::None
+            })
+            .await
+            .expect("authority rejection is not a database failure");
+        assert!(authorize_called.load(std::sync::atomic::Ordering::Acquire));
+        assert_eq!(outcome, PlaylistEntryAddOutcome::Rejected);
+        assert!(playlist_entries(&db, &playlist.id).await.is_empty());
+
+        let committed = manager
+            .add_entries_if_authorized(&playlist.id, &[input], || Some(()))
+            .await
+            .expect("fresh authority commits");
+        let PlaylistEntryAddOutcome::Committed(entries) = committed else {
+            panic!("unconditional authority must commit");
+        };
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].position, 0, "rollback leaves no position gap");
+    }
+
+    #[tokio::test]
     async fn aligned_playlist_load_retains_every_occurrence_and_only_joins_exact_local_rows() {
         let db = in_memory_db().await;
         let manager = PlaylistManager::new(db.clone());
@@ -2110,6 +2262,101 @@ mod tests {
             "local deletion preserves durable identity"
         );
         assert_eq!(loaded[4].stored.local_track_id, None);
+    }
+
+    #[tokio::test]
+    async fn local_playlist_export_is_all_or_none_for_remote_and_unresolved_entries() {
+        let db = in_memory_db().await;
+        let manager = PlaylistManager::new(db.clone());
+        let playlist = manager
+            .create_playlist("Local-only export boundary", false)
+            .await
+            .expect("create playlist");
+
+        assert!(matches!(
+            manager
+                .local_playlist_export(&playlist.id)
+                .await
+                .expect("prepare empty export"),
+            LocalPlaylistExport::Ready(tracks) if tracks.is_empty()
+        ));
+
+        let local = insert_track(
+            &db,
+            "export-local",
+            "/music/export-local.flac",
+            "Local title",
+            "Local artist",
+            "Local album",
+            Some(180),
+        )
+        .await;
+        manager
+            .add_entries(
+                &playlist.id,
+                &[
+                    PlaylistEntryInput::local(&local).expect("local playlist input"),
+                    PlaylistEntryInput::local(&local).expect("duplicate local playlist input"),
+                ],
+            )
+            .await
+            .expect("append local occurrences");
+
+        let LocalPlaylistExport::Ready(tracks) = manager
+            .local_playlist_export(&playlist.id)
+            .await
+            .expect("prepare complete local export")
+        else {
+            panic!("fully resolved local playlist must be exportable");
+        };
+        assert_eq!(
+            tracks
+                .iter()
+                .map(|track| track.id.as_str())
+                .collect::<Vec<_>>(),
+            vec![local.id.as_str(), local.id.as_str()],
+            "local order and duplicate occurrences must be preserved"
+        );
+
+        let remote = manager
+            .add_entries(
+                &playlist.id,
+                &[PlaylistEntryInput::new(
+                    MediaKey::new(
+                        SourceId::random(),
+                        TrackId::remote("export-remote").expect("remote track ID"),
+                    ),
+                    "Remote title",
+                    "Remote artist",
+                    "Remote album",
+                    Some(200),
+                )],
+            )
+            .await
+            .expect("append remote occurrence");
+        assert!(matches!(
+            manager
+                .local_playlist_export(&playlist.id)
+                .await
+                .expect("reject remote export"),
+            LocalPlaylistExport::UnsupportedEntries
+        ));
+
+        manager
+            .remove_entries(&playlist.id, &[remote[0].id.clone()])
+            .await
+            .expect("remove remote occurrence");
+        track::Entity::delete_by_id(local.id)
+            .exec(&db)
+            .await
+            .expect("delete local row and clear its resolution cache");
+        assert!(matches!(
+            manager
+                .local_playlist_export(&playlist.id)
+                .await
+                .expect("reject unresolved local export"),
+            LocalPlaylistExport::UnsupportedEntries
+        ));
     }
 
     #[tokio::test]

--- a/src/source_lifecycle.rs
+++ b/src/source_lifecycle.rs
@@ -13,6 +13,7 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::future::Future;
+use std::hash::Hash;
 use std::panic::AssertUnwindSafe;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -26,8 +27,8 @@ use uuid::Uuid;
 
 use crate::architecture::backend::BackendResult;
 use crate::architecture::error::BackendError;
-use crate::architecture::media::MediaLease;
 use crate::architecture::media::ResolvedHttpRequest;
+use crate::architecture::media::{MediaLease, MediaLeasePermit};
 use crate::architecture::{SourceId, ViewOrigin};
 use crate::local::resolver::ResolvedFileMedia;
 
@@ -579,6 +580,42 @@ pub struct CurrentAcceptedCatalogue<T> {
     pub session_epoch: u64,
     pub authority: MediaLease,
     pub value: T,
+}
+
+/// One exact catalogue member required by a commit-scoped caller.
+///
+/// The selected key remains generic so the lifecycle layer can validate it
+/// through a bounded registry-owned payload selector without learning any
+/// backend catalogue representation.
+pub struct CatalogueCommitRequest<K> {
+    pub source_id: SourceId,
+    pub catalogue_generation: u64,
+    pub session_epoch: u64,
+    pub selected: K,
+}
+
+/// Opaque admission that orders one commit before exact session/catalogue
+/// invalidation can complete or publish.
+///
+/// Dropping this value is the only operation: it releases every in-flight
+/// permit. Callers must not retain it while asking the lifecycle registry to
+/// replace or disconnect one of the admitted sources.
+pub struct CatalogueCommitAuthority {
+    permits: Vec<MediaLeasePermit>,
+}
+
+impl CatalogueCommitAuthority {
+    #[cfg(test)]
+    pub(crate) fn permit_count(&self) -> usize {
+        self.permits.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn revocation_started(&self) -> bool {
+        self.permits
+            .iter()
+            .any(MediaLeasePermit::revocation_started)
+    }
 }
 
 impl<S> AcceptedSnapshot<S> {
@@ -2117,6 +2154,92 @@ impl<A: LifecycleAdapter + ?Sized, S> SourceLifecycleRegistry<A, S> {
                 &catalogue_value,
             ))
         .then_some(selected)
+    }
+
+    /// Atomically admit one commit section over exact catalogue members.
+    ///
+    /// All unique catalogue guards are validated and acquire both their
+    /// session and catalogue permits while the lifecycle state lock remains
+    /// held. Immutable payload snapshots for all unique selected keys are
+    /// cloned in that same observation, then the bounded membership selector
+    /// runs after the lock is released. The permits keep those snapshots
+    /// authoritative throughout that unlocked validation.
+    ///
+    /// Replacement and disconnect also revoke under the state lock, so they
+    /// can neither slip between validation and acquisition nor publish an
+    /// invalidation until the returned authority is dropped. There is
+    /// intentionally no registry-lock recheck after permits are acquired: an
+    /// invalidator may already be waiting for those permits while holding the
+    /// state lock.
+    pub(crate) fn acquire_catalogue_commit_authority<K, Validate>(
+        &self,
+        requests: &[CatalogueCommitRequest<K>],
+        validate: Validate,
+    ) -> Option<CatalogueCommitAuthority>
+    where
+        K: Eq + Hash,
+        Validate: Fn(&S, &K) -> bool,
+    {
+        let (authority, selections) = {
+            let state = lock(&self.inner.state);
+            if state.gate != RegistryGate::Running {
+                return None;
+            }
+
+            let mut unique_tracks = HashSet::with_capacity(requests.len());
+            let mut unique_guards = HashSet::with_capacity(requests.len());
+            let mut leases = Vec::with_capacity(requests.len());
+            let mut selections = Vec::with_capacity(requests.len());
+            for request in requests {
+                let track_key = (
+                    request.source_id,
+                    request.session_epoch,
+                    request.catalogue_generation,
+                    &request.selected,
+                );
+                if !unique_tracks.insert(track_key) {
+                    continue;
+                }
+
+                let entry = state.entries.get(&request.source_id)?;
+                let active = entry.active.as_ref()?;
+                let catalogue = entry.catalogue.as_ref()?;
+                if active.epoch != request.session_epoch {
+                    return None;
+                }
+                if catalogue.session_epoch != request.session_epoch {
+                    return None;
+                }
+                if catalogue.generation != request.catalogue_generation {
+                    return None;
+                }
+                if !active.lease.is_active() || !catalogue.authority.is_active() {
+                    return None;
+                }
+                selections.push((Arc::clone(&catalogue.value), &request.selected));
+
+                let guard = (
+                    request.source_id,
+                    request.session_epoch,
+                    request.catalogue_generation,
+                );
+                if unique_guards.insert(guard) {
+                    leases.push((active.lease.clone(), catalogue.authority.clone()));
+                }
+            }
+
+            let mut permits = Vec::with_capacity(leases.len().saturating_mul(2));
+            for (session, catalogue) in leases {
+                permits.push(session.try_acquire()?);
+                permits.push(catalogue.try_acquire()?);
+            }
+            (CatalogueCommitAuthority { permits }, selections)
+        };
+
+        selections
+            .into_iter()
+            .all(|(catalogue, selected)| validate(catalogue.as_ref(), selected))
+            .then_some(authority)
     }
 
     /// Recheck the exact immutable catalogue captured before an unlocked

--- a/src/source_registry.rs
+++ b/src/source_registry.rs
@@ -29,10 +29,11 @@ use crate::architecture::{MediaKey, SourceId, TrackId, ViewOrigin};
 use crate::external_file::{ExternalFileCandidate, ExternalFileHint};
 use crate::local::resolver::ResolvedFileMedia;
 use crate::source_lifecycle::{
-    AdapterCloseFuture, AdapterStream, AdapterTaskResult, CloseAuthority,
-    ConstructionCancellationPolicy, FailureCategory, LifecycleAdapter, LifecycleBaseline,
-    LifecycleSnapshot, ProvenanceClaimId, RefreshLane, RefreshTaskResult, RetirementWaiter,
-    ShutdownBarrier, SourceLifecycleRegistry, SourceProvenance,
+    AdapterCloseFuture, AdapterStream, AdapterTaskResult, CatalogueCommitAuthority,
+    CatalogueCommitRequest, CloseAuthority, ConstructionCancellationPolicy, FailureCategory,
+    LifecycleAdapter, LifecycleBaseline, LifecycleSnapshot, ProvenanceClaimId, RefreshLane,
+    RefreshTaskResult, RetirementWaiter, ShutdownBarrier, SourceLifecycleRegistry,
+    SourceProvenance,
 };
 use url::Url;
 
@@ -733,6 +734,31 @@ impl PublicHttpAuthority for SourceRegistryInner {
 #[derive(Clone)]
 pub struct SourceRegistry {
     inner: Arc<SourceRegistryInner>,
+}
+
+/// Opaque authority retaining every remote session and catalogue selected for
+/// one regular-playlist database commit.
+///
+/// The lifecycle permit is declared before the registry owner so it is
+/// released first during drop. This prevents final-handle teardown from
+/// waiting on a permit owned by the value currently being destroyed.
+#[must_use = "regular-playlist commit authority must be retained through the database commit"]
+pub struct RegularPlaylistCommitAuthority {
+    #[allow(dead_code)] // Retention through Drop is the authority operation.
+    authority: CatalogueCommitAuthority,
+    _registry: Arc<SourceRegistryInner>,
+}
+
+impl RegularPlaylistCommitAuthority {
+    #[cfg(test)]
+    fn permit_count(&self) -> usize {
+        self.authority.permit_count()
+    }
+
+    #[cfg(test)]
+    fn revocation_started(&self) -> bool {
+        self.authority.revocation_started()
+    }
 }
 
 /// Pathless identity and catalogue projection for one admitted OS-opened
@@ -1442,6 +1468,46 @@ impl SourceRegistry {
             .all(|(observed, current)| regular_playlist_authority_eq(observed, current))
     }
 
+    /// Acquire commit-scoped authority for an ordered remote playlist plan.
+    ///
+    /// Every occurrence must be an available exact catalogue member. The
+    /// lifecycle registry deduplicates repeated tracks and guards, validates
+    /// the complete batch in one locked observation, and admits in-flight
+    /// session/catalogue permits before returning. The opaque result must be
+    /// retained until the database transaction has committed.
+    pub fn acquire_regular_playlist_commit_authority(
+        &self,
+        resolutions: &[RegularPlaylistTrackResolution],
+    ) -> Option<RegularPlaylistCommitAuthority> {
+        let mut requests = Vec::with_capacity(resolutions.len());
+        for resolution in resolutions {
+            let RegularPlaylistTrackResolution::Available(track) = resolution else {
+                return None;
+            };
+            let guard = track.guard();
+            if track.media_key.source_id != guard.source_id {
+                return None;
+            }
+            requests.push(CatalogueCommitRequest {
+                source_id: guard.source_id,
+                catalogue_generation: guard.catalogue_generation,
+                session_epoch: guard.session_epoch,
+                selected: track.media_key.track_id.clone(),
+            });
+        }
+
+        let authority = self
+            .inner
+            .lifecycle
+            .acquire_catalogue_commit_authority(&requests, |payload, track_id| {
+                payload.regular_playlist_track(track_id).is_some()
+            })?;
+        Some(RegularPlaylistCommitAuthority {
+            authority,
+            _registry: Arc::clone(&self.inner),
+        })
+    }
+
     /// Resolve one stream only through the exact catalogue guard that minted
     /// the playlist row. The returned protected request carries the accepted
     /// catalogue's revocable lease, so a same-session catalogue replacement
@@ -1746,6 +1812,8 @@ mod tests {
 
     use async_trait::async_trait;
     use axum::http::{Method, StatusCode};
+    use sea_orm::Database;
+    use sea_orm_migration::MigratorTrait;
     use tokio::runtime::Handle;
     use tokio::sync::{oneshot, watch};
     use tokio::time::{timeout, Duration};
@@ -1755,7 +1823,11 @@ mod tests {
     use crate::architecture::models::{
         Album, Artist, LibraryStats, SearchResults, SortField, SortOrder,
     };
+    use crate::db::migration::Migrator;
     use crate::http_test_service::{MockHttpService, MockResponse, MockRoute};
+    use crate::local::playlist_manager::{
+        PlaylistEntryAddOutcome, PlaylistEntryInput, PlaylistManager,
+    };
 
     use super::*;
 
@@ -2013,6 +2085,19 @@ mod tests {
 
     fn registry() -> SourceRegistry {
         SourceRegistry::new(Handle::current())
+    }
+
+    async fn playlist_manager_fixture(name: &str) -> (PlaylistManager, String) {
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("connect in-memory database");
+        Migrator::up(&db, None).await.expect("run migrations");
+        let manager = PlaylistManager::new(db);
+        let playlist = manager
+            .create_playlist(name, false)
+            .await
+            .expect("create regular playlist");
+        (manager, playlist.id)
     }
 
     fn minimal_wav_bytes(sample: u8) -> Vec<u8> {
@@ -2448,6 +2533,226 @@ mod tests {
         assert!(!metadata_debug.contains("stream_url"));
         assert!(!metadata_debug.contains("cover_art_url"));
         assert!(!metadata_debug.contains("file_path"));
+
+        registry.shutdown().wait().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn playlist_commit_authority_blocks_catalogue_publish_and_rejects_stale_guard() {
+        let registry = registry();
+        let source_id = SourceId::random();
+        let track_id = TrackId::remote("commit-guarded-track").expect("track ID");
+        let probe = FakeProbe::new(true);
+        connect_playlist_fixture(
+            &registry,
+            source_id,
+            probe.playlist_adapter("commit-refresh", vec![fixture_track(track_id.clone())]),
+        )
+        .await;
+
+        let key = MediaKey::new(source_id, track_id.clone());
+        let resolved = registry.resolve_regular_playlist_tracks(&[key.clone(), key]);
+        let authority = registry
+            .acquire_regular_playlist_commit_authority(&resolved)
+            .expect("current duplicate occurrences are admitted");
+        assert_eq!(
+            authority.permit_count(),
+            2,
+            "one unique guard owns one session and one catalogue permit"
+        );
+
+        let mut invalidations = registry.subscribe_invalidations();
+        let owner = registry
+            .inner
+            .lifecycle
+            .begin_refresh(source_id, RefreshLane::Catalogue)
+            .expect("catalogue refresh admitted");
+        let generation = owner.generation();
+        let (started_tx, started_rx) = oneshot::channel();
+        let (finish_tx, finish_rx) = oneshot::channel();
+        let refreshed_track_id = track_id.clone();
+        owner.spawn(move |_session, _cancellation| async move {
+            let _ = started_tx.send(());
+            let _ = finish_rx.await;
+            let mut track = fixture_track(refreshed_track_id);
+            track.title = "Replacement catalogue".to_string();
+            RefreshTaskResult::Refreshed(AcceptedSourcePayload::catalogue(
+                vec![track],
+                RegularPlaylistCapability::SourceScopedEntries,
+            ))
+        });
+        started_rx.await.expect("refresh task started");
+        let _ = invalidations.borrow_and_update();
+        finish_tx.send(()).expect("refresh task remains alive");
+
+        timeout(Duration::from_secs(2), async {
+            while !authority.revocation_started() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("catalogue replacement reached revocation");
+        assert!(
+            !invalidations
+                .has_changed()
+                .expect("invalidation sender alive"),
+            "replacement cannot publish while commit authority is retained"
+        );
+
+        drop(authority);
+        timeout(Duration::from_secs(2), invalidations.changed())
+            .await
+            .expect("replacement publishes after permit release")
+            .expect("invalidation sender alive");
+        timeout(Duration::from_secs(2), async {
+            loop {
+                if registry
+                    .snapshot(source_id)
+                    .and_then(|snapshot| snapshot.catalogue)
+                    .is_some_and(|catalogue| catalogue.generation == generation)
+                {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("replacement catalogue accepted");
+        assert!(registry
+            .acquire_regular_playlist_commit_authority(&resolved)
+            .is_none());
+
+        registry.shutdown().wait().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn playlist_final_authority_rejection_rolls_back_after_disconnect_wins() {
+        let registry = registry();
+        let source_id = SourceId::random();
+        let track_id = TrackId::remote("commit-stale-track").expect("track ID");
+        let probe = FakeProbe::new(true);
+        connect_playlist_fixture(
+            &registry,
+            source_id,
+            probe.playlist_adapter("commit-stale", vec![fixture_track(track_id.clone())]),
+        )
+        .await;
+
+        let media_key = MediaKey::new(source_id, track_id);
+        let resolved = registry.resolve_regular_playlist_tracks(std::slice::from_ref(&media_key));
+        let (manager, playlist_id) = playlist_manager_fixture("Rejected guarded commit").await;
+        let input = PlaylistEntryInput::new(
+            media_key,
+            available(&resolved[0]).metadata().title(),
+            available(&resolved[0]).metadata().artist_name(),
+            available(&resolved[0]).metadata().album_title(),
+            available(&resolved[0]).metadata().duration_secs(),
+        );
+
+        let disconnect_waiter = Arc::new(Mutex::new(None));
+        let waiter_slot = Arc::clone(&disconnect_waiter);
+        let outcome = manager
+            .add_entries_if_authorized(&playlist_id, &[input], || {
+                let waiter = registry.disconnect(source_id).expect("disconnect admitted");
+                *lock(&waiter_slot) = Some(waiter);
+                registry.acquire_regular_playlist_commit_authority(&resolved)
+            })
+            .await
+            .expect("stale authority is a typed rejection");
+        assert_eq!(outcome, PlaylistEntryAddOutcome::Rejected);
+        assert!(manager
+            .get_playlist_entries(&playlist_id)
+            .await
+            .expect("load rolled-back playlist")
+            .is_empty());
+        let waiter = lock(&disconnect_waiter)
+            .take()
+            .expect("disconnect waiter retained");
+        waiter.wait().await;
+
+        registry.shutdown().wait().await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn playlist_commit_authority_blocks_disconnect_publish_and_rejects_stale_guard() {
+        let registry = registry();
+        let source_id = SourceId::random();
+        let track_id = TrackId::remote("commit-disconnect-track").expect("track ID");
+        let probe = FakeProbe::new(true);
+        connect_playlist_fixture(
+            &registry,
+            source_id,
+            probe.playlist_adapter("commit-disconnect", vec![fixture_track(track_id.clone())]),
+        )
+        .await;
+
+        let media_key = MediaKey::new(source_id, track_id);
+        let resolved = registry.resolve_regular_playlist_tracks(std::slice::from_ref(&media_key));
+        let (manager, playlist_id) = playlist_manager_fixture("Guarded commit").await;
+        let input = PlaylistEntryInput::new(
+            media_key,
+            available(&resolved[0]).metadata().title(),
+            available(&resolved[0]).metadata().artist_name(),
+            available(&resolved[0]).metadata().album_title(),
+            available(&resolved[0]).metadata().duration_secs(),
+        );
+        let mut invalidations = registry.subscribe_invalidations();
+        let _ = invalidations.borrow_and_update();
+        let (disconnect_tx, disconnect_rx) = std::sync::mpsc::sync_channel(1);
+        let outcome = manager
+            .add_entries_if_authorized(&playlist_id, &[input], || {
+                let authority = registry
+                    .acquire_regular_playlist_commit_authority(&resolved)
+                    .expect("current occurrence is admitted at the commit boundary");
+                let disconnecting = registry.clone();
+                let _disconnect_worker = std::thread::spawn(move || {
+                    let waiter = disconnecting
+                        .disconnect(source_id)
+                        .expect("disconnect admitted");
+                    disconnect_tx
+                        .send(waiter)
+                        .expect("disconnect receiver remains alive");
+                });
+
+                let deadline = std::time::Instant::now() + Duration::from_secs(2);
+                while !authority.revocation_started() {
+                    assert!(
+                        std::time::Instant::now() < deadline,
+                        "disconnect reached revocation"
+                    );
+                    std::thread::yield_now();
+                }
+                assert!(
+                    !invalidations
+                        .has_changed()
+                        .expect("invalidation sender alive"),
+                    "disconnect cannot publish before the database commit"
+                );
+                Some(authority)
+            })
+            .await
+            .expect("guarded append has no database failure");
+        assert!(matches!(outcome, PlaylistEntryAddOutcome::Committed(_)));
+        assert_eq!(
+            manager
+                .get_playlist_entries(&playlist_id)
+                .await
+                .expect("load committed occurrence")
+                .len(),
+            1
+        );
+
+        let waiter = disconnect_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("disconnect returns after commit releases authority");
+        timeout(Duration::from_secs(2), invalidations.changed())
+            .await
+            .expect("disconnect publishes after commit")
+            .expect("invalidation sender alive");
+        assert!(registry
+            .acquire_regular_playlist_commit_authority(&resolved)
+            .is_none());
+        waiter.wait().await;
 
         registry.shutdown().wait().await;
     }

--- a/src/source_registry.rs
+++ b/src/source_registry.rs
@@ -72,8 +72,6 @@ pub enum RegularPlaylistCapability {
 /// Guards are minted only by a successful registry lookup and must never be
 /// persisted. A session replacement changes `session_epoch`; a same-session
 /// catalogue replacement changes `catalogue_generation`.
-// Record A intentionally lands this authority surface before Record B wires UI consumers.
-#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct RegularPlaylistCatalogueGuard {
     source_id: SourceId,
@@ -81,7 +79,6 @@ pub struct RegularPlaylistCatalogueGuard {
     catalogue_generation: u64,
 }
 
-#[allow(dead_code)]
 impl RegularPlaylistCatalogueGuard {
     pub const fn source_id(self) -> SourceId {
         self.source_id
@@ -98,7 +95,6 @@ impl RegularPlaylistCatalogueGuard {
 
 /// Fixed, non-sensitive reason that a persisted source-scoped identity cannot
 /// currently be projected from a regular playlist.
-#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RegularPlaylistUnavailableReason {
     SourceUnavailable,
@@ -110,7 +106,6 @@ pub enum RegularPlaylistUnavailableReason {
 /// Closed failure returned by guarded regular-playlist media resolution.
 /// Raw adapter errors, URLs, credentials, and native IDs never cross this
 /// boundary.
-#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
 pub enum RegularPlaylistMediaError {
     #[error("regular playlist media authority is unavailable")]
@@ -120,7 +115,6 @@ pub enum RegularPlaylistMediaError {
 }
 
 /// One available regular-playlist track resolved from an exact live catalogue.
-#[allow(dead_code)]
 #[derive(Clone)]
 pub struct RegularPlaylistTrack {
     media_key: MediaKey,
@@ -128,7 +122,6 @@ pub struct RegularPlaylistTrack {
     metadata: RegularPlaylistTrackMetadata,
 }
 
-#[allow(dead_code)]
 impl RegularPlaylistTrack {
     pub fn media_key(&self) -> &MediaKey {
         &self.media_key
@@ -141,6 +134,29 @@ impl RegularPlaylistTrack {
     pub fn metadata(&self) -> &RegularPlaylistTrackMetadata {
         &self.metadata
     }
+
+    /// Construct a registry-shaped available result for cross-module UI
+    /// tests without making catalogue guards forgeable in production.
+    #[cfg(test)]
+    pub(crate) fn for_ui_test(
+        media_key: MediaKey,
+        session_epoch: u64,
+        catalogue_generation: u64,
+        track: &Track,
+    ) -> Self {
+        assert_ne!(media_key.source_id, SourceId::local());
+        assert_ne!(session_epoch, 0);
+        assert_ne!(catalogue_generation, 0);
+        Self {
+            guard: RegularPlaylistCatalogueGuard {
+                source_id: media_key.source_id,
+                session_epoch,
+                catalogue_generation,
+            },
+            media_key,
+            metadata: RegularPlaylistTrackMetadata::from_track(track),
+        }
+    }
 }
 
 /// Whitelisted display, sorting, rating, and history metadata for a regular
@@ -149,7 +165,6 @@ impl RegularPlaylistTrack {
 /// This is deliberately not a `Track` clone. Adding a new field to `Track`
 /// cannot silently expose a locator, credential, or future private adapter
 /// detail across the playlist authority boundary.
-#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct RegularPlaylistTrackMetadata {
     title: String,
@@ -172,7 +187,6 @@ pub struct RegularPlaylistTrackMetadata {
     last_played: Option<chrono::DateTime<chrono::Utc>>,
 }
 
-#[allow(dead_code)]
 impl RegularPlaylistTrackMetadata {
     fn from_track(track: &Track) -> Self {
         Self {
@@ -237,6 +251,9 @@ impl RegularPlaylistTrackMetadata {
         self.year
     }
 
+    // Kept in the explicit catalogue whitelist for future source-aware sort
+    // projections; Record B does not yet expose a Date Added column.
+    #[allow(dead_code)]
     pub fn date_added(&self) -> Option<chrono::DateTime<chrono::Utc>> {
         self.date_added
     }
@@ -265,6 +282,9 @@ impl RegularPlaylistTrackMetadata {
         self.rating
     }
 
+    // Remote history is intentionally read-only. The value may cross this
+    // sanitized boundary even though local-only history UI does not consume it.
+    #[allow(dead_code)]
     pub fn last_played(&self) -> Option<chrono::DateTime<chrono::Utc>> {
         self.last_played
     }
@@ -273,7 +293,6 @@ impl RegularPlaylistTrackMetadata {
 /// One unavailable regular-playlist identity. Its optional private guard lets
 /// the registry distinguish a still-current missing/unsupported catalogue
 /// observation from a replacement without exposing lifecycle internals.
-#[allow(dead_code)]
 #[derive(Clone)]
 pub struct RegularPlaylistUnavailable {
     media_key: MediaKey,
@@ -281,7 +300,6 @@ pub struct RegularPlaylistUnavailable {
     observed_guard: Option<RegularPlaylistCatalogueGuard>,
 }
 
-#[allow(dead_code)]
 impl RegularPlaylistUnavailable {
     pub fn media_key(&self) -> &MediaKey {
         &self.media_key
@@ -293,14 +311,12 @@ impl RegularPlaylistUnavailable {
 }
 
 /// Ordered result of resolving one persisted source-scoped playlist identity.
-#[allow(dead_code)]
 #[derive(Clone)]
 pub enum RegularPlaylistTrackResolution {
     Available(Box<RegularPlaylistTrack>),
     Unavailable(RegularPlaylistUnavailable),
 }
 
-#[allow(dead_code)]
 impl RegularPlaylistTrackResolution {
     pub fn media_key(&self) -> &MediaKey {
         match self {
@@ -426,13 +442,10 @@ pub enum ViewLoadResult {
 struct AcceptedSourcePayload {
     tracks: Arc<Vec<Track>>,
     public_streams: HashMap<TrackId, PublicHttpEndpoint>,
-    #[allow(dead_code)]
     regular_playlist_capability: RegularPlaylistCapability,
-    #[allow(dead_code)]
     regular_playlist_index: RegularPlaylistTrackIndex,
 }
 
-#[allow(dead_code)]
 #[derive(Clone)]
 enum RegularPlaylistTrackIndex {
     Unsupported,
@@ -480,7 +493,6 @@ impl AcceptedSourcePayload {
         AcceptedView::published(Arc::clone(&self.tracks))
     }
 
-    #[allow(dead_code)]
     fn regular_playlist_track(&self, track_id: &TrackId) -> Option<&Track> {
         if self.regular_playlist_capability != RegularPlaylistCapability::SourceScopedEntries {
             return None;
@@ -1306,7 +1318,6 @@ impl SourceRegistry {
     /// observed independently under the lifecycle lock, while metadata copies
     /// and ordering work happen outside it. Similar metadata, another source's
     /// matching native ID, and endpoint identity are never considered.
-    #[allow(dead_code)]
     pub fn resolve_regular_playlist_tracks(
         &self,
         media_keys: &[MediaKey],
@@ -1416,7 +1427,6 @@ impl SourceRegistry {
     /// Recheck that an ordered lookup result still describes the current
     /// source/catalogue authority. Metadata is immutable within a guard, so
     /// only exact identity, guard, and closed availability state are compared.
-    #[allow(dead_code)]
     pub fn are_regular_playlist_tracks_current(
         &self,
         resolutions: &[RegularPlaylistTrackResolution],
@@ -1436,7 +1446,6 @@ impl SourceRegistry {
     /// the playlist row. The returned protected request carries the accepted
     /// catalogue's revocable lease, so a same-session catalogue replacement
     /// also invalidates a request after resolution but before consumption.
-    #[allow(dead_code)]
     pub async fn resolve_regular_playlist_stream(
         &self,
         guard: RegularPlaylistCatalogueGuard,
@@ -1469,7 +1478,6 @@ impl SourceRegistry {
 
     /// Artwork counterpart of [`Self::resolve_regular_playlist_stream`] with
     /// the same exact pre/post guard checks and catalogue-generation lease.
-    #[allow(dead_code)]
     pub async fn resolve_regular_playlist_artwork(
         &self,
         guard: RegularPlaylistCatalogueGuard,
@@ -1555,7 +1563,6 @@ impl SourceRegistry {
     }
 }
 
-#[allow(dead_code)]
 fn regular_playlist_authority_eq(
     observed: &RegularPlaylistTrackResolution,
     current: &RegularPlaylistTrackResolution,
@@ -1577,7 +1584,6 @@ fn regular_playlist_authority_eq(
     }
 }
 
-#[allow(dead_code)]
 fn regular_playlist_media_error(
     error: crate::source_lifecycle::CatalogueMediaResolveError,
 ) -> RegularPlaylistMediaError {

--- a/src/ui/context_menu.rs
+++ b/src/ui/context_menu.rs
@@ -5,13 +5,13 @@
 //! platform context-menu key / Shift+F10.
 
 use adw::prelude::*;
-use sea_orm::{EntityTrait, QueryFilter};
 use std::rc::Rc;
 
-use super::browser;
 use super::objects::{SourceObject, TrackObject};
-use super::tracklist;
 use super::window_state::WindowState;
+use crate::architecture::{MediaKey, SourceId, TrackId};
+use crate::local::playlist_manager::PlaylistEntryInput;
+use crate::source_registry::{RegularPlaylistTrackResolution, SourceRegistry};
 
 const CONTEXT_MENU_ACTION_GROUP: &str = "tracklist-ctx";
 
@@ -69,43 +69,154 @@ impl ContextMenuPopupPlan {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum PlaylistAddSupport {
-    LocalLibrary,
-    UnsupportedSource,
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum PlaylistAddCandidate {
+    Local(MediaKey),
+    Remote {
+        media_key: MediaKey,
+        session_epoch: u64,
+        catalogue_generation: u64,
+    },
 }
 
-impl PlaylistAddSupport {
-    fn from_source_key(source_key: &str) -> Self {
-        if source_key == "local" {
-            Self::LocalLibrary
-        } else {
-            Self::UnsupportedSource
-        }
-    }
-
-    fn activation(self) -> PlaylistAddActivation {
+impl PlaylistAddCandidate {
+    #[cfg(test)]
+    fn media_key(&self) -> &MediaKey {
         match self {
-            Self::LocalLibrary => PlaylistAddActivation::WriteLocalPlaylist,
-            Self::UnsupportedSource => PlaylistAddActivation::ExplainUnsupportedSource,
+            Self::Local(media_key) | Self::Remote { media_key, .. } => media_key,
         }
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum PlaylistAddActivation {
-    WriteLocalPlaylist,
-    ExplainUnsupportedSource,
+struct PlaylistAddPlan {
+    inputs: Vec<PlaylistEntryInput>,
+    authority: Vec<RegularPlaylistTrackResolution>,
 }
 
-#[derive(Clone, Copy)]
-struct PlaylistAddInteraction<'a> {
-    window: &'a gtk::glib::WeakRef<adw::ApplicationWindow>,
-    support: PlaylistAddSupport,
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PlaylistMutationOutcome {
+    Committed,
+    Rejected,
+    Failed,
+}
+
+#[derive(Clone)]
+struct PlaylistMutationContext {
+    window: gtk::glib::WeakRef<adw::ApplicationWindow>,
+    rt_handle: tokio::runtime::Handle,
+    source_registry: SourceRegistry,
+    track_store: gtk::gio::ListStore,
+    master_tracks: std::rc::Rc<std::cell::RefCell<Vec<TrackObject>>>,
+    source_tracks:
+        std::rc::Rc<std::cell::RefCell<std::collections::HashMap<String, Vec<TrackObject>>>>,
+    active_source_key: std::rc::Rc<std::cell::RefCell<String>>,
+    source_navigation: std::rc::Rc<std::cell::RefCell<super::source_navigation::SourceNavigation>>,
+    browser_widget: gtk::Box,
+    browser_state: super::browser::BrowserState,
+    status_label: gtk::Label,
+    column_view: gtk::ColumnView,
+}
+
+impl PlaylistMutationContext {
+    fn from_window(state: &WindowState) -> Self {
+        Self {
+            window: state.window.downgrade(),
+            rt_handle: state.rt_handle.clone(),
+            source_registry: state.source_registry.clone(),
+            track_store: state.track_store.clone(),
+            master_tracks: state.master_tracks.clone(),
+            source_tracks: state.source_tracks.clone(),
+            active_source_key: state.active_source_key.clone(),
+            source_navigation: state.source_navigation.clone(),
+            browser_widget: state.browser_widget.clone(),
+            browser_state: state.browser_state.clone(),
+            status_label: state.status_label.clone(),
+            column_view: state.column_view.clone(),
+        }
+    }
+
+    fn owns_navigation(&self, source_key: &str) -> bool {
+        *self.active_source_key.borrow() == source_key
+            && self.source_navigation.borrow().is_key(source_key)
+    }
+
+    fn current_request(&self, source_key: &str) -> Option<super::source_navigation::SourceRequest> {
+        let navigation = self.source_navigation.borrow();
+        navigation
+            .latest_request(source_key)
+            .filter(|request| navigation.is_current(request))
+    }
+
+    fn owns_request(&self, request: &super::source_navigation::SourceRequest) -> bool {
+        *self.active_source_key.borrow() == request.source_key()
+            && self.source_navigation.borrow().is_current(request)
+    }
+
+    fn show_unsupported(&self) {
+        if let Some(window) = self.window.upgrade() {
+            show_unsupported_playlist_add_dialog(&window);
+        }
+    }
+
+    fn show_mutation_failed(&self) {
+        if let Some(window) = self.window.upgrade() {
+            show_playlist_mutation_failed_dialog(&window);
+        }
+    }
+
+    fn refresh_playlist_after_commit(&self, playlist_id: &str) {
+        let source_key = format!("{}{playlist_id}", super::playback::PLAYLIST_SOURCE_PREFIX);
+        self.source_navigation
+            .borrow_mut()
+            .invalidate_key(&source_key);
+        self.source_tracks.borrow_mut().remove(&source_key);
+        if !self.owns_navigation(&source_key) {
+            return;
+        }
+
+        let request = self
+            .source_navigation
+            .borrow_mut()
+            .select(source_key.clone());
+        // A committed removal must not leave the now-invalid occurrence
+        // actionable while the authoritative replacement projection loads.
+        // Add uses the same path so a playlist opened during the write cannot
+        // expose a stale pre-commit snapshot either.
+        super::window::display_tracks(
+            &[],
+            &self.track_store,
+            &self.master_tracks,
+            &self.browser_widget,
+            &self.browser_state,
+            &self.status_label,
+            &self.column_view,
+        );
+        super::source_connect::load_playlist_source(
+            self.rt_handle.clone(),
+            self.source_registry.clone(),
+            playlist_id.to_string(),
+            request,
+            self.source_navigation.clone(),
+            self.source_tracks.clone(),
+            self.active_source_key.clone(),
+            self.track_store.clone(),
+            self.master_tracks.clone(),
+            self.browser_widget.clone(),
+            self.browser_state.clone(),
+            self.status_label.clone(),
+            self.column_view.clone(),
+        );
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct UnsupportedPlaylistAddCopy {
+    heading: String,
+    body: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PlaylistMutationFailedCopy {
     heading: String,
     body: String,
 }
@@ -120,6 +231,24 @@ fn unsupported_playlist_add_copy(locale: &str) -> UnsupportedPlaylistAddCopy {
 
 fn show_unsupported_playlist_add_dialog(window: &adw::ApplicationWindow) {
     let copy = unsupported_playlist_add_copy(&rust_i18n::locale());
+    let dialog = adw::AlertDialog::builder()
+        .heading(&copy.heading)
+        .body(&copy.body)
+        .build();
+    dialog.add_response("ok", rust_i18n::t!("dialogs.ok").as_ref());
+    dialog.present(Some(window));
+}
+
+fn playlist_mutation_failed_copy(locale: &str) -> PlaylistMutationFailedCopy {
+    PlaylistMutationFailedCopy {
+        heading: rust_i18n::t!("regular_playlist.mutation_failed_heading", locale = locale)
+            .into_owned(),
+        body: rust_i18n::t!("regular_playlist.mutation_failed_body", locale = locale).into_owned(),
+    }
+}
+
+fn show_playlist_mutation_failed_dialog(window: &adw::ApplicationWindow) {
+    let copy = playlist_mutation_failed_copy(&rust_i18n::locale());
     let dialog = adw::AlertDialog::builder()
         .heading(&copy.heading)
         .body(&copy.body)
@@ -183,28 +312,19 @@ fn expose_context_menu_accessibility(column_view: &gtk::ColumnView) {
 /// open the same selection-snapshotted action model relative to the focused
 /// tracklist, and are consumed only when a non-empty menu was opened.
 pub fn setup_context_menu(state: &WindowState) {
-    // The controllers retaining `popup_menu` live below this window. Keep a
-    // weak handle so the action factory cannot form a window ownership cycle.
-    let window = state.window.downgrade();
     let sm = state.sort_model.clone();
     let sidebar_store = state.sidebar_store.clone();
     let active_source_key = state.active_source_key.clone();
-    let rt_handle = state.rt_handle.clone();
-    let track_store = state.track_store.clone();
-    let source_tracks = state.source_tracks.clone();
-    let source_navigation = state.source_navigation.clone();
-    let master_tracks = state.master_tracks.clone();
-    let status_label = state.status_label.clone();
-    let browser_widget = state.browser_widget.clone();
-    let browser_state = state.browser_state.clone();
+    let mutation_context = PlaylistMutationContext::from_window(state);
 
     let popup_menu = Rc::new(
         move |cv: &gtk::ColumnView, anchor: Option<gtk::gdk::Rectangle>| {
             let active_key = active_source_key.borrow().clone();
             let is_playlist_view = active_key.starts_with("playlist:");
-            let playlist_add_support = PlaylistAddSupport::from_source_key(&active_key);
 
-            // Collect selected track URIs from the MultiSelection model.
+            // Freeze exact selected row identities while constructing this
+            // one-shot popover. No later mutation consults a URI, source label,
+            // or whatever rows happen to occupy these GTK positions.
             let selection_model = cv.model();
             let Some(sel) = selection_model.and_then(|m| m.downcast::<gtk::MultiSelection>().ok())
             else {
@@ -220,6 +340,7 @@ pub fn setup_context_menu(state: &WindowState) {
 
             let menu = gtk::gio::Menu::new();
             let action_group = gtk::gio::SimpleActionGroup::new();
+            let interaction_request = mutation_context.current_request(&active_key);
 
             if is_playlist_view {
                 build_remove_from_playlist_action(
@@ -228,14 +349,8 @@ pub fn setup_context_menu(state: &WindowState) {
                     &active_key,
                     &sm,
                     &popup_plan.selection,
-                    &rt_handle,
-                    &track_store,
-                    &source_tracks,
-                    &source_navigation,
-                    &master_tracks,
-                    &status_label,
-                    &browser_widget,
-                    &browser_state,
+                    interaction_request.as_ref(),
+                    &mutation_context,
                 );
             } else {
                 build_add_to_playlist_actions(
@@ -244,11 +359,8 @@ pub fn setup_context_menu(state: &WindowState) {
                     &sidebar_store,
                     &sm,
                     &popup_plan.selection,
-                    &rt_handle,
-                    PlaylistAddInteraction {
-                        window: &window,
-                        support: playlist_add_support,
-                    },
+                    interaction_request.as_ref(),
+                    &mutation_context,
                 );
             }
 
@@ -338,165 +450,74 @@ pub fn setup_context_menu(state: &WindowState) {
 // ═══════════════════════════════════════════════════════════════════════
 
 /// Build the "Remove from Playlist" action for playlist views.
-#[allow(clippy::too_many_arguments)]
 fn build_remove_from_playlist_action(
     menu: &gtk::gio::Menu,
     action_group: &gtk::gio::SimpleActionGroup,
     active_key: &str,
     sm: &gtk::SortListModel,
     selection: &SelectionSnapshot,
-    rt_handle: &tokio::runtime::Handle,
-    track_store: &gtk::gio::ListStore,
-    source_tracks: &std::rc::Rc<
-        std::cell::RefCell<std::collections::HashMap<String, Vec<TrackObject>>>,
-    >,
-    source_navigation: &std::rc::Rc<std::cell::RefCell<super::source_navigation::SourceNavigation>>,
-    master_tracks: &std::rc::Rc<std::cell::RefCell<Vec<TrackObject>>>,
-    status_label: &gtk::Label,
-    browser_widget: &gtk::Box,
-    browser_state: &browser::BrowserState,
+    interaction_request: Option<&super::source_navigation::SourceRequest>,
+    context: &PlaylistMutationContext,
 ) {
-    let playlist_id = active_key
-        .strip_prefix("playlist:")
-        .unwrap_or("")
-        .to_string();
-    let rt = rt_handle.clone();
-    let track_store = track_store.clone();
-    let source_tracks = source_tracks.clone();
-    let source_navigation = source_navigation.clone();
-    let master_tracks = master_tracks.clone();
-    let status_label = status_label.clone();
-    let browser_widget = browser_widget.clone();
-    let browser_state = browser_state.clone();
-    let active_key = active_key.to_string();
-
-    // Collect URIs of selected tracks.
-    let selected_uris = collect_selected_uris(sm, selection);
+    let Some(playlist_id) = active_key
+        .strip_prefix(super::playback::PLAYLIST_SOURCE_PREFIX)
+        .filter(|playlist_id| !playlist_id.is_empty())
+        .map(str::to_string)
+    else {
+        return;
+    };
+    let Some(entry_ids) = collect_selected_playlist_entry_ids(sm, selection) else {
+        // Smart-playlist and malformed rows do not carry durable occurrence
+        // bindings. Hiding the action avoids pretending a live query can be
+        // mutated like a regular playlist.
+        return;
+    };
 
     let remove_action = gtk::gio::SimpleAction::new("remove-from-playlist", None);
-    let uris = selected_uris;
+    let interaction_request = interaction_request.cloned();
+    let context = context.clone();
     remove_action.connect_activate(move |_, _| {
-        let pid = playlist_id.clone();
-        let uris = uris.clone();
-        let track_store = track_store.clone();
-        let source_tracks = source_tracks.clone();
-        let source_navigation = source_navigation.clone();
-        let master_tracks = master_tracks.clone();
-        let status_label = status_label.clone();
-        let browser_widget = browser_widget.clone();
-        let browser_state = browser_state.clone();
-        let active_key = active_key.clone();
-
-        // A popover action can outlive the rows it was built for. It must not
-        // mutate another source, and an already-running refresh must not put
-        // the just-removed entry back afterward.
-        if !source_navigation.borrow().is_key(&active_key) {
+        let Some(request) = interaction_request.as_ref() else {
+            return;
+        };
+        if !context.owns_request(request) {
             return;
         }
-        source_navigation.borrow_mut().select(active_key.clone());
 
-        // Remove from the visible store immediately. Honour the per-URI
-        // selection count so that selecting one of N duplicate rows removes
-        // exactly one occurrence, not all N.
-        let mut remaining = selection_counts(&uris);
-        let mut i: u32 = 0;
-        while i < track_store.n_items() {
-            let uri = track_store
-                .item(i)
-                .and_downcast::<TrackObject>()
-                .map(|t| t.uri());
-            let mut remove = false;
-            if let Some(u) = uri.as_deref() {
-                if let Some(count) = remaining.get_mut(u) {
-                    if *count > 0 {
-                        *count -= 1;
-                        remove = true;
-                    }
-                }
-            }
-            if remove {
-                track_store.remove(i);
-                // Don't advance `i` — the next item shifted down into
-                // this slot.
-            } else {
-                i += 1;
-            }
-        }
-
-        // Update master + status (same per-URI count limit as the store).
-        {
-            let mut st = source_tracks.borrow_mut();
-            if let Some(tracks) = st.get_mut(&active_key) {
-                let mut remaining = selection_counts(&uris);
-                tracks.retain(|t| match remaining.get_mut(t.uri().as_str()) {
-                    Some(count) if *count > 0 => {
-                        *count -= 1;
-                        false // remove this occurrence
-                    }
-                    _ => true, // keep
-                });
-            }
-        }
-        let st = source_tracks.borrow();
-        let current = st.get(&active_key).cloned().unwrap_or_default();
-        *master_tracks.borrow_mut() = current.clone();
-        tracklist::update_status(&status_label, &current);
-        browser::rebuild_browser_data(&browser_widget, &browser_state, &current);
-
-        // Remove from DB in background.
-        rt.spawn(async move {
-            match crate::db::connection::init_db().await {
+        let pid = playlist_id.clone();
+        let ids = entry_ids.clone();
+        let removed_count = ids.len();
+        let (result_tx, result_rx) = async_channel::bounded(1);
+        context.rt_handle.spawn(async move {
+            let outcome = match crate::db::connection::init_db().await {
                 Ok(db) => {
-                    let mgr = crate::local::playlist_manager::PlaylistManager::new(db.clone());
-                    // Get all entries for this playlist, match by track file path.
-                    if let Ok(entries) = crate::db::entities::playlist_entry::Entity::find()
-                        .filter(
-                            <crate::db::entities::playlist_entry::Column as sea_orm::ColumnTrait>::eq(
-                                &crate::db::entities::playlist_entry::Column::PlaylistId,
-                                &pid,
-                            ),
-                        )
-                        .filter(
-                            <crate::db::entities::playlist_entry::Column as sea_orm::ColumnTrait>::eq(
-                                &crate::db::entities::playlist_entry::Column::SourceId,
-                                crate::architecture::SourceId::local().to_string(),
-                            ),
-                        )
-                        .filter(
-                            <crate::db::entities::playlist_entry::Column as sea_orm::ColumnTrait>::is_not_null(
-                                &crate::db::entities::playlist_entry::Column::LocalTrackId,
-                            ),
-                        )
-                        .all(&db)
-                        .await
-                    {
-                        // Honour the per-URI selection count so duplicate
-                        // entries are removed one-for-one with the selected
-                        // rows rather than all at once.
-                        let mut remaining = selection_counts(&uris);
-                        for entry in entries {
-                            if let Some(ref track_id) = entry.local_track_id {
-                                // Look up the track to get its file path / URI.
-                                if let Ok(Some(track)) = crate::db::entities::track::Entity::find_by_id(track_id.clone())
-                                    .one(&db)
-                                    .await
-                                {
-                                    let track_uri = url::Url::from_file_path(&track.file_path)
-                                        .map(|u| u.to_string())
-                                        .unwrap_or_default();
-                                    if let Some(count) = remaining.get_mut(track_uri.as_str()) {
-                                        if *count > 0 {
-                                            *count -= 1;
-                                            let _ = mgr.remove_entry(&entry.id).await;
-                                        }
-                                    }
-                                }
-                            }
+                    let manager = crate::local::playlist_manager::PlaylistManager::new(db);
+                    match manager.remove_entries(&pid, &ids).await {
+                        Ok(()) => PlaylistMutationOutcome::Committed,
+                        Err(error) => {
+                            tracing::error!(%error, playlist = %pid, "Failed to remove exact playlist occurrences");
+                            PlaylistMutationOutcome::Failed
                         }
                     }
                 }
-                Err(e) => {
-                    tracing::error!(error = %e, "Failed to open DB for playlist remove");
+                Err(error) => {
+                    tracing::error!(%error, "Failed to open DB for playlist removal");
+                    PlaylistMutationOutcome::Failed
+                }
+            };
+            let _ = result_tx.send(outcome).await;
+        });
+
+        let context = context.clone();
+        let playlist_id = playlist_id.clone();
+        gtk::glib::MainContext::default().spawn_local(async move {
+            match result_rx.recv().await {
+                Ok(PlaylistMutationOutcome::Committed) => {
+                    tracing::info!(playlist = %playlist_id, count = removed_count, "Playlist occurrences removed");
+                    context.refresh_playlist_after_commit(&playlist_id);
+                }
+                Ok(PlaylistMutationOutcome::Rejected | PlaylistMutationOutcome::Failed) | Err(_) => {
+                    context.show_mutation_failed();
                 }
             }
         });
@@ -515,10 +536,11 @@ fn build_add_to_playlist_actions(
     sidebar_store: &gtk::gio::ListStore,
     sm: &gtk::SortListModel,
     selection: &SelectionSnapshot,
-    rt_handle: &tokio::runtime::Handle,
-    interaction: PlaylistAddInteraction<'_>,
+    interaction_request: Option<&super::source_navigation::SourceRequest>,
+    context: &PlaylistMutationContext,
 ) {
     let mut has_playlists = false;
+    let candidates = collect_selected_add_candidates(sm, selection);
 
     // Find all regular playlists from the sidebar store.
     let n = sidebar_store.n_items();
@@ -541,78 +563,79 @@ fn build_add_to_playlist_actions(
                 let pl_name = src.name();
                 let pl_id = src.playlist_id();
                 let action_name = format!("add-to-{}", pl_id.replace('-', "_"));
-
-                // Collect selected URIs.
-                let selected_uris = collect_selected_uris(sm, selection);
-
-                let rt = rt_handle.clone();
                 let add_action = gtk::gio::SimpleAction::new(&action_name, None);
-                let uris = selected_uris;
                 let pid = pl_id.clone();
-                // Materialize a fresh owned weak handle for the `'static`
-                // action closure; never let the borrowed factory input escape.
-                let window = interaction
-                    .window
-                    .upgrade()
-                    .map(|window| window.downgrade());
-                let activation = interaction.support.activation();
+                let interaction_request = interaction_request.cloned();
+                let candidates = candidates.clone();
+                let context = context.clone();
                 add_action.connect_activate(move |_, _| {
-                    if activation == PlaylistAddActivation::ExplainUnsupportedSource {
-                        if let Some(window) = window.as_ref().and_then(|window| window.upgrade()) {
-                            show_unsupported_playlist_add_dialog(&window);
-                        }
+                    let Some(request) = interaction_request.as_ref() else {
+                        context.show_unsupported();
+                        return;
+                    };
+                    if !context.owns_request(request) {
+                        context.show_unsupported();
                         return;
                     }
 
-                    let uris = uris.clone();
+                    let Some(candidates) = candidates.clone() else {
+                        context.show_unsupported();
+                        return;
+                    };
+                    let Ok(plan) =
+                        prepare_playlist_add_plan(&context.source_registry, &candidates)
+                    else {
+                        context.show_unsupported();
+                        return;
+                    };
+
                     let pid = pid.clone();
-                    rt.spawn(async move {
-                        match crate::db::connection::init_db().await {
+                    let worker_pid = pid.clone();
+                    let registry = context.source_registry.clone();
+                    let (result_tx, result_rx) = async_channel::bounded(1);
+                    context.rt_handle.spawn(async move {
+                        let outcome = match crate::db::connection::init_db().await {
                             Ok(db) => {
-                                let mgr = crate::local::playlist_manager::PlaylistManager::new(db.clone());
-                                let mut added = 0usize;
-                                let mut skipped = 0usize;
-                                for uri in &uris {
-                                    // Convert file:// URI back to path, find track in DB.
-                                    // Remote (http/https) tracks have no local DB row and
-                                    // cannot be added to a local playlist — count them as
-                                    // skipped rather than dropping them silently.
-                                    let mut ok = false;
-                                    if let Ok(url) = url::Url::parse(uri) {
-                                        if let Ok(path) = url.to_file_path() {
-                                            let path_str = path.to_string_lossy().to_string();
-                                            if let Ok(Some(track)) = <crate::db::entities::track::Entity as sea_orm::EntityTrait>::find()
-                                                .filter(<crate::db::entities::track::Column as sea_orm::ColumnTrait>::eq(
-                                                    &crate::db::entities::track::Column::FilePath,
-                                                    &path_str,
-                                                ))
-                                                .one(&db)
-                                                .await
-                                            {
-                                                ok = mgr.add_track(&pid, &track).await.is_ok();
-                                            }
+                                let manager =
+                                    crate::local::playlist_manager::PlaylistManager::new(db);
+                                // This is the mutation's authority
+                                // linearization point. The storage operation
+                                // follows immediately and commits the whole
+                                // ordered selection or none of it.
+                                if !registry
+                                    .are_regular_playlist_tracks_current(&plan.authority)
+                                {
+                                    PlaylistMutationOutcome::Rejected
+                                } else {
+                                    match manager.add_entries(&worker_pid, &plan.inputs).await {
+                                        Ok(_) => PlaylistMutationOutcome::Committed,
+                                        Err(error) => {
+                                            tracing::error!(%error, playlist = %worker_pid, "Failed to add exact playlist occurrences");
+                                            PlaylistMutationOutcome::Failed
                                         }
                                     }
-                                    if ok {
-                                        added += 1;
-                                    } else {
-                                        skipped += 1;
-                                    }
                                 }
-                                if skipped > 0 {
-                                    tracing::warn!(
-                                        playlist = %pid,
-                                        added,
-                                        skipped,
-                                        "Some tracks could not be added (remote or missing tracks aren't supported in local playlists)"
-                                    );
-                                }
-                                // Report the count actually inserted, not the
-                                // full selection size.
-                                tracing::info!(playlist = %pid, count = added, "Tracks added to playlist");
                             }
-                            Err(e) => {
-                                tracing::error!(error = %e, "Failed to open DB for playlist add");
+                            Err(error) => {
+                                tracing::error!(%error, "Failed to open DB for playlist add");
+                                PlaylistMutationOutcome::Failed
+                            }
+                        };
+                        let _ = result_tx.send(outcome).await;
+                    });
+
+                    let context = context.clone();
+                    let playlist_id = pid.clone();
+                    let count = candidates.len();
+                    gtk::glib::MainContext::default().spawn_local(async move {
+                        match result_rx.recv().await {
+                            Ok(PlaylistMutationOutcome::Committed) => {
+                                tracing::info!(playlist = %playlist_id, count, "Tracks added to playlist");
+                                context.refresh_playlist_after_commit(&playlist_id);
+                            }
+                            Ok(PlaylistMutationOutcome::Rejected) => context.show_unsupported(),
+                            Ok(PlaylistMutationOutcome::Failed) | Err(_) => {
+                                context.show_mutation_failed();
                             }
                         }
                     });
@@ -625,6 +648,158 @@ fn build_add_to_playlist_actions(
             }
         }
     }
+}
+
+fn collect_selected_add_candidates(
+    sm: &gtk::SortListModel,
+    selection: &SelectionSnapshot,
+) -> Option<Vec<PlaylistAddCandidate>> {
+    selection
+        .positions
+        .iter()
+        .map(|position| {
+            let track = sm.item(*position)?.downcast::<TrackObject>().ok()?;
+            playlist_add_candidate(&track)
+        })
+        .collect()
+}
+
+fn playlist_add_candidate(track: &TrackObject) -> Option<PlaylistAddCandidate> {
+    let source_id = track.source_id()?;
+    let track_id = if source_id == SourceId::local() {
+        TrackId::new(track.track_id()).ok()?
+    } else {
+        TrackId::remote(track.track_id()).ok()?
+    };
+    let media_key = MediaKey::new(source_id, track_id);
+    if source_id == SourceId::local() {
+        Some(PlaylistAddCandidate::Local(media_key))
+    } else {
+        Some(PlaylistAddCandidate::Remote {
+            media_key,
+            session_epoch: track.source_session_epoch()?,
+            catalogue_generation: track.source_catalogue_generation()?,
+        })
+    }
+}
+
+fn prepare_playlist_add_plan(
+    registry: &SourceRegistry,
+    candidates: &[PlaylistAddCandidate],
+) -> Result<PlaylistAddPlan, ()> {
+    if candidates.is_empty() {
+        return Err(());
+    }
+    let remote_keys = candidates
+        .iter()
+        .filter_map(|candidate| match candidate {
+            PlaylistAddCandidate::Local(_) => None,
+            PlaylistAddCandidate::Remote { media_key, .. } => Some(media_key.clone()),
+        })
+        .collect::<Vec<_>>();
+    let authority = registry.resolve_regular_playlist_tracks(&remote_keys);
+    prepare_playlist_add_plan_from_authority(candidates, authority)
+}
+
+fn prepare_playlist_add_plan_from_authority(
+    candidates: &[PlaylistAddCandidate],
+    authority: Vec<RegularPlaylistTrackResolution>,
+) -> Result<PlaylistAddPlan, ()> {
+    let expected_remote = candidates
+        .iter()
+        .filter(|candidate| matches!(candidate, PlaylistAddCandidate::Remote { .. }))
+        .count();
+    if candidates.is_empty() || authority.len() != expected_remote {
+        return Err(());
+    }
+
+    let mut remote = authority.iter();
+    let mut inputs = Vec::with_capacity(candidates.len());
+    for candidate in candidates {
+        match candidate {
+            PlaylistAddCandidate::Local(media_key) => {
+                // PlaylistManager resolves and snapshots exact local metadata
+                // inside the write transaction. Cached GTK metadata is never
+                // treated as persistence authority.
+                inputs.push(PlaylistEntryInput::new(media_key.clone(), "", "", "", None));
+            }
+            PlaylistAddCandidate::Remote {
+                media_key,
+                session_epoch,
+                catalogue_generation,
+            } => {
+                let Some(RegularPlaylistTrackResolution::Available(track)) = remote.next() else {
+                    return Err(());
+                };
+                let guard = track.guard();
+                if track.media_key() != media_key
+                    || !catalogue_observation_matches(
+                        media_key.source_id,
+                        *session_epoch,
+                        *catalogue_generation,
+                        guard.source_id(),
+                        guard.session_epoch(),
+                        guard.catalogue_generation(),
+                    )
+                {
+                    return Err(());
+                }
+                let metadata = track.metadata();
+                inputs.push(PlaylistEntryInput::new(
+                    media_key.clone(),
+                    metadata.title(),
+                    metadata.artist_name(),
+                    metadata.album_title(),
+                    metadata.duration_secs(),
+                ));
+            }
+        }
+    }
+    if remote.next().is_some() {
+        return Err(());
+    }
+    Ok(PlaylistAddPlan { inputs, authority })
+}
+
+fn catalogue_observation_matches(
+    expected_source: SourceId,
+    expected_epoch: u64,
+    expected_generation: u64,
+    actual_source: SourceId,
+    actual_epoch: u64,
+    actual_generation: u64,
+) -> bool {
+    expected_source == actual_source
+        && expected_epoch == actual_epoch
+        && expected_generation == actual_generation
+}
+
+fn collect_selected_playlist_entry_ids(
+    sm: &gtk::SortListModel,
+    selection: &SelectionSnapshot,
+) -> Option<Vec<String>> {
+    let bindings = selection.positions.iter().map(|position| {
+        sm.item(*position)
+            .and_downcast::<TrackObject>()
+            .and_then(|track| track.playlist_occurrence_binding())
+    });
+    exact_playlist_entry_ids(bindings)
+}
+
+fn exact_playlist_entry_ids(
+    bindings: impl IntoIterator<Item = Option<super::objects::PlaylistOccurrenceBinding>>,
+) -> Option<Vec<String>> {
+    let mut seen = std::collections::HashSet::new();
+    let mut entry_ids = Vec::new();
+    for binding in bindings {
+        let binding = binding?;
+        let entry_id = binding.entry_id().to_string();
+        if !seen.insert(entry_id.clone()) {
+            return None;
+        }
+        entry_ids.push(entry_id);
+    }
+    (!entry_ids.is_empty()).then_some(entry_ids)
 }
 
 /// Build the "Properties…" action for selected tracks.
@@ -727,33 +902,6 @@ fn active_source_is_automatic_device(
     })
 }
 
-/// Build a map of `uri -> number of selected rows with that uri`.
-///
-/// A playlist may legitimately contain the same track more than once, so
-/// removal must honour the count of selected rows (remove exactly N
-/// occurrences) rather than treating the selection as a set and deleting
-/// every matching entry.
-fn selection_counts(uris: &[String]) -> std::collections::HashMap<&str, usize> {
-    let mut counts = std::collections::HashMap::new();
-    for uri in uris {
-        *counts.entry(uri.as_str()).or_insert(0) += 1;
-    }
-    counts
-}
-
-/// Collect URIs of selected tracks from the sort model.
-fn collect_selected_uris(sm: &gtk::SortListModel, selection: &SelectionSnapshot) -> Vec<String> {
-    let mut uris = Vec::new();
-    for &position in &selection.positions {
-        if let Some(item) = sm.item(position) {
-            if let Some(track) = item.downcast_ref::<TrackObject>() {
-                uris.push(track.uri());
-            }
-        }
-    }
-    uris
-}
-
 /// Traverse a `PopoverMenu`'s widget tree and disable scrollbars on any
 /// internal `ScrolledWindow`.  GTK4's `PopoverMenu::from_model()` wraps
 /// its content in a `ScrolledWindow` that adds unnecessary scrollbars
@@ -779,46 +927,218 @@ mod tests {
 
     use super::*;
 
-    #[test]
-    fn playlist_add_support_is_exactly_local_and_fail_closed() {
-        assert_eq!(
-            PlaylistAddSupport::from_source_key("local"),
-            PlaylistAddSupport::LocalLibrary
-        );
-        assert_eq!(
-            PlaylistAddSupport::from_source_key("local").activation(),
-            PlaylistAddActivation::WriteLocalPlaylist
-        );
-
-        let remote = crate::architecture::SourceId::remote(
-            "subsonic",
-            &url::Url::parse("https://music.example.test/root/").expect("remote URL"),
-        )
-        .expect("remote source ID")
-        .to_string();
-        let radio = crate::architecture::SourceId::radio_browser().to_string();
-        let removable = crate::architecture::SourceId::removable("device:opaque-id")
-            .expect("removable source ID")
-            .to_string();
-
-        for source_key in [
-            remote.as_str(),
-            radio.as_str(),
-            removable.as_str(),
-            "playlist:local-view",
-            "remote-looking-but-malformed",
-            "",
-        ] {
-            assert_eq!(
-                PlaylistAddSupport::from_source_key(source_key),
-                PlaylistAddSupport::UnsupportedSource,
-                "{source_key:?} must not enter the local-only playlist write path"
-            );
-            assert_eq!(
-                PlaylistAddSupport::from_source_key(source_key).activation(),
-                PlaylistAddActivation::ExplainUnsupportedSource
-            );
+    fn remote_catalogue_track(
+        track_id: TrackId,
+        title: &str,
+    ) -> crate::architecture::models::Track {
+        crate::architecture::models::Track {
+            id: uuid::Uuid::new_v4(),
+            native_track_id: Some(track_id),
+            title: title.to_string(),
+            artist_name: "Current remote artist".to_string(),
+            album_artist_name: None,
+            artist_id: None,
+            album_title: "Current remote album".to_string(),
+            album_id: None,
+            track_number: Some(4),
+            disc_number: Some(1),
+            duration_secs: Some(245),
+            composer: None,
+            genre: Some("Remote genre".to_string()),
+            year: Some(2026),
+            file_path: Some("/private/must-not-cross.mp3".to_string()),
+            stream_url: Some(
+                url::Url::parse("https://secret.invalid/audio?token=private")
+                    .expect("fixture stream URL"),
+            ),
+            cover_art_url: Some(
+                url::Url::parse("https://secret.invalid/art?token=private")
+                    .expect("fixture artwork URL"),
+            ),
+            date_added: None,
+            date_modified: None,
+            bitrate_kbps: Some(320),
+            sample_rate_hz: Some(48_000),
+            format: Some("mp3".to_string()),
+            play_count: Some(12),
+            rating: crate::architecture::models::TrackRating::read_only(None),
+            last_played: None,
         }
+    }
+
+    #[test]
+    fn local_add_candidates_use_exact_row_identity_in_selection_order() {
+        let first = TrackObject::new(
+            1,
+            "Cached title must not authorize storage",
+            60,
+            "Artist",
+            "Album",
+            "",
+            "",
+            0,
+            "",
+            0,
+            0,
+            0,
+            "",
+            "file:///private/first.flac",
+        );
+        first.set_track_id("first-id");
+        assert!(first.set_source_id(SourceId::local()));
+        let second = TrackObject::new(
+            2,
+            "Second",
+            60,
+            "Artist",
+            "Album",
+            "",
+            "",
+            0,
+            "",
+            0,
+            0,
+            0,
+            "",
+            "file:///private/second.flac",
+        );
+        second.set_track_id("second-id");
+        assert!(second.set_source_id(SourceId::local()));
+
+        let candidates = [&second, &first]
+            .into_iter()
+            .map(playlist_add_candidate)
+            .collect::<Option<Vec<_>>>()
+            .expect("exact local candidates");
+        assert_eq!(
+            candidates
+                .iter()
+                .map(|candidate| candidate.media_key().track_id.as_str())
+                .collect::<Vec<_>>(),
+            ["second-id", "first-id"]
+        );
+        assert!(candidates
+            .iter()
+            .all(|candidate| matches!(candidate, PlaylistAddCandidate::Local(_))));
+    }
+
+    #[test]
+    fn mixed_add_plan_consumes_exact_available_remote_authority_in_order() {
+        let local_key = MediaKey::new(
+            SourceId::local(),
+            TrackId::new("local-track").expect("local track ID"),
+        );
+        let remote_source = SourceId::random();
+        let remote_id = TrackId::remote("remote-track").expect("remote track ID");
+        let remote_key = MediaKey::new(remote_source, remote_id.clone());
+        let remote_track = remote_catalogue_track(remote_id, "Current remote title");
+        let available = crate::source_registry::RegularPlaylistTrack::for_ui_test(
+            remote_key.clone(),
+            7,
+            11,
+            &remote_track,
+        );
+        let candidates = vec![
+            PlaylistAddCandidate::Local(local_key.clone()),
+            PlaylistAddCandidate::Remote {
+                media_key: remote_key.clone(),
+                session_epoch: 7,
+                catalogue_generation: 11,
+            },
+            PlaylistAddCandidate::Remote {
+                media_key: remote_key.clone(),
+                session_epoch: 7,
+                catalogue_generation: 11,
+            },
+        ];
+        let authority = vec![
+            RegularPlaylistTrackResolution::Available(Box::new(available.clone())),
+            RegularPlaylistTrackResolution::Available(Box::new(available)),
+        ];
+
+        let plan = prepare_playlist_add_plan_from_authority(&candidates, authority)
+            .expect("exact current mixed selection");
+        assert_eq!(
+            plan.inputs
+                .iter()
+                .map(|input| &input.media_key)
+                .collect::<Vec<_>>(),
+            [&local_key, &remote_key, &remote_key]
+        );
+        assert_eq!(plan.inputs[0].title, "");
+        for input in &plan.inputs[1..] {
+            assert_eq!(input.title, "Current remote title");
+            assert_eq!(input.artist, "Current remote artist");
+            assert_eq!(input.album, "Current remote album");
+            assert_eq!(input.duration_secs, Some(245));
+            let rendered = format!("{input:?}");
+            assert!(!rendered.contains("secret.invalid"));
+            assert!(!rendered.contains("token=private"));
+            assert!(!rendered.contains("must-not-cross"));
+        }
+        assert_eq!(plan.authority.len(), 2);
+
+        let stale = vec![RegularPlaylistTrackResolution::Available(Box::new(
+            crate::source_registry::RegularPlaylistTrack::for_ui_test(
+                remote_key,
+                7,
+                12,
+                &remote_track,
+            ),
+        ))];
+        assert!(prepare_playlist_add_plan_from_authority(&candidates[..2], stale).is_err());
+    }
+
+    #[test]
+    fn exact_remove_plan_preserves_duplicate_media_occurrences_but_rejects_duplicate_entry_ids() {
+        let track_id = TrackId::new("same-media").expect("track ID");
+        let first = super::super::objects::PlaylistOccurrenceBinding::available_local(
+            "entry-one",
+            track_id.clone(),
+        )
+        .expect("first occurrence");
+        let duplicate = super::super::objects::PlaylistOccurrenceBinding::available_local(
+            "entry-two",
+            track_id,
+        )
+        .expect("duplicate occurrence");
+        assert_eq!(
+            exact_playlist_entry_ids([Some(first.clone()), Some(duplicate)]),
+            Some(vec!["entry-one".to_string(), "entry-two".to_string()])
+        );
+        assert!(exact_playlist_entry_ids([Some(first.clone()), Some(first)]).is_none());
+    }
+
+    #[test]
+    fn remove_is_hidden_for_smart_or_unbound_rows_but_accepts_unavailable_occurrences() {
+        assert!(exact_playlist_entry_ids([None]).is_none());
+        let unavailable = super::super::objects::PlaylistOccurrenceBinding::unavailable(
+            "missing-entry",
+            SourceId::local(),
+            Some(TrackId::new("missing-track").expect("track ID")),
+            super::super::objects::PlaylistRowUnavailableReason::LocalTrackMissing,
+        )
+        .expect("unavailable durable occurrence");
+        assert_eq!(
+            exact_playlist_entry_ids([Some(unavailable)]),
+            Some(vec!["missing-entry".to_string()])
+        );
+    }
+
+    #[test]
+    fn catalogue_observation_rejects_stale_source_epoch_or_generation() {
+        let source = SourceId::random();
+        assert!(catalogue_observation_matches(source, 7, 11, source, 7, 11));
+        assert!(!catalogue_observation_matches(
+            source,
+            7,
+            11,
+            SourceId::random(),
+            7,
+            11
+        ));
+        assert!(!catalogue_observation_matches(source, 7, 11, source, 8, 11));
+        assert!(!catalogue_observation_matches(source, 7, 11, source, 7, 12));
     }
 
     #[test]
@@ -829,6 +1149,22 @@ mod tests {
 
         for locale in rust_i18n::available_locales!() {
             let localized = unsupported_playlist_add_copy(&locale);
+            assert!(!localized.heading.is_empty(), "{locale}: empty heading");
+            assert!(!localized.body.is_empty(), "{locale}: empty body");
+            if locale != "en" {
+                assert_ne!(localized, english, "{locale} must not fall back to English");
+            }
+        }
+    }
+
+    #[test]
+    fn playlist_mutation_failure_copy_is_localized_for_every_catalog() {
+        let english = playlist_mutation_failed_copy("en");
+        assert!(!english.heading.is_empty());
+        assert!(!english.body.is_empty());
+
+        for locale in rust_i18n::available_locales!() {
+            let localized = playlist_mutation_failed_copy(&locale);
             assert!(!localized.heading.is_empty(), "{locale}: empty heading");
             assert!(!localized.body.is_empty(), "{locale}: empty body");
             if locale != "en" {

--- a/src/ui/context_menu.rs
+++ b/src/ui/context_menu.rs
@@ -10,7 +10,7 @@ use std::rc::Rc;
 use super::objects::{SourceObject, TrackObject};
 use super::window_state::WindowState;
 use crate::architecture::{MediaKey, SourceId, TrackId};
-use crate::local::playlist_manager::PlaylistEntryInput;
+use crate::local::playlist_manager::{PlaylistEntryAddOutcome, PlaylistEntryInput};
 use crate::source_registry::{RegularPlaylistTrackResolution, SourceRegistry};
 
 const CONTEXT_MENU_ACTION_GROUP: &str = "tracklist-ctx";
@@ -598,21 +598,33 @@ fn build_add_to_playlist_actions(
                             Ok(db) => {
                                 let manager =
                                     crate::local::playlist_manager::PlaylistManager::new(db);
-                                // This is the mutation's authority
-                                // linearization point. The storage operation
-                                // follows immediately and commits the whole
-                                // ordered selection or none of it.
-                                if !registry
-                                    .are_regular_playlist_tracks_current(&plan.authority)
+                                // Stage the complete ordered mutation first,
+                                // then acquire exact live authority at the
+                                // transaction's final commit boundary. The
+                                // manager retains it through commit; stale
+                                // acquisition rejects and rolls back every
+                                // staged insert.
+                                match manager
+                                    .add_entries_if_authorized(
+                                        &worker_pid,
+                                        &plan.inputs,
+                                        || {
+                                            registry.acquire_regular_playlist_commit_authority(
+                                                &plan.authority,
+                                            )
+                                        },
+                                    )
+                                    .await
                                 {
-                                    PlaylistMutationOutcome::Rejected
-                                } else {
-                                    match manager.add_entries(&worker_pid, &plan.inputs).await {
-                                        Ok(_) => PlaylistMutationOutcome::Committed,
-                                        Err(error) => {
-                                            tracing::error!(%error, playlist = %worker_pid, "Failed to add exact playlist occurrences");
-                                            PlaylistMutationOutcome::Failed
-                                        }
+                                    Ok(PlaylistEntryAddOutcome::Committed(_)) => {
+                                        PlaylistMutationOutcome::Committed
+                                    }
+                                    Ok(PlaylistEntryAddOutcome::Rejected) => {
+                                        PlaylistMutationOutcome::Rejected
+                                    }
+                                    Err(error) => {
+                                        tracing::error!(%error, playlist = %worker_pid, "Failed to add exact playlist occurrences");
+                                        PlaylistMutationOutcome::Failed
                                     }
                                 }
                             }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -15,6 +15,7 @@ pub mod persistence;
 pub mod playback;
 pub mod playlist_actions;
 pub mod playlist_editor;
+pub mod playlist_projection;
 pub mod preferences;
 pub mod properties_dialog;
 pub mod radio;

--- a/src/ui/objects/mod.rs
+++ b/src/ui/objects/mod.rs
@@ -10,3 +10,6 @@ mod track_object;
 pub use browser_item::BrowserItem;
 pub use source_object::SourceObject;
 pub use track_object::TrackObject;
+pub use track_object::{
+    PlaylistOccurrenceBinding, PlaylistOccurrenceState, PlaylistRowUnavailableReason,
+};

--- a/src/ui/objects/track_object.rs
+++ b/src/ui/objects/track_object.rs
@@ -7,8 +7,145 @@ use gtk::glib;
 use gtk::subclass::prelude::*;
 
 use crate::architecture::models::TrackRating;
+use crate::architecture::{SourceId, TrackId};
+use crate::source_registry::RegularPlaylistCatalogueGuard;
 
 static NEXT_ROW_INSTANCE_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Closed, non-sensitive reason that one durable playlist occurrence cannot
+/// currently supply a playable row.
+///
+/// Local states are kept separate because an imported occurrence that has
+/// never matched a library track is different from one whose exact local
+/// track disappeared. Remote states mirror the registry's closed result and
+/// never retain backend errors, locators, or stale metadata.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PlaylistRowUnavailableReason {
+    LocalTrackMissing,
+    LocalTrackUnmatched,
+    SourceUnavailable,
+    UnsupportedSource,
+    InvalidCatalogue,
+    TrackMissing,
+}
+
+/// Transient authority state attached to one rendered regular-playlist row.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PlaylistOccurrenceState {
+    AvailableLocal,
+    AvailableRemote(RegularPlaylistCatalogueGuard),
+    Unavailable(PlaylistRowUnavailableReason),
+}
+
+/// Exact durable occurrence identity plus its current presentation authority.
+///
+/// `entry_id` identifies the removable/reorderable occurrence. `source_id`
+/// and `track_id` identify its media owner; a missing track ID is permitted
+/// only for an unmatched local import. The remote catalogue guard is
+/// transient and is never written back to playlist storage.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PlaylistOccurrenceBinding {
+    entry_id: String,
+    source_id: SourceId,
+    track_id: Option<TrackId>,
+    state: PlaylistOccurrenceState,
+}
+
+impl PlaylistOccurrenceBinding {
+    fn new(
+        entry_id: impl Into<String>,
+        source_id: SourceId,
+        track_id: Option<TrackId>,
+        state: PlaylistOccurrenceState,
+    ) -> Option<Self> {
+        let entry_id = entry_id.into();
+        if entry_id.is_empty() {
+            return None;
+        }
+
+        let valid = match state {
+            PlaylistOccurrenceState::AvailableLocal => {
+                source_id == SourceId::local() && track_id.is_some()
+            }
+            PlaylistOccurrenceState::AvailableRemote(guard) => {
+                source_id != SourceId::local()
+                    && track_id.is_some()
+                    && guard.source_id() == source_id
+            }
+            PlaylistOccurrenceState::Unavailable(
+                PlaylistRowUnavailableReason::LocalTrackMissing,
+            ) => source_id == SourceId::local() && track_id.is_some(),
+            PlaylistOccurrenceState::Unavailable(
+                PlaylistRowUnavailableReason::LocalTrackUnmatched,
+            ) => source_id == SourceId::local() && track_id.is_none(),
+            PlaylistOccurrenceState::Unavailable(
+                PlaylistRowUnavailableReason::SourceUnavailable
+                | PlaylistRowUnavailableReason::UnsupportedSource
+                | PlaylistRowUnavailableReason::InvalidCatalogue
+                | PlaylistRowUnavailableReason::TrackMissing,
+            ) => source_id != SourceId::local() && track_id.is_some(),
+        };
+        valid.then_some(Self {
+            entry_id,
+            source_id,
+            track_id,
+            state,
+        })
+    }
+
+    pub(crate) fn available_local(entry_id: impl Into<String>, track_id: TrackId) -> Option<Self> {
+        Self::new(
+            entry_id,
+            SourceId::local(),
+            Some(track_id),
+            PlaylistOccurrenceState::AvailableLocal,
+        )
+    }
+
+    pub(crate) fn available_remote(
+        entry_id: impl Into<String>,
+        source_id: SourceId,
+        track_id: TrackId,
+        guard: RegularPlaylistCatalogueGuard,
+    ) -> Option<Self> {
+        Self::new(
+            entry_id,
+            source_id,
+            Some(track_id),
+            PlaylistOccurrenceState::AvailableRemote(guard),
+        )
+    }
+
+    pub(crate) fn unavailable(
+        entry_id: impl Into<String>,
+        source_id: SourceId,
+        track_id: Option<TrackId>,
+        reason: PlaylistRowUnavailableReason,
+    ) -> Option<Self> {
+        Self::new(
+            entry_id,
+            source_id,
+            track_id,
+            PlaylistOccurrenceState::Unavailable(reason),
+        )
+    }
+
+    pub(crate) fn entry_id(&self) -> &str {
+        &self.entry_id
+    }
+
+    pub(crate) const fn source_id(&self) -> SourceId {
+        self.source_id
+    }
+
+    pub(crate) fn track_id(&self) -> Option<&TrackId> {
+        self.track_id.as_ref()
+    }
+
+    pub(crate) const fn state(&self) -> PlaylistOccurrenceState {
+        self.state
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Inner (private) implementation
@@ -18,6 +155,11 @@ mod imp {
 
     #[derive(Debug, Default)]
     pub struct TrackObject {
+        /// Exact owner of this row's media identity. UI-only legacy rows may
+        /// omit it; architecture-backed rows must set it explicitly.
+        pub source_id: Cell<Option<SourceId>>,
+        /// Durable regular-playlist occurrence plus its transient live state.
+        pub(super) playlist_occurrence: RefCell<Option<PlaylistOccurrenceBinding>>,
         /// Stable backend-provided track identifier.  Sources without a
         /// native identifier fall back to the playable URI in `track_id()`.
         pub track_id: RefCell<String>,
@@ -27,6 +169,9 @@ mod imp {
         /// Non-secret lifecycle epoch that published a source-owned row.
         /// Zero means the row is not owned by a lifecycle session.
         pub source_session_epoch: Cell<u64>,
+        /// Accepted source-wide catalogue generation that published the row.
+        /// Zero means the row is not a catalogue observation.
+        pub source_catalogue_generation: Cell<u64>,
         /// Identity of this concrete UI row instance. Duplicate playlist
         /// entries share `track_id` but receive distinct row IDs.
         pub row_instance_id: Cell<u64>,
@@ -208,6 +353,42 @@ impl TrackObject {
         imp.has_explicit_track_id.set(true);
     }
 
+    /// Return the exact media owner carried by this row, when one has been
+    /// assigned. This never derives identity from a URI or navigation key.
+    pub(crate) fn source_id(&self) -> Option<SourceId> {
+        self.imp().source_id.get()
+    }
+
+    /// Assign an exact row owner without allowing it to contradict an
+    /// attached durable playlist occurrence.
+    pub(crate) fn set_source_id(&self, source_id: SourceId) -> bool {
+        if self
+            .imp()
+            .playlist_occurrence
+            .borrow()
+            .as_ref()
+            .is_some_and(|binding| binding.source_id() != source_id)
+        {
+            return false;
+        }
+        self.imp().source_id.set(Some(source_id));
+        true
+    }
+
+    pub(crate) fn playlist_occurrence_binding(&self) -> Option<PlaylistOccurrenceBinding> {
+        self.imp().playlist_occurrence.borrow().clone()
+    }
+
+    /// Attach one validated playlist occurrence and make its source/native
+    /// identity authoritative for this row. An unmatched local occurrence
+    /// receives an explicit empty track ID so `track_id()` cannot fall back to
+    /// a locator retained by a legacy constructor.
+    pub(crate) fn set_playlist_occurrence_binding(&self, binding: PlaylistOccurrenceBinding) {
+        self.imp().source_id.set(Some(binding.source_id()));
+        self.set_track_id(binding.track_id().map_or("", TrackId::as_str));
+        self.imp().playlist_occurrence.replace(Some(binding));
+    }
+
     pub(crate) fn source_session_epoch(&self) -> Option<u64> {
         let epoch = self.imp().source_session_epoch.get();
         (epoch != 0).then_some(epoch)
@@ -216,6 +397,16 @@ impl TrackObject {
     pub(crate) fn set_source_session_epoch(&self, epoch: u64) {
         debug_assert_ne!(epoch, 0, "lifecycle session epochs are non-zero");
         self.imp().source_session_epoch.set(epoch);
+    }
+
+    pub(crate) fn source_catalogue_generation(&self) -> Option<u64> {
+        let generation = self.imp().source_catalogue_generation.get();
+        (generation != 0).then_some(generation)
+    }
+
+    pub(crate) fn set_source_catalogue_generation(&self, generation: u64) {
+        debug_assert_ne!(generation, 0, "catalogue generations are non-zero");
+        self.imp().source_catalogue_generation.set(generation);
     }
 
     pub fn set_album_artist(&self, name: &str) {
@@ -294,6 +485,113 @@ mod tests {
         assert_eq!(first.track_id(), duplicate.track_id());
         assert_ne!(first.row_instance_id(), duplicate.row_instance_id());
         assert_eq!(first.row_instance_id(), first.clone().row_instance_id());
+    }
+
+    #[test]
+    fn playlist_binding_replaces_locator_fallback_with_exact_optional_identity() {
+        let row = track("file:///private/reconciliation/evidence.flac");
+        let binding = PlaylistOccurrenceBinding::unavailable(
+            "unmatched-entry",
+            SourceId::local(),
+            None,
+            PlaylistRowUnavailableReason::LocalTrackUnmatched,
+        )
+        .expect("valid unmatched local occurrence");
+
+        row.set_playlist_occurrence_binding(binding.clone());
+
+        assert_eq!(row.source_id(), Some(SourceId::local()));
+        assert_eq!(row.track_id(), "");
+        assert_eq!(row.playlist_occurrence_binding(), Some(binding));
+    }
+
+    #[test]
+    fn duplicate_playlist_media_keeps_distinct_durable_occurrence_ids() {
+        let track_id = TrackId::new("same-track").expect("track ID");
+        let first_binding =
+            PlaylistOccurrenceBinding::available_local("entry-one", track_id.clone())
+                .expect("first occurrence");
+        let duplicate_binding =
+            PlaylistOccurrenceBinding::available_local("entry-two", track_id.clone())
+                .expect("duplicate occurrence");
+        let first = track("file:///same.flac");
+        let duplicate = track("file:///same.flac");
+        first.set_playlist_occurrence_binding(first_binding);
+        duplicate.set_playlist_occurrence_binding(duplicate_binding);
+
+        let first_binding = first.playlist_occurrence_binding().expect("first binding");
+        let duplicate_binding = duplicate
+            .playlist_occurrence_binding()
+            .expect("duplicate binding");
+        assert_eq!(first_binding.track_id(), Some(&track_id));
+        assert_eq!(duplicate_binding.track_id(), Some(&track_id));
+        assert_ne!(first_binding.entry_id(), duplicate_binding.entry_id());
+        assert_ne!(first.row_instance_id(), duplicate.row_instance_id());
+    }
+
+    #[test]
+    fn playlist_binding_state_and_source_invariants_fail_closed() {
+        let local_track = TrackId::new("local-track").expect("local track ID");
+        let remote_track = TrackId::remote("remote-track").expect("remote track ID");
+        let remote_source = SourceId::remote(
+            "subsonic",
+            &url::Url::parse("https://music.example.test/").expect("remote URL"),
+        )
+        .expect("remote source");
+
+        let missing = PlaylistOccurrenceBinding::unavailable(
+            "missing-entry",
+            SourceId::local(),
+            Some(local_track.clone()),
+            PlaylistRowUnavailableReason::LocalTrackMissing,
+        )
+        .expect("valid missing local occurrence");
+        assert_eq!(
+            missing.state(),
+            PlaylistOccurrenceState::Unavailable(PlaylistRowUnavailableReason::LocalTrackMissing)
+        );
+
+        let unavailable = PlaylistOccurrenceBinding::unavailable(
+            "remote-entry",
+            remote_source,
+            Some(remote_track.clone()),
+            PlaylistRowUnavailableReason::SourceUnavailable,
+        )
+        .expect("valid unavailable remote occurrence");
+        assert_eq!(unavailable.source_id(), remote_source);
+        assert_eq!(unavailable.track_id(), Some(&remote_track));
+        assert_eq!(
+            unavailable.state(),
+            PlaylistOccurrenceState::Unavailable(PlaylistRowUnavailableReason::SourceUnavailable)
+        );
+
+        assert!(PlaylistOccurrenceBinding::available_local("", local_track.clone()).is_none());
+        assert!(PlaylistOccurrenceBinding::unavailable(
+            "wrong-local-state",
+            SourceId::local(),
+            Some(local_track),
+            PlaylistRowUnavailableReason::TrackMissing,
+        )
+        .is_none());
+        assert!(PlaylistOccurrenceBinding::unavailable(
+            "wrong-remote-state",
+            remote_source,
+            Some(remote_track),
+            PlaylistRowUnavailableReason::LocalTrackMissing,
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn source_catalogue_observation_preserves_exact_nonzero_values() {
+        let row = track("");
+        assert_eq!(row.source_session_epoch(), None);
+        assert_eq!(row.source_catalogue_generation(), None);
+
+        row.set_source_session_epoch(17);
+        row.set_source_catalogue_generation(29);
+        assert_eq!(row.source_session_epoch(), Some(17));
+        assert_eq!(row.source_catalogue_generation(), Some(29));
     }
 
     #[test]

--- a/src/ui/playback.rs
+++ b/src/ui/playback.rs
@@ -18,16 +18,18 @@ use crate::architecture::{MediaKey, SourceId, TrackId, ViewOrigin};
 use crate::audio::output::AudioOutput;
 use crate::audio::{PlayerEvent, PlayerEventGeneration, PlayerState};
 use crate::local::playback_history::PlaybackHistoryProgress;
+use crate::source_registry::RegularPlaylistCatalogueGuard;
 use crate::ui::header_bar::RepeatMode;
-use crate::ui::objects::TrackObject;
+use crate::ui::objects::{PlaylistOccurrenceState, TrackObject};
 
 use super::album_art;
 
 /// The source key of the local library.
 pub const LOCAL_SOURCE_KEY: &str = "local";
 
-/// The source-key prefix of every playlist view. Playlists are projections of
-/// the local library, so their queue items carry library track IDs too.
+/// The source-key prefix of every playlist view. A playlist remains only the
+/// view origin; each queue item carries its actual media owner's source and
+/// native track identity.
 pub const PLAYLIST_SOURCE_PREFIX: &str = "playlist:";
 
 /// Previous restarts the current item only after this position. At exactly
@@ -132,7 +134,17 @@ pub(super) fn refresh_projected_library_uris(
         return 0;
     }
 
-    let projected_ids: HashSet<String> = projected_rows.iter().map(TrackObject::track_id).collect();
+    let accepts_local_refresh = |row: &TrackObject| {
+        row.source_id() == Some(SourceId::local())
+            && row
+                .playlist_occurrence_binding()
+                .is_none_or(|binding| binding.state() == PlaylistOccurrenceState::AvailableLocal)
+    };
+    let projected_ids: HashSet<String> = projected_rows
+        .iter()
+        .filter(|row| accepts_local_refresh(row))
+        .map(TrackObject::track_id)
+        .collect();
     let mut committed_uris = HashMap::with_capacity(projected_ids.len());
     for track in committed_local_rows {
         let track_id = track.track_id();
@@ -147,6 +159,9 @@ pub(super) fn refresh_projected_library_uris(
 
     let mut refreshed = 0;
     for row in projected_rows {
+        if !accepts_local_refresh(row) {
+            continue;
+        }
         let Some(uri) = committed_uris.get(&row.track_id()) else {
             continue;
         };
@@ -166,9 +181,9 @@ pub struct PlaybackIdentity {
 }
 
 impl PlaybackIdentity {
-    fn new(view: &QueueView, track_id: TrackId) -> Self {
+    fn new(view: &QueueView, source_id: SourceId, track_id: TrackId) -> Self {
         Self {
-            media_key: MediaKey::new(view.source_id, track_id),
+            media_key: MediaKey::new(source_id, track_id),
             view_origin: view.origin.clone(),
         }
     }
@@ -218,6 +233,10 @@ pub struct QueueItem {
     /// Stable media identity remains `(SourceId, TrackId)`; the epoch prevents
     /// a captured queue from being retargeted to a replacement login.
     source_session_epoch: Option<u64>,
+    /// Exact accepted catalogue authority carried by a source-scoped regular
+    /// playlist occurrence. This is transient queue state and is revalidated
+    /// separately for stream and artwork at the point of use.
+    regular_playlist_guard: Option<RegularPlaylistCatalogueGuard>,
     /// This exact queue item owns a hidden ephemeral external-file source.
     /// Random SourceIds are also valid persisted remote identities, so source
     /// shape alone cannot safely recover this lifecycle distinction later.
@@ -233,7 +252,12 @@ pub struct QueueItem {
 }
 
 impl QueueItem {
-    fn from_track(identity: PlaybackIdentity, track: &TrackObject, occurrence: usize) -> Self {
+    fn from_track(
+        identity: PlaybackIdentity,
+        track: &TrackObject,
+        occurrence: usize,
+        regular_playlist_guard: Option<RegularPlaylistCatalogueGuard>,
+    ) -> Self {
         let is_library = is_library_source(identity.media_key.source_id);
         let duration_ms = match track.duration_secs() {
             0 => None,
@@ -243,12 +267,16 @@ impl QueueItem {
             identity,
             occurrence,
             row_instance_id: Some(track.row_instance_id()),
-            source_session_epoch: track.source_session_epoch(),
+            source_session_epoch: regular_playlist_guard
+                .map(RegularPlaylistCatalogueGuard::session_epoch)
+                .or_else(|| track.source_session_epoch()),
+            regular_playlist_guard,
             external_session: false,
             duration_ms,
-            // Local, playlist, and lifecycle-owned queues retain identity,
-            // ordering, and metadata but never a locator. Every output load
-            // resolves the exact source/track/epoch at the point of use.
+            // Local and lifecycle-owned rows (including either kind of
+            // regular-playlist occurrence) retain identity, ordering, and
+            // metadata but never a locator. Every output load resolves the
+            // exact source/track/authority at the point of use.
             uri: if is_library || track.source_session_epoch().is_some() {
                 String::new()
             } else {
@@ -271,6 +299,7 @@ impl QueueItem {
             occurrence: 0,
             row_instance_id: None,
             source_session_epoch: Some(session.session_epoch()),
+            regular_playlist_guard: None,
             external_session: true,
             duration_ms: track
                 .duration_secs
@@ -299,6 +328,7 @@ impl QueueItem {
             occurrence: 0,
             row_instance_id: None,
             source_session_epoch: None,
+            regular_playlist_guard: None,
             external_session: false,
             duration_ms: None,
             uri,
@@ -319,6 +349,7 @@ impl QueueItem {
             occurrence: 0,
             row_instance_id: None,
             source_session_epoch: Some(session_epoch),
+            regular_playlist_guard: None,
             external_session: true,
             duration_ms: None,
             uri: String::new(),
@@ -496,9 +527,24 @@ impl PlaybackSession {
     /// or library that reused the same server-native track identifiers.
     pub(crate) fn clear_if_source(&mut self, source_id: &str) -> bool {
         if self
-            .current_identity()
-            .is_none_or(|identity| !identity_is_owned_by_source(identity, source_id))
+            .queue
+            .iter()
+            .all(|item| !identity_is_owned_by_source(&item.identity, source_id))
         {
+            return false;
+        }
+        self.clear();
+        true
+    }
+
+    /// Clear a mixed regular-playlist queue only when it retained a guard
+    /// minted by the replaced catalogue. Ordinary source queues intentionally
+    /// keep their epoch-based behavior across same-session refreshes.
+    pub(crate) fn clear_if_playlist_authority(&mut self, source_id: SourceId) -> bool {
+        if self.queue.iter().all(|item| {
+            item.regular_playlist_guard
+                .is_none_or(|guard| guard.source_id() != source_id)
+        }) {
             return false;
         }
         self.clear();
@@ -1075,6 +1121,47 @@ struct CapturedQueue {
     selected_index: usize,
 }
 
+fn row_playback_identity(
+    view: &QueueView,
+    track: &TrackObject,
+) -> Option<(PlaybackIdentity, Option<RegularPlaylistCatalogueGuard>)> {
+    if let Some(binding) = track.playlist_occurrence_binding() {
+        let track_id = binding.track_id()?.clone();
+        let guard = match binding.state() {
+            PlaylistOccurrenceState::AvailableLocal => None,
+            PlaylistOccurrenceState::AvailableRemote(guard) => Some(guard),
+            PlaylistOccurrenceState::Unavailable(_) => return None,
+        };
+        return Some((
+            PlaybackIdentity::new(view, binding.source_id(), track_id),
+            guard,
+        ));
+    }
+
+    let source_id = track.source_id().unwrap_or(view.source_id);
+    let track_id = TrackId::new(track.track_id()).ok()?;
+    Some((PlaybackIdentity::new(view, source_id, track_id), None))
+}
+
+fn row_position_identity(view: &QueueView, track: &TrackObject) -> Option<(u64, MediaKey)> {
+    let (identity, _) = row_playback_identity(view, track)?;
+    Some((track.row_instance_id(), identity.media_key))
+}
+
+fn playable_model_positions(model: &impl IsA<gtk::gio::ListModel>, source_key: &str) -> Vec<u32> {
+    let Some(view) = queue_view(source_key) else {
+        return Vec::new();
+    };
+    (0..model.n_items())
+        .filter(|position| {
+            model
+                .item(*position)
+                .and_downcast::<TrackObject>()
+                .is_some_and(|track| row_playback_identity(&view, &track).is_some())
+        })
+        .collect()
+}
+
 /// Capture the current sorted/filtered projection as a playback-owned queue.
 ///
 /// All entry points that start playback from the track list go through this
@@ -1095,15 +1182,19 @@ fn capture_visible_queue(
         let Some(track) = model.item(model_index).and_downcast::<TrackObject>() else {
             continue;
         };
-        let Ok(track_id) = TrackId::new(track.track_id()) else {
+        let Some((identity, regular_playlist_guard)) = row_playback_identity(&view, &track) else {
             continue;
         };
         if model_index == selected_position {
             selected_index = Some(items.len());
         }
-        let identity = PlaybackIdentity::new(&view, track_id);
         let occurrence = occurrences.entry(identity.media_key.clone()).or_default();
-        items.push(QueueItem::from_track(identity, &track, *occurrence));
+        items.push(QueueItem::from_track(
+            identity,
+            &track,
+            *occurrence,
+            regular_playlist_guard,
+        ));
         *occurrence += 1;
     }
 
@@ -1283,7 +1374,18 @@ pub fn play_or_start(ctx: &PlaybackContext, shuffle: bool) -> bool {
             ctx.active_output.borrow().play();
             true
         }
-        PlayRequest::StartAt(position) => play_track_at(position, ctx),
+        PlayRequest::StartAt(_) => {
+            let source_key = ctx.active_source_key.borrow().clone();
+            let playable = playable_model_positions(&ctx.model, &source_key);
+            let position = if shuffle {
+                playable
+                    .get(fastrand::usize(..playable.len().max(1)))
+                    .copied()
+            } else {
+                playable.first().copied()
+            };
+            position.is_some_and(|position| play_track_at(position, ctx))
+        }
         PlayRequest::Unavailable => false,
     }
 }
@@ -1436,10 +1538,19 @@ fn play_current(ctx: &PlaybackContext) -> bool {
         let media_ctrl = Rc::clone(&ctx.media_ctrl);
         let album_art = ctx.album_art.clone();
         let external_session = item.external_session;
+        let regular_playlist_guard = item.regular_playlist_guard;
         glib::MainContext::default().spawn_local(async move {
-            let resolved = source_registry
-                .resolve_stream(source_id, expected_session_epoch, track_id)
-                .await;
+            let resolved = if let Some(guard) = regular_playlist_guard {
+                source_registry
+                    .resolve_regular_playlist_stream(guard, track_id)
+                    .await
+                    .map_err(|error| error.to_string())
+            } else {
+                source_registry
+                    .resolve_stream(source_id, expected_session_epoch, track_id)
+                    .await
+                    .map_err(|error| error.to_string())
+            };
             match resolved {
                 Ok(request) => {
                     if !session.borrow_mut().finish_pending_resolution(generation) {
@@ -1588,19 +1699,21 @@ fn update_now_playing_ui(
     // Scroll only when the queue's source and item are present in the current
     // view. Navigation still works when the user is viewing another source or
     // has filtered the playing item out.
-    if identity.is_some_and(|identity| {
-        identity_belongs_to_source(identity, &ctx.active_source_key.borrow())
-    }) {
+    let active_source_key = ctx.active_source_key.borrow().clone();
+    if let Some((identity, view)) = identity
+        .filter(|identity| identity_belongs_to_source(identity, &active_source_key))
+        .and_then(|identity| queue_view(&active_source_key).map(|view| (identity, view)))
+    {
         if let Some(position) = find_queue_item_position(
             ctx.model.n_items(),
-            identity.map_or("", |identity| identity.media_key.track_id.as_str()),
+            &identity.media_key,
             item.occurrence,
             item.row_instance_id,
             |index| {
                 ctx.model
                     .item(index)
                     .and_downcast::<TrackObject>()
-                    .map(|track| (track.row_instance_id(), track.track_id()))
+                    .and_then(|track| row_position_identity(&view, &track))
             },
         ) {
             ctx.column_view.scroll_to(
@@ -1618,12 +1731,21 @@ fn update_now_playing_ui(
         let source_registry = ctx.source_registry.clone();
         let source_id = identity.media_key.source_id;
         let track_id = identity.media_key.track_id.clone();
+        let regular_playlist_guard = item.regular_playlist_guard;
         let album_art = ctx.album_art.clone();
         glib::MainContext::default().spawn_local(async move {
-            match source_registry
-                .resolve_artwork(source_id, expected_session_epoch, track_id)
-                .await
-            {
+            let resolved = if let Some(guard) = regular_playlist_guard {
+                source_registry
+                    .resolve_regular_playlist_artwork(guard, track_id)
+                    .await
+                    .map_err(|error| error.to_string())
+            } else {
+                source_registry
+                    .resolve_artwork(source_id, expected_session_epoch, track_id)
+                    .await
+                    .map_err(|error| error.to_string())
+            };
+            match resolved {
                 Ok(Some(request)) => {
                     album_art::fetch_resolved_album_art(&album_art, request, generation);
                 }
@@ -1655,12 +1777,12 @@ fn update_now_playing_ui(
 
 fn find_queue_item_position(
     item_count: u32,
-    track_id: &str,
+    media_key: &MediaKey,
     target_occurrence: usize,
     row_instance_id: Option<u64>,
-    mut item_at: impl FnMut(u32) -> Option<(u64, String)>,
+    mut item_at: impl FnMut(u32) -> Option<(u64, MediaKey)>,
 ) -> Option<u32> {
-    let items: Vec<Option<(u64, String)>> = (0..item_count).map(&mut item_at).collect();
+    let items: Vec<Option<(u64, MediaKey)>> = (0..item_count).map(&mut item_at).collect();
     if let Some(row_instance_id) = row_instance_id {
         if let Some(position) = items.iter().position(|item| {
             item.as_ref()
@@ -1672,7 +1794,7 @@ fn find_queue_item_position(
 
     let mut occurrence = 0usize;
     for (index, item) in items.into_iter().enumerate() {
-        if item.as_ref().map(|(_, id)| id.as_str()) != Some(track_id) {
+        if item.as_ref().map(|(_, key)| key) != Some(media_key) {
             continue;
         }
         if occurrence == target_occurrence {
@@ -1976,6 +2098,7 @@ mod tests {
         let view = queue_view(source).expect("test source identity");
         let identity = PlaybackIdentity::new(
             &view,
+            view.source_id,
             TrackId::new(id.to_string()).expect("test track identity"),
         );
         QueueItem {
@@ -1983,6 +2106,7 @@ mod tests {
             occurrence: 0,
             row_instance_id: None,
             source_session_epoch: None,
+            regular_playlist_guard: None,
             external_session: false,
             duration_ms: None,
             uri: if is_library_source(view.source_id) {
@@ -2081,9 +2205,10 @@ mod tests {
         let view = queue_view(source).expect("test source identity");
         let identity = PlaybackIdentity::new(
             &view,
+            row.source_id().unwrap_or(view.source_id),
             TrackId::new(row.track_id()).expect("test track identity"),
         );
-        QueueItem::from_track(identity, row, occurrence)
+        QueueItem::from_track(identity, row, occurrence, None)
     }
 
     fn refreshed_metadata() -> QueueTrackRefresh {
@@ -2285,11 +2410,16 @@ mod tests {
         let first = projected_row("a", "file:///music/old-a.flac");
         let unrelated = projected_row("b", "file:///music/b.flac");
         let duplicate = projected_row("a", "file:///music/old-a.flac");
+        for row in [&first, &unrelated, &duplicate] {
+            assert!(row.set_source_id(SourceId::local()));
+        }
         let rows = vec![first, unrelated, duplicate];
         let identities: Vec<u64> = rows.iter().map(TrackObject::row_instance_id).collect();
 
         let renamed = projected_row("a", "file:///music/renamed-a.flac");
         let empty = projected_row("b", "");
+        assert!(renamed.set_source_id(SourceId::local()));
+        assert!(empty.set_source_id(SourceId::local()));
         assert_eq!(refresh_projected_library_uris(&rows, &[renamed, empty]), 2);
 
         assert_eq!(rows[0].uri(), "file:///music/renamed-a.flac");
@@ -2302,6 +2432,49 @@ mod tests {
             identities,
             "URI refresh must preserve duplicate occurrence identity and order"
         );
+    }
+
+    #[test]
+    fn local_uri_refresh_never_retargets_a_remote_playlist_identity_collision() {
+        let local = projected_row("shared-id", "file:///music/old.flac");
+        assert!(local.set_source_id(SourceId::local()));
+        let remote = projected_row("shared-id", "");
+        let remote_source = SourceId::random();
+        assert!(remote.set_source_id(remote_source));
+        let replacement = projected_row("shared-id", "file:///music/new.flac");
+
+        assert_eq!(
+            refresh_projected_library_uris(&[local.clone(), remote.clone()], &[replacement]),
+            1
+        );
+        assert_eq!(local.uri(), "file:///music/new.flac");
+        assert_eq!(remote.uri(), "");
+        assert_eq!(remote.source_id(), Some(remote_source));
+    }
+
+    #[test]
+    fn local_uri_refresh_does_not_revive_an_unavailable_playlist_occurrence() {
+        use crate::ui::objects::{PlaylistOccurrenceBinding, PlaylistRowUnavailableReason};
+
+        let missing_id = TrackId::new("missing-local").expect("local track ID");
+        let unavailable = projected_row(missing_id.as_str(), "");
+        unavailable.set_playlist_occurrence_binding(
+            PlaylistOccurrenceBinding::unavailable(
+                "entry-missing",
+                SourceId::local(),
+                Some(missing_id),
+                PlaylistRowUnavailableReason::LocalTrackMissing,
+            )
+            .expect("missing local occurrence"),
+        );
+        let replacement = projected_row("missing-local", "file:///music/reappeared.flac");
+
+        assert_eq!(
+            refresh_projected_library_uris(std::slice::from_ref(&unavailable), &[replacement],),
+            0,
+            "only a new authoritative playlist projection may make the row available",
+        );
+        assert!(unavailable.uri().is_empty());
     }
 
     #[test]
@@ -2418,6 +2591,173 @@ mod tests {
         assert!(!session.has_current());
         assert!(!session.accepts_event_generation(b_again.generation));
         assert_eq!(output_state.borrow().stops, 1);
+    }
+
+    #[test]
+    fn regular_playlist_capture_skips_unavailable_rows_without_losing_duplicate_occurrences() {
+        use crate::ui::objects::{PlaylistOccurrenceBinding, PlaylistRowUnavailableReason};
+
+        let playlist_key = "playlist:mixed";
+        let stable_id = TrackId::new("same-local-track").expect("local track ID");
+        let first = projected_row(stable_id.as_str(), "file:///music/same.flac");
+        first.set_playlist_occurrence_binding(
+            PlaylistOccurrenceBinding::available_local("entry-first", stable_id.clone())
+                .expect("first occurrence"),
+        );
+        let missing = projected_row("missing-local-track", "");
+        missing.set_playlist_occurrence_binding(
+            PlaylistOccurrenceBinding::unavailable(
+                "entry-missing",
+                SourceId::local(),
+                Some(TrackId::new("missing-local-track").expect("missing local ID")),
+                PlaylistRowUnavailableReason::LocalTrackMissing,
+            )
+            .expect("missing occurrence"),
+        );
+        let duplicate = projected_row(stable_id.as_str(), "file:///music/same.flac");
+        duplicate.set_playlist_occurrence_binding(
+            PlaylistOccurrenceBinding::available_local("entry-duplicate", stable_id)
+                .expect("duplicate occurrence"),
+        );
+
+        let store = gtk::gio::ListStore::new::<TrackObject>();
+        store.append(&first);
+        store.append(&missing);
+        store.append(&duplicate);
+
+        assert_eq!(playable_model_positions(&store, playlist_key), [0, 2]);
+        assert!(
+            capture_visible_queue(&store, playlist_key, 1).is_none(),
+            "activating an unavailable row must not install a replacement queue"
+        );
+        let captured =
+            capture_visible_queue(&store, playlist_key, 2).expect("duplicate is playable");
+        assert_eq!(captured.selected_index, 1);
+        assert_eq!(captured.items.len(), 2);
+        assert_eq!(
+            captured
+                .items
+                .iter()
+                .map(|item| item.identity.media_key.track_id.as_str())
+                .collect::<Vec<_>>(),
+            ["same-local-track", "same-local-track"]
+        );
+        assert_eq!(captured.items[0].occurrence, 0);
+        assert_eq!(captured.items[1].occurrence, 1);
+        assert!(captured.items.iter().all(|item| {
+            item.identity.view_origin == Some(ViewOrigin::Playlist("mixed".to_string()))
+        }));
+    }
+
+    #[test]
+    fn available_remote_projection_carries_exact_guard_into_duplicate_queue_occurrences() {
+        use crate::local::playlist_manager::{LoadedPlaylistEntry, StoredPlaylistEntry};
+        use crate::source_registry::{RegularPlaylistTrack, RegularPlaylistTrackResolution};
+        use crate::ui::playlist_projection::project_playlist_rows;
+
+        let source_id = SourceId::random();
+        let track_id = TrackId::remote("remote/native-id").expect("remote track ID");
+        let media_key = MediaKey::new(source_id, track_id.clone());
+        let catalogue_track = crate::architecture::models::Track {
+            id: uuid::Uuid::new_v4(),
+            native_track_id: Some(track_id.clone()),
+            title: "Current remote title".to_string(),
+            artist_name: "Current remote artist".to_string(),
+            album_artist_name: None,
+            artist_id: None,
+            album_title: "Current remote album".to_string(),
+            album_id: None,
+            track_number: Some(3),
+            disc_number: Some(1),
+            duration_secs: Some(211),
+            composer: None,
+            genre: Some("Remote genre".to_string()),
+            year: Some(2026),
+            file_path: Some("/private/must-not-cross.flac".to_string()),
+            stream_url: Some(
+                url::Url::parse("https://secret.invalid/audio?token=private")
+                    .expect("fixture stream URL"),
+            ),
+            cover_art_url: Some(
+                url::Url::parse("https://secret.invalid/art?token=private")
+                    .expect("fixture artwork URL"),
+            ),
+            date_added: None,
+            date_modified: None,
+            bitrate_kbps: Some(1_024),
+            sample_rate_hz: Some(96_000),
+            format: Some("flac".to_string()),
+            play_count: Some(9),
+            rating: crate::architecture::models::TrackRating::read_only(None),
+            last_played: None,
+        };
+        let available =
+            RegularPlaylistTrack::for_ui_test(media_key.clone(), 17, 29, &catalogue_track);
+        let loaded = |entry_id: &str, position: i32| LoadedPlaylistEntry {
+            stored: StoredPlaylistEntry {
+                id: entry_id.to_string(),
+                playlist_id: "mixed".to_string(),
+                position,
+                source_id,
+                track_id: Some(track_id.clone()),
+                local_track_id: None,
+                match_title: "private persisted fingerprint".to_string(),
+                match_artist: "private persisted artist".to_string(),
+                match_album: "private persisted album".to_string(),
+                match_duration_secs: Some(999),
+                match_file_path: None,
+            },
+            local_track: None,
+        };
+        let projected = project_playlist_rows(
+            vec![loaded("entry-first", 0), loaded("entry-duplicate", 1)],
+            vec![
+                RegularPlaylistTrackResolution::Available(Box::new(available.clone())),
+                RegularPlaylistTrackResolution::Available(Box::new(available)),
+            ],
+        )
+        .expect("exact remote projection");
+        let rows = projected
+            .into_iter()
+            .map(crate::ui::source_connect::playlist_row_to_object)
+            .collect::<Vec<_>>();
+
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().all(|row| {
+            row.source_id() == Some(source_id)
+                && row.source_session_epoch() == Some(17)
+                && row.source_catalogue_generation() == Some(29)
+                && row.title() == "Current remote title"
+                && row.uri().is_empty()
+                && row.cover_art_url().is_empty()
+        }));
+        assert_ne!(rows[0].row_instance_id(), rows[1].row_instance_id());
+
+        let store = gtk::gio::ListStore::new::<TrackObject>();
+        for row in &rows {
+            store.append(row);
+        }
+        let captured = capture_visible_queue(&store, "playlist:mixed", 1)
+            .expect("duplicate remote occurrence is playable");
+        assert_eq!(captured.selected_index, 1);
+        assert_eq!(captured.items.len(), 2);
+        for (occurrence, item) in captured.items.iter().enumerate() {
+            assert_eq!(item.identity.media_key, media_key);
+            assert_eq!(
+                item.identity.view_origin,
+                Some(ViewOrigin::playlist("mixed").expect("playlist origin"))
+            );
+            assert_eq!(item.occurrence, occurrence);
+            assert_eq!(item.source_session_epoch, Some(17));
+            let guard = item
+                .regular_playlist_guard
+                .expect("available remote occurrence keeps its closed guard");
+            assert_eq!(guard.source_id(), source_id);
+            assert_eq!(guard.session_epoch(), 17);
+            assert_eq!(guard.catalogue_generation(), 29);
+            assert!(item.uri().is_empty());
+            assert!(item.cover_art_url.is_empty());
+        }
     }
 
     #[test]
@@ -2969,6 +3309,19 @@ mod tests {
 
         assert!(session.clear_if_source("remote-a"));
         assert!(!session.accepts_event_generation(retired_generation));
+        assert!(!session.has_current());
+        assert!(session.queue.is_empty());
+    }
+
+    #[test]
+    fn source_retirement_clears_a_mixed_queue_before_navigation_reaches_it() {
+        let mut session = PlaybackSession::default();
+        assert!(session.replace_queue(
+            vec![item(LOCAL_SOURCE_KEY, "local"), item("remote-a", "remote")],
+            0,
+        ));
+        assert_eq!(current_source(&session), SourceId::local());
+        assert!(session.clear_if_source("remote-a"));
         assert!(!session.has_current());
         assert!(session.queue.is_empty());
     }
@@ -3691,13 +4044,14 @@ mod tests {
         let mut second = first.clone();
         second.occurrence = 1;
         second.row_instance_id = Some(22);
+        let media_key = first.identity.media_key.clone();
         let mut session = PlaybackSession::default();
         assert!(session.replace_queue(vec![first, second], 1));
 
         assert_eq!(current_id(&session), "same-track");
         assert_eq!(session.current().map(|item| item.occurrence), Some(1));
         assert_eq!(
-            find_queue_item_position(4, "same-track", 1, Some(22), |index| {
+            find_queue_item_position(4, &media_key, 1, Some(22), |index| {
                 [
                     (11, "same-track"),
                     (12, "other"),
@@ -3705,9 +4059,78 @@ mod tests {
                     (33, "same-track"),
                 ]
                 .get(index as usize)
-                .map(|(row_id, track_id)| (*row_id, (*track_id).to_string()))
+                .map(|(row_id, track_id)| {
+                    (
+                        *row_id,
+                        MediaKey::new(
+                            media_key.source_id,
+                            TrackId::new(*track_id).expect("test track ID"),
+                        ),
+                    )
+                })
             }),
             Some(2)
         );
+    }
+
+    #[test]
+    fn rebuilt_row_fallback_matches_source_and_track_identity() {
+        let shared_track_id = TrackId::new("same-native-id").expect("shared track ID");
+        let local_key = MediaKey::new(SourceId::local(), shared_track_id.clone());
+        let remote_key = MediaKey::new(SourceId::random(), shared_track_id);
+        let rebuilt_rows = [
+            Some((101, remote_key.clone())),
+            None, // unavailable or malformed rows do not participate
+            Some((102, local_key.clone())),
+            Some((103, remote_key.clone())),
+            Some((104, local_key.clone())),
+        ];
+
+        assert_eq!(
+            find_queue_item_position(5, &local_key, 0, None, |index| {
+                rebuilt_rows[index as usize].clone()
+            }),
+            Some(2),
+            "a remote row with the same native ID must not capture the local occurrence"
+        );
+        assert_eq!(
+            find_queue_item_position(5, &remote_key, 1, None, |index| {
+                rebuilt_rows[index as usize].clone()
+            }),
+            Some(3),
+            "occurrence counting must be scoped to the complete media key"
+        );
+    }
+
+    #[test]
+    fn rebuilt_row_candidates_skip_unavailable_and_malformed_playlist_rows() {
+        use crate::ui::objects::{PlaylistOccurrenceBinding, PlaylistRowUnavailableReason};
+
+        let view = queue_view("playlist:mixed").expect("playlist view");
+        let available_id = TrackId::new("available").expect("available track ID");
+        let available = projected_row(available_id.as_str(), "file:///music/available.flac");
+        available.set_playlist_occurrence_binding(
+            PlaylistOccurrenceBinding::available_local("entry-available", available_id.clone())
+                .expect("available occurrence"),
+        );
+        let unavailable = projected_row("missing", "");
+        unavailable.set_playlist_occurrence_binding(
+            PlaylistOccurrenceBinding::unavailable(
+                "entry-unavailable",
+                SourceId::local(),
+                Some(TrackId::new("missing").expect("missing track ID")),
+                PlaylistRowUnavailableReason::LocalTrackMissing,
+            )
+            .expect("unavailable occurrence"),
+        );
+        let malformed = projected_row("initially-valid", "");
+        malformed.set_track_id("");
+
+        assert_eq!(
+            row_position_identity(&view, &available).map(|(_, key)| key),
+            Some(MediaKey::new(SourceId::local(), available_id))
+        );
+        assert_eq!(row_position_identity(&view, &unavailable), None);
+        assert_eq!(row_position_identity(&view, &malformed), None);
     }
 }

--- a/src/ui/playback.rs
+++ b/src/ui/playback.rs
@@ -1702,7 +1702,7 @@ fn update_now_playing_ui(
     let active_source_key = ctx.active_source_key.borrow().clone();
     if let Some((identity, view)) = identity
         .filter(|identity| identity_belongs_to_source(identity, &active_source_key))
-        .and_then(|identity| queue_view(&active_source_key).map(|view| (identity, view)))
+        .zip(queue_view(&active_source_key))
     {
         if let Some(position) = find_queue_item_position(
             ctx.model.n_items(),

--- a/src/ui/playlist_actions.rs
+++ b/src/ui/playlist_actions.rs
@@ -424,6 +424,14 @@ fn show_playlist_alert(win: &adw::ApplicationWindow, heading: &str, body: &str) 
     alert.present(Some(win));
 }
 
+fn local_only_export_unsupported_body(locale: &str) -> String {
+    rust_i18n::t!(
+        "playlist_io.export_local_only_unsupported_body",
+        locale = locale
+    )
+    .into_owned()
+}
+
 /// Opens an XSPF v1 file, parses it off the async worker threads, imports the
 /// playlist transactionally, and publishes the committed playlist in the
 /// sidebar together with an explicit outcome summary.
@@ -671,10 +679,19 @@ fn handle_export_playlist(
                             .into_owned()
                         })?
                     } else {
-                        mgr.get_playlist_tracks(&pid).await.map_err(|error| {
+                        match mgr.local_playlist_export(&pid).await.map_err(|error| {
                             rust_i18n::t!("playlist_io.playlist_tracks_read_failed", error = error)
                                 .into_owned()
-                        })?
+                        })? {
+                            crate::local::playlist_manager::LocalPlaylistExport::Ready(tracks) => {
+                                tracks
+                            }
+                            crate::local::playlist_manager::LocalPlaylistExport::UnsupportedEntries => {
+                                return Err(local_only_export_unsupported_body(
+                                    rust_i18n::locale().as_ref(),
+                                ));
+                            }
+                        }
                     };
 
                     let export_path = path.clone();
@@ -727,4 +744,23 @@ fn handle_export_playlist(
             });
         },
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::local_only_export_unsupported_body;
+
+    #[test]
+    fn local_only_export_refusal_is_localized_without_english_fallback() {
+        let english = local_only_export_unsupported_body("en");
+        assert!(!english.is_empty());
+
+        for locale in rust_i18n::available_locales!() {
+            let localized = local_only_export_unsupported_body(&locale);
+            assert!(!localized.is_empty(), "{locale}: empty refusal copy");
+            if locale != "en" {
+                assert_ne!(localized, english, "{locale} must not fall back to English");
+            }
+        }
+    }
 }

--- a/src/ui/playlist_projection.rs
+++ b/src/ui/playlist_projection.rs
@@ -1,0 +1,450 @@
+//! Pure regular-playlist projection from durable occurrences and live source
+//! authority into UI-ready row specifications.
+//!
+//! Storage order is authoritative. Every durable occurrence produces exactly
+//! one row specification or the entire projection fails closed. Remote
+//! results are consumed positionally only for non-local entries and must name
+//! the exact same `(SourceId, TrackId)`. Unavailable rows carry no fingerprint
+//! or stale display metadata.
+
+use thiserror::Error;
+
+use crate::architecture::SourceId;
+use crate::db::entities::track;
+use crate::local::playlist_manager::LoadedPlaylistEntry;
+use crate::source_registry::{
+    RegularPlaylistTrack, RegularPlaylistTrackResolution, RegularPlaylistUnavailableReason,
+};
+
+use super::objects::{PlaylistOccurrenceBinding, PlaylistRowUnavailableReason};
+
+/// Display content for one durable regular-playlist occurrence.
+///
+/// An unavailable row is deliberately a unit variant: normalized persistence
+/// fingerprints and stale catalogue metadata cannot cross this boundary.
+#[derive(Clone)]
+pub enum PlaylistRowContent {
+    AvailableLocal(track::Model),
+    AvailableRemote(RegularPlaylistTrack),
+    Unavailable,
+}
+
+/// One ordered UI projection row with its exact durable occurrence binding.
+#[derive(Clone)]
+pub struct PlaylistRowSpec {
+    binding: PlaylistOccurrenceBinding,
+    content: PlaylistRowContent,
+}
+
+impl PlaylistRowSpec {
+    fn new(binding: PlaylistOccurrenceBinding, content: PlaylistRowContent) -> Self {
+        Self { binding, content }
+    }
+
+    #[cfg(test)]
+    pub fn binding(&self) -> &PlaylistOccurrenceBinding {
+        &self.binding
+    }
+
+    #[cfg(test)]
+    pub fn content(&self) -> &PlaylistRowContent {
+        &self.content
+    }
+
+    pub fn into_parts(self) -> (PlaylistOccurrenceBinding, PlaylistRowContent) {
+        (self.binding, self.content)
+    }
+}
+
+/// Closed structural failure. It contains no persisted identity, fingerprint,
+/// locator, registry error, or adapter detail.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum PlaylistProjectionError {
+    #[error("playlist remote-resolution count did not match durable occurrences")]
+    RemoteResolutionCountMismatch,
+    #[error("playlist remote resolution did not match its durable media identity")]
+    RemoteIdentityMismatch,
+    #[error("playlist local row did not match its durable media identity")]
+    LocalIdentityMismatch,
+    #[error("playlist occurrence could not form a valid row binding")]
+    InvalidOccurrenceBinding,
+}
+
+/// Project ordered durable entries using ordered live resolutions for only
+/// their non-local occurrences.
+///
+/// The result is all-or-none. Duplicates remain separate because the durable
+/// `entry_id` is copied into every binding rather than deduplicating by media
+/// identity.
+pub fn project_playlist_rows(
+    entries: Vec<LoadedPlaylistEntry>,
+    remote_resolutions: Vec<RegularPlaylistTrackResolution>,
+) -> Result<Vec<PlaylistRowSpec>, PlaylistProjectionError> {
+    let expected_remote = entries
+        .iter()
+        .filter(|entry| entry.stored.source_id != SourceId::local())
+        .count();
+    if expected_remote != remote_resolutions.len() {
+        return Err(PlaylistProjectionError::RemoteResolutionCountMismatch);
+    }
+
+    let mut remote_resolutions = remote_resolutions.into_iter();
+    let mut rows = Vec::with_capacity(entries.len());
+    for loaded in entries {
+        let row = if loaded.stored.source_id == SourceId::local() {
+            project_local(loaded)?
+        } else {
+            let resolution = remote_resolutions
+                .next()
+                .ok_or(PlaylistProjectionError::RemoteResolutionCountMismatch)?;
+            project_remote(loaded, resolution)?
+        };
+        rows.push(row);
+    }
+    debug_assert_eq!(remote_resolutions.len(), 0);
+    Ok(rows)
+}
+
+fn project_local(loaded: LoadedPlaylistEntry) -> Result<PlaylistRowSpec, PlaylistProjectionError> {
+    let stored = loaded.stored;
+    match loaded.local_track {
+        Some(track) => {
+            let Some(track_id) = stored.track_id else {
+                return Err(PlaylistProjectionError::LocalIdentityMismatch);
+            };
+            if stored.local_track_id.as_ref() != Some(&track_id) || track.id != track_id.as_str() {
+                return Err(PlaylistProjectionError::LocalIdentityMismatch);
+            }
+            let binding = PlaylistOccurrenceBinding::available_local(stored.id, track_id)
+                .ok_or(PlaylistProjectionError::InvalidOccurrenceBinding)?;
+            Ok(PlaylistRowSpec::new(
+                binding,
+                PlaylistRowContent::AvailableLocal(track),
+            ))
+        }
+        None => {
+            let (track_id, reason) = match stored.track_id {
+                Some(track_id) => (
+                    Some(track_id),
+                    PlaylistRowUnavailableReason::LocalTrackMissing,
+                ),
+                None => (None, PlaylistRowUnavailableReason::LocalTrackUnmatched),
+            };
+            let binding = PlaylistOccurrenceBinding::unavailable(
+                stored.id,
+                SourceId::local(),
+                track_id,
+                reason,
+            )
+            .ok_or(PlaylistProjectionError::InvalidOccurrenceBinding)?;
+            Ok(PlaylistRowSpec::new(
+                binding,
+                PlaylistRowContent::Unavailable,
+            ))
+        }
+    }
+}
+
+fn project_remote(
+    loaded: LoadedPlaylistEntry,
+    resolution: RegularPlaylistTrackResolution,
+) -> Result<PlaylistRowSpec, PlaylistProjectionError> {
+    if loaded.local_track.is_some() {
+        return Err(PlaylistProjectionError::LocalIdentityMismatch);
+    }
+    let stored = loaded.stored;
+    let media_key = stored
+        .media_key()
+        .ok_or(PlaylistProjectionError::RemoteIdentityMismatch)?;
+    if resolution.media_key() != &media_key {
+        return Err(PlaylistProjectionError::RemoteIdentityMismatch);
+    }
+
+    match resolution {
+        RegularPlaylistTrackResolution::Available(track) => {
+            let track = *track;
+            let binding = PlaylistOccurrenceBinding::available_remote(
+                stored.id,
+                media_key.source_id,
+                media_key.track_id,
+                track.guard(),
+            )
+            .ok_or(PlaylistProjectionError::InvalidOccurrenceBinding)?;
+            Ok(PlaylistRowSpec::new(
+                binding,
+                PlaylistRowContent::AvailableRemote(track),
+            ))
+        }
+        RegularPlaylistTrackResolution::Unavailable(unavailable) => {
+            let binding = PlaylistOccurrenceBinding::unavailable(
+                stored.id,
+                media_key.source_id,
+                Some(media_key.track_id),
+                map_registry_reason(unavailable.reason()),
+            )
+            .ok_or(PlaylistProjectionError::InvalidOccurrenceBinding)?;
+            Ok(PlaylistRowSpec::new(
+                binding,
+                PlaylistRowContent::Unavailable,
+            ))
+        }
+    }
+}
+
+const fn map_registry_reason(
+    reason: RegularPlaylistUnavailableReason,
+) -> PlaylistRowUnavailableReason {
+    match reason {
+        RegularPlaylistUnavailableReason::SourceUnavailable => {
+            PlaylistRowUnavailableReason::SourceUnavailable
+        }
+        RegularPlaylistUnavailableReason::UnsupportedSource => {
+            PlaylistRowUnavailableReason::UnsupportedSource
+        }
+        RegularPlaylistUnavailableReason::InvalidCatalogue => {
+            PlaylistRowUnavailableReason::InvalidCatalogue
+        }
+        RegularPlaylistUnavailableReason::TrackMissing => {
+            PlaylistRowUnavailableReason::TrackMissing
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::architecture::{MediaKey, TrackId};
+    use crate::local::playlist_manager::StoredPlaylistEntry;
+    use crate::source_registry::SourceRegistry;
+
+    use super::*;
+
+    fn local_track(id: &str, title: &str) -> track::Model {
+        track::Model {
+            id: id.to_string(),
+            file_path: format!("/library/{id}.flac"),
+            title: title.to_string(),
+            artist_name: "Artist".to_string(),
+            album_artist_name: None,
+            album_title: "Album".to_string(),
+            genre: None,
+            composer: None,
+            year: None,
+            track_number: None,
+            disc_number: None,
+            duration_secs: None,
+            bitrate_kbps: None,
+            sample_rate_hz: None,
+            format: None,
+            play_count: 0,
+            last_played_at_ms: None,
+            rating: None,
+            date_added: String::new(),
+            date_modified: String::new(),
+            file_size_bytes: None,
+        }
+    }
+
+    fn loaded_local(
+        entry_id: &str,
+        position: i32,
+        track_id: Option<&str>,
+        local_track: Option<track::Model>,
+    ) -> LoadedPlaylistEntry {
+        let track_id = track_id.map(|id| TrackId::new(id).expect("local track ID"));
+        LoadedPlaylistEntry {
+            stored: StoredPlaylistEntry {
+                id: entry_id.to_string(),
+                playlist_id: "playlist".to_string(),
+                position,
+                source_id: SourceId::local(),
+                track_id: track_id.clone(),
+                local_track_id: local_track.as_ref().and_then(|_| track_id.clone()),
+                match_title: "private normalized title sentinel".to_string(),
+                match_artist: "private normalized artist sentinel".to_string(),
+                match_album: "private normalized album sentinel".to_string(),
+                match_duration_secs: Some(123),
+                match_file_path: Some("/private/reconciliation/sentinel.flac".to_string()),
+            },
+            local_track,
+        }
+    }
+
+    fn loaded_remote(
+        entry_id: &str,
+        position: i32,
+        source_id: SourceId,
+        track_id: &str,
+    ) -> LoadedPlaylistEntry {
+        LoadedPlaylistEntry {
+            stored: StoredPlaylistEntry {
+                id: entry_id.to_string(),
+                playlist_id: "playlist".to_string(),
+                position,
+                source_id,
+                track_id: Some(TrackId::remote(track_id).expect("remote track ID")),
+                local_track_id: None,
+                match_title: "private remote title sentinel".to_string(),
+                match_artist: "private remote artist sentinel".to_string(),
+                match_album: "private remote album sentinel".to_string(),
+                match_duration_secs: Some(321),
+                match_file_path: None,
+            },
+            local_track: None,
+        }
+    }
+
+    #[test]
+    fn local_projection_preserves_order_duplicates_and_missing_states() {
+        let first = local_track("same-track", "First current title");
+        let rows = project_playlist_rows(
+            vec![
+                loaded_local("entry-one", 0, Some("same-track"), Some(first.clone())),
+                loaded_local("entry-missing", 1, Some("missing-track"), None),
+                loaded_local("entry-two", 2, Some("same-track"), Some(first)),
+                loaded_local("entry-unmatched", 3, None, None),
+            ],
+            Vec::new(),
+        )
+        .expect("ordered local projection");
+
+        assert_eq!(rows.len(), 4);
+        assert_eq!(rows[0].binding().entry_id(), "entry-one");
+        assert_eq!(rows[1].binding().entry_id(), "entry-missing");
+        assert_eq!(rows[2].binding().entry_id(), "entry-two");
+        assert_eq!(rows[3].binding().entry_id(), "entry-unmatched");
+        assert_eq!(
+            rows[0].binding().track_id(),
+            rows[2].binding().track_id(),
+            "duplicate media identity must retain separate durable rows"
+        );
+        assert_eq!(
+            rows[1].binding().state(),
+            crate::ui::objects::PlaylistOccurrenceState::Unavailable(
+                PlaylistRowUnavailableReason::LocalTrackMissing
+            )
+        );
+        assert_eq!(
+            rows[3].binding().state(),
+            crate::ui::objects::PlaylistOccurrenceState::Unavailable(
+                PlaylistRowUnavailableReason::LocalTrackUnmatched
+            )
+        );
+        assert!(matches!(
+            rows[0].content(),
+            PlaylistRowContent::AvailableLocal(track) if track.title == "First current title"
+        ));
+        assert!(matches!(rows[1].content(), PlaylistRowContent::Unavailable));
+    }
+
+    #[tokio::test]
+    async fn mixed_rows_keep_order_source_scope_and_no_fingerprints() {
+        let registry = SourceRegistry::new(tokio::runtime::Handle::current());
+        let first_source = SourceId::random();
+        let second_source = SourceId::random();
+        let local = local_track("local-track", "Current local title");
+        let shared_id = TrackId::remote("shared-native-id").expect("remote track ID");
+        let keys = vec![
+            MediaKey::new(first_source, shared_id.clone()),
+            MediaKey::new(second_source, shared_id),
+        ];
+        let resolutions = registry.resolve_regular_playlist_tracks(&keys);
+        let rows = project_playlist_rows(
+            vec![
+                loaded_local("local-entry", 0, Some("local-track"), Some(local)),
+                loaded_remote("first-entry", 1, first_source, "shared-native-id"),
+                loaded_local("missing-entry", 2, Some("missing-local"), None),
+                loaded_remote("second-entry", 3, second_source, "shared-native-id"),
+            ],
+            resolutions,
+        )
+        .expect("mixed projection");
+
+        assert_eq!(rows[0].binding().entry_id(), "local-entry");
+        assert_eq!(rows[0].binding().source_id(), SourceId::local());
+        assert_eq!(rows[1].binding().entry_id(), "first-entry");
+        assert_eq!(rows[1].binding().source_id(), first_source);
+        assert_eq!(rows[2].binding().entry_id(), "missing-entry");
+        assert_eq!(rows[3].binding().entry_id(), "second-entry");
+        assert_eq!(rows[3].binding().source_id(), second_source);
+        for row in [&rows[1], &rows[3]] {
+            assert_eq!(
+                row.binding().state(),
+                crate::ui::objects::PlaylistOccurrenceState::Unavailable(
+                    PlaylistRowUnavailableReason::SourceUnavailable
+                )
+            );
+            assert!(matches!(row.content(), PlaylistRowContent::Unavailable));
+            let debug = format!("{:?}", row.binding());
+            assert!(!debug.contains("private remote"));
+            assert!(!debug.contains("reconciliation"));
+        }
+        assert!(matches!(
+            rows[0].content(),
+            PlaylistRowContent::AvailableLocal(track) if track.title == "Current local title"
+        ));
+        assert!(matches!(rows[2].content(), PlaylistRowContent::Unavailable));
+
+        registry.shutdown().wait().await;
+    }
+
+    #[tokio::test]
+    async fn remote_resolution_count_and_full_identity_mismatches_fail_closed() {
+        let registry = SourceRegistry::new(tokio::runtime::Handle::current());
+        let stored_source = SourceId::random();
+        let another_source = SourceId::random();
+        let entry = loaded_remote("entry", 0, stored_source, "same-id");
+
+        assert!(matches!(
+            project_playlist_rows(vec![entry.clone()], Vec::new()),
+            Err(PlaylistProjectionError::RemoteResolutionCountMismatch)
+        ));
+
+        let wrong = registry.resolve_regular_playlist_tracks(&[MediaKey::new(
+            another_source,
+            TrackId::remote("same-id").expect("remote track ID"),
+        )]);
+        assert!(matches!(
+            project_playlist_rows(vec![entry], wrong),
+            Err(PlaylistProjectionError::RemoteIdentityMismatch)
+        ));
+
+        registry.shutdown().wait().await;
+    }
+
+    #[test]
+    fn malformed_local_resolution_fails_the_whole_projection_without_fallback() {
+        let mismatched = local_track("different-track", "Wrong current row");
+        assert!(matches!(
+            project_playlist_rows(
+                vec![loaded_local(
+                    "entry",
+                    0,
+                    Some("expected-track"),
+                    Some(mismatched),
+                )],
+                Vec::new(),
+            ),
+            Err(PlaylistProjectionError::LocalIdentityMismatch)
+        ));
+    }
+
+    #[test]
+    fn every_registry_unavailability_reason_has_one_closed_ui_state() {
+        assert_eq!(
+            map_registry_reason(RegularPlaylistUnavailableReason::SourceUnavailable),
+            PlaylistRowUnavailableReason::SourceUnavailable
+        );
+        assert_eq!(
+            map_registry_reason(RegularPlaylistUnavailableReason::UnsupportedSource),
+            PlaylistRowUnavailableReason::UnsupportedSource
+        );
+        assert_eq!(
+            map_registry_reason(RegularPlaylistUnavailableReason::InvalidCatalogue),
+            PlaylistRowUnavailableReason::InvalidCatalogue
+        );
+        assert_eq!(
+            map_registry_reason(RegularPlaylistUnavailableReason::TrackMissing),
+            PlaylistRowUnavailableReason::TrackMissing
+        );
+    }
+}

--- a/src/ui/source_connect.rs
+++ b/src/ui/source_connect.rs
@@ -10,10 +10,16 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use tracing::info;
 
+use crate::architecture::SourceId;
 use crate::local::engine::LibraryEvent;
+use crate::source_registry::RegularPlaylistTrackResolution;
 
-use super::objects::{SourceObject, TrackObject};
+use super::objects::{
+    PlaylistOccurrenceBinding, PlaylistOccurrenceState, PlaylistRowUnavailableReason, SourceObject,
+    TrackObject,
+};
 use super::playback::refresh_projected_library_uris;
+use super::playlist_projection::{project_playlist_rows, PlaylistRowContent, PlaylistRowSpec};
 use super::preferences;
 use super::radio::{apply_radio_columns, handle_radio_nearme, is_radio_backend, radio_view_origin};
 use super::server_dialogs::{show_auth_dialog, validate_remote_server_url};
@@ -25,7 +31,11 @@ use super::window::{arch_track_to_object, display_tracks};
 use super::window_state::WindowState;
 
 enum PlaylistLoadOutcome {
-    Loaded(Vec<crate::architecture::models::Track>),
+    Smart(Vec<crate::architecture::models::Track>),
+    Regular {
+        rows: Vec<PlaylistRowSpec>,
+        authority: Vec<RegularPlaylistTrackResolution>,
+    },
     Missing,
     Failed,
 }
@@ -302,11 +312,110 @@ fn evict_source_completion(
     }
 }
 
+fn playlist_unavailable_reason_text(reason: PlaylistRowUnavailableReason) -> String {
+    playlist_unavailable_reason_text_for_locale(reason, &rust_i18n::locale())
+}
+
+fn playlist_unavailable_reason_text_for_locale(
+    reason: PlaylistRowUnavailableReason,
+    locale: &str,
+) -> String {
+    let key = match reason {
+        PlaylistRowUnavailableReason::LocalTrackMissing
+        | PlaylistRowUnavailableReason::LocalTrackUnmatched
+        | PlaylistRowUnavailableReason::TrackMissing => "regular_playlist.track_missing",
+        PlaylistRowUnavailableReason::SourceUnavailable => "regular_playlist.source_unavailable",
+        PlaylistRowUnavailableReason::UnsupportedSource => "regular_playlist.source_unsupported",
+        PlaylistRowUnavailableReason::InvalidCatalogue => {
+            "regular_playlist.source_catalogue_unavailable"
+        }
+    };
+    rust_i18n::t!(key, locale = locale).into_owned()
+}
+
+fn unavailable_playlist_row(binding: PlaylistOccurrenceBinding) -> TrackObject {
+    let reason = match binding.state() {
+        PlaylistOccurrenceState::Unavailable(reason) => reason,
+        PlaylistOccurrenceState::AvailableLocal | PlaylistOccurrenceState::AvailableRemote(_) => {
+            unreachable!("unavailable content carries a closed unavailable binding")
+        }
+    };
+    let row = TrackObject::new(
+        0,
+        rust_i18n::t!("regular_playlist.unavailable_track").as_ref(),
+        0,
+        &playlist_unavailable_reason_text(reason),
+        "",
+        "",
+        "",
+        0,
+        "",
+        0,
+        0,
+        0,
+        "",
+        "",
+    );
+    row.set_playlist_occurrence_binding(binding);
+    row
+}
+
+fn remote_playlist_row(
+    binding: PlaylistOccurrenceBinding,
+    track: crate::source_registry::RegularPlaylistTrack,
+) -> TrackObject {
+    let metadata = track.metadata();
+    let row = TrackObject::new(
+        metadata.track_number().unwrap_or(0),
+        metadata.title(),
+        metadata.duration_secs().unwrap_or(0),
+        metadata.artist_name(),
+        metadata.album_title(),
+        metadata.genre().unwrap_or("Unknown"),
+        metadata.composer().unwrap_or(""),
+        metadata.year().unwrap_or(0),
+        &metadata
+            .date_modified()
+            .map(|date| date.format("%Y-%m-%d").to_string())
+            .unwrap_or_default(),
+        metadata.bitrate_kbps().unwrap_or(0),
+        metadata.sample_rate_hz().unwrap_or(0),
+        metadata.play_count().unwrap_or(0),
+        metadata.format().unwrap_or(""),
+        "",
+    );
+    if let Some(album_artist) = metadata.album_artist_name() {
+        row.set_album_artist(album_artist);
+    }
+    row.set_disc_number(metadata.disc_number().unwrap_or(0));
+    row.set_rating(metadata.rating());
+    let guard = track.guard();
+    row.set_source_session_epoch(guard.session_epoch());
+    row.set_source_catalogue_generation(guard.catalogue_generation());
+    row.set_playlist_occurrence_binding(binding);
+    row
+}
+
+pub(super) fn playlist_row_to_object(spec: PlaylistRowSpec) -> TrackObject {
+    let (binding, content) = spec.into_parts();
+    match content {
+        PlaylistRowContent::AvailableLocal(track) => {
+            let architecture_track = crate::local::engine::db_model_to_track(&track);
+            let row = arch_track_to_object(&architecture_track);
+            row.set_playlist_occurrence_binding(binding);
+            row
+        }
+        PlaylistRowContent::AvailableRemote(track) => remote_playlist_row(binding, track),
+        PlaylistRowContent::Unavailable => unavailable_playlist_row(binding),
+    }
+}
+
 /// Load and publish a playlist through the same generation-owned path used by
 /// both explicit navigation and post-reconciliation refreshes.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn load_playlist_source(
     rt_handle: tokio::runtime::Handle,
+    source_registry: crate::source_registry::SourceRegistry,
     playlist_id: String,
     request: SourceRequest,
     navigation: Rc<RefCell<SourceNavigation>>,
@@ -320,6 +429,7 @@ pub(super) fn load_playlist_source(
     column_view: gtk::ColumnView,
 ) {
     let (tracks_tx, tracks_rx) = async_channel::bounded::<PlaylistLoadOutcome>(1);
+    let registry_for_load = source_registry.clone();
 
     rt_handle.spawn(async move {
         let outcome = match crate::db::connection::init_db().await {
@@ -327,21 +437,54 @@ pub(super) fn load_playlist_source(
                 let manager = crate::local::playlist_manager::PlaylistManager::new(db);
                 match manager.get_playlist(&playlist_id).await {
                     Ok(Some(playlist)) => {
-                        let models = if playlist.is_smart {
-                            manager.evaluate_smart_playlist(&playlist_id).await
+                        if playlist.is_smart {
+                            match manager.evaluate_smart_playlist(&playlist_id).await {
+                                Ok(models) => PlaylistLoadOutcome::Smart(
+                                    models
+                                        .iter()
+                                        .map(crate::local::engine::db_model_to_track)
+                                        .collect(),
+                                ),
+                                Err(error) => {
+                                    tracing::warn!(%error, "Failed to evaluate smart playlist");
+                                    PlaylistLoadOutcome::Failed
+                                }
+                            }
                         } else {
-                            manager.get_playlist_tracks(&playlist_id).await
-                        };
-                        match models {
-                            Ok(models) => PlaylistLoadOutcome::Loaded(
-                                models
-                                    .iter()
-                                    .map(crate::local::engine::db_model_to_track)
-                                    .collect(),
-                            ),
-                            Err(error) => {
-                                tracing::warn!(%error, "Failed to load playlist tracks");
-                                PlaylistLoadOutcome::Failed
+                            match manager.load_playlist_entries(&playlist_id).await {
+                                Ok(entries) => {
+                                    let remote_keys = entries
+                                        .iter()
+                                        .filter(|entry| {
+                                            entry.stored.source_id != SourceId::local()
+                                        })
+                                        .filter_map(|entry| entry.stored.media_key())
+                                        .collect::<Vec<_>>();
+                                    let authority = registry_for_load
+                                        .resolve_regular_playlist_tracks(&remote_keys);
+                                    match project_playlist_rows(entries, authority.clone()) {
+                                        Ok(rows)
+                                            if registry_for_load
+                                                .are_regular_playlist_tracks_current(&authority) =>
+                                        {
+                                            PlaylistLoadOutcome::Regular { rows, authority }
+                                        }
+                                        Ok(_) => {
+                                            tracing::debug!(
+                                                "Playlist catalogue changed while rows were projected"
+                                            );
+                                            PlaylistLoadOutcome::Failed
+                                        }
+                                        Err(error) => {
+                                            tracing::warn!(%error, "Playlist projection failed closed");
+                                            PlaylistLoadOutcome::Failed
+                                        }
+                                    }
+                                }
+                                Err(error) => {
+                                    tracing::warn!(%error, "Failed to load regular playlist entries");
+                                    PlaylistLoadOutcome::Failed
+                                }
                             }
                         }
                     }
@@ -367,8 +510,21 @@ pub(super) fn load_playlist_source(
         let Ok(outcome) = tracks_rx.recv().await else {
             return;
         };
-        let tracks = match outcome {
-            PlaylistLoadOutcome::Loaded(tracks) => tracks,
+        let objects = match outcome {
+            PlaylistLoadOutcome::Smart(tracks) => {
+                tracks.iter().map(arch_track_to_object).collect::<Vec<_>>()
+            }
+            PlaylistLoadOutcome::Regular { rows, authority } => {
+                if !source_registry.are_regular_playlist_tracks_current(&authority) {
+                    tracing::debug!(
+                        source = %request.source_key(),
+                        generation = request.generation(),
+                        "Discarding playlist rows whose catalogue authority changed before publication"
+                    );
+                    return;
+                }
+                rows.into_iter().map(playlist_row_to_object).collect()
+            }
             PlaylistLoadOutcome::Missing => {
                 if evict_source_completion(
                     &navigation,
@@ -395,7 +551,6 @@ pub(super) fn load_playlist_source(
                 return;
             }
         };
-        let objects: Vec<TrackObject> = tracks.iter().map(arch_track_to_object).collect();
 
         // A paired rename may commit while this database result is in flight.
         // Overlay the latest committed local paths at the GTK publication
@@ -585,6 +740,7 @@ pub fn setup_source_connect(state: &WindowState) {
 
             load_playlist_source(
                 rt_handle.clone(),
+                source_registry.clone(),
                 playlist_id,
                 request,
                 source_navigation.clone(),
@@ -1053,10 +1209,11 @@ mod tests {
     use url::Url;
 
     use super::{
-        cache_source_completion, evict_source_completion, prepare_remote_auth_submission,
+        cache_source_completion, evict_source_completion,
+        playlist_unavailable_reason_text_for_locale, prepare_remote_auth_submission,
         remote_failure_category, resolve_source_key, retained_removable_connect_failure,
-        with_active_source_key_snapshot, PendingConnection, RemoteFailureCategory,
-        SourceNavigation, TrackObject,
+        with_active_source_key_snapshot, PendingConnection, PlaylistRowUnavailableReason,
+        RemoteFailureCategory, SourceNavigation, TrackObject,
     };
     use crate::architecture::error::BackendError;
     use crate::architecture::AdvertisedHttpRoute;
@@ -1377,6 +1534,42 @@ mod tests {
                         "{locale} must not fall back to English for {category:?}"
                     );
                 }
+            }
+        }
+    }
+
+    #[test]
+    fn every_playlist_unavailable_state_has_non_fallback_localized_copy() {
+        let reasons = [
+            PlaylistRowUnavailableReason::LocalTrackMissing,
+            PlaylistRowUnavailableReason::LocalTrackUnmatched,
+            PlaylistRowUnavailableReason::SourceUnavailable,
+            PlaylistRowUnavailableReason::UnsupportedSource,
+            PlaylistRowUnavailableReason::InvalidCatalogue,
+            PlaylistRowUnavailableReason::TrackMissing,
+        ];
+        let english_title =
+            rust_i18n::t!("regular_playlist.unavailable_track", locale = "en").into_owned();
+        let english_reasons =
+            reasons.map(|reason| playlist_unavailable_reason_text_for_locale(reason, "en"));
+
+        for locale in rust_i18n::available_locales!() {
+            let title =
+                rust_i18n::t!("regular_playlist.unavailable_track", locale = locale).into_owned();
+            assert!(!title.is_empty(), "{locale}: empty unavailable title");
+            for (reason, english) in reasons.into_iter().zip(english_reasons.iter()) {
+                let localized = playlist_unavailable_reason_text_for_locale(reason, &locale);
+                assert!(!localized.is_empty(), "{locale}: empty {reason:?} copy");
+                if locale != "en" {
+                    assert_ne!(
+                        localized,
+                        english.as_str(),
+                        "{locale}: fallback for {reason:?}"
+                    );
+                }
+            }
+            if locale != "en" {
+                assert_ne!(title, english_title, "{locale}: unavailable title fallback");
             }
         }
     }

--- a/src/ui/tracklist.rs
+++ b/src/ui/tracklist.rs
@@ -11,11 +11,11 @@ use gtk::gio;
 use gtk::prelude::*;
 
 use crate::architecture::models::{Rating, RatingCapability, TrackRating};
-use crate::architecture::TrackId;
+use crate::architecture::{SourceId, TrackId};
 use crate::local::engine::LibraryCommand;
 
 use super::library_commands::LibraryCommandAdmission;
-use super::objects::TrackObject;
+use super::objects::{PlaylistOccurrenceState, TrackObject};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct RatingCellPresentation {
@@ -328,6 +328,21 @@ fn add_sorted_column<F, S>(
             .and_downcast::<gtk::Label>()
             .expect("Label");
         label.set_text(&getter(&track));
+        if matches!(
+            track
+                .playlist_occurrence_binding()
+                .map(|binding| binding.state()),
+            Some(PlaylistOccurrenceState::Unavailable(_))
+        ) {
+            let accessible = format!("{} — {}", track.title(), track.artist());
+            label.add_css_class("dim-label");
+            label.set_tooltip_text(Some(&accessible));
+            label.update_property(&[gtk::accessible::Property::Label(&accessible)]);
+        } else {
+            label.remove_css_class("dim-label");
+            label.set_tooltip_text(None);
+            label.reset_property(gtk::AccessibleProperty::Label);
+        }
     });
 
     // Clear label text on recycle to prevent stale data from appearing
@@ -336,6 +351,9 @@ fn add_sorted_column<F, S>(
         let list_item = list_item.downcast_ref::<gtk::ListItem>().expect("ListItem");
         if let Some(label) = list_item.child().and_downcast::<gtk::Label>() {
             label.set_text("");
+            label.remove_css_class("dim-label");
+            label.set_tooltip_text(None);
+            label.reset_property(gtk::AccessibleProperty::Label);
         }
     });
 
@@ -461,12 +479,26 @@ fn add_rating_column(column_view: &gtk::ColumnView, library_commands: LibraryCom
             .and_downcast::<gtk::MenuButton>()
             .expect("rating MenuButton");
         let presentation = rating_cell_presentation(track.rating(), &rust_i18n::locale());
+        let unavailable = matches!(
+            track
+                .playlist_occurrence_binding()
+                .map(|binding| binding.state()),
+            Some(PlaylistOccurrenceState::Unavailable(_))
+        );
+        let accessible_label = if unavailable {
+            format!("{} — {}", track.title(), track.artist())
+        } else {
+            presentation.accessible_label.clone()
+        };
         button.set_label(&presentation.text);
-        button.set_sensitive(presentation.editable);
-        button.set_tooltip_text(Some(&presentation.accessible_label));
-        button.update_property(&[gtk::accessible::Property::Label(
-            &presentation.accessible_label,
-        )]);
+        button.set_sensitive(presentation.editable && local_rating_track_id(&track).is_some());
+        button.set_tooltip_text(Some(&accessible_label));
+        button.update_property(&[gtk::accessible::Property::Label(&accessible_label)]);
+        if unavailable {
+            button.add_css_class("dim-label");
+        } else {
+            button.remove_css_class("dim-label");
+        }
 
         if let Some(spin) = rating_spin_button(&button) {
             spin.set_value(f64::from(presentation.input_value));
@@ -480,6 +512,7 @@ fn add_rating_column(column_view: &gtk::ColumnView, library_commands: LibraryCom
             button.set_sensitive(false);
             button.set_label("");
             button.set_tooltip_text(None);
+            button.remove_css_class("dim-label");
             button.reset_property(gtk::AccessibleProperty::Label);
             if let Some(spin) = rating_spin_button(&button) {
                 spin.set_value(100.0);
@@ -543,13 +576,26 @@ fn queue_rating_command(
     let Some(track) = list_item.item().and_downcast::<TrackObject>() else {
         return false;
     };
-    if !matches!(track.rating(), TrackRating::Writable { .. }) {
-        return false;
-    }
-    let Ok(track_id) = TrackId::new(track.track_id()) else {
+    let Some(track_id) = local_rating_track_id(&track) else {
         return false;
     };
     commands.try_send(LibraryCommand::SetTrackRating { track_id, rating })
+}
+
+fn local_rating_track_id(track: &TrackObject) -> Option<TrackId> {
+    if track.source_id() != Some(SourceId::local()) {
+        return None;
+    }
+    if !matches!(track.rating(), TrackRating::Writable { .. }) {
+        return None;
+    }
+    if track
+        .playlist_occurrence_binding()
+        .is_some_and(|binding| binding.state() != PlaylistOccurrenceState::AvailableLocal)
+    {
+        return None;
+    }
+    TrackId::new(track.track_id()).ok()
 }
 
 fn rating_cell_presentation(rating: TrackRating, locale: &str) -> RatingCellPresentation {
@@ -821,5 +867,61 @@ mod tests {
             ],
             "Note",
         ));
+    }
+
+    #[test]
+    fn rating_write_requires_local_source_even_when_native_ids_and_cached_capability_collide() {
+        let native_id = "shared-native-id";
+        let writable = TrackRating::writable(Some(Rating::new(80).expect("rating")));
+        let local = track(native_id, writable);
+        assert!(local.set_source_id(SourceId::local()));
+        let remote = track(native_id, writable);
+        assert!(remote.set_source_id(SourceId::random()));
+
+        assert_eq!(
+            local_rating_track_id(&local).as_ref().map(TrackId::as_str),
+            Some(native_id)
+        );
+        assert_eq!(local_rating_track_id(&remote), None);
+    }
+
+    #[test]
+    fn rating_write_rejects_unavailable_or_malformed_playlist_bindings() {
+        use crate::ui::objects::{PlaylistOccurrenceBinding, PlaylistRowUnavailableReason};
+
+        let available_id = TrackId::new("available-local").expect("available track ID");
+        let available = track(
+            available_id.as_str(),
+            TrackRating::writable(Some(Rating::new(75).expect("rating"))),
+        );
+        available.set_playlist_occurrence_binding(
+            PlaylistOccurrenceBinding::available_local("entry-available", available_id.clone())
+                .expect("available binding"),
+        );
+
+        let unavailable_id = TrackId::new("missing-local").expect("missing track ID");
+        let unavailable = track(
+            unavailable_id.as_str(),
+            TrackRating::writable(Some(Rating::new(75).expect("rating"))),
+        );
+        unavailable.set_playlist_occurrence_binding(
+            PlaylistOccurrenceBinding::unavailable(
+                "entry-unavailable",
+                SourceId::local(),
+                Some(unavailable_id),
+                PlaylistRowUnavailableReason::LocalTrackMissing,
+            )
+            .expect("unavailable binding"),
+        );
+
+        let missing_source = track("missing-source", TrackRating::writable(None));
+        let malformed_id = track("initially-valid", TrackRating::writable(None));
+        assert!(malformed_id.set_source_id(SourceId::local()));
+        malformed_id.set_track_id("");
+
+        assert_eq!(local_rating_track_id(&available), Some(available_id));
+        assert_eq!(local_rating_track_id(&unavailable), None);
+        assert_eq!(local_rating_track_id(&missing_source), None);
+        assert_eq!(local_rating_track_id(&malformed_id), None);
     }
 }

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -59,6 +59,7 @@ const BROWSER_POS: i32 = 220;
 type SharedAudioOutput = Rc<RefCell<Box<dyn AudioOutput>>>;
 type PlaybackUiReset = Rc<dyn Fn()>;
 type SourcePlaybackInvalidator = Rc<dyn Fn(&str)>;
+type PlaylistPlaybackInvalidator = Rc<dyn Fn(crate::architecture::SourceId)>;
 
 fn configured_server_url(variable: &'static str) -> Option<String> {
     let raw = std::env::var(variable).ok()?;
@@ -144,6 +145,7 @@ fn set_remote_connecting_generation(
 
 #[derive(Clone)]
 struct SourceReducerContext {
+    rt_handle: tokio::runtime::Handle,
     source_registry: crate::source_registry::SourceRegistry,
     sidebar_store: gtk::gio::ListStore,
     sidebar_selection: gtk::SingleSelection,
@@ -160,6 +162,7 @@ struct SourceReducerContext {
     column_view: gtk::ColumnView,
     app_config: Rc<RefCell<preferences::AppConfig>>,
     invalidate_source_playback: SourcePlaybackInvalidator,
+    invalidate_playlist_playback: PlaylistPlaybackInvalidator,
 }
 
 #[derive(Default)]
@@ -310,8 +313,10 @@ impl SourceReducerContext {
     fn from_window(
         state: &WindowState,
         invalidate_source_playback: SourcePlaybackInvalidator,
+        invalidate_playlist_playback: PlaylistPlaybackInvalidator,
     ) -> Self {
         Self {
+            rt_handle: state.rt_handle.clone(),
             source_registry: state.source_registry.clone(),
             sidebar_store: state.sidebar_store.clone(),
             sidebar_selection: state.sidebar_selection.clone(),
@@ -328,6 +333,7 @@ impl SourceReducerContext {
             column_view: state.column_view.clone(),
             app_config: state.app_config.clone(),
             invalidate_source_playback,
+            invalidate_playlist_playback,
         }
     }
 }
@@ -746,7 +752,14 @@ fn publish_radio_view(
         .value
         .tracks()
         .iter()
-        .map(|track| arch_remote_track_to_object(track, accepted.session_epoch))
+        .map(|track| {
+            arch_remote_track_to_object(
+                track,
+                crate::architecture::SourceId::radio_browser(),
+                accepted.session_epoch,
+                accepted.generation,
+            )
+        })
         .collect();
     context
         .source_tracks
@@ -824,6 +837,7 @@ fn reconcile_source_baseline(
         radio_prerequisite_pending,
         &ui_owned_sources,
     );
+    let mut playlist_authority_changed = !clear_projections.is_empty();
 
     // Projection loss is authoritative before any plain row-state rebind.
     // In particular, a selected retained passwordless DAAP row must already
@@ -950,6 +964,10 @@ fn reconcile_source_baseline(
         {
             let identity = (catalogue.generation, catalogue.session_epoch);
             if reducer.published_catalogues.get(&source_id) != Some(&identity) {
+                playlist_authority_changed = true;
+                if reducer.published_catalogues.contains_key(&source_id) {
+                    (context.invalidate_playlist_playback)(source_id);
+                }
                 if reducer
                     .published_catalogues
                     .get(&source_id)
@@ -963,7 +981,14 @@ fn reconcile_source_baseline(
                     .value
                     .tracks()
                     .iter()
-                    .map(|track| arch_remote_track_to_object(track, catalogue.session_epoch))
+                    .map(|track| {
+                        arch_remote_track_to_object(
+                            track,
+                            source_id,
+                            catalogue.session_epoch,
+                            catalogue.generation,
+                        )
+                    })
                     .collect();
                 publish_remote_library(
                     source_id,
@@ -1071,14 +1096,35 @@ fn reconcile_source_baseline(
             "Source lifecycle reducer observed shutdown gate"
         );
     }
+
+    if playlist_authority_changed && !baseline.shutting_down {
+        invalidate_playlist_projections(
+            &context.rt_handle,
+            &context.source_registry,
+            &context.source_navigation,
+            &context.source_tracks,
+            &context.active_source_key,
+            &context.track_store,
+            &context.master_tracks,
+            &context.browser_widget,
+            &context.browser_state,
+            &context.status_label,
+            &context.column_view,
+        );
+    }
 }
 
 fn setup_source_lifecycle_reducer(
     state: &WindowState,
     mut invalidations: tokio::sync::watch::Receiver<u64>,
     invalidate_source_playback: SourcePlaybackInvalidator,
+    invalidate_playlist_playback: PlaylistPlaybackInvalidator,
 ) {
-    let context = SourceReducerContext::from_window(state, invalidate_source_playback);
+    let context = SourceReducerContext::from_window(
+        state,
+        invalidate_source_playback,
+        invalidate_playlist_playback,
+    );
     glib::MainContext::default().spawn_local(async move {
         let mut reducer = SourceReducerState::default();
         let baseline = context.source_registry.snapshot_all();
@@ -1352,6 +1398,27 @@ pub fn build_window(
                 clear_ui();
             }
             info!("Stopped playback owned by a retired source");
+        })
+    };
+    let invalidate_playlist_playback: PlaylistPlaybackInvalidator = {
+        let playback_session = playback_session.clone();
+        let active_output_slot = active_output_slot.clone();
+        let playback_ui_reset_slot = playback_ui_reset_slot.clone();
+        Rc::new(move |source_id| {
+            if !playback_session
+                .borrow_mut()
+                .clear_if_playlist_authority(source_id)
+            {
+                return;
+            }
+
+            if let Some(active_output) = active_output_slot.borrow().as_ref().cloned() {
+                active_output.borrow().stop();
+            }
+            if let Some(clear_ui) = playback_ui_reset_slot.borrow().as_ref().cloned() {
+                clear_ui();
+            }
+            info!(%source_id, "Stopped playlist playback after catalogue authority changed");
         })
     };
 
@@ -1843,6 +1910,7 @@ pub fn build_window(
         &source_connection_state,
         source_invalidations,
         invalidate_source_playback.clone(),
+        invalidate_playlist_playback,
     );
 
     // ═══════════════════════════════════════════════════════════════════
@@ -1871,6 +1939,7 @@ pub fn build_window(
             setup_library_events(
                 engine_rx,
                 rt_handle.clone(),
+                source_registry.clone(),
                 track_store,
                 status_label,
                 master_tracks,
@@ -2914,6 +2983,7 @@ pub fn build_window(
     setup_library_events(
         engine_rx,
         rt_handle.clone(),
+        source_registry,
         track_store,
         status_label,
         master_tracks,
@@ -3051,6 +3121,7 @@ fn replace_existing_local_track(rows: &mut [TrackObject], replacement: &TrackObj
 #[allow(clippy::too_many_arguments)]
 fn invalidate_playlist_projections(
     rt_handle: &tokio::runtime::Handle,
+    source_registry: &crate::source_registry::SourceRegistry,
     source_navigation: &Rc<RefCell<SourceNavigation>>,
     source_tracks: &Rc<RefCell<HashMap<String, Vec<TrackObject>>>>,
     active_source_key: &Rc<RefCell<String>>,
@@ -3095,6 +3166,7 @@ fn invalidate_playlist_projections(
         let request = source_navigation.borrow_mut().select(active_key);
         super::source_connect::load_playlist_source(
             rt_handle.clone(),
+            source_registry.clone(),
             playlist_id,
             request,
             source_navigation.clone(),
@@ -3115,6 +3187,7 @@ fn invalidate_playlist_projections(
 fn setup_library_events(
     engine_rx: async_channel::Receiver<LibraryEvent>,
     rt_handle: tokio::runtime::Handle,
+    source_registry: crate::source_registry::SourceRegistry,
     track_store: gtk::gio::ListStore,
     status_label: gtk::Label,
     master_tracks: Rc<RefCell<Vec<TrackObject>>>,
@@ -3402,6 +3475,7 @@ fn setup_library_events(
 
                     invalidate_playlist_projections(
                         &rt_handle,
+                        &source_registry,
                         &source_navigation,
                         &source_tracks,
                         &active_source_key,
@@ -3422,6 +3496,7 @@ fn setup_library_events(
                 LibraryEvent::PlaylistProjectionsInvalidated => {
                     invalidate_playlist_projections(
                         &rt_handle,
+                        &source_registry,
                         &source_navigation,
                         &source_tracks,
                         &active_source_key,
@@ -3805,16 +3880,24 @@ pub fn arch_track_to_object(t: &crate::architecture::models::Track) -> TrackObje
         })
         .unwrap_or_default();
 
-    track_to_object(t, &uri, t.cover_art_url.as_ref().map(url::Url::as_str))
+    let object = track_to_object(t, &uri, t.cover_art_url.as_ref().map(url::Url::as_str));
+    let source_bound = object.set_source_id(crate::architecture::SourceId::local());
+    debug_assert!(source_bound, "a fresh local row accepts its exact owner");
+    object
 }
 
 /// Convert a remote track into a pathless row bound to one adopted session.
 fn arch_remote_track_to_object(
     track: &crate::architecture::models::Track,
+    source_id: crate::architecture::SourceId,
     session_epoch: u64,
+    catalogue_generation: u64,
 ) -> TrackObject {
     let object = track_to_object(track, "", None);
+    let source_bound = object.set_source_id(source_id);
+    debug_assert!(source_bound, "a fresh remote row accepts its exact owner");
     object.set_source_session_epoch(session_epoch);
+    object.set_source_catalogue_generation(catalogue_generation);
     object
 }
 
@@ -4045,10 +4128,13 @@ mod identity_tests {
             last_played: None,
         };
 
-        let row = arch_remote_track_to_object(&track, 9);
+        let source_id = crate::architecture::SourceId::random();
+        let row = arch_remote_track_to_object(&track, source_id, 9, 17);
         assert_eq!(row.track_id(), "rating-track");
         assert_eq!(row.rating(), rating);
+        assert_eq!(row.source_id(), Some(source_id));
         assert_eq!(row.source_session_epoch(), Some(9));
+        assert_eq!(row.source_catalogue_generation(), Some(17));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Integrate authenticated Subsonic, Jellyfin, Plex, and DAAP tracks into regular Tributary playlists using exact source-scoped identity.
- Preserve playlist order and duplicate occurrences, render localized unavailable rows when a source or track disappears, and remove the exact selected occurrence.
- Route remote playback and artwork through current-session source authority while keeping ratings and playback history local-only.
- Make multi-track additions all-or-none: stage the SQL transaction, acquire exact current source authority immediately before commit, roll back if refresh or disconnect wins, and retain commit permits until commit or rollback completes.
- Refuse mixed-source or unresolved regular-playlist XSPF export before touching the destination instead of silently truncating it to local tracks.
- Update the README, changelog, task tracker, roadmap, source-scoped playlist contract, lifecycle architecture, and all 13 locales.

## Review follow-up

- Fixed Rust 1.97 Clippy `manual_option_zip` compatibility.
- Closed the reported authority time-of-check/time-of-use race by coupling final validation and authority ownership to the database transaction.
- Added deterministic coverage for disconnect-wins rollback, catalogue replacement, permit revocation, current-thread commit versus disconnect, cancellation-safe completion ownership, duplicate guard deduplication, and all-or-none XSPF refusal.

## Validation

- `cargo test --release`: 1,144 passed
- `cargo +1.92 check --all-targets --locked`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --release -- -D warnings`
- `cargo build --release --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`

Implements the mixed-source regular-playlist portion of #47. Import and pull synchronization of playlists owned by a Subsonic server remain a separate follow-up capability.
