### PR TITLE
Harden release component boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
+
+      - name: Test package compliance policies
+        run: |
+          build-aux/linux/test-package-compliance.sh
+          scripts/test-macos-package-policy.sh
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
       - name: Run cargo audit
@@ -103,7 +108,7 @@ jobs:
     steps:
       - name: Install system dependencies (Fedora)
         run: |
-          dnf install -y gcc gcc-c++ gtk4-devel libadwaita-devel \
+          dnf install -y elfutils gcc gcc-c++ gtk4-devel libadwaita-devel \
             dbus-devel \
             gstreamer1-devel gstreamer1-plugins-base-devel \
             gstreamer1-plugins-good gstreamer1-plugins-bad-free gstreamer1-plugins-ugly-free gstreamer1-libav \
@@ -138,6 +143,9 @@ jobs:
 
       - name: Build (release)
         run: cargo build --release
+
+      - name: Validate Linux binary payload
+        run: build-aux/linux/validate-package-compliance.sh --elf target/release/tributary
 
       - name: Run tests
         run: cargo test --release
@@ -331,6 +339,24 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Parse bundler with Windows PowerShell 5.1
+        if: matrix.arch == 'x86_64'
+        shell: powershell
+        run: |
+          $parseTokens = $null
+          $parseErrors = $null
+          $null = [System.Management.Automation.Language.Parser]::ParseFile(
+            (Resolve-Path 'scripts/build-windows.ps1').Path,
+            [ref]$parseTokens,
+            [ref]$parseErrors
+          )
+          if (@($parseErrors).Count -gt 0) {
+            foreach ($parseError in @($parseErrors)) {
+              Write-Error $parseError.Message
+            }
+            exit 1
+          }
+
       - name: Set up MSYS2 (${{ matrix.msystem }})
         uses: msys2/setup-msys2@v2.32.0
         env:
@@ -451,6 +477,12 @@ jobs:
       - name: Test Flatpak permission policy
         run: build-aux/flatpak/test-permissions.sh
 
+      - name: Test Linux package compliance policy
+        run: |
+          command -v ostree
+          command -v readelf || command -v eu-readelf
+          build-aux/linux/test-package-compliance.sh
+
       - name: Install Python dependencies
         run: |
           python3 -m pip install --requirement build-aux/flatpak/generator-requirements.txt \
@@ -465,6 +497,9 @@ jobs:
           bundle: tributary.flatpak
           manifest-path: build-aux/flatpak/io.github.tributary.Tributary.yml
           cache-key: flatpak-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Validate completed Flatpak bundle payload
+        run: build-aux/flatpak/validate-bundle-compliance.sh tributary.flatpak
 
       - name: Upload Flatpak bundle
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
     steps:
       - name: Install system dependencies (Fedora)
         run: |
-          dnf install -y elfutils gcc gcc-c++ gtk4-devel libadwaita-devel \
+          dnf install -y binutils gcc gcc-c++ gtk4-devel libadwaita-devel \
             dbus-devel \
             gstreamer1-devel gstreamer1-plugins-base-devel \
             gstreamer1-plugins-good gstreamer1-plugins-bad-free gstreamer1-plugins-ugly-free gstreamer1-libav \
@@ -295,6 +295,13 @@ jobs:
           cargo test --release --target ${{ matrix.rust_target }}
 
       - name: Create .app bundle and .dmg
+        # Production must pin the repository policy and platform inspectors,
+        # ignoring the helper's deliberately injectable test hooks.
+        env:
+          TRIBUTARY_FORBIDDEN_COMPONENTS_FILE: /dev/null
+          MACOS_FIND_COMMAND: /usr/bin/true
+          MACOS_OTOOL_COMMAND: /usr/bin/false
+          MACOS_OD_COMMAND: /usr/bin/false
         run: |
           # Copy the target-specific binary to the default location expected by build-macos.sh
           mkdir -p target/release
@@ -480,7 +487,7 @@ jobs:
       - name: Test Linux package compliance policy
         run: |
           command -v ostree
-          command -v readelf || command -v eu-readelf
+          command -v readelf
           build-aux/linux/test-package-compliance.sh
 
       - name: Install Python dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Install Flatpak & Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y flatpak flatpak-builder elfutils ostree python3-pip
+          sudo apt-get install -y binutils flatpak flatpak-builder ostree python3-pip
 
           # Fix Polkit permission errors for headless bare-metal Flatpak
           sudo mkdir -p /etc/polkit-1/rules.d
@@ -421,7 +421,7 @@ jobs:
     steps:
       - name: Install system dependencies
         run: |
-          dnf install -y cpio elfutils gcc rpm-build gtk4-devel libadwaita-devel \
+          dnf install -y binutils cpio gcc rpm-build gtk4-devel libadwaita-devel \
             dbus-devel \
             gstreamer1-devel gstreamer1-plugins-base-devel \
             pkgconf-pkg-config git curl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Install Flatpak & Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y flatpak flatpak-builder elfutils python3-pip
+          sudo apt-get install -y flatpak flatpak-builder elfutils ostree python3-pip
 
           # Fix Polkit permission errors for headless bare-metal Flatpak
           sudo mkdir -p /etc/polkit-1/rules.d
@@ -144,6 +144,11 @@ jobs:
           manifest-path: build-aux/flatpak/io.github.tributary.Tributary.yml
           cache-key: flatpak-${{ matrix.arch }}-${{ hashFiles('**/Cargo.lock') }}
           arch: ${{ matrix.arch }}
+
+      - name: Validate completed Flatpak bundle payload
+        run: >-
+          build-aux/flatpak/validate-bundle-compliance.sh
+          tributary-linux-${{ matrix.arch }}.flatpak
 
       - name: Upload Flatpak as workflow artifact
         uses: actions/upload-artifact@v7
@@ -355,7 +360,7 @@ jobs:
       - name: Install system dependencies
         run: |
           apt-get update
-          apt-get install -y build-essential curl git pkg-config \
+          apt-get install -y binutils build-essential curl git pkg-config \
             libgtk-4-dev libadwaita-1-dev \
             libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
             libdbus-1-dev
@@ -385,6 +390,11 @@ jobs:
       - name: Build .deb package
         run: cargo deb -o target/debian/tributary-${{ matrix.deb_arch }}.deb
 
+      - name: Validate completed .deb payload
+        run: >-
+          build-aux/linux/validate-package-compliance.sh --deb
+          target/debian/tributary-${{ matrix.deb_arch }}.deb
+
       - name: Upload .deb as workflow artifact
         uses: actions/upload-artifact@v7
         with:
@@ -411,7 +421,7 @@ jobs:
     steps:
       - name: Install system dependencies
         run: |
-          dnf install -y gcc gtk4-devel libadwaita-devel \
+          dnf install -y cpio elfutils gcc rpm-build gtk4-devel libadwaita-devel \
             dbus-devel \
             gstreamer1-devel gstreamer1-plugins-base-devel \
             pkgconf-pkg-config git curl
@@ -449,6 +459,11 @@ jobs:
           RPM_FILE=$(ls target/generate-rpm/*.rpm | head -1)
           mv "$RPM_FILE" "target/generate-rpm/tributary-${{ matrix.rpm_arch }}.rpm"
 
+      - name: Validate completed .rpm payload
+        run: >-
+          build-aux/linux/validate-package-compliance.sh --rpm
+          target/generate-rpm/tributary-${{ matrix.rpm_arch }}.rpm
+
       - name: Upload .rpm as workflow artifact
         uses: actions/upload-artifact@v7
         with:
@@ -466,7 +481,7 @@ jobs:
     steps:
       - name: Install system dependencies
         run: |
-          pacman -Syu --noconfirm git gtk4 libadwaita gstreamer sqlite \
+          pacman -Syu --noconfirm binutils git libarchive gtk4 libadwaita gstreamer sqlite \
             gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav dbus rust
 
       - uses: actions/checkout@v7
@@ -506,6 +521,11 @@ jobs:
           PKG_FILE=$(ls /home/builder/tributary/*.pkg.tar.zst | head -1)
           mkdir -p dist
           cp "$PKG_FILE" dist/tributary-x86_64.pkg.tar.zst
+
+      - name: Validate completed Arch package payload
+        run: >-
+          build-aux/linux/validate-package-compliance.sh --arch
+          dist/tributary-x86_64.pkg.tar.zst
 
       - name: Upload Arch package as workflow artifact
         uses: actions/upload-artifact@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -524,20 +524,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Release artifacts now reject unused optical-disc decryption and DRM components** — The Windows
   and macOS helpers previously copied the installed GStreamer plugin directory broadly and followed
   each plugin's native dependency closure. That could carry an unrelated host component such as the
-  observed `libdvdcss-2.dll` into Tributary even though Tributary has no DVD, Blu-ray, or protected
-  media feature. One shared, fail-closed filename policy now excludes unused DVD/Blu-ray access
-  plugins, dedicated CSS/AACS/BD+/MakeMKV-style decrypt bridges, conventional AACS key databases,
-  and proprietary content-decryption modules before traversal, rejects a denied transitive
-  dependency, and scans the finished payload before archive, installer, signing, or disk-image
-  creation. Link-based denied-component escapes and incomplete inspection paths fail closed;
-  Windows reopens the final ZIP and installer-only mode revalidates its existing tree so stale
-  incremental files cannot
-  bypass the gate. Native `.deb`, `.rpm`, Arch, and Flatpak application payloads receive
-  corresponding relationship, control/installer-script, direct-ELF, and final-content checks,
-  including the independent Packit/COPR RPM buildroot, without treating a separately delivered
-  system/Flatpak runtime as bundled by Tributary. Ordinary audio codecs, TLS, and general-purpose
+  observed `libdvdcss-2.dll` into Tributary even though Tributary has no DVD, Blu-ray, or
+  DRM-protected media feature. One shared, fail-closed filename policy now excludes unused
+  DVD/Blu-ray access plugins, dedicated CSS/AACS/BD+/MakeMKV-style decrypt bridges, the Debian
+  `libdvd-pkg` installer, conventional AACS key databases, and proprietary content-decryption
+  modules before traversal; it rejects denied transitive dependencies and recognizable path
+  references and scans the finished payload before archive, installer, signing, or disk-image
+  creation. Link-based denied-component escapes and incomplete inspection paths fail closed.
+  Windows validates forced-copy sources, performs a bounded hidden-inclusive final PE-import pass,
+  reopens the final ZIP, and repeats tree/import validation in installer-only mode so stale or
+  post-closure files cannot bypass the gate. macOS pins its canonical policy and inspection tools,
+  checks native plugin/dependency source paths and linked dependency, rpath, and load-command path
+  components under a fixed ASCII locale, and recognizes Mach-O files by magic even in nonstandard
+  locations without executable bits. Native `.deb`, `.rpm`, Arch, and Flatpak application payloads
+  receive corresponding relationship, control/installer-script, all-bracketed ELF dynamic metadata,
+  program-interpreter, and final-content checks—including the independent Packit/COPR RPM buildroot—
+  without treating a separately delivered system/Flatpak runtime as bundled by Tributary. The gate
+  requires GNU `readelf`, rather than the elfutils variant that leaves filtered-library names as
+  unresolved offsets, and failed ELF inspection cleans its private temporary state. Ordinary audio
+  codecs, TLS, and general-purpose
   cryptography remain supported and are explicitly distinguished from dedicated copy-control
-  bypass components in the documented release policy. The accompanying sender-provenance review
+  bypass components in the documented release policy. The generic `libbluray` navigation library
+  required by MSYS2's FFmpeg/libav build remains eligible because it does not itself provide DRM
+  decryption; the unused `gstbluray` plugin and separate AACS/BD+ libraries remain denied. The
+  accompanying sender-provenance review
   also confirmed that current official GStreamer, Homebrew, and MSYS2 packages do not provide the
   `raopsink` element previously claimed for AirPlay 1, so the ineffective instruction to install
   `gst-plugins-bad` is replaced by an honest unavailable-sender message. GStreamer's removed legacy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -519,6 +519,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a relative date rule is reopened and saved.
   ([#137](https://github.com/jm2/tributary/pull/137))
 
+### Security
+
+- **Release artifacts now reject unused optical-disc decryption and DRM components** — The Windows
+  and macOS helpers previously copied the installed GStreamer plugin directory broadly and followed
+  each plugin's native dependency closure. That could carry an unrelated host component such as the
+  observed `libdvdcss-2.dll` into Tributary even though Tributary has no DVD, Blu-ray, or protected
+  media feature. One shared, fail-closed filename policy now excludes unused DVD/Blu-ray access
+  plugins, dedicated CSS/AACS/BD+/MakeMKV-style decrypt bridges, conventional AACS key databases,
+  and proprietary content-decryption modules before traversal, rejects a denied transitive
+  dependency, and scans the finished payload before archive, installer, signing, or disk-image
+  creation. Link-based denied-component escapes and incomplete inspection paths fail closed;
+  Windows reopens the final ZIP and installer-only mode revalidates its existing tree so stale
+  incremental files cannot
+  bypass the gate. Native `.deb`, `.rpm`, Arch, and Flatpak application payloads receive
+  corresponding relationship, control/installer-script, direct-ELF, and final-content checks,
+  including the independent Packit/COPR RPM buildroot, without treating a separately delivered
+  system/Flatpak runtime as bundled by Tributary. Ordinary audio codecs, TLS, and general-purpose
+  cryptography remain supported and are explicitly distinguished from dedicated copy-control
+  bypass components in the documented release policy. The accompanying sender-provenance review
+  also confirmed that current official GStreamer, Homebrew, and MSYS2 packages do not provide the
+  `raopsink` element previously claimed for AirPlay 1, so the ineffective instruction to install
+  `gst-plugins-bad` is replaced by an honest unavailable-sender message. GStreamer's removed legacy
+  `apexsink` used a public key to encrypt outbound audio and is not bundled by Tributary.
+
 ### Fixed
 - **Linux library reads no longer feed a recursive rescan loop** — Filesystem notifications
   explicitly classified as access or access-time observations and produced by Tributary's own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -532,9 +532,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   references and scans the finished payload before archive, installer, signing, or disk-image
   creation. Link-based denied-component escapes and incomplete inspection paths fail closed.
   Windows validates forced-copy sources, performs a bounded hidden-inclusive final PE-import pass,
-  reopens the final ZIP, and repeats tree/import validation in installer-only mode so stale or
-  post-closure files cannot bypass the gate. macOS pins its canonical policy and inspection tools,
-  checks native plugin/dependency source paths and linked dependency, rpath, and load-command path
+  recognizes the legacy system `.drv` module spelling used by current GTK packages while placing
+  any bundled DRV in the same inspected target set, reopens the final ZIP, and repeats tree/import
+  validation in installer-only mode so stale or post-closure files cannot bypass the gate. macOS
+  pins its canonical policy and inspection tools, checks native plugin/dependency source paths and
+  linked dependency, rpath, and load-command path
   components under a fixed ASCII locale, and recognizes Mach-O files by magic even in nonstandard
   locations without executable bits. Native `.deb`, `.rpm`, Arch, and Flatpak application payloads
   receive corresponding relationship, control/installer-script, all-bracketed ELF dynamic metadata,

--- a/README.md
+++ b/README.md
@@ -302,13 +302,13 @@ This produces `dist/tributary-windows.zip` with the executable and all required 
 
 ### Release artifact component policy
 
-Tributary does not play DVDs, Blu-ray discs, or protected media. Its packaging helpers exclude and
+Tributary does not play DVDs, Blu-ray discs, or DRM-protected media. Its packaging helpers exclude and
 fail closed on dedicated optical-disc copy-control/decryption components, unused disc-access
 plugins that can introduce them transitively, and proprietary content-decryption modules. Windows
 and macOS validate their self-contained application trees; native Linux packages validate their
 own payload, package relationships, and installer metadata, while Flatpak validates its complete
 app-owned commit (`/app`, exports, and metadata) rather than the separately delivered shared
-runtime. Windows rejects filesystem links before copying and reopens the completed ZIP, while the
+runtime. Windows rejects filesystem reparse points before copying and reopens the completed ZIP, while the
 same final validation protects incremental and installer-only packaging from stale files.
 
 Ordinary audio codecs, TLS, and general-purpose cryptography are intentionally distinct from that

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ Tributary provides a unified interface for managing and streaming music from mul
 | XDG music directory support (non-English locales) | ✅ |
 | Network connection guard (prevents duplicate auth) | ✅ |
 | i18n/l10n framework (13 languages, auto locale detection) | ✅ |
-| Audio output selector (local + MPD, iTunes AirPlay-style) | ✅ |
+| Audio output selector (local + MPD + Chromecast; AirPlay discovery seam) | ✅ |
 | MPD output backend (sink-only, TCP with security hardening) | ✅ Requires explicit exclusive-control confirmation |
 | Output switching (click to swap local ↔ MPD) | ✅ |
-| AirPlay 1 (RAOP) output | ✅ Requires GStreamer's `raopsink` element (ships in `gst-plugins-bad`); a missing element fails with an actionable install message |
-| AirPlay 2 / HomeKit output | ❌ Not yet supported — see [AirPlay 2 roadmap](#airplay-2-roadmap) below |
+| AirPlay 1 (RAOP) output | ⚠️ Discovery and a fail-closed integration seam exist, but current supported GStreamer/Homebrew/MSYS2 packages do not ship the required `raopsink` sender |
+| AirPlay 2 / HomeKit output | ❌ Not yet supported — see [AirPlay roadmap](#airplay-roadmap) below |
 | Chromecast output (Cast V2 — local files + remote sources) | ✅ |
 | Album artist sort (preference toggle) | ✅ |
 | Smart playlist compound sort (multi-key ordering) | ✅ |
@@ -300,6 +300,22 @@ rustup target add x86_64-pc-windows-gnullvm
 
 This produces `dist/tributary-windows.zip` with the executable and all required DLLs/resources.
 
+### Release artifact component policy
+
+Tributary does not play DVDs, Blu-ray discs, or protected media. Its packaging helpers exclude and
+fail closed on dedicated optical-disc copy-control/decryption components, unused disc-access
+plugins that can introduce them transitively, and proprietary content-decryption modules. Windows
+and macOS validate their self-contained application trees; native Linux packages validate their
+own payload, package relationships, and installer metadata, while Flatpak validates its complete
+app-owned commit (`/app`, exports, and metadata) rather than the separately delivered shared
+runtime. Windows rejects filesystem links before copying and reopens the completed ZIP, while the
+same final validation protects incremental and installer-only packaging from stale files.
+
+Ordinary audio codecs, TLS, and general-purpose cryptography are intentionally distinct from that
+deny policy and remain available for supported playback. See the
+[release component policy](docs/release-component-policy.md) for the exact enforcement and review
+boundary.
+
 ### Flatpak (Linux)
 
 The manifest builds offline (`CARGO_NET_OFFLINE=true`) from a generated
@@ -310,7 +326,7 @@ same location.
 
 ```bash
 # Install the tools and configure Flathub for this user:
-sudo apt install flatpak flatpak-builder python3-venv
+sudo apt install binutils flatpak flatpak-builder ostree python3-venv
 flatpak remote-add --if-not-exists --user flathub \
   https://dl.flathub.org/repo/flathub.flatpakrepo
 
@@ -481,7 +497,7 @@ src/
 │   ├── output.rs           # AudioOutput trait abstraction
 │   ├── local_output.rs     # Local GStreamer playback (AudioOutput impl)
 │   ├── mpd_output.rs       # MPD TCP output (AudioOutput impl)
-│   ├── airplay_output.rs   # AirPlay 1/RAOP GStreamer output
+│   ├── airplay_output.rs   # Runtime-gated AirPlay 1/RAOP sender seam
 │   ├── chromecast_output.rs# Chromecast/Cast V2 output (local + remote)
 │   └── cast_http_server.rs # Embedded LAN-only HTTP server for Chromecast
 ├── db/
@@ -969,8 +985,9 @@ playlist projections only after commit. Normal shutdown first closes the shared 
 disables playback/media/open-file producers, and appends a FIFO marker, so no later callback can
 queue behind the admitted history/root-trust commands it waits to finish. The disabled window can
 remain visible while an earlier serialized library scan finishes.
-AirPlay 1 contributes the same evidence through generation-scoped 500 ms position updates. Remote,
-radio, removable, and ephemeral files do not write local history. Recently Played now uses one
+The gated AirPlay 1 seam contributes the same evidence through generation-scoped 500 ms position
+updates only when an external compatible sender is present. Remote, radio, removable, and ephemeral
+files do not write local history. Recently Played now uses one
 evaluation clock and includes only valid, non-future last-played instants in the inclusive previous
 14 days, newest first with stable track-ID ties; null or corrupt history yields an intentional empty
 playlist. Top 25 admits positive counts—including legacy counts with no timestamp—then uses count
@@ -997,9 +1014,15 @@ Open **Preferences** from the hamburger menu (☰) to:
 
 ---
 
-## AirPlay 2 roadmap
+## AirPlay roadmap
 
-AirPlay 2 receivers (HomePod, recent Apple TVs, AirPlay-2-certified third-party speakers) advertise via `_airplay._tcp.local.` and are detected by the discovery layer today, but the output implementation only speaks the legacy RAOP protocol via GStreamer's `raopsink` element. AirPlay 2 uses a different protocol stack and cannot be driven by `raopsink`, so AirPlay-2-only devices are filtered out of the output selector to avoid silent playback failures. Re-enabling them requires real sender-side support to land first.
+Legacy RAOP receivers are discovered today, but Tributary's AirPlay 1 path is only a runtime-gated
+integration seam for a GStreamer element named `raopsink`. Current official GStreamer,
+Homebrew, and MSYS2 packages do not ship that element, so supported builds report AirPlay 1 as
+unavailable instead of recommending an unrelated package. AirPlay 2 receivers (HomePod, recent
+Apple TVs, and AirPlay-2-certified third-party speakers) advertise via `_airplay._tcp.local.` and
+are also detected by discovery, but remain filtered out because AirPlay 2 needs a different sender
+protocol stack. Both paths require a maintained sender implementation and real-device validation.
 
 Sender-side AirPlay 2 support requires, at minimum:
 
@@ -1013,7 +1036,8 @@ Each of these has specifics (key exchange algorithms, audio codec, RTSP/HTTP ver
 Likely paths forward (each to be evaluated when the work begins):
 
 - **Subprocess delegation** to a maintained external tool. Cheaper to integrate, but adds a runtime dependency outside the single-binary distribution model.
-- **A pure-Rust sender implementation**, either in-tree or as a contributed `gst-plugins-rs` element, so it can plug into the same pipeline pattern `raopsink` uses today. Higher engineering cost; cleanest distribution story.
+- **A pure-Rust sender implementation**, either in-tree or as a contributed `gst-plugins-rs`
+  element. Higher engineering cost; cleanest distribution and provenance story.
 - **Wait for an upstream component** to mature to the point that one of the above becomes obviously preferable.
 
 The hook for whichever path is chosen is `service_type: "airplay2"` in [`src/discovery.rs`](src/discovery.rs); today that branch is dropped by [`src/ui/discovery_handler.rs`](src/ui/discovery_handler.rs), and that's where AirPlay 2 sender support will plug in.

--- a/build-aux/arch/PKGBUILD
+++ b/build-aux/arch/PKGBUILD
@@ -29,6 +29,12 @@ build() {
   cargo build --release
 }
 
+check() {
+  cd "$startdir"
+  build-aux/linux/test-package-compliance.sh
+  build-aux/linux/validate-package-compliance.sh --elf target/release/tributary
+}
+
 package() {
   cd "$startdir"
 
@@ -52,4 +58,8 @@ package() {
 
   # License
   install -Dm644 "LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+
+  # Keep the completed package payload covered even when a third-party builder
+  # invokes makepkg with --nocheck and skips check().
+  build-aux/linux/validate-package-compliance.sh --tree "$pkgdir"
 }

--- a/build-aux/flatpak/io.github.tributary.Tributary.yml
+++ b/build-aux/flatpak/io.github.tributary.Tributary.yml
@@ -60,6 +60,9 @@ modules:
             "data/icons/hicolor/${size}x${size}/apps/io.github.tributary.Tributary.png"
             "/app/share/icons/hicolor/${size}x${size}/apps/io.github.tributary.Tributary.png";
         done
+      # Inspect only the app-owned /app payload. The referenced GNOME runtime
+      # remains outside the bundle and continues to provide ordinary codecs.
+      - bash build-aux/linux/validate-package-compliance.sh --tree /app
     sources:
       - type: dir
         path: ../..

--- a/build-aux/flatpak/validate-bundle-compliance.sh
+++ b/build-aux/flatpak/validate-bundle-compliance.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Import the completed single-file bundle into an isolated OSTree repository
+# and inspect the complete app commit: its /app files, exported metadata/assets,
+# and commit metadata. Flatpak bundles omit the referenced platform runtime, so
+# ordinary runtime codecs remain outside Tributary's app-owned boundary.
+
+set -eu
+set -f
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+validator="$script_dir/../linux/validate-package-compliance.sh"
+bundle=${1:-}
+
+if [ -z "$bundle" ] || [ "$#" -ne 1 ]; then
+    echo "Usage: validate-bundle-compliance.sh FILE.flatpak" >&2
+    exit 2
+fi
+if [ ! -f "$bundle" ]; then
+    echo "Flatpak bundle not found: $bundle" >&2
+    exit 2
+fi
+for command in flatpak ostree; do
+    command -v "$command" >/dev/null 2>&1 || {
+        echo "Flatpak bundle validator requires '$command'" >&2
+        exit 2
+    }
+done
+
+temp_dir=$(mktemp -d)
+trap 'rm -rf "$temp_dir"' EXIT HUP INT TERM
+repository="$temp_dir/repository"
+checkout="$temp_dir/checkout"
+refs="$temp_dir/refs"
+
+ostree --repo="$repository" init --mode=bare-user-only
+flatpak build-import-bundle "$repository" "$bundle" >/dev/null
+ostree --repo="$repository" refs > "$refs"
+
+app_ref=
+ref_count=0
+while IFS= read -r ref || [ -n "$ref" ]; do
+    [ -n "$ref" ] || continue
+    case "$ref" in
+        app/io.github.tributary.Tributary/*/*)
+            ref_count=$((ref_count + 1))
+            app_ref=$ref
+            ;;
+        *)
+            echo "Flatpak bundle contains an unexpected ref: $ref" >&2
+            exit 1
+            ;;
+    esac
+done < "$refs"
+
+[ "$ref_count" -eq 1 ] || {
+    echo "Flatpak bundle must contain exactly one Tributary app ref (found $ref_count)" >&2
+    exit 1
+}
+
+ostree --repo="$repository" checkout "$app_ref" "$checkout"
+[ -d "$checkout/files" ] || {
+    echo "Flatpak app commit does not contain a files payload" >&2
+    exit 1
+}
+[ -f "$checkout/metadata" ] || {
+    echo "Flatpak app commit does not contain application metadata" >&2
+    exit 1
+}
+"$validator" --metadata "$checkout/metadata"
+"$validator" --tree "$checkout"
+
+echo "Flatpak app commit complies with bundled-component policy: $bundle"

--- a/build-aux/linux/test-package-compliance.sh
+++ b/build-aux/linux/test-package-compliance.sh
@@ -1,0 +1,414 @@
+#!/usr/bin/env bash
+# Deterministic positive/negative coverage for the Linux payload scanner. No
+# real package manager, public network, media runtime, or forbidden component
+# is required.
+
+set -euo pipefail
+set -f
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repository_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
+validator="$script_dir/validate-package-compliance.sh"
+policy="$repository_root/build-aux/packaging/forbidden-bundled-components.txt"
+temp_dir=$(mktemp -d)
+trap 'rm -rf "$temp_dir"' EXIT HUP INT TERM
+
+expect_status()
+{
+    expected=$1
+    shift
+    set +e
+    "$@" > /dev/null 2>&1
+    actual=$?
+    set -e
+    [ "$actual" -eq "$expected" ] || {
+        echo "Expected status $expected, got $actual: $*" >&2
+        exit 1
+    }
+}
+
+first_token=$(awk '
+    /^[[:space:]]*#/ { next }
+    /^[[:space:]]*$/ { next }
+    { gsub(/^[[:space:]]+|[[:space:]]+$/, ""); print tolower($0); exit }
+' "$policy")
+[ -n "$first_token" ] || {
+    echo "Shared bundled-component policy unexpectedly empty" >&2
+    exit 1
+}
+
+# Ordinary codecs, generic crypto, and similarly prefixed but unrelated names
+# remain eligible. The shared list is deliberately the only negative source.
+mkdir -p "$temp_dir/allowed/lib/gstreamer-1.0"
+touch "$temp_dir/allowed/lib/gstreamer-1.0/libgstlibav.so"
+touch "$temp_dir/allowed/lib/libavcodec.so.62"
+touch "$temp_dir/allowed/lib/libcrypto.so.3"
+touch "$temp_dir/allowed/lib/libblurhash.so"
+"$validator" --tree "$temp_dir/allowed"
+
+mkdir -p "$temp_dir/rejected"
+while IFS= read -r line || [ -n "$line" ]; do
+    token=$(printf '%s' "$line" | tr -d '\r')
+    token=$(printf '%s' "$token" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    case "$token" in
+        '' | \#*) continue ;;
+    esac
+    candidate="$temp_dir/rejected/prefix-${token}-suffix.so"
+    touch "$candidate"
+    expect_status 1 "$validator" --tree "$temp_dir/rejected"
+    rm -f "$candidate"
+done < "$policy"
+
+uppercase=$(printf '%s' "$first_token" | tr '[:lower:]' '[:upper:]')
+touch "$temp_dir/rejected/${uppercase}.SO"
+expect_status 1 "$validator" --tree "$temp_dir/rejected"
+rm -f "$temp_dir/rejected/${uppercase}.SO"
+
+ln -s "../${first_token}.so" "$temp_dir/rejected/innocent-link.so"
+expect_status 1 "$validator" --tree "$temp_dir/rejected"
+rm -f "$temp_dir/rejected/innocent-link.so"
+
+ln -s "../${first_token}/libinnocent.so" "$temp_dir/rejected/innocent-link.so"
+expect_status 1 "$validator" --tree "$temp_dir/rejected"
+rm -f "$temp_dir/rejected/innocent-link.so"
+
+# A traversal error after producing partial output must fail the scan. This is
+# the regression case that process substitution would otherwise conceal.
+mkdir -p "$temp_dir/find-tools"
+printf '%s\n' \
+    '#!/bin/sh' \
+    'printf "%s\\0" "$1/lib/gstreamer-1.0/libgstlibav.so"' \
+    'exit 7' \
+    > "$temp_dir/find-tools/find"
+chmod +x "$temp_dir/find-tools/find"
+expect_status 1 env PATH="$temp_dir/find-tools:$PATH" \
+    "$validator" --tree "$temp_dir/allowed"
+
+# A partial magic read followed by an od error must fail even during a tree
+# scan; it must not silently reclassify the regular file as non-ELF.
+mkdir -p "$temp_dir/od-tools"
+printf '%s\n' \
+    '#!/bin/sh' \
+    'printf " 7f 45"' \
+    'exit 7' \
+    > "$temp_dir/od-tools/od"
+chmod +x "$temp_dir/od-tools/od"
+expect_status 1 env PATH="$temp_dir/od-tools:$PATH" \
+    "$validator" --tree "$temp_dir/allowed"
+
+printf 'depends = gstreamer1.0-plugins-good\n' > "$temp_dir/allowed-metadata"
+"$validator" --metadata "$temp_dir/allowed-metadata"
+printf 'depends = %s-runtime\n' "$first_token" > "$temp_dir/rejected-metadata"
+expect_status 1 "$validator" --metadata "$temp_dir/rejected-metadata"
+
+# Tokenizer failure after partial allowed output must not become a policy pass.
+real_tr=$(command -v tr)
+mkdir -p "$temp_dir/tr-tools"
+printf '%s\n' \
+    '#!/bin/sh' \
+    'if [ "$1" = -s ]; then' \
+    '  echo gstreamer1.0-plugins-good' \
+    '  exit 7' \
+    'fi' \
+    'exec "$TEST_REAL_TR" "$@"' \
+    > "$temp_dir/tr-tools/tr"
+chmod +x "$temp_dir/tr-tools/tr"
+expect_status 1 env PATH="$temp_dir/tr-tools:$PATH" TEST_REAL_TR="$real_tr" \
+    "$validator" --metadata "$temp_dir/allowed-metadata"
+
+# Drive ELF dependency parsing through a fixed fake inspector. This covers a
+# renamed payload whose basename is harmless but DT_NEEDED is prohibited.
+mkdir -p "$temp_dir/tools"
+printf '%s\n' \
+    '#!/bin/sh' \
+    'last=' \
+    'for argument in "$@"; do last=$argument; done' \
+    'case "$last" in' \
+    '  *rejected-elf) dependency=${TEST_FORBIDDEN_TOKEN}.so.1 ;;' \
+    '  *) dependency=libgstreamer-1.0.so.0 ;;' \
+    'esac' \
+    'printf " 0x0000000000000001 (NEEDED) Shared library: [%s]\\n" "$dependency"' \
+    > "$temp_dir/tools/readelf"
+chmod +x "$temp_dir/tools/readelf"
+printf '\177ELFfixture' > "$temp_dir/allowed-elf"
+printf '\177ELFfixture' > "$temp_dir/rejected-elf"
+PATH="$temp_dir/tools:$PATH" TEST_FORBIDDEN_TOKEN="$first_token" \
+    "$validator" --elf "$temp_dir/allowed-elf"
+expect_status 1 env PATH="$temp_dir/tools:$PATH" TEST_FORBIDDEN_TOKEN="$first_token" \
+    "$validator" --elf "$temp_dir/rejected-elf"
+
+# Exercise each native archive boundary with deterministic fake package tools.
+# The validator must reject both a declared dependency and a file introduced
+# only while extracting the completed package payload.
+mkdir -p "$temp_dir/archive-tools"
+printf '%s\n' \
+    '#!/bin/sh' \
+    'case "$1" in' \
+    '  --control)' \
+    '    destination=$3' \
+    '    mkdir -p "$destination"' \
+    '    printf "Package: tributary\\nDepends: gstreamer1.0-plugins-good\\n" > "$destination/control"' \
+    '    printf "#!/bin/sh\\n/sbin/ldconfig\\n" > "$destination/postinst"' \
+    '    case "${TEST_ARCHIVE_MODE:-allowed}" in' \
+    '      forbidden-dependency)' \
+    '        printf "Recommends: %s-runtime\\n" "$TEST_FORBIDDEN_TOKEN" >> "$destination/control"' \
+    '        ;;' \
+    '      forbidden-script)' \
+    '        printf "curl https://example.invalid/%s/install.sh\\n" "$TEST_FORBIDDEN_TOKEN" >> "$destination/postinst"' \
+    '        ;;' \
+    '      binary-control)' \
+    '        printf "\\000\\001binary" > "$destination/blob"' \
+    '        ;;' \
+    '    esac' \
+    '    ;;' \
+    '  --extract)' \
+    '    destination=$3' \
+    '    mkdir -p "$destination/usr/lib"' \
+    '    if [ "${TEST_ARCHIVE_MODE:-allowed}" = forbidden-payload ]; then' \
+    '      touch "$destination/usr/lib/${TEST_FORBIDDEN_TOKEN}.so"' \
+    '    else' \
+    '      touch "$destination/usr/lib/libgstlibav.so"' \
+    '    fi' \
+    '    ;;' \
+    '  *) exit 2 ;;' \
+    'esac' \
+    > "$temp_dir/archive-tools/dpkg-deb"
+printf '%s\n' \
+    '#!/bin/sh' \
+    'case "$2:${TEST_ARCHIVE_MODE:-allowed}" in' \
+    '  --recommends:forbidden-dependency)' \
+    '    echo "${TEST_FORBIDDEN_TOKEN}-runtime"' \
+    '    ;;' \
+    '  --scripts:forbidden-script)' \
+    '    echo "curl https://example.invalid/${TEST_FORBIDDEN_TOKEN}/install.sh"' \
+    '    ;;' \
+    '  --requires:*|--recommends:*|--suggests:*|--supplements:*|--enhances:*)' \
+    '    echo gstreamer1-plugins-good' \
+    '    ;;' \
+    '  *) echo none ;;' \
+    'esac' \
+    > "$temp_dir/archive-tools/rpm"
+printf '%s\n' '#!/bin/sh' 'exit 0' > "$temp_dir/archive-tools/rpm2cpio"
+printf '%s\n' \
+    '#!/bin/sh' \
+    'mkdir -p usr/lib' \
+    'if [ "${TEST_ARCHIVE_MODE:-allowed}" = forbidden-payload ]; then' \
+    '  touch "usr/lib/${TEST_FORBIDDEN_TOKEN}.so"' \
+    'else' \
+    '  touch usr/lib/libgstlibav.so' \
+    'fi' \
+    > "$temp_dir/archive-tools/cpio"
+printf '%s\n' \
+    '#!/bin/sh' \
+    'case "$1" in' \
+    '  -xOf)' \
+    '    if [ "${TEST_ARCHIVE_MODE:-allowed}" = forbidden-dependency ]; then' \
+    '      echo "depend = ${TEST_FORBIDDEN_TOKEN}-runtime"' \
+    '    else' \
+    '      echo "depend = gst-plugins-good"' \
+    '    fi' \
+    '    ;;' \
+    '  -xf)' \
+    '    destination=$4' \
+    '    mkdir -p "$destination/usr/lib"' \
+    '    if [ "${TEST_ARCHIVE_MODE:-allowed}" = forbidden-payload ]; then' \
+    '      touch "$destination/usr/lib/${TEST_FORBIDDEN_TOKEN}.so"' \
+    '    else' \
+    '      touch "$destination/usr/lib/libgstlibav.so"' \
+    '    fi' \
+    '    if [ "${TEST_ARCHIVE_MODE:-allowed}" = forbidden-script ]; then' \
+    '      printf "curl https://example.invalid/%s/install.sh\\n" "$TEST_FORBIDDEN_TOKEN" > "$destination/.INSTALL"' \
+    '    fi' \
+    '    ;;' \
+    '  *) exit 2 ;;' \
+    'esac' \
+    > "$temp_dir/archive-tools/bsdtar"
+chmod +x \
+    "$temp_dir/archive-tools/dpkg-deb" \
+    "$temp_dir/archive-tools/rpm" \
+    "$temp_dir/archive-tools/rpm2cpio" \
+    "$temp_dir/archive-tools/cpio" \
+    "$temp_dir/archive-tools/bsdtar"
+touch "$temp_dir/fixture.deb" "$temp_dir/fixture.rpm" "$temp_dir/fixture.pkg.tar.zst"
+for package_mode in deb rpm arch; do
+    package="$temp_dir/fixture.$package_mode"
+    [ "$package_mode" != arch ] || package="$temp_dir/fixture.pkg.tar.zst"
+    PATH="$temp_dir/archive-tools:$PATH" TEST_FORBIDDEN_TOKEN="$first_token" \
+        "$validator" "--$package_mode" "$package"
+    archive_modes="forbidden-dependency forbidden-payload"
+    case "$package_mode" in
+        deb) archive_modes="$archive_modes forbidden-script binary-control" ;;
+        rpm) archive_modes="$archive_modes forbidden-script" ;;
+        arch) archive_modes="$archive_modes forbidden-script" ;;
+    esac
+    for archive_mode in $archive_modes; do
+        expect_status 1 env PATH="$temp_dir/archive-tools:$PATH" \
+            TEST_FORBIDDEN_TOKEN="$first_token" TEST_ARCHIVE_MODE="$archive_mode" \
+            "$validator" "--$package_mode" "$package"
+    done
+done
+
+# Exercise the complete Flatpak app-commit boundary without requiring
+# Flatpak/OSTree on the unit-test host. The production workflow still imports
+# and checks out the real completed bundle with those tools before upload.
+mkdir -p "$temp_dir/flatpak-tools"
+printf '%s\n' \
+    '#!/bin/sh' \
+    'exit 0' \
+    > "$temp_dir/flatpak-tools/flatpak"
+printf '%s\n' \
+    '#!/bin/sh' \
+    'operation=' \
+    'last=' \
+    'for argument in "$@"; do' \
+    '  last=$argument' \
+    '  case "$argument" in init|refs|checkout) operation=$argument ;; esac' \
+    'done' \
+    'case "$operation" in' \
+    '  init) exit 0 ;;' \
+    '  refs)' \
+    '    if [ "${TEST_BUNDLE_MODE:-allowed}" = unexpected-ref ]; then' \
+    '      echo runtime/org.example.Unexpected/x86_64/master' \
+    '    else' \
+    '      echo app/io.github.tributary.Tributary/x86_64/master' \
+    '    fi' \
+    '    ;;' \
+    '  checkout)' \
+    '    mkdir -p "$last/files" "$last/export/share/applications"' \
+    '    touch "$last/files/libgstlibav.so"' \
+    '    touch "$last/export/share/applications/io.github.tributary.Tributary.desktop"' \
+    '    printf "[Application]\\nruntime=org.gnome.Platform/x86_64/49\\n" > "$last/metadata"' \
+    '    case "${TEST_BUNDLE_MODE:-allowed}" in' \
+    '      forbidden-export)' \
+    '        touch "$last/export/share/applications/${TEST_FORBIDDEN_TOKEN}.desktop"' \
+    '        ;;' \
+    '      forbidden-metadata)' \
+    '        printf "extension=%s-runtime\\n" "$TEST_FORBIDDEN_TOKEN" >> "$last/metadata"' \
+    '        ;;' \
+    '    esac' \
+    '    ;;' \
+    '  *) exit 2 ;;' \
+    'esac' \
+    > "$temp_dir/flatpak-tools/ostree"
+chmod +x "$temp_dir/flatpak-tools/flatpak" "$temp_dir/flatpak-tools/ostree"
+touch "$temp_dir/tributary.flatpak"
+PATH="$temp_dir/flatpak-tools:$PATH" \
+    "$repository_root/build-aux/flatpak/validate-bundle-compliance.sh" \
+    "$temp_dir/tributary.flatpak" > /dev/null
+for bundle_mode in forbidden-export forbidden-metadata; do
+    expect_status 1 env PATH="$temp_dir/flatpak-tools:$PATH" \
+        TEST_BUNDLE_MODE="$bundle_mode" TEST_FORBIDDEN_TOKEN="$first_token" \
+        "$repository_root/build-aux/flatpak/validate-bundle-compliance.sh" \
+        "$temp_dir/tributary.flatpak"
+done
+expect_status 1 env PATH="$temp_dir/flatpak-tools:$PATH" \
+    TEST_BUNDLE_MODE=unexpected-ref \
+    "$repository_root/build-aux/flatpak/validate-bundle-compliance.sh" \
+    "$temp_dir/tributary.flatpak"
+
+# Missing, empty, malformed, and duplicate shared policy data are all setup
+# failures, never an implicit allow-all fallback.
+for fixture in missing empty malformed duplicate; do
+    mkdir -p "$temp_dir/$fixture/build-aux/linux" "$temp_dir/$fixture/build-aux/packaging"
+    cp "$validator" "$temp_dir/$fixture/build-aux/linux/validate-package-compliance.sh"
+done
+rm -f "$temp_dir/missing/build-aux/packaging/forbidden-bundled-components.txt"
+: > "$temp_dir/empty/build-aux/packaging/forbidden-bundled-components.txt"
+printf 'valid-token\nbad token\n' \
+    > "$temp_dir/malformed/build-aux/packaging/forbidden-bundled-components.txt"
+printf 'duplicate\nDUPLICATE\n' \
+    > "$temp_dir/duplicate/build-aux/packaging/forbidden-bundled-components.txt"
+for fixture in missing empty malformed duplicate; do
+    expect_status 2 "$temp_dir/$fixture/build-aux/linux/validate-package-compliance.sh" \
+        --tree "$temp_dir/allowed"
+done
+
+"$script_dir/validate-package-metadata.sh" > /dev/null
+
+require_literal()
+{
+    needle=$1
+    file=$2
+    grep -Fq -- "$needle" "$file" || {
+        echo "Missing Linux package compliance contract '$needle' in $file" >&2
+        exit 1
+    }
+}
+
+assert_before()
+{
+    earlier=$1
+    later=$2
+    file=$3
+    earlier_line=$(grep -nF -- "$earlier" "$file" | cut -d: -f1)
+    later_line=$(grep -nF -- "$later" "$file" | cut -d: -f1)
+    case "$earlier_line:$later_line" in
+        *$'\n'* | :* | *:)
+            echo "Ordering contract is missing or ambiguous in $file: $earlier / $later" >&2
+            exit 1
+            ;;
+    esac
+    [ "$earlier_line" -lt "$later_line" ] || {
+        echo "Compliance validation must precede artifact upload: $earlier / $later" >&2
+        exit 1
+    }
+}
+
+build_linux="$repository_root/scripts/build-linux.sh"
+flatpak_manifest="$repository_root/build-aux/flatpak/io.github.tributary.Tributary.yml"
+flatpak_validator="$repository_root/build-aux/flatpak/validate-bundle-compliance.sh"
+ci_workflow="$repository_root/.github/workflows/ci.yml"
+release_workflow="$repository_root/.github/workflows/release.yml"
+arch_pkgbuild="$repository_root/build-aux/arch/PKGBUILD"
+rpm_spec="$repository_root/build-aux/rpm/tributary.spec"
+
+require_literal 'validate-package-compliance.sh --tree /app' "$flatpak_manifest"
+require_literal '"$validator" --metadata "$checkout/metadata"' "$flatpak_validator"
+require_literal '"$validator" --tree "$checkout"' "$flatpak_validator"
+require_literal 'LC_ALL=C "$inspector" -d -- "$file"' "$validator"
+require_literal '"$PACKAGE_VALIDATOR" --elf target/release/tributary' "$build_linux"
+require_literal 'require_elf_inspector' "$build_linux"
+require_literal 'require_validator_tool ostree' "$build_linux"
+require_literal 'require_validator_tool dpkg-deb' "$build_linux"
+require_literal 'require_validator_tool rpm' "$build_linux"
+require_literal 'require_validator_tool rpm2cpio' "$build_linux"
+require_literal 'require_validator_tool cpio' "$build_linux"
+require_literal 'require_validator_tool bsdtar' "$build_linux"
+assert_before 'preflight_artifact_tools # fail before build work' \
+    '# ── Rust Build' "$build_linux"
+require_literal '"$PACKAGE_VALIDATOR" --deb "$DEB_FILE"' "$build_linux"
+require_literal '"$PACKAGE_VALIDATOR" --rpm "$RPM_FILE"' "$build_linux"
+require_literal '"$PACKAGE_VALIDATOR" --arch "dist/$PKG_FILE"' "$build_linux"
+require_literal '"$FLATPAK_BUNDLE_VALIDATOR" tributary.flatpak' "$build_linux"
+require_literal 'validate-package-compliance.sh --elf target/release/tributary' "$arch_pkgbuild"
+require_literal 'validate-package-compliance.sh --tree "$pkgdir"' "$arch_pkgbuild"
+require_literal 'validate-package-compliance.sh --elf target/release/tributary' "$rpm_spec"
+require_literal 'validate-package-compliance.sh --tree "%{buildroot}"' "$rpm_spec"
+assert_before 'validate-package-compliance.sh --tree "%{buildroot}"' \
+    '%check' "$rpm_spec"
+
+require_literal 'build-aux/linux/test-package-compliance.sh' "$ci_workflow"
+require_literal 'scripts/test-macos-package-policy.sh' "$ci_workflow"
+require_literal 'validate-package-compliance.sh --elf target/release/tributary' "$ci_workflow"
+require_literal 'command -v ostree' "$ci_workflow"
+require_literal 'command -v readelf || command -v eu-readelf' "$ci_workflow"
+assert_before 'name: Validate completed Flatpak bundle payload' \
+    'name: Upload Flatpak bundle' "$ci_workflow"
+
+require_literal 'flatpak flatpak-builder elfutils ostree python3-pip' "$release_workflow"
+require_literal 'cpio elfutils gcc rpm-build' "$release_workflow"
+require_literal 'binutils git libarchive' "$release_workflow"
+require_literal 'validate-bundle-compliance.sh' "$release_workflow"
+require_literal 'validate-package-compliance.sh --deb' "$release_workflow"
+require_literal 'validate-package-compliance.sh --rpm' "$release_workflow"
+require_literal 'validate-package-compliance.sh --arch' "$release_workflow"
+assert_before 'name: Validate completed Flatpak bundle payload' \
+    'name: Upload Flatpak as workflow artifact' "$release_workflow"
+assert_before 'name: Validate completed .deb payload' \
+    'name: Upload .deb as workflow artifact' "$release_workflow"
+assert_before 'name: Validate completed .rpm payload' \
+    'name: Upload .rpm as workflow artifact' "$release_workflow"
+assert_before 'name: Validate completed Arch package payload' \
+    'name: Upload Arch package as workflow artifact' "$release_workflow"
+
+echo "Linux package compliance positive and negative tests passed"

--- a/build-aux/linux/test-package-compliance.sh
+++ b/build-aux/linux/test-package-compliance.sh
@@ -44,6 +44,7 @@ touch "$temp_dir/allowed/lib/gstreamer-1.0/libgstlibav.so"
 touch "$temp_dir/allowed/lib/libavcodec.so.62"
 touch "$temp_dir/allowed/lib/libcrypto.so.3"
 touch "$temp_dir/allowed/lib/libblurhash.so"
+touch "$temp_dir/allowed/lib/libbluray.so.2"
 "$validator" --tree "$temp_dir/allowed"
 
 mkdir -p "$temp_dir/rejected"
@@ -116,26 +117,66 @@ chmod +x "$temp_dir/tr-tools/tr"
 expect_status 1 env PATH="$temp_dir/tr-tools:$PATH" TEST_REAL_TR="$real_tr" \
     "$validator" --metadata "$temp_dir/allowed-metadata"
 
-# Drive ELF dependency parsing through a fixed fake inspector. This covers a
-# renamed payload whose basename is harmless but DT_NEEDED is prohibited.
+# Drive ELF reference parsing through a fixed fake inspector. This covers a
+# renamed payload whose basename is harmless but a dynamic tag or PT_INTERP
+# names a prohibited component.
 mkdir -p "$temp_dir/tools"
 printf '%s\n' \
     '#!/bin/sh' \
+    'mode=$1' \
     'last=' \
     'for argument in "$@"; do last=$argument; done' \
+    'if [ "$mode" = -l ]; then' \
+    '  case "$last" in' \
+    '    *rejected-elf-interpreter)' \
+    '      printf "      [Requesting program interpreter: /lib/%s.so.1]\\n" "$TEST_FORBIDDEN_TOKEN"' \
+    '      ;;' \
+    '    *) printf "Elf file type is DYN (Shared object file)\\n" ;;' \
+    '  esac' \
+    '  exit 0' \
+    'fi' \
     'case "$last" in' \
-    '  *rejected-elf) dependency=${TEST_FORBIDDEN_TOKEN}.so.1 ;;' \
-    '  *) dependency=libgstreamer-1.0.so.0 ;;' \
+    '  *rejected-elf-needed)' \
+    '    printf " 0x0000000000000001 (NEEDED) Shared library: [%s.so.1]\\n" "$TEST_FORBIDDEN_TOKEN"' \
+    '    ;;' \
+    '  *rejected-elf-filter)' \
+    '    printf " 0x000000007fffffff (FILTER) Filter library: [%s.so.1]\\n" "$TEST_FORBIDDEN_TOKEN"' \
+    '    ;;' \
+    '  *rejected-elf-audit)' \
+    '    printf " 0x000000006ffffefc (AUDIT) Audit library: [%s.so.1]\\n" "$TEST_FORBIDDEN_TOKEN"' \
+    '    ;;' \
+    '  *rejected-elf-runpath)' \
+    '    printf " 0x000000000000001d (RUNPATH) Library runpath: [/opt/%s/lib]\\n" "$TEST_FORBIDDEN_TOKEN"' \
+    '    ;;' \
+    '  *rejected-elf-soname)' \
+    '    printf " 0x000000000000000e (SONAME) Library soname: [lib%s-proxy.so]\\n" "$TEST_FORBIDDEN_TOKEN"' \
+    '    ;;' \
+    '  *)' \
+    '    printf " 0x0000000000000001 (NEEDED) Shared library: [libgstreamer-1.0.so.0]\\n"' \
+    '    ;;' \
     'esac' \
-    'printf " 0x0000000000000001 (NEEDED) Shared library: [%s]\\n" "$dependency"' \
     > "$temp_dir/tools/readelf"
 chmod +x "$temp_dir/tools/readelf"
 printf '\177ELFfixture' > "$temp_dir/allowed-elf"
-printf '\177ELFfixture' > "$temp_dir/rejected-elf"
 PATH="$temp_dir/tools:$PATH" TEST_FORBIDDEN_TOKEN="$first_token" \
     "$validator" --elf "$temp_dir/allowed-elf"
-expect_status 1 env PATH="$temp_dir/tools:$PATH" TEST_FORBIDDEN_TOKEN="$first_token" \
-    "$validator" --elf "$temp_dir/rejected-elf"
+for elf_reference in needed filter audit runpath soname interpreter; do
+    fixture="$temp_dir/rejected-elf-$elf_reference"
+    printf '\177ELFfixture' > "$fixture"
+    expect_status 1 env PATH="$temp_dir/tools:$PATH" \
+        TEST_FORBIDDEN_TOKEN="$first_token" "$validator" --elf "$fixture"
+done
+
+# A rejected ELF must clean its private inspection files even though the
+# policy failure exits from nested dependency-token validation.
+mkdir -p "$temp_dir/elf-cleanup-tmp"
+expect_status 1 env TMPDIR="$temp_dir/elf-cleanup-tmp" \
+    PATH="$temp_dir/tools:$PATH" TEST_FORBIDDEN_TOKEN="$first_token" \
+    "$validator" --elf "$temp_dir/rejected-elf-filter"
+if find "$temp_dir/elf-cleanup-tmp" -mindepth 1 -print -quit | grep -q .; then
+    echo "ELF validation leaked private inspection files" >&2
+    exit 1
+fi
 
 # Exercise each native archive boundary with deterministic fake package tools.
 # The validator must reject both a declared dependency and a file introduced
@@ -391,12 +432,12 @@ require_literal 'build-aux/linux/test-package-compliance.sh' "$ci_workflow"
 require_literal 'scripts/test-macos-package-policy.sh' "$ci_workflow"
 require_literal 'validate-package-compliance.sh --elf target/release/tributary' "$ci_workflow"
 require_literal 'command -v ostree' "$ci_workflow"
-require_literal 'command -v readelf || command -v eu-readelf' "$ci_workflow"
+require_literal 'command -v readelf' "$ci_workflow"
 assert_before 'name: Validate completed Flatpak bundle payload' \
     'name: Upload Flatpak bundle' "$ci_workflow"
 
-require_literal 'flatpak flatpak-builder elfutils ostree python3-pip' "$release_workflow"
-require_literal 'cpio elfutils gcc rpm-build' "$release_workflow"
+require_literal 'binutils flatpak flatpak-builder ostree python3-pip' "$release_workflow"
+require_literal 'binutils cpio gcc rpm-build' "$release_workflow"
 require_literal 'binutils git libarchive' "$release_workflow"
 require_literal 'validate-bundle-compliance.sh' "$release_workflow"
 require_literal 'validate-package-compliance.sh --deb' "$release_workflow"

--- a/build-aux/linux/validate-package-compliance.sh
+++ b/build-aux/linux/validate-package-compliance.sh
@@ -135,14 +135,11 @@ check_dependency_text()
 
 elf_inspector()
 {
-    if command -v readelf >/dev/null 2>&1; then
-        printf '%s\n' readelf
-    elif command -v eu-readelf >/dev/null 2>&1; then
-        printf '%s\n' eu-readelf
-    else
-        echo "Linux package compliance validator requires readelf or eu-readelf" >&2
+    command -v readelf >/dev/null 2>&1 || {
+        echo "Linux package compliance validator requires GNU readelf (binutils)" >&2
         exit 2
-    fi
+    }
+    printf '%s\n' readelf
 }
 
 is_elf()
@@ -155,7 +152,7 @@ is_elf()
 }
 
 check_elf()
-{
+(
     file=$1
     required=${2:-false}
     if is_elf "$file"; then
@@ -168,16 +165,28 @@ check_elf()
     fi
 
     inspector=$(elf_inspector)
-    dynamic=$(mktemp)
+    inspection_dir=$(mktemp -d)
+    trap 'rm -rf "$inspection_dir"' EXIT HUP INT TERM
+    dynamic="$inspection_dir/dynamic"
+    program_headers="$inspection_dir/program-headers"
+    references="$inspection_dir/references"
     if ! LC_ALL=C "$inspector" -d -- "$file" > "$dynamic" 2>/dev/null; then
-        rm -f "$dynamic"
-        fail "could not inspect ELF dependencies: $file"
+        fail "could not inspect ELF dynamic section: $file"
     fi
-    dependencies=$(mktemp)
-    LC_ALL=C sed -n 's/.*Shared library: \[\([^]]*\)\].*/\1/p' "$dynamic" > "$dependencies"
-    check_dependency_text "$dependencies"
-    rm -f "$dynamic" "$dependencies"
-}
+    if ! LC_ALL=C "$inspector" -l -- "$file" > "$program_headers" 2>/dev/null; then
+        fail "could not inspect ELF program headers: $file"
+    fi
+    # DT_NEEDED is only one way an ELF can name another component. Inspect all
+    # bracket-valued dynamic metadata (including FILTER, AUXILIARY, AUDIT,
+    # DEPAUDIT, SONAME, and RUNPATH) plus PT_INTERP from program headers.
+    if ! LC_ALL=C sed -n 's/.*\[\([^]]*\)\].*/\1/p' "$dynamic" > "$references"; then
+        fail "could not parse ELF dynamic section: $file"
+    fi
+    if ! LC_ALL=C sed -n 's/.*\[\([^]]*\)\].*/\1/p' "$program_headers" >> "$references"; then
+        fail "could not parse ELF program headers: $file"
+    fi
+    check_dependency_text "$references"
+)
 
 check_entry()
 {

--- a/build-aux/linux/validate-package-compliance.sh
+++ b/build-aux/linux/validate-package-compliance.sh
@@ -1,0 +1,360 @@
+#!/usr/bin/env bash
+# Linux artifact policy: Tributary may use ordinary distro/runtime codecs, but
+# its own payload must not bundle or link dedicated optical-disc copy-control
+# decrypt components. This is intentionally Linux-only; other platforms own
+# their independent package layouts and validation.
+
+set -euo pipefail
+set -f
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repository_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
+policy_file="$repository_root/build-aux/packaging/forbidden-bundled-components.txt"
+
+usage()
+{
+    cat >&2 <<'EOF'
+Usage:
+  validate-package-compliance.sh --tree DIRECTORY
+  validate-package-compliance.sh --elf FILE
+  validate-package-compliance.sh --deb FILE.deb
+  validate-package-compliance.sh --rpm FILE.rpm
+  validate-package-compliance.sh --arch FILE.pkg.tar.zst
+  validate-package-compliance.sh --metadata FILE...
+EOF
+    exit 2
+}
+
+fail()
+{
+    echo "Linux package compliance violation: $*" >&2
+    exit 1
+}
+
+require_command()
+{
+    command -v "$1" >/dev/null 2>&1 || {
+        echo "Linux package compliance validator requires '$1'" >&2
+        exit 2
+    }
+}
+
+load_policy()
+{
+    [ -f "$policy_file" ] || {
+        echo "Required bundled-component policy is missing: $policy_file" >&2
+        exit 2
+    }
+
+    policy_tokens=
+    while IFS= read -r line || [ -n "$line" ]; do
+        token=$(printf '%s' "$line" | tr -d '\r')
+        token=$(printf '%s' "$token" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        case "$token" in
+            '' | \#*) continue ;;
+        esac
+        case "$token" in
+            [A-Za-z0-9]* ) ;;
+            *)
+                echo "Bundled-component policy contains an invalid filename token: $token" >&2
+                exit 2
+                ;;
+        esac
+        case "$token" in
+            *[!A-Za-z0-9._+-]*)
+                echo "Bundled-component policy contains an invalid filename token: $token" >&2
+                exit 2
+                ;;
+        esac
+        token=$(printf '%s' "$token" | tr '[:upper:]' '[:lower:]')
+        for existing in $policy_tokens; do
+            [ "$existing" != "$token" ] || {
+                echo "Bundled-component policy contains a duplicate filename token: $token" >&2
+                exit 2
+            }
+        done
+        policy_tokens="${policy_tokens}${policy_tokens:+ }${token}"
+    done < "$policy_file"
+    [ -n "$policy_tokens" ] || {
+        echo "Bundled-component policy contains no filename tokens: $policy_file" >&2
+        exit 2
+    }
+}
+
+forbidden_component()
+{
+    component=${1##*/}
+    component=${component,,}
+    for token in $policy_tokens; do
+        case "$component" in
+            *"$token"*) return 0 ;;
+        esac
+    done
+    return 1
+}
+
+forbidden_path_component()
+{
+    path=${1,,}
+    for token in $policy_tokens; do
+        case "$path" in
+            *"$token"*) return 0 ;;
+        esac
+    done
+    return 1
+}
+
+check_component()
+{
+    forbidden_component "$1" && fail "prohibited component '$1'"
+    return 0
+}
+
+check_path_components()
+{
+    forbidden_path_component "$1" && fail "prohibited component reference '$1'"
+    return 0
+}
+
+check_dependency_text()
+(
+    input=$1
+    # Inspect tokenized package relationships and plain-text installer
+    # metadata, never arbitrary binary contents. The shared reviewed list is
+    # the sole negative source; ordinary codecs and general-purpose crypto
+    # remain eligible unless that policy changes.
+    tokens=$(mktemp)
+    trap 'rm -f "$tokens"' EXIT HUP INT TERM
+    if ! LC_ALL=C tr -s '[:space:],()[]<>=:;|"' '\n' < "$input" > "$tokens"; then
+        fail "could not tokenize dependency metadata: $input"
+    fi
+    while IFS= read -r token || [ -n "$token" ]; do
+        [ -z "$token" ] || check_path_components "$token"
+    done < "$tokens"
+)
+
+elf_inspector()
+{
+    if command -v readelf >/dev/null 2>&1; then
+        printf '%s\n' readelf
+    elif command -v eu-readelf >/dev/null 2>&1; then
+        printf '%s\n' eu-readelf
+    else
+        echo "Linux package compliance validator requires readelf or eu-readelf" >&2
+        exit 2
+    fi
+}
+
+is_elf()
+{
+    [ -f "$1" ] || return 1
+    if ! magic=$(LC_ALL=C od -An -tx1 -N4 -- "$1" 2>/dev/null | tr -d ' \n'); then
+        return 2
+    fi
+    [ "$magic" = 7f454c46 ]
+}
+
+check_elf()
+{
+    file=$1
+    required=${2:-false}
+    if is_elf "$file"; then
+        :
+    else
+        magic_status=$?
+        [ "$magic_status" -eq 1 ] || fail "could not inspect file magic: $file"
+        [ "$required" = false ] || fail "expected an ELF artifact: $file"
+        return 0
+    fi
+
+    inspector=$(elf_inspector)
+    dynamic=$(mktemp)
+    if ! LC_ALL=C "$inspector" -d -- "$file" > "$dynamic" 2>/dev/null; then
+        rm -f "$dynamic"
+        fail "could not inspect ELF dependencies: $file"
+    fi
+    dependencies=$(mktemp)
+    LC_ALL=C sed -n 's/.*Shared library: \[\([^]]*\)\].*/\1/p' "$dynamic" > "$dependencies"
+    check_dependency_text "$dependencies"
+    rm -f "$dynamic" "$dependencies"
+}
+
+check_entry()
+{
+    entry=$1
+    check_component "$entry"
+    if [ -L "$entry" ]; then
+        target=$(readlink -- "$entry") || fail "could not inspect symlink: $entry"
+        check_path_components "$target"
+    elif [ -f "$entry" ]; then
+        check_elf "$entry" false
+    fi
+}
+
+check_tree()
+(
+    root=$1
+    [ -d "$root" ] || {
+        echo "Linux package payload directory not found: $root" >&2
+        exit 2
+    }
+
+    # Process substitution hides find's exit status from the parent shell.
+    # Enumerate first and inspect only after a complete, successful traversal
+    # so unreadable or disappearing payload paths can never yield a partial
+    # policy pass.
+    entries=$(mktemp)
+    trap 'rm -f "$entries"' EXIT HUP INT TERM
+    if ! find "$root" -mindepth 1 -print0 > "$entries"; then
+        fail "could not enumerate package payload tree: $root"
+    fi
+    while IFS= read -r -d '' entry; do
+        check_entry "$entry"
+    done < "$entries"
+)
+
+check_text_metadata_file()
+{
+    entry=$1
+    [ -f "$entry" ] && [ ! -L "$entry" ] || \
+        fail "package control metadata is not a regular file: $entry"
+    # Installer metadata is defined as text. Reject an unexpected binary
+    # member instead of substring-scanning arbitrary bytes as script tokens.
+    if [ -s "$entry" ] && ! LC_ALL=C grep -Iq '' "$entry"; then
+        fail "package control metadata is not plain text: $entry"
+    fi
+    check_dependency_text "$entry"
+}
+
+check_text_metadata_tree()
+(
+    root=$1
+    entries=$(mktemp)
+    trap 'rm -f "$entries"' EXIT HUP INT TERM
+    if ! find "$root" -type f -print0 > "$entries"; then
+        fail "could not enumerate package control metadata: $root"
+    fi
+    while IFS= read -r -d '' entry; do
+        check_text_metadata_file "$entry"
+    done < "$entries"
+)
+
+extract_deb()
+{
+    package=$1
+    require_command dpkg-deb
+    temp_dir=$(mktemp -d)
+    trap 'rm -rf "$temp_dir"' EXIT HUP INT TERM
+    dpkg-deb --control "$package" "$temp_dir/control" || \
+        fail "could not extract Debian control metadata"
+    check_tree "$temp_dir/control"
+    check_text_metadata_tree "$temp_dir/control"
+    dpkg-deb --extract "$package" "$temp_dir/payload" || fail "could not extract Debian package"
+    check_tree "$temp_dir/payload"
+}
+
+extract_rpm()
+{
+    package=$1
+    require_command rpm
+    require_command rpm2cpio
+    require_command cpio
+    temp_dir=$(mktemp -d)
+    trap 'rm -rf "$temp_dir"' EXIT HUP INT TERM
+    : > "$temp_dir/header-metadata"
+    for query in \
+        --requires --recommends --suggests --supplements --enhances \
+        --conflicts --obsoletes --provides \
+        --scripts --triggers --filetriggers
+    do
+        rpm -qp "$query" "$package" >> "$temp_dir/header-metadata" 2>/dev/null || \
+            fail "could not read RPM header metadata ($query)"
+    done
+    check_dependency_text "$temp_dir/header-metadata"
+    rpm2cpio "$package" > "$temp_dir/payload.cpio" || fail "could not decode RPM payload"
+    mkdir "$temp_dir/payload"
+    (cd "$temp_dir/payload" && cpio -idm --quiet < "$temp_dir/payload.cpio") || \
+        fail "could not extract RPM payload"
+    check_tree "$temp_dir/payload"
+}
+
+extract_arch()
+{
+    package=$1
+    require_command bsdtar
+    temp_dir=$(mktemp -d)
+    trap 'rm -rf "$temp_dir"' EXIT HUP INT TERM
+    bsdtar -xOf "$package" .PKGINFO > "$temp_dir/pkginfo" || \
+        fail "could not read Arch package metadata"
+    check_dependency_text "$temp_dir/pkginfo"
+    mkdir "$temp_dir/payload"
+    bsdtar -xf "$package" -C "$temp_dir/payload" || fail "could not extract Arch package"
+    check_tree "$temp_dir/payload"
+    install_script="$temp_dir/payload/.INSTALL"
+    if [ -e "$install_script" ] || [ -L "$install_script" ]; then
+        check_text_metadata_file "$install_script"
+    fi
+}
+
+load_policy
+
+[ "$#" -ge 2 ] || usage
+mode=$1
+shift
+
+case "$mode" in
+    --tree)
+        [ "$#" -eq 1 ] || usage
+        check_tree "$1"
+        ;;
+    --elf)
+        [ "$#" -eq 1 ] || usage
+        [ -f "$1" ] || {
+            echo "Linux ELF artifact not found: $1" >&2
+            exit 2
+        }
+        check_component "$1"
+        check_elf "$1" true
+        ;;
+    --deb)
+        [ "$#" -eq 1 ] || usage
+        [ -f "$1" ] || {
+            echo "Debian artifact not found: $1" >&2
+            exit 2
+        }
+        extract_deb "$1"
+        ;;
+    --rpm)
+        [ "$#" -eq 1 ] || usage
+        [ -f "$1" ] || {
+            echo "RPM artifact not found: $1" >&2
+            exit 2
+        }
+        extract_rpm "$1"
+        ;;
+    --arch)
+        [ "$#" -eq 1 ] || usage
+        [ -f "$1" ] || {
+            echo "Arch artifact not found: $1" >&2
+            exit 2
+        }
+        extract_arch "$1"
+        ;;
+    --metadata)
+        [ "$#" -ge 1 ] || usage
+        for metadata in "$@"; do
+            [ -f "$metadata" ] || {
+                echo "Linux packaging metadata not found: $metadata" >&2
+                exit 2
+            }
+            check_dependency_text "$metadata"
+        done
+        ;;
+    --entry)
+        [ "$#" -eq 1 ] || usage
+        check_entry "$1"
+        ;;
+    *)
+        usage
+        ;;
+esac

--- a/build-aux/linux/validate-package-metadata.sh
+++ b/build-aux/linux/validate-package-metadata.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Pin the inputs which can add Linux payloads or direct package dependencies.
+# Ordinary distro GStreamer packages stay permitted; the shared policy is
+# applied only to explicit component names in these reviewed build inputs.
+
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repository_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
+validator="$script_dir/validate-package-compliance.sh"
+
+"$validator" --metadata \
+    "$repository_root/Cargo.toml" \
+    "$repository_root/Cargo.lock" \
+    "$repository_root/build-aux/flatpak/io.github.tributary.Tributary.yml" \
+    "$repository_root/build-aux/arch/PKGBUILD" \
+    "$repository_root/build-aux/rpm/tributary.spec"
+
+echo "Linux packaging inputs contain no forbidden direct components"

--- a/build-aux/packaging/forbidden-bundled-components.txt
+++ b/build-aux/packaging/forbidden-bundled-components.txt
@@ -2,11 +2,12 @@
 # Keep this focused on optical-disc copy-control and proprietary DRM support;
 # ordinary media codecs and general-purpose cryptography are not prohibited.
 dvdcss
+dvd-pkg
 dvdread
 dvdnav
 aacs
 bdplus
-bluray
+gstbluray
 mmbd
 makemkv
 decss

--- a/build-aux/packaging/forbidden-bundled-components.txt
+++ b/build-aux/packaging/forbidden-bundled-components.txt
@@ -1,0 +1,19 @@
+# Case-insensitive filename substrings that release bundles must not contain.
+# Keep this focused on optical-disc copy-control and proprietary DRM support;
+# ordinary media codecs and general-purpose cryptography are not prohibited.
+dvdcss
+dvdread
+dvdnav
+aacs
+bdplus
+bluray
+mmbd
+makemkv
+decss
+dvdcpxm
+resindvd
+dvdspu
+widevinecdm
+playready
+fairplay
+keydb.cfg

--- a/build-aux/rpm/tributary.spec
+++ b/build-aux/rpm/tributary.spec
@@ -10,7 +10,7 @@ Source0:        https://github.com/jm2/tributary/archive/refs/tags/v%{version}.t
 BuildRequires:  rust
 BuildRequires:  cargo
 BuildRequires:  bash
-BuildRequires:  elfutils
+BuildRequires:  binutils
 BuildRequires:  gcc
 BuildRequires:  pkgconf-pkg-config
 BuildRequires:  libadwaita-devel

--- a/build-aux/rpm/tributary.spec
+++ b/build-aux/rpm/tributary.spec
@@ -9,6 +9,8 @@ Source0:        https://github.com/jm2/tributary/archive/refs/tags/v%{version}.t
 
 BuildRequires:  rust
 BuildRequires:  cargo
+BuildRequires:  bash
+BuildRequires:  elfutils
 BuildRequires:  gcc
 BuildRequires:  pkgconf-pkg-config
 BuildRequires:  libadwaita-devel
@@ -55,7 +57,12 @@ for size in 16x16 24x24 32x32 48x48 64x64 128x128 256x256 512x512; do
         %{buildroot}%{_datadir}/icons/hicolor/${size}/apps/io.github.tributary.Tributary.png
 done
 
+# Validate the installed tree even when a build service skips its test phase.
+build-aux/linux/validate-package-compliance.sh --tree "%{buildroot}"
+
 %check
+build-aux/linux/test-package-compliance.sh
+build-aux/linux/validate-package-compliance.sh --elf target/release/tributary
 desktop-file-validate %{buildroot}%{_datadir}/applications/*.desktop
 appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/*.metainfo.xml
 

--- a/docs/playback-history.md
+++ b/docs/playback-history.md
@@ -84,10 +84,12 @@ known-duration media.
   evidence.
 - Replaying content after a backward seek may earn new observed listening time, but the occurrence's
   one-shot latch still permits at most one count.
-- Local GStreamer, MPD, Chromecast, and AirPlay 1 feed the shared generation-scoped event contract.
-  AirPlay's dedicated RAOP pipeline samples position and duration every 500 ms only while Playing;
-  its weak session reference stops the timer at teardown, and a delayed old-generation sample is
-  rejected rather than credited to a replacement load.
+- Local GStreamer, MPD, and Chromecast feed the shared generation-scoped event contract. The gated
+  AirPlay 1 seam does the same only when an external compatible `raopsink` sender is registered;
+  supported packages do not currently provide one. Its dedicated RAOP pipeline samples position
+  and duration every 500 ms only while Playing; its weak session reference stops the timer at
+  teardown, and a delayed old-generation sample is rejected rather than credited to a replacement
+  load.
 - Progress accounting uses positions and monotonic sequencing, never elapsed UTC time. The UTC
   clock is sampled only when the one-shot threshold decision is emitted—whether by a position
   crossing, late duration acceptance, or qualifying unknown-duration natural end.
@@ -158,8 +160,8 @@ The production pipeline now implements the schema and progress contract end to e
 5. The UI replaces the exact existing local row by stable ID, allowing a Plays-sorted view to
    reorder immediately, and invalidates active and cached regular/smart-playlist projections. It
    never URI-matches or appends a row that disappeared concurrently.
-6. AirPlay 1 now publishes the same accepted position evidence as the other implemented outputs
-   through a generation-scoped 500 ms timer.
+6. The gated AirPlay 1 seam publishes the same accepted position evidence through a
+   generation-scoped 500 ms timer only when an external compatible sender is registered.
 
 This pipeline also drives the seeded Recently Played and Top 25 rules. Every committed history
 event invalidates cached playlist projections before reloading an active playlist; the navigation

--- a/docs/release-component-policy.md
+++ b/docs/release-component-policy.md
@@ -1,0 +1,112 @@
+# Release component policy
+
+Last reviewed: 2026-07-20
+
+Tributary is a music-library application. It does not implement DVD, Blu-ray, protected-media,
+or proprietary content-decryption-module playback, so release artifacts must not contain dedicated
+copy-control circumvention components or the unused optical-disc access plugins that can introduce
+them transitively.
+
+This is a conservative release-engineering boundary, not a representation that a filename by
+itself determines a component's legal status and not legal advice. Laws, licenses, patents, and
+distribution rules vary by jurisdiction. A release owner must still review any new media stack,
+codec, protocol, or packaging source on its own facts.
+
+## Denied release components
+
+[`build-aux/packaging/forbidden-bundled-components.txt`](../build-aux/packaging/forbidden-bundled-components.txt)
+is the machine-readable, case-insensitive filename-token policy used by every packaging helper.
+It covers:
+
+- dedicated CSS, AACS, BD+, and MakeMKV-style optical-disc decryption bridges;
+- DVD and Blu-ray navigation/access libraries and GStreamer plugins that Tributary does not use;
+  these are excluded conservatively even when a particular library does not itself decrypt media;
+- standalone MakeMKV tooling and conventional AACS key-database artifacts; and
+- proprietary browser/video content-decryption modules such as Widevine, PlayReady, or FairPlay.
+
+The policy intentionally does not deny ordinary audio decoders, container parsers, TLS libraries,
+or general-purpose cryptography. Those components support Tributary's normal authorized playback
+and transport security and are distinct from a dedicated copy-control bypass facility. Their
+licenses and any applicable codec-patent obligations remain a separate distribution review.
+
+## Enforcement
+
+Packaging fails closed when the policy file is missing, malformed, or empty. Platform helpers then
+apply the policy at the boundaries available to them:
+
+- Windows and macOS omit denied GStreamer plugins before native dependency traversal, reject a
+  denied dependency discovered during that traversal, and recursively scan the finished portable
+  application before archive, installer, signing, or disk-image creation. Windows also rejects
+  filesystem reparse points before any bundle write, reopens the completed ZIP to validate every
+  entry name, and makes installer-only mode revalidate its existing distribution tree so a stale
+  incremental bundle cannot bypass the gate.
+- Native Linux packages contain Tributary's payload rather than copies of distribution-provided
+  GStreamer libraries. The helper checks Debian control data and maintainer scripts, RPM strong and
+  weak relationships and scriptlets, Arch `.INSTALL` maintainer scripts, the executable's direct
+  ELF dependencies, and each completed `.deb`, `.rpm`, and Arch payload. The RPM build recipe also
+  validates its installed buildroot, and the Arch recipe validates its installed tree even when
+  `check()` is skipped. This boundary does not treat the contents of separately resolved
+  distribution packages as bundled in Tributary's package and does not attest those repositories.
+- Flatpak validation scans the complete application commit: the `/app` payload and its ELF
+  dependencies, app-owned exports, and application metadata. The separately delivered, shared
+  Freedesktop/GNOME runtime is outside Tributary's bundle and outside that payload claim.
+
+Repository tests pin the shared-policy use and fail-closed placement in all three helpers. Release
+jobs run those helpers or the same validators directly. Windows ZIP, native Linux package, and
+Flatpak outputs are reopened and inspected before upload; the macOS app and Windows installer
+source tree are inspected immediately before their trusted container tools run.
+
+## Review boundary
+
+Any change that weakens the denied list, adds a new bundled media framework/plugin source, enables
+optical-disc or protected-media playback, or adds a content-decryption module requires a dedicated
+design and distribution review. Do not add a silent exception to one platform script. Update the
+shared policy, this document, tests, and changelog together, with the reason and artifact evidence
+recorded in review.
+
+The same review applies to a sender implementation that embeds protocol key material: a key being
+public rather than private does not establish that its provenance or distribution is appropriate.
+Normal authenticated transport encryption does not require a policy exception.
+
+The 2026-07-20 sender review found that current official GStreamer, Homebrew, and MSYS2 packages do
+not ship the `raopsink` element Tributary had described as an AirPlay 1 dependency. GStreamer's
+historical, differently named `apexsink` was
+[removed after remaining unported](https://github.com/GStreamer/gst-plugins-bad/commit/9b5de053995488d5ddc78c1bf4df651101271d70);
+its [legacy implementation](https://github.com/GStreamer/gst-plugins-bad/blob/1.10.4/ext/apexsink/gstapexraop.c)
+embedded only an RSA public modulus/exponent used to encrypt a generated outbound session key, not
+a private key or protected-media decryptor. That distinction is useful
+provenance evidence, not a legal conclusion and not a maintained sender path. Tributary therefore
+does not bundle that legacy implementation and no longer tells users that `gst-plugins-bad`
+provides `raopsink`. See the current [GStreamer element index](https://gstreamer.freedesktop.org/documentation/plugins_doc.html),
+[MSYS2 package](https://packages.msys2.org/packages/mingw-w64-clang-x86_64-gst-plugins-bad?repo=clang64),
+and [Homebrew formula](https://formulae.brew.sh/formula/gstreamer) for the supported dependency
+boundary.
+
+The gates detect accidental inclusion under recognizable component filenames and declared native
+dependencies; they are not semantic malware scanners and cannot prove the behavior of an
+arbitrarily renamed binary. They also do not recursively unpack an innocuously named nested
+archive; Tributary's install manifests intentionally introduce no such container. Adding one is a
+review-boundary change. Release inputs must therefore continue to come from the pinned or
+documented package sources used by the build workflows.
+
+A capability-derived audio-plugin allowlist and narrower native distribution relationships would
+be stronger than recognizable-name denial, but they are not safe to guess from one build host:
+GStreamer autoplugging, platform sinks, remote-source handling, supported containers, and any
+future selected AirPlay sender must all remain covered. Some distributions place unused
+disc-access plugins in the same broad plugin packages as supported audio capabilities; that does
+not place them in Tributary's package payload, but it is a valid least-privilege follow-up. Treat
+both changes as a separate cross-platform packaging improvement with a real playback matrix, not
+as an unreviewed tightening of this emergency gate.
+
+## Reference boundary
+
+The conservative classification is informed by the official project descriptions for
+[libdvdcss](https://images.videolan.org/developers/libdvdcss.html),
+[libaacs](https://images.videolan.org/developers/libaacs.html), and
+[libbdplus](https://images.videolan.org/developers/libbdplus.html), together with GStreamer's own
+[distribution and licensing guidance](https://gstreamer.freedesktop.org/documentation/frequently-asked-questions/licensing.html).
+Those upstream pages make different claims about their projects and do not establish Tributary's
+legal obligations. They are provenance for why an audio-only application takes the simpler course
+of omitting the entire unused stack. For U.S. releases, the relevant statutory text is
+[17 U.S.C. § 1201](https://uscode.house.gov/view.xhtml?req=%28title%3A17+section%3A1201+edition%3Aprelim%29);
+release owners should obtain qualified advice when a future feature changes this boundary.

--- a/docs/release-component-policy.md
+++ b/docs/release-component-policy.md
@@ -44,10 +44,12 @@ apply the policy at the boundaries available to them:
   denied dependency discovered during that traversal, and recursively scan the finished portable
   application before archive, installer, signing, or disk-image creation. Windows rejects source
   and destination filesystem reparse points before bundle writes, performs a bounded final import
-  pass over every hidden-inclusive DLL/EXE, reopens the completed ZIP to validate every entry name,
-  and makes installer-only mode repeat both the tree and import gates so a stale incremental bundle
-  cannot bypass them. macOS release builds pin the repository policy and system inspection tools
-  instead of honoring the helper's test hooks; native plugin/dependency source paths and linked
+  pass over every hidden-inclusive DLL/DRV/EXE, accepts the legacy system `.drv` import-module form
+  used by current GTK packages without exempting a bundled DRV from inspection, reopens the
+  completed ZIP to validate every entry name, and makes installer-only mode repeat both the tree
+  and import gates so a stale incremental bundle cannot bypass them. macOS release builds pin the
+  repository policy and system inspection tools instead of honoring the helper's test hooks;
+  native plugin/dependency source paths and linked
   dependency, rpath, and load-command paths are checked component by component under a fixed ASCII
   locale, and Mach-O magic triggers import inspection even without an executable bit or conventional
   name.

--- a/docs/release-component-policy.md
+++ b/docs/release-component-policy.md
@@ -2,7 +2,7 @@
 
 Last reviewed: 2026-07-20
 
-Tributary is a music-library application. It does not implement DVD, Blu-ray, protected-media,
+Tributary is a music-library application. It does not implement DVD, Blu-ray, DRM-protected-media,
 or proprietary content-decryption-module playback, so release artifacts must not contain dedicated
 copy-control circumvention components or the unused optical-disc access plugins that can introduce
 them transitively.
@@ -19,15 +19,21 @@ is the machine-readable, case-insensitive filename-token policy used by every pa
 It covers:
 
 - dedicated CSS, AACS, BD+, and MakeMKV-style optical-disc decryption bridges;
-- DVD and Blu-ray navigation/access libraries and GStreamer plugins that Tributary does not use;
-  these are excluded conservatively even when a particular library does not itself decrypt media;
-- standalone MakeMKV tooling and conventional AACS key-database artifacts; and
+- dedicated DVD access libraries and unused DVD/Blu-ray GStreamer plugins that Tributary does not
+  use; these are excluded conservatively even when a particular library does not itself decrypt
+  media;
+- standalone MakeMKV tooling, the dedicated Debian `libdvd-pkg` installer, and conventional AACS
+  key-database artifacts; and
 - proprietary browser/video content-decryption modules such as Widevine, PlayReady, or FairPlay.
 
 The policy intentionally does not deny ordinary audio decoders, container parsers, TLS libraries,
 or general-purpose cryptography. Those components support Tributary's normal authorized playback
 and transport security and are distinct from a dedicated copy-control bypass facility. Their
 licenses and any applicable codec-patent obligations remain a separate distribution review.
+VideoLAN states that `libbluray` itself contains no DRM-circumvention tool; MSYS2's ordinary
+FFmpeg/libav build links it transitively for Blu-ray access/navigation, so the generic library is
+allowed while the unused `gstbluray` playback plugin and the separate AACS/BD+ decrypt libraries
+remain denied.
 
 ## Enforcement
 
@@ -36,14 +42,21 @@ apply the policy at the boundaries available to them:
 
 - Windows and macOS omit denied GStreamer plugins before native dependency traversal, reject a
   denied dependency discovered during that traversal, and recursively scan the finished portable
-  application before archive, installer, signing, or disk-image creation. Windows also rejects
-  filesystem reparse points before any bundle write, reopens the completed ZIP to validate every
-  entry name, and makes installer-only mode revalidate its existing distribution tree so a stale
-  incremental bundle cannot bypass the gate.
+  application before archive, installer, signing, or disk-image creation. Windows rejects source
+  and destination filesystem reparse points before bundle writes, performs a bounded final import
+  pass over every hidden-inclusive DLL/EXE, reopens the completed ZIP to validate every entry name,
+  and makes installer-only mode repeat both the tree and import gates so a stale incremental bundle
+  cannot bypass them. macOS release builds pin the repository policy and system inspection tools
+  instead of honoring the helper's test hooks; native plugin/dependency source paths and linked
+  dependency, rpath, and load-command paths are checked component by component under a fixed ASCII
+  locale, and Mach-O magic triggers import inspection even without an executable bit or conventional
+  name.
 - Native Linux packages contain Tributary's payload rather than copies of distribution-provided
   GStreamer libraries. The helper checks Debian control data and maintainer scripts, RPM strong and
-  weak relationships and scriptlets, Arch `.INSTALL` maintainer scripts, the executable's direct
-  ELF dependencies, and each completed `.deb`, `.rpm`, and Arch payload. The RPM build recipe also
+  weak relationships and scriptlets, Arch `.INSTALL` maintainer scripts, every bracket-valued ELF
+  dynamic-section reference plus the program interpreter, and each completed `.deb`, `.rpm`, and
+  Arch payload. ELF inspection uses GNU `readelf` because the elfutils variant does not resolve all
+  filtered-library names, and uses a private, failure-cleaned workspace. The RPM build recipe also
   validates its installed buildroot, and the Arch recipe validates its installed tree even when
   `check()` is skipped. This boundary does not treat the contents of separately resolved
   distribution packages as bundled in Tributary's package and does not attest those repositories.
@@ -51,15 +64,16 @@ apply the policy at the boundaries available to them:
   dependencies, app-owned exports, and application metadata. The separately delivered, shared
   Freedesktop/GNOME runtime is outside Tributary's bundle and outside that payload claim.
 
-Repository tests pin the shared-policy use and fail-closed placement in all three helpers. Release
-jobs run those helpers or the same validators directly. Windows ZIP, native Linux package, and
-Flatpak outputs are reopened and inspected before upload; the macOS app and Windows installer
-source tree are inspected immediately before their trusted container tools run.
+Repository tests pin the shared-policy use and fail-closed placement in all three helpers, including
+hostile macOS test-hook values and Windows PowerShell 5.1 parsing. Release jobs run those helpers or
+the same validators directly. Windows ZIP, native Linux package, and Flatpak outputs are reopened
+and inspected before upload; the macOS app and Windows installer source tree are inspected
+immediately before their trusted container tools run.
 
 ## Review boundary
 
 Any change that weakens the denied list, adds a new bundled media framework/plugin source, enables
-optical-disc or protected-media playback, or adds a content-decryption module requires a dedicated
+optical-disc or DRM-protected-media playback, or adds a content-decryption module requires a dedicated
 design and distribution review. Do not add a silent exception to one platform script. Update the
 shared policy, this document, tests, and changelog together, with the reason and artifact evidence
 recorded in review.
@@ -74,7 +88,7 @@ historical, differently named `apexsink` was
 [removed after remaining unported](https://github.com/GStreamer/gst-plugins-bad/commit/9b5de053995488d5ddc78c1bf4df651101271d70);
 its [legacy implementation](https://github.com/GStreamer/gst-plugins-bad/blob/1.10.4/ext/apexsink/gstapexraop.c)
 embedded only an RSA public modulus/exponent used to encrypt a generated outbound session key, not
-a private key or protected-media decryptor. That distinction is useful
+a private key or DRM-protected-media decryptor. That distinction is useful
 provenance evidence, not a legal conclusion and not a maintained sender path. Tributary therefore
 does not bundle that legacy implementation and no longer tells users that `gst-plugins-bad`
 provides `raopsink`. See the current [GStreamer element index](https://gstreamer.freedesktop.org/documentation/plugins_doc.html),
@@ -102,11 +116,15 @@ as an unreviewed tightening of this emergency gate.
 
 The conservative classification is informed by the official project descriptions for
 [libdvdcss](https://images.videolan.org/developers/libdvdcss.html),
+[libbluray](https://www.videolan.org/developers/libbluray.html),
 [libaacs](https://images.videolan.org/developers/libaacs.html), and
 [libbdplus](https://images.videolan.org/developers/libbdplus.html), together with GStreamer's own
 [distribution and licensing guidance](https://gstreamer.freedesktop.org/documentation/frequently-asked-questions/licensing.html).
 Those upstream pages make different claims about their projects and do not establish Tributary's
 legal obligations. They are provenance for why an audio-only application takes the simpler course
-of omitting the entire unused stack. For U.S. releases, the relevant statutory text is
+of omitting dedicated decryptors and unused optical-disc playback plugins. Debian's
+[`libdvd-pkg` documentation](https://sources.debian.org/data/contrib/libd/libdvd-pkg/1.6.0-1-1/debian/README.Debian)
+is the provenance for denying that dedicated installer relationship even when its package name
+does not contain `dvdcss`. For U.S. releases, the relevant statutory text is
 [17 U.S.C. § 1201](https://uscode.house.gov/view.xhtml?req=%28title%3A17+section%3A1201+edition%3Aprelim%29);
 release owners should obtain qualified advice when a future feature changes this boundary.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -32,7 +32,9 @@ settings remain the next slices.
 - Local, Subsonic, Jellyfin, Plex, and DAAP publish complete catalogues through the shared
   `MediaBackend` seam. Connected remotes, Radio-Browser, removable media, and operating-system-opened
   files use the common `SourceRegistry` lifecycle and playback-time authority model.
-- AirPlay 1/RAOP, Chromecast, MPD, and local playback are implemented. AirPlay 2/HomeKit is not.
+- Chromecast, MPD, and local playback are implemented. AirPlay discovery and a fail-closed
+  `raopsink` integration seam exist, but current supported GStreamer/Homebrew/MSYS2 packages do not
+  supply that sender; AirPlay 1 and AirPlay 2 therefore still need a maintained implementation.
 - Regular-playlist storage now has a source-scoped foundation: migration 13 gives every valid
   existing entry the built-in local `SourceId`, makes `(source_id, track_id)` canonical, and
   retains a separate nullable local-track foreign-key cache for deletion and reconciliation.
@@ -87,7 +89,8 @@ settings remain the next slices.
   defines occurrence, threshold, duration, seek/retry/restart, clock, and legacy semantics.
   `PlaybackSession` rejects stale/rejected generations and re-anchors discontinuities; the library
   engine atomically updates one stable local track ID, and committed changes refresh the Plays row
-  and invalidate playlist projections. AirPlay 1 supplies generation-scoped 500 ms progress.
+  and invalidate playlist projections. The gated AirPlay 1 seam supplies generation-scoped 500 ms
+  progress only when an external compatible sender element is present.
   Recently Played evaluates one inclusive 14-day clock window over representable, non-future
   timestamps, newest first with stable ID ties. Top 25 selects and presents positive counts by
   count descending, last-played descending with unknown timestamps last, then stable ID, capped at
@@ -152,8 +155,9 @@ before starting large protocol or transfer subsystems.
    history, root-trust, media-key, seek, and open-file callbacks inert before the drain. The engine
    atomically updates one stable local ID with a saturating count and monotonic timestamp, then
    refreshes the Plays row and invalidates active/cached playlist
-   projections only after commit. AirPlay 1 now publishes generation-scoped position evidence on a
-   500 ms timer. Recently Played uses one clock snapshot, an inclusive preceding 14-day window over
+   projections only after commit. The gated AirPlay 1 seam publishes generation-scoped position
+   evidence on a 500 ms timer only when an external compatible sender is present. Recently Played
+   uses one clock snapshot, an inclusive preceding 14-day window over
    valid non-future timestamps, newest-first presentation, and a stable-ID tie-breaker. Top 25
    admits only positive counts—including legacy counts without timestamps—and selects/presents at
    most 25 by count descending, last-played descending with unknown timestamps last, then stable
@@ -372,11 +376,14 @@ not mistaken for work already underway.
 | [#11 — Offline cache/download](https://github.com/jm2/tributary/issues/11) | No remote download or offline catalogue subsystem. | Large persistent cache/download epic with quota, retry, reconciliation, and secure auth handling. |
 | [#8 — Android synchronization](https://github.com/jm2/tributary/issues/8) | Mounted-device browse/play exists; transfer, sync, automount, and MTP do not. | Large transfer/sync epic with MTP, write authority, planning, progress, conflicts, and rollback. |
 
-## AirPlay 2
+## AirPlay senders
 
 AirPlay 2 receivers advertise via `_airplay._tcp.local.` and discovery labels them as `airplay2`,
-but the UI deliberately filters them out because Tributary currently has only an AirPlay 1/RAOP
-sender through GStreamer's `raopsink`.
+but the UI deliberately filters them out because Tributary has no maintained AirPlay 2 sender.
+Legacy RAOP receivers are visible, but their output path is a runtime-gated seam for an element
+named `raopsink`; current official GStreamer, Homebrew, and MSYS2 packages do not ship it. The
+previous package-install guidance was therefore incorrect and has been replaced by an honest
+unavailable message.
 
 No sender dependency or protocol implementation has been selected. The implementation must first
 confirm current reverse-engineering and interoperability details for:
@@ -392,6 +399,13 @@ distribution model, platform packaging, license, maintenance health, and real-de
 must be part of that decision. This work should start with a design issue; it is not currently an
 active implementation.
 
+Any selected media or sender dependency must also preserve Tributary's
+[release component policy](release-component-policy.md): application artifacts omit dedicated
+copy-control circumvention components, unused optical-disc access stacks, and proprietary
+content-decryption modules. Ordinary authenticated protocol encryption and media decoding are not
+treated as circumvention by filename, but each new dependency still needs its own license,
+distribution, key-material provenance, and interoperability review.
+
 ## Other explicit follow-ups and accepted limits
 
 ### Engineering follow-ups
@@ -403,6 +417,12 @@ active implementation.
   supported runtime floor and has been validated on affected multi-channel hardware.
 - A direct end-to-end watcher-backlog/root-confirmation ordering harness would strengthen existing
   component and engine-loop coverage, although the remediation acceptance record is already closed.
+- Evaluate replacing the broad Windows/macOS GStreamer plugin copy with a capability-derived audio
+  allowlist and narrowing native Linux's broad plugin-package relationships after a cross-platform
+  playback/output matrix can prove all supported containers, remote sources, local sinks, and
+  any selected AirPlay sender. The current shared deny policy already blocks the known
+  optical-disc/decryption/CDM families in Tributary-owned payloads and fails closed at artifact
+  boundaries.
 
 ### Deliberate current limitations, not scheduled commitments
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -401,10 +401,11 @@ active implementation.
 
 Any selected media or sender dependency must also preserve Tributary's
 [release component policy](release-component-policy.md): application artifacts omit dedicated
-copy-control circumvention components, unused optical-disc access stacks, and proprietary
-content-decryption modules. Ordinary authenticated protocol encryption and media decoding are not
-treated as circumvention by filename, but each new dependency still needs its own license,
-distribution, key-material provenance, and interoperability review.
+copy-control circumvention components, unused optical-disc playback plugins, and proprietary
+content-decryption modules. Ordinary authenticated protocol encryption, media decoding, and the
+non-decrypting `libbluray` access/navigation library required transitively by supported FFmpeg
+builds are not treated as circumvention by filename, but each new dependency still needs its own
+license, distribution, key-material provenance, and interoperability review.
 
 ## Other explicit follow-ups and accepted limits
 
@@ -421,8 +422,8 @@ distribution, key-material provenance, and interoperability review.
   allowlist and narrowing native Linux's broad plugin-package relationships after a cross-platform
   playback/output matrix can prove all supported containers, remote sources, local sinks, and
   any selected AirPlay sender. The current shared deny policy already blocks the known
-  optical-disc/decryption/CDM families in Tributary-owned payloads and fails closed at artifact
-  boundaries.
+  dedicated decrypt/CDM families and unused disc-playback plugins in Tributary-owned payloads and
+  fails closed at artifact boundaries.
 
 ### Deliberate current limitations, not scheduled commitments
 

--- a/docs/task.md
+++ b/docs/task.md
@@ -63,8 +63,9 @@ change the feature total. It removes the observed path by which broad Windows/ma
 bundling could pull unused optical-disc access and decryption components into an artifact, adds a
 single reviewed deny policy, and makes Windows, macOS, native Linux, and Flatpak payload validation
 fail closed. Review and CI follow-up also pinned production macOS inspection inputs, covered
-nonstandard Mach-O and ELF reference paths, made Windows source-copy and final PE gates complete,
-and distinguished FFmpeg's non-decrypting `libbluray` dependency from the denied `gstbluray`,
+nonstandard Mach-O and ELF reference paths, made Windows source-copy and final PE gates complete
+across DLL/DRV/EXE module forms, and distinguished FFmpeg's non-decrypting `libbluray` dependency
+from the denied `gstbluray`,
 AACS, and BD+ components. Its exact scope and limitations are recorded in
 [`release-component-policy.md`](release-component-policy.md). P2.1 Last.fm remains the feature
 focus after this urgent distribution safeguard. The same provenance review established that no
@@ -754,7 +755,7 @@ selecting and validating a maintained AirPlay path.
 
 | Date | Task | PR | Result |
 |---|---|---|---|
-| 2026-07-20 | Cross-platform release-component containment | [#152](https://github.com/jm2/tributary/pull/152) | Replaced permissive disc-component bundling with one shared deny policy; filtered before native dependency traversal; rejected denied transitive dependencies and recognizable path references; rejected link-based, test-hook, and incomplete-inspection escapes; and added final Windows ZIP/PE, macOS, native Linux, Packit/COPR, and complete Flatpak app-commit gates, including stale-tree and installer-only paths. Review regressions cover nonstandard Mach-O placement, all bracket-valued ELF dynamic tags plus the program interpreter, source-copy reparse points, failure-cleaned temporary state, and the deliberate `libbluray`/decryptor distinction. The dependency audit also removed false `gst-plugins-bad`/`raopsink` install guidance and folded maintained AirPlay sender selection into P2.4. Ordinary codecs and transport cryptography remain intentionally available. This distribution safeguard does not advance the 14/38 feature numerator. |
+| 2026-07-20 | Cross-platform release-component containment | [#152](https://github.com/jm2/tributary/pull/152) | Replaced permissive disc-component bundling with one shared deny policy; filtered before native dependency traversal; rejected denied transitive dependencies and recognizable path references; rejected link-based, test-hook, and incomplete-inspection escapes; and added final Windows ZIP/PE, macOS, native Linux, Packit/COPR, and complete Flatpak app-commit gates, including stale-tree and installer-only paths. Review regressions cover nonstandard Mach-O placement, all bracket-valued ELF dynamic tags plus the program interpreter, source-copy reparse points, Windows DLL/DRV/EXE import forms, failure-cleaned temporary state, and the deliberate `libbluray`/decryptor distinction. The dependency audit also removed false `gst-plugins-bad`/`raopsink` install guidance and folded maintained AirPlay sender selection into P2.4. Ordinary codecs and transport cryptography remain intentionally available. This distribution safeguard does not advance the 14/38 feature numerator. |
 | 2026-07-18 | Backlog reset | — | Archived the holistic-review tracker and established the audited feature backlog; no implementation record completed. |
 | 2026-07-18 | P1.1 bounded shuffle history | [#132](https://github.com/jm2/tributary/pull/132) | Retained ten real prior occurrences, fixed forward traversal and complete Repeat All cycles, unified Previous dispatch, made toggle/reset semantics explicit, and added lifecycle/rollback regressions. |
 | 2026-07-18 | P1.2 honest unsupported playlist actions | [#133](https://github.com/jm2/tributary/pull/133) | Refused non-local Add to Playlist actions with an all-or-none localized dialog before database work, localized the existing context-menu labels, and regressed the fail-closed source policy plus every shipped catalog. |

--- a/docs/task.md
+++ b/docs/task.md
@@ -62,7 +62,10 @@ The cross-platform release-component containment work implemented in PR #152 on 
 change the feature total. It removes the observed path by which broad Windows/macOS GStreamer
 bundling could pull unused optical-disc access and decryption components into an artifact, adds a
 single reviewed deny policy, and makes Windows, macOS, native Linux, and Flatpak payload validation
-fail closed. Its exact scope and limitations are recorded in
+fail closed. Review and CI follow-up also pinned production macOS inspection inputs, covered
+nonstandard Mach-O and ELF reference paths, made Windows source-copy and final PE gates complete,
+and distinguished FFmpeg's non-decrypting `libbluray` dependency from the denied `gstbluray`,
+AACS, and BD+ components. Its exact scope and limitations are recorded in
 [`release-component-policy.md`](release-component-policy.md). P2.1 Last.fm remains the feature
 focus after this urgent distribution safeguard. The same provenance review established that no
 current supported GStreamer/Homebrew/MSYS2 package provides the claimed `raopsink` element; its
@@ -751,7 +754,7 @@ selecting and validating a maintained AirPlay path.
 
 | Date | Task | PR | Result |
 |---|---|---|---|
-| 2026-07-20 | Cross-platform release-component containment | [#152](https://github.com/jm2/tributary/pull/152) | Replaced permissive disc-component bundling with one shared deny policy; filtered before native dependency traversal; rejected denied transitive dependencies; rejected link-based and incomplete-inspection escapes; and added final Windows ZIP, macOS, native Linux, Packit/COPR, and complete Flatpak app-commit gates, including stale-tree and installer-only paths. The dependency audit also removed false `gst-plugins-bad`/`raopsink` install guidance and folded maintained AirPlay sender selection into P2.4. Ordinary codecs and transport cryptography remain intentionally available. This distribution safeguard does not advance the 14/38 feature numerator. |
+| 2026-07-20 | Cross-platform release-component containment | [#152](https://github.com/jm2/tributary/pull/152) | Replaced permissive disc-component bundling with one shared deny policy; filtered before native dependency traversal; rejected denied transitive dependencies and recognizable path references; rejected link-based, test-hook, and incomplete-inspection escapes; and added final Windows ZIP/PE, macOS, native Linux, Packit/COPR, and complete Flatpak app-commit gates, including stale-tree and installer-only paths. Review regressions cover nonstandard Mach-O placement, all bracket-valued ELF dynamic tags plus the program interpreter, source-copy reparse points, failure-cleaned temporary state, and the deliberate `libbluray`/decryptor distinction. The dependency audit also removed false `gst-plugins-bad`/`raopsink` install guidance and folded maintained AirPlay sender selection into P2.4. Ordinary codecs and transport cryptography remain intentionally available. This distribution safeguard does not advance the 14/38 feature numerator. |
 | 2026-07-18 | Backlog reset | — | Archived the holistic-review tracker and established the audited feature backlog; no implementation record completed. |
 | 2026-07-18 | P1.1 bounded shuffle history | [#132](https://github.com/jm2/tributary/pull/132) | Retained ten real prior occurrences, fixed forward traversal and complete Repeat All cycles, unified Previous dispatch, made toggle/reset semantics explicit, and added lifecycle/rollback regressions. |
 | 2026-07-18 | P1.2 honest unsupported playlist actions | [#133](https://github.com/jm2/tributary/pull/133) | Refused non-local Add to Playlist actions with an all-or-none localized dialog before database work, localized the existing context-menu labels, and regressed the fail-closed source policy plus every shipped catalog. |

--- a/docs/task.md
+++ b/docs/task.md
@@ -58,7 +58,7 @@ evidence for authoritative reconciliation. It intentionally omits the original p
 unparseable-file cache so transient parser and I/O failures remain retryable. It is tracked outside
 the 38-record feature backlog.
 
-The cross-platform release-component containment work prepared on 2026-07-20 likewise does not
+The cross-platform release-component containment work implemented in PR #152 on 2026-07-20 likewise does not
 change the feature total. It removes the observed path by which broad Windows/macOS GStreamer
 bundling could pull unused optical-disc access and decryption components into an artifact, adds a
 single reviewed deny policy, and makes Windows, macOS, native Linux, and Flatpak payload validation
@@ -751,7 +751,7 @@ selecting and validating a maintained AirPlay path.
 
 | Date | Task | PR | Result |
 |---|---|---|---|
-| 2026-07-20 | Cross-platform release-component containment | Pending | Replaced permissive disc-component bundling with one shared deny policy; filtered before native dependency traversal; rejected denied transitive dependencies; rejected link-based and incomplete-inspection escapes; and added final Windows ZIP, macOS, native Linux, Packit/COPR, and complete Flatpak app-commit gates, including stale-tree and installer-only paths. The dependency audit also removed false `gst-plugins-bad`/`raopsink` install guidance and folded maintained AirPlay sender selection into P2.4. Ordinary codecs and transport cryptography remain intentionally available. This distribution safeguard does not advance the 14/38 feature numerator. |
+| 2026-07-20 | Cross-platform release-component containment | [#152](https://github.com/jm2/tributary/pull/152) | Replaced permissive disc-component bundling with one shared deny policy; filtered before native dependency traversal; rejected denied transitive dependencies; rejected link-based and incomplete-inspection escapes; and added final Windows ZIP, macOS, native Linux, Packit/COPR, and complete Flatpak app-commit gates, including stale-tree and installer-only paths. The dependency audit also removed false `gst-plugins-bad`/`raopsink` install guidance and folded maintained AirPlay sender selection into P2.4. Ordinary codecs and transport cryptography remain intentionally available. This distribution safeguard does not advance the 14/38 feature numerator. |
 | 2026-07-18 | Backlog reset | — | Archived the holistic-review tracker and established the audited feature backlog; no implementation record completed. |
 | 2026-07-18 | P1.1 bounded shuffle history | [#132](https://github.com/jm2/tributary/pull/132) | Retained ten real prior occurrences, fixed forward traversal and complete Repeat All cycles, unified Previous dispatch, made toggle/reset semantics explicit, and added lifecycle/rollback regressions. |
 | 2026-07-18 | P1.2 honest unsupported playlist actions | [#133](https://github.com/jm2/tributary/pull/133) | Refused non-local Add to Playlist actions with an all-or-none localized dialog before database work, localized the existing context-menu labels, and regressed the fail-closed source policy plus every shipped catalog. |

--- a/docs/task.md
+++ b/docs/task.md
@@ -58,6 +58,17 @@ evidence for authoritative reconciliation. It intentionally omits the original p
 unparseable-file cache so transient parser and I/O failures remain retryable. It is tracked outside
 the 38-record feature backlog.
 
+The cross-platform release-component containment work prepared on 2026-07-20 likewise does not
+change the feature total. It removes the observed path by which broad Windows/macOS GStreamer
+bundling could pull unused optical-disc access and decryption components into an artifact, adds a
+single reviewed deny policy, and makes Windows, macOS, native Linux, and Flatpak payload validation
+fail closed. Its exact scope and limitations are recorded in
+[`release-component-policy.md`](release-component-policy.md). P2.1 Last.fm remains the feature
+focus after this urgent distribution safeguard. The same provenance review established that no
+current supported GStreamer/Homebrew/MSYS2 package provides the claimed `raopsink` element; its
+incorrect package-install guidance is now honest, and the existing P2.4 sender-design records cover
+selecting and validating a maintained AirPlay path.
+
 ## P1 — Correctness and shared feature foundations
 
 ### P1.1 — Harden and document existing shuffled playback history
@@ -145,9 +156,10 @@ the 38-record feature backlog.
   barrier deliberately does not claim to drain filesystem-watcher events, and the disabled window
   may remain visible until the serialized scan finishes. Only a committed update publishes the
   replacement row; the live local Plays value
-  refreshes by stable ID and active/cached playlist projections are invalidated. AirPlay 1 now
-  contributes the same evidence through generation-scoped 500 ms position samples. The complete
-  contract is in [`playback-history.md`](playback-history.md).
+  refreshes by stable ID and active/cached playlist projections are invalidated. The gated AirPlay
+  1 seam contributes the same evidence through generation-scoped 500 ms position samples only when
+  an external compatible sender is registered. The complete contract is in
+  [`playback-history.md`](playback-history.md).
 
   The seeded history consumers now use one immutable clock snapshot per evaluation. Recently
   Played accepts only representable, non-future `last_played` instants in the inclusive preceding
@@ -666,13 +678,15 @@ the 38-record feature backlog.
 - [ ] Implement the supported equalizer path and accessible settings UI, then test format changes,
   gapless navigation, disabled/bypass behavior, clipping policy, and each output's supported or
   explicitly unavailable state.
-- [ ] Open and complete an AirPlay 2 sender design investigation covering maintained dependencies,
-  pairing, encrypted control, audio/timing, licensing, packaging, and real-device test requirements.
-- [ ] Implement the selected AirPlay 2 pairing/control/audio path without exposing unsupported
-  discovered receivers in the output selector; keep simultaneous multi-room sync out of scope
-  unless separately approved.
-- [ ] Validate AirPlay 2 interoperability and packaging on supported platforms and representative
-  receivers, including reconnect, cancellation, authentication failure, and actionable diagnostics.
+- [ ] Open and complete an AirPlay sender design investigation that first resolves the current
+  non-shipped `raopsink` seam, then scopes maintained RAOP and/or AirPlay 2 dependencies, pairing,
+  encrypted control, audio/timing, licensing, key provenance, packaging, and real-device tests.
+- [ ] Implement the selected maintained AirPlay sender path without presenting unsupported
+  discovered receivers as playable; keep simultaneous multi-room sync out of scope unless
+  separately approved.
+- [ ] Validate the selected AirPlay interoperability and packaging paths on supported platforms and
+  representative receivers, including reconnect, cancellation, authentication failure, and
+  actionable diagnostics.
 - [ ] Add receiver-facing IPv6 Chromecast media tickets where a reachable scoped address can be
   published safely; retain fail-closed omission for unusable endpoints.
 - [ ] Design and implement an optional detectable MPD exclusive-control/ownership mode before
@@ -728,11 +742,16 @@ the 38-record feature backlog.
   “similarly named” matching are not scheduled. XSPF is the supported interchange path.
 - Automount/eject, markerless read-only root enrollment, stronger native removable IDs, and saved
   endpoint rebind are candidates rather than committed work until they receive scoped issues.
+- A capability-derived Windows/macOS GStreamer audio-plugin allowlist and narrower native Linux
+  plugin-package relationships are possible stronger least-privilege packaging boundaries, not a
+  scheduled feature record. They require a real cross-platform container/source/output playback
+  matrix before replacing the current shared fail-closed deny policy safely.
 
 ## Implementation log
 
 | Date | Task | PR | Result |
 |---|---|---|---|
+| 2026-07-20 | Cross-platform release-component containment | Pending | Replaced permissive disc-component bundling with one shared deny policy; filtered before native dependency traversal; rejected denied transitive dependencies; rejected link-based and incomplete-inspection escapes; and added final Windows ZIP, macOS, native Linux, Packit/COPR, and complete Flatpak app-commit gates, including stale-tree and installer-only paths. The dependency audit also removed false `gst-plugins-bad`/`raopsink` install guidance and folded maintained AirPlay sender selection into P2.4. Ordinary codecs and transport cryptography remain intentionally available. This distribution safeguard does not advance the 14/38 feature numerator. |
 | 2026-07-18 | Backlog reset | — | Archived the holistic-review tracker and established the audited feature backlog; no implementation record completed. |
 | 2026-07-18 | P1.1 bounded shuffle history | [#132](https://github.com/jm2/tributary/pull/132) | Retained ten real prior occurrences, fixed forward traversal and complete Repeat All cycles, unified Previous dispatch, made toggle/reset semantics explicit, and added lifecycle/rollback regressions. |
 | 2026-07-18 | P1.2 honest unsupported playlist actions | [#133](https://github.com/jm2/tributary/pull/133) | Refused non-local Add to Playlist actions with an all-or-none localized dialog before database work, localized the existing context-menu labels, and regressed the fail-closed source policy plus every shipped catalog. |

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -299,7 +299,7 @@ errors:
     decoder_failed: "Audiodecoder ist fehlgeschlagen"
     audio_output_failed: "Audioausgabe ist fehlgeschlagen"
     playback_failed: "Audiowiedergabe ist fehlgeschlagen"
-    airplay_raopsink_missing: "AirPlay benötigt das GStreamer-Element raopsink – bitte das Paket gst-plugins-bad installieren und Tributary neu starten"
+    airplay_raopsink_missing: "AirPlay-1-Wiedergabe ist nicht verfügbar: Dieser Build enthält keinen kompatiblen GStreamer-raopsink-Sender"
     mpd_exclusive_control_required: "Fügen Sie diese MPD-Ausgabe erneut hinzu, bestätigen Sie die exklusive Partitionskontrolle und wählen Sie sie dann vor der Wiedergabe erneut aus"
 
 # ── About dialog ───────────────────────────────────────────────────

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -332,7 +332,7 @@ errors:
     decoder_failed: "Audio decoder failed"
     audio_output_failed: "Audio output failed"
     playback_failed: "Audio playback failed"
-    airplay_raopsink_missing: "AirPlay requires GStreamer's raopsink element — install the gst-plugins-bad package and restart Tributary"
+    airplay_raopsink_missing: "AirPlay 1 playback is unavailable: this build has no compatible GStreamer raopsink sender"
     mpd_exclusive_control_required: "Re-add this MPD output, confirm exclusive partition control, then select it again before playback"
 
 # ── About dialog ───────────────────────────────────────────────────

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -299,7 +299,7 @@ errors:
     decoder_failed: "Falló el decodificador de audio"
     audio_output_failed: "Falló la salida de audio"
     playback_failed: "Falló la reproducción de audio"
-    airplay_raopsink_missing: "AirPlay requiere el elemento raopsink de GStreamer: instale el paquete gst-plugins-bad y reinicie Tributary"
+    airplay_raopsink_missing: "La reproducción mediante AirPlay 1 no está disponible: esta compilación no incluye un emisor raopsink de GStreamer compatible"
     mpd_exclusive_control_required: "Vuelva a agregar esta salida MPD, confirme el control exclusivo de la partición y vuelva a seleccionarla antes de reproducir"
 
 # ── About dialog ───────────────────────────────────────────────────

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -299,7 +299,7 @@ errors:
     decoder_failed: "Le décodeur audio a échoué"
     audio_output_failed: "La sortie audio a échoué"
     playback_failed: "La lecture audio a échoué"
-    airplay_raopsink_missing: "AirPlay nécessite l'élément raopsink de GStreamer — installez le paquet gst-plugins-bad puis redémarrez Tributary"
+    airplay_raopsink_missing: "La lecture AirPlay 1 n'est pas disponible : cette version ne contient aucun émetteur GStreamer raopsink compatible"
     mpd_exclusive_control_required: "Ajoutez à nouveau cette sortie MPD, confirmez le contrôle exclusif de la partition, puis sélectionnez-la à nouveau avant la lecture"
 
 # ── About dialog ───────────────────────────────────────────────────

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -299,7 +299,7 @@ errors:
     decoder_failed: "Si è verificato un errore nel decoder audio"
     audio_output_failed: "Si è verificato un errore nell’uscita audio"
     playback_failed: "La riproduzione audio non è riuscita"
-    airplay_raopsink_missing: "AirPlay richiede l'elemento raopsink di GStreamer: installa il pacchetto gst-plugins-bad e riavvia Tributary"
+    airplay_raopsink_missing: "La riproduzione AirPlay 1 non è disponibile: questa build non include un trasmettitore raopsink GStreamer compatibile"
     mpd_exclusive_control_required: "Aggiungi di nuovo questa uscita MPD, conferma il controllo esclusivo della partizione, quindi selezionala di nuovo prima della riproduzione"
 
 # ── About dialog ───────────────────────────────────────────────────

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -299,7 +299,7 @@ errors:
     decoder_failed: "オーディオデコーダーでエラーが発生しました"
     audio_output_failed: "オーディオ出力に失敗しました"
     playback_failed: "オーディオ再生に失敗しました"
-    airplay_raopsink_missing: "AirPlay には GStreamer の raopsink エレメントが必要です。gst-plugins-bad パッケージをインストールしてから Tributary を再起動してください"
+    airplay_raopsink_missing: "AirPlay 1 再生は利用できません。このビルドには互換性のある GStreamer raopsink 送信機が含まれていません"
     mpd_exclusive_control_required: "この MPD 出力を再追加してパーティションの排他的制御を確認し、再生前にもう一度選択してください"
 
 # ── About dialog ───────────────────────────────────────────────────

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -299,7 +299,7 @@ errors:
     decoder_failed: "오디오 디코더에 오류가 발생했습니다"
     audio_output_failed: "오디오 출력에 실패했습니다"
     playback_failed: "오디오 재생에 실패했습니다"
-    airplay_raopsink_missing: "AirPlay를 사용하려면 GStreamer의 raopsink 요소가 필요합니다. gst-plugins-bad 패키지를 설치한 후 Tributary를 다시 시작하세요"
+    airplay_raopsink_missing: "AirPlay 1 재생을 사용할 수 없습니다. 이 빌드에는 호환되는 GStreamer raopsink 송신기가 없습니다"
     mpd_exclusive_control_required: "이 MPD 출력을 다시 추가하고 파티션 독점 제어를 확인한 다음 재생 전에 다시 선택하세요"
 
 # ── About dialog ───────────────────────────────────────────────────

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -299,7 +299,7 @@ errors:
     decoder_failed: "De audiodecoder is mislukt"
     audio_output_failed: "De audio-uitvoer is mislukt"
     playback_failed: "Het afspelen van audio is mislukt"
-    airplay_raopsink_missing: "AirPlay vereist het GStreamer-element raopsink – installeer het pakket gst-plugins-bad en start Tributary opnieuw"
+    airplay_raopsink_missing: "AirPlay 1-weergave is niet beschikbaar: deze build bevat geen compatibele GStreamer-raopsink-zender"
     mpd_exclusive_control_required: "Voeg deze MPD-uitvoer opnieuw toe, bevestig exclusieve partitiecontrole en selecteer deze opnieuw vóór het afspelen"
 
 # ── About dialog ───────────────────────────────────────────────────

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -299,7 +299,7 @@ errors:
     decoder_failed: "Wystąpił błąd dekodera dźwięku"
     audio_output_failed: "Wystąpił błąd wyjścia dźwięku"
     playback_failed: "Odtwarzanie dźwięku nie powiodło się"
-    airplay_raopsink_missing: "AirPlay wymaga elementu raopsink z GStreamera — zainstaluj pakiet gst-plugins-bad i uruchom Tributary ponownie"
+    airplay_raopsink_missing: "Odtwarzanie AirPlay 1 jest niedostępne: ta kompilacja nie zawiera zgodnego nadajnika GStreamer raopsink"
     mpd_exclusive_control_required: "Dodaj ponownie to wyjście MPD, potwierdź wyłączną kontrolę nad partycją, a następnie wybierz je ponownie przed odtwarzaniem"
 
 # ── About dialog ───────────────────────────────────────────────────

--- a/locales/pt-BR.yml
+++ b/locales/pt-BR.yml
@@ -299,7 +299,7 @@ errors:
     decoder_failed: "Falha no decodificador de áudio"
     audio_output_failed: "Falha na saída de áudio"
     playback_failed: "Falha na reprodução de áudio"
-    airplay_raopsink_missing: "O AirPlay requer o elemento raopsink do GStreamer — instale o pacote gst-plugins-bad e reinicie o Tributary"
+    airplay_raopsink_missing: "A reprodução via AirPlay 1 não está disponível: esta compilação não inclui um transmissor raopsink compatível do GStreamer"
     mpd_exclusive_control_required: "Adicione novamente esta saída MPD, confirme o controle exclusivo da partição e selecione-a novamente antes da reprodução"
 
 # ── About dialog ───────────────────────────────────────────────────

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -299,7 +299,7 @@ errors:
     decoder_failed: "Сбой аудиодекодера"
     audio_output_failed: "Сбой аудиовыхода"
     playback_failed: "Сбой воспроизведения аудио"
-    airplay_raopsink_missing: "Для AirPlay требуется элемент raopsink из GStreamer — установите пакет gst-plugins-bad и перезапустите Tributary"
+    airplay_raopsink_missing: "Воспроизведение через AirPlay 1 недоступно: в этой сборке нет совместимого передатчика raopsink для GStreamer"
     mpd_exclusive_control_required: "Повторно добавьте этот выход MPD, подтвердите исключительный контроль раздела, затем снова выберите его перед воспроизведением"
 
 # ── About dialog ───────────────────────────────────────────────────

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -299,7 +299,7 @@ errors:
     decoder_failed: "音频解码器发生错误"
     audio_output_failed: "音频输出失败"
     playback_failed: "音频播放失败"
-    airplay_raopsink_missing: "AirPlay 需要 GStreamer 的 raopsink 元素。请安装 gst-plugins-bad 软件包，然后重新启动 Tributary"
+    airplay_raopsink_missing: "AirPlay 1 播放不可用：此版本不包含兼容的 GStreamer raopsink 发送器"
     mpd_exclusive_control_required: "请重新添加此 MPD 输出，确认对分区的独占控制，然后在播放前再次选择它"
 
 # ── About dialog ───────────────────────────────────────────────────

--- a/locales/zh-TW.yml
+++ b/locales/zh-TW.yml
@@ -299,7 +299,7 @@ errors:
     decoder_failed: "音訊解碼器發生錯誤"
     audio_output_failed: "音訊輸出失敗"
     playback_failed: "音訊播放失敗"
-    airplay_raopsink_missing: "AirPlay 需要 GStreamer 的 raopsink 元素。請安裝 gst-plugins-bad 套件，然後重新啟動 Tributary"
+    airplay_raopsink_missing: "AirPlay 1 播放無法使用：此版本未包含相容的 GStreamer raopsink 傳送器"
     mpd_exclusive_control_required: "請重新新增此 MPD 輸出，確認對分割區的獨佔控制，然後在播放前再次選取它"
 
 # ── About dialog ───────────────────────────────────────────────────

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -6,6 +6,9 @@ set -euo pipefail
 SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(CDPATH= cd -- "${SCRIPT_DIR}/.." && pwd)"
 cd "${REPO_ROOT}"
+PACKAGE_VALIDATOR="${REPO_ROOT}/build-aux/linux/validate-package-compliance.sh"
+PACKAGE_METADATA_VALIDATOR="${REPO_ROOT}/build-aux/linux/validate-package-metadata.sh"
+FLATPAK_BUNDLE_VALIDATOR="${REPO_ROOT}/build-aux/flatpak/validate-bundle-compliance.sh"
 
 print_usage() {
   cat <<'EOF'
@@ -28,11 +31,16 @@ Quick-exit modes (run one task and exit):
 
 Packaging:
   --flatpak         Build a Flatpak bundle (requires flatpak, flatpak-builder,
-                    Python generator dependencies, and a user Flathub remote;
-                    does not require host Rust/GTK development packages).
-  --deb             Build a .deb package via cargo-deb.
-  --rpm             Build an .rpm package via cargo-generate-rpm.
-  --arch-pkg        Build an Arch .pkg.tar.zst via makepkg.
+                    Python generator dependencies, ostree, readelf/eu-readelf,
+                    and a user Flathub remote; does not require host Rust/GTK
+                    development packages).
+  --deb             Build a .deb package via cargo-deb (requires dpkg-deb).
+  --rpm             Build an .rpm package via cargo-generate-rpm (requires
+                    rpm, rpm2cpio, and cpio).
+  --arch-pkg        Build an Arch .pkg.tar.zst via makepkg (requires bsdtar).
+
+All native builds require readelf (binutils) or eu-readelf (elfutils) for the
+artifact compliance gate.
 
 Other:
   -h, --help        Show this help and exit.
@@ -73,15 +81,50 @@ if { $CHECK || $FMT || $CLIPPY || $COVERAGE; } && \
   error "Quick-exit and packaging modes cannot be combined"
 fi
 
+require_validator_tool() {
+  command -v "$1" &>/dev/null || error "$1 not found (required for artifact validation)"
+}
+
+require_elf_inspector() {
+  command -v readelf &>/dev/null || command -v eu-readelf &>/dev/null || \
+    error "readelf/eu-readelf not found. Install binutils or elfutils for artifact validation"
+}
+
+preflight_artifact_tools() {
+  # Formatting, static checks, and coverage do not produce a release artifact.
+  if $CHECK || $FMT || $CLIPPY || $COVERAGE; then
+    return
+  fi
+
+  require_elf_inspector
+  if $FLATPAK; then
+    require_validator_tool flatpak
+    require_validator_tool flatpak-builder
+    require_validator_tool python3
+    require_validator_tool ostree
+  fi
+  if $DEB; then
+    require_validator_tool dpkg-deb
+  fi
+  if $RPM; then
+    require_validator_tool rpm
+    require_validator_tool rpm2cpio
+    require_validator_tool cpio
+  fi
+  if $ARCH_PKG; then
+    require_validator_tool bsdtar
+  fi
+}
+
+preflight_artifact_tools # fail before build work
+
 build_flatpak() {
-  command -v flatpak         &>/dev/null || error "flatpak not found. Install: sudo apt install flatpak"
-  command -v flatpak-builder &>/dev/null || error "flatpak-builder not found. Install: sudo apt install flatpak-builder"
-  command -v python3          &>/dev/null || error "python3 not found (required to generate cargo sources)"
   if ! flatpak remote-list --user --columns=name | grep -Fxq flathub; then
     error "Flathub user remote not found. Run: flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo"
   fi
 
   local manifest="build-aux/flatpak/io.github.tributary.Tributary.yml"
+  "$PACKAGE_METADATA_VALIDATOR"
   info "Generating cargo-sources.json..."
   bash build-aux/flatpak/generate-cargo-sources.sh
 
@@ -90,6 +133,7 @@ build_flatpak() {
     --repo=repo build-dir "$manifest"
   flatpak build-bundle repo tributary.flatpak io.github.tributary.Tributary \
     --runtime-repo=https://dl.flathub.org/repo/flathub.flatpakrepo
+  "$FLATPAK_BUNDLE_VALIDATOR" tributary.flatpak
   info "Flatpak bundle: $(pwd)/tributary.flatpak"
 }
 
@@ -167,8 +211,10 @@ if $COVERAGE; then
 fi
 
 # ── Rust Build ───────────────────────────────────────────────────────────────
+"$PACKAGE_METADATA_VALIDATOR"
 info "Building Tributary (release)..."
 cargo build --release
+"$PACKAGE_VALIDATOR" --elf target/release/tributary
 info "Binary: $(pwd)/target/release/tributary"
 
 # ── Install Icons (if running with --install or as root) ─────────────────────
@@ -189,6 +235,7 @@ if $DEB; then
   cargo deb
   DEB_FILE=$(ls target/debian/*.deb 2>/dev/null | head -1)
   if [[ -n "$DEB_FILE" ]]; then
+    "$PACKAGE_VALIDATOR" --deb "$DEB_FILE"
     info "Debian package: $(pwd)/$DEB_FILE"
   else
     error "cargo-deb did not produce a .deb file"
@@ -206,6 +253,7 @@ if $RPM; then
   cargo generate-rpm
   RPM_FILE=$(ls target/generate-rpm/*.rpm 2>/dev/null | head -1)
   if [[ -n "$RPM_FILE" ]]; then
+    "$PACKAGE_VALIDATOR" --rpm "$RPM_FILE"
     info "RPM package: $(pwd)/$RPM_FILE"
   else
     error "cargo-generate-rpm did not produce an .rpm file"
@@ -229,6 +277,7 @@ if $ARCH_PKG; then
   if [[ -n "$PKG_FILE" ]]; then
     mkdir -p dist
     mv "$PKG_FILE" dist/
+    "$PACKAGE_VALIDATOR" --arch "dist/$PKG_FILE"
     info "Arch package: $(pwd)/dist/$PKG_FILE"
   else
     error "makepkg did not produce a .pkg.tar.zst file"

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -31,7 +31,7 @@ Quick-exit modes (run one task and exit):
 
 Packaging:
   --flatpak         Build a Flatpak bundle (requires flatpak, flatpak-builder,
-                    Python generator dependencies, ostree, readelf/eu-readelf,
+                    Python generator dependencies, ostree, GNU readelf,
                     and a user Flathub remote; does not require host Rust/GTK
                     development packages).
   --deb             Build a .deb package via cargo-deb (requires dpkg-deb).
@@ -39,8 +39,8 @@ Packaging:
                     rpm, rpm2cpio, and cpio).
   --arch-pkg        Build an Arch .pkg.tar.zst via makepkg (requires bsdtar).
 
-All native builds require readelf (binutils) or eu-readelf (elfutils) for the
-artifact compliance gate.
+All native builds require GNU readelf (binutils) for the artifact compliance
+gate. The elfutils variant does not resolve every dynamic reference we deny.
 
 Other:
   -h, --help        Show this help and exit.
@@ -86,8 +86,8 @@ require_validator_tool() {
 }
 
 require_elf_inspector() {
-  command -v readelf &>/dev/null || command -v eu-readelf &>/dev/null || \
-    error "readelf/eu-readelf not found. Install binutils or elfutils for artifact validation"
+  command -v readelf &>/dev/null || \
+    error "GNU readelf not found. Install binutils for artifact validation"
 }
 
 preflight_artifact_tools() {

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -59,6 +59,14 @@ MACOS_PACKAGE_POLICY_HELPER="${SCRIPT_DIR}/macos-package-policy.sh"
 # shellcheck source=macos-package-policy.sh
 source "$MACOS_PACKAGE_POLICY_HELPER"
 
+# Test-only policy hooks remain available to the sourced helper, but a release
+# build must use the repository policy and the platform inspection tools even
+# when its parent environment happens to define those hook names.
+readonly MACOS_BUNDLED_COMPONENT_POLICY="${SCRIPT_DIR}/../build-aux/packaging/forbidden-bundled-components.txt"
+readonly MACOS_FIND_COMMAND="/usr/bin/find"
+readonly MACOS_OTOOL_COMMAND="/usr/bin/otool"
+readonly MACOS_OD_COMMAND="/usr/bin/od"
+
 APP_NAME="Tributary"
 BUNDLE_ID="io.github.tributary.Tributary"
 BINARY="target/release/tributary"
@@ -128,10 +136,13 @@ if $COVERAGE; then
   exit 0
 fi
 
-if ! macos_package_policy_load; then
+for policy_tool in "$MACOS_FIND_COMMAND" "$MACOS_OTOOL_COMMAND" "$MACOS_OD_COMMAND"; do
+  [[ -x "$policy_tool" ]] || error "Required macOS package-policy tool is unavailable: ${policy_tool}"
+done
+if ! macos_package_policy_load "$MACOS_BUNDLED_COMPONENT_POLICY"; then
   error "$MACOS_PACKAGE_POLICY_REASON"
 fi
-info "Loaded ${#MACOS_FORBIDDEN_COMPONENT_TOKENS[@]} forbidden bundle filename tokens."
+info "Loaded ${MACOS_FORBIDDEN_COMPONENT_TOKEN_COUNT} forbidden bundle filename tokens."
 
 # ── Rust Build ───────────────────────────────────────────────────────────────
 info "Building Tributary (release)..."

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -52,6 +52,13 @@ info()  { echo -e "${GREEN}[tributary]${NC} $*"; }
 warn()  { echo -e "${YELLOW}[tributary]${NC} $*"; }
 error() { echo -e "${RED}[tributary]${NC} $*" >&2; exit 1; }
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MACOS_PACKAGE_POLICY_HELPER="${SCRIPT_DIR}/macos-package-policy.sh"
+[[ -f "$MACOS_PACKAGE_POLICY_HELPER" ]] \
+  || error "macOS package-policy helper is missing: ${MACOS_PACKAGE_POLICY_HELPER}"
+# shellcheck source=macos-package-policy.sh
+source "$MACOS_PACKAGE_POLICY_HELPER"
+
 APP_NAME="Tributary"
 BUNDLE_ID="io.github.tributary.Tributary"
 BINARY="target/release/tributary"
@@ -120,6 +127,11 @@ if $COVERAGE; then
   cargo llvm-cov --all-targets --all-features --locked --summary-only
   exit 0
 fi
+
+if ! macos_package_policy_load; then
+  error "$MACOS_PACKAGE_POLICY_REASON"
+fi
+info "Loaded ${#MACOS_FORBIDDEN_COMPONENT_TOKENS[@]} forbidden bundle filename tokens."
 
 # ── Rust Build ───────────────────────────────────────────────────────────────
 info "Building Tributary (release)..."
@@ -213,9 +225,21 @@ GST_PLUGIN_DEST="${RESOURCES_DIR}/lib/gstreamer-1.0"
 if [[ -d "$GST_PLUGIN_SRC" ]]; then
   info "Bundling GStreamer plugins..."
   mkdir -p "$GST_PLUGIN_DEST"
-  cp "${GST_PLUGIN_SRC}"/*.dylib "$GST_PLUGIN_DEST/" 2>/dev/null || true
-  GST_PLUGIN_COUNT=$(ls -1 "$GST_PLUGIN_DEST"/*.dylib 2>/dev/null | wc -l | tr -d ' ')
-  info "Bundled ${GST_PLUGIN_COUNT} GStreamer plugins."
+  GST_PLUGIN_COUNT=0
+  GST_PLUGIN_EXCLUDED=0
+  for plugin in "${GST_PLUGIN_SRC}"/*.dylib; do
+    [[ -f "$plugin" ]] || continue
+    if ! macos_stage_gstreamer_plugin "$plugin" "$GST_PLUGIN_DEST"; then
+      error "GStreamer plugin policy inspection failed: ${MACOS_PACKAGE_POLICY_REASON}"
+    fi
+    if [[ "$MACOS_PACKAGE_POLICY_RESULT" == excluded ]]; then
+      warn "Excluding GStreamer plugin: ${MACOS_PACKAGE_POLICY_REASON}"
+      GST_PLUGIN_EXCLUDED=$((GST_PLUGIN_EXCLUDED + 1))
+    else
+      GST_PLUGIN_COUNT=$((GST_PLUGIN_COUNT + 1))
+    fi
+  done
+  info "Bundled ${GST_PLUGIN_COUNT} GStreamer plugins; excluded ${GST_PLUGIN_EXCLUDED} by policy."
 else
   warn "GStreamer plugin directory not found at ${GST_PLUGIN_SRC}"
 fi
@@ -318,6 +342,11 @@ copy_dylib() {
   local basename
   basename="$(basename "$src")"
   local dest="${FRAMEWORKS_DIR}/${basename}"
+
+  if ! macos_validate_macho_copy_control "$src"; then
+    error "Refusing recursive dylib dependency: ${MACOS_PACKAGE_POLICY_REASON}"
+  fi
+
   [[ -f "$dest" ]] && return 1
   cp "$src" "$dest"
   chmod u+w "$dest"
@@ -438,6 +467,11 @@ if [[ -d "$ADWAITA_SCALABLE" ]]; then
   info "Adwaita scalable icons: ${ADWAITA_SVG_COUNT} SVGs found."
 fi
 
+if ! macos_validate_bundle_copy_control "$APP_BUNDLE"; then
+  error "macOS bundle component-policy validation failed before signing: ${MACOS_PACKAGE_POLICY_REASON}"
+fi
+info "macOS bundle component policy passed before signing."
+
 # ── Ad-hoc Code Signing ─────────────────────────────────────────────────────
 # macOS 13+ kills unsigned binaries launched from .app bundles (SIGKILL / exit 9).
 # After install_name_tool modifies binaries, any existing signature is invalidated.
@@ -520,6 +554,10 @@ info "Signed runtime probe and final signature verification passed."
 
 # ── DMG ──────────────────────────────────────────────────────────────────────
 if $MAKE_DMG; then
+  if ! macos_validate_bundle_copy_control "$APP_BUNDLE"; then
+    error "macOS bundle component-policy validation failed before DMG creation: ${MACOS_PACKAGE_POLICY_REASON}"
+  fi
+  info "macOS bundle component policy passed before DMG creation."
   info "Creating .dmg disk image..."
   mkdir -p dist
   rm -f "dist/${APP_NAME}.dmg"

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -88,6 +88,209 @@ function Write-Info { Write-Host "[tributary] $args" -ForegroundColor Green }
 function Write-Warn { Write-Host "[tributary] $args" -ForegroundColor Yellow }
 function Write-Err { Write-Host "[tributary] $args" -ForegroundColor Red; exit 1 }
 
+# Tributary does not play encrypted optical discs or proprietary DRM media.
+# Load the shared filename-token policy once and apply it at every Windows copy
+# boundary. Ordinary codecs, TLS libraries, and generic cryptography remain
+# eligible for the bundle.
+function Import-ForbiddenBundledComponentPolicy {
+    param([string]$Path)
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        Write-Err "Required bundled-component policy is missing: $Path"
+    }
+
+    $tokens = [System.Collections.Generic.List[string]]::new()
+    $known = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::OrdinalIgnoreCase
+    )
+    foreach ($line in [System.IO.File]::ReadAllLines($Path)) {
+        $token = $line.Trim()
+        if (-not $token -or $token.StartsWith('#')) { continue }
+        if ($token -notmatch '^[A-Za-z0-9][A-Za-z0-9._+-]*$') {
+            Write-Err "Bundled-component policy contains an invalid filename token: '$token'"
+        }
+        if (-not $known.Add($token)) {
+            Write-Err "Bundled-component policy contains a duplicate filename token: '$token'"
+        }
+        $tokens.Add($token)
+    }
+    if ($tokens.Count -eq 0) {
+        Write-Err "Bundled-component policy contains no filename tokens: $Path"
+    }
+    return @($tokens)
+}
+
+$RepositoryRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')).ProviderPath
+$ForbiddenBundledComponentPolicyPath = Join-Path $RepositoryRoot 'build-aux\packaging\forbidden-bundled-components.txt'
+$ForbiddenBundledComponentTokens = @(Import-ForbiddenBundledComponentPolicy $ForbiddenBundledComponentPolicyPath)
+
+function Test-ForbiddenBundledComponentName {
+    param([AllowNull()][string]$Name)
+    if ([string]::IsNullOrWhiteSpace($Name)) { return $false }
+    $fileName = [System.IO.Path]::GetFileName($Name)
+    foreach ($token in $ForbiddenBundledComponentTokens) {
+        if ($fileName.IndexOf($token, [System.StringComparison]::OrdinalIgnoreCase) -ge 0) {
+            return $true
+        }
+    }
+    return $false
+}
+
+function Test-ForbiddenBundledRelativePath {
+    param([AllowNull()][string]$RelativePath)
+    if ([string]::IsNullOrWhiteSpace($RelativePath)) { return $false }
+    foreach ($component in @($RelativePath -split '[\\/]')) {
+        if ($component -and (Test-ForbiddenBundledComponentName $component)) {
+            return $true
+        }
+    }
+    return $false
+}
+
+# Enumerate a filesystem tree ourselves so PowerShell 5.1 and 7 use the same
+# rule: include hidden files and directories, report reparse points as bundle
+# members, but never recurse through a junction/symlink into an external tree.
+function Get-WindowsTreeMembersWithoutReparseTraversal {
+    param([string]$Root)
+    if (-not (Test-Path -LiteralPath $Root -PathType Container)) { return @() }
+
+    $members = [System.Collections.Generic.List[System.IO.FileSystemInfo]]::new()
+    $pendingDirectories = [System.Collections.Queue]::new()
+    $rootItem = Get-Item -LiteralPath $Root -Force -ErrorAction Stop
+    $rootIsReparsePoint = ($rootItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0
+    if ($rootIsReparsePoint) {
+        $members.Add($rootItem)
+        return @($members)
+    }
+    $pendingDirectories.Enqueue($rootItem.FullName)
+    while ($pendingDirectories.Count -gt 0) {
+        $directory = [string]$pendingDirectories.Dequeue()
+        foreach ($member in @(Get-ChildItem -LiteralPath $directory -Force -ErrorAction Stop)) {
+            $members.Add($member)
+            $isDirectory = ($member.Attributes -band [System.IO.FileAttributes]::Directory) -ne 0
+            $isReparsePoint = ($member.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0
+            if ($isDirectory -and -not $isReparsePoint) {
+                $pendingDirectories.Enqueue($member.FullName)
+            }
+        }
+    }
+    return @($members)
+}
+
+function Get-ForbiddenWindowsBundleMembers {
+    param([string]$Root)
+    if (-not (Test-Path -LiteralPath $Root -PathType Container)) { return @() }
+
+    $rootFull = (Get-Item -LiteralPath $Root -Force -ErrorAction Stop).FullName.TrimEnd(
+        [char[]]@('\', '/')
+    )
+    return @(Get-WindowsTreeMembersWithoutReparseTraversal $rootFull | Where-Object {
+        $relativePath = $_.FullName.Substring($rootFull.Length).TrimStart([char[]]@('\', '/'))
+        Test-ForbiddenBundledRelativePath $relativePath
+    })
+}
+
+function Get-WindowsBundleReparsePointMembers {
+    param([string]$Root)
+    if (-not (Test-Path -LiteralPath $Root -PathType Container)) { return @() }
+    return @(Get-WindowsTreeMembersWithoutReparseTraversal $Root | Where-Object {
+        ($_.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0
+    })
+}
+
+function Assert-WindowsBundleRootIsNotReparsePoint {
+    param([string]$Root)
+    $rootItem = Get-Item -LiteralPath $Root -Force -ErrorAction Stop
+    if (($rootItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+        Write-Err "Windows bundle root must not be a filesystem reparse point: $($rootItem.FullName)"
+    }
+}
+
+# Delete selected entries deepest-first and non-recursively. DirectoryInfo's
+# zero-argument Delete removes a directory or reparse-point link itself; it
+# cannot walk into a junction target. Every real descendant was enumerated and
+# selected separately because its relative path inherits the forbidden parent.
+function Remove-ForbiddenWindowsBundleMembers {
+    param([string]$Root)
+    $forbiddenMembers = @(Get-ForbiddenWindowsBundleMembers $Root | Sort-Object `
+        @{ Expression = { $_.FullName.Length }; Descending = $true })
+    foreach ($member in $forbiddenMembers) {
+        try {
+            if (($member.Attributes -band [System.IO.FileAttributes]::ReadOnly) -ne 0) {
+                $member.Attributes = $member.Attributes -band (-bnot [System.IO.FileAttributes]::ReadOnly)
+            }
+            $member.Delete()
+        }
+        catch [System.IO.FileNotFoundException] { }
+        catch [System.IO.DirectoryNotFoundException] { }
+        catch {
+            throw "Could not safely remove forbidden bundle member '$($member.FullName)': $($_.Exception.Message)"
+        }
+    }
+    return $forbiddenMembers.Count
+}
+
+function Assert-WindowsBundleComponentPolicy {
+    param([string]$Root)
+    $forbiddenMembers = @(Get-ForbiddenWindowsBundleMembers $Root)
+    $reparsePointMembers = @(Get-WindowsBundleReparsePointMembers $Root)
+    if ($forbiddenMembers.Count -eq 0 -and $reparsePointMembers.Count -eq 0) { return }
+
+    $forbiddenSample = @($forbiddenMembers | Select-Object -First 8 | ForEach-Object {
+        $relativePath = $_.FullName.Substring($Root.Length).TrimStart('\', '/')
+        if ($relativePath) { $relativePath } else { '<bundle-root>' }
+    }) -join ', '
+    if ($forbiddenMembers.Count -gt 8) { $forbiddenSample += ', ...' }
+    $reparseSample = @($reparsePointMembers | Select-Object -First 8 | ForEach-Object {
+        $relativePath = $_.FullName.Substring($Root.Length).TrimStart('\', '/')
+        if ($relativePath) { $relativePath } else { '<bundle-root>' }
+    }) -join ', '
+    if ($reparsePointMembers.Count -gt 8) { $reparseSample += ', ...' }
+
+    $details = [System.Collections.Generic.List[string]]::new()
+    if ($forbiddenMembers.Count -gt 0) {
+        $details.Add("$($forbiddenMembers.Count) forbidden component(s): $forbiddenSample")
+    }
+    if ($reparsePointMembers.Count -gt 0) {
+        $details.Add("$($reparsePointMembers.Count) filesystem reparse point(s): $reparseSample")
+    }
+    Write-Err "Windows bundle violates the bundled-component policy ($($details -join '; '))"
+}
+
+function Assert-WindowsZipComponentPolicy {
+    param([string]$Path)
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        Write-Err "Completed Windows ZIP was not found for policy validation: $Path"
+    }
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction Stop
+    $archive = [System.IO.Compression.ZipFile]::OpenRead(
+        (Resolve-Path -LiteralPath $Path).ProviderPath
+    )
+    $forbiddenEntryCount = 0
+    $forbiddenEntrySample = [System.Collections.Generic.List[string]]::new()
+    try {
+        foreach ($entry in $archive.Entries) {
+            $entryPath = $entry.FullName.TrimEnd([char[]]@('\', '/'))
+            if ($entryPath -and (Test-ForbiddenBundledRelativePath $entryPath)) {
+                $forbiddenEntryCount++
+                if ($forbiddenEntrySample.Count -lt 8) {
+                    $forbiddenEntrySample.Add($entry.FullName)
+                }
+            }
+        }
+    }
+    finally {
+        $archive.Dispose()
+    }
+
+    if ($forbiddenEntryCount -gt 0) {
+        $sample = $forbiddenEntrySample -join ', '
+        if ($forbiddenEntryCount -gt $forbiddenEntrySample.Count) { $sample += ', ...' }
+        Remove-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue
+        Write-Err "Completed Windows ZIP contains $forbiddenEntryCount forbidden entry name(s): $sample"
+    }
+}
+
 function Get-BoundedProbeDiagnostic {
     param(
         [string]$Path,
@@ -231,8 +434,9 @@ $DIST = "dist\tributary-windows"
 
 # ── Inno Setup only mode ─────────────────────────────────────────────────────
 # When -InnoSetup is passed with -SkipBundle, use an existing, already-probed
-# dist tree and skip straight to installer creation. This intentionally does
-# not claim to validate a tree that may have been changed since its bundle run.
+# dist tree and skip straight to installer creation. The runtime probe is not
+# repeated, but the existing tree still crosses the component-policy gate
+# immediately before the installer compiler runs.
 if ($InnoSetup -and $SkipBundle) {
     Write-Info "Building Inno Setup installer from the existing dist tree (bundle/runtime probe skipped)..."
 
@@ -262,6 +466,7 @@ if ($InnoSetup -and $SkipBundle) {
     $issFile = "build-aux\inno\tributary.iss"
     $sourceDir = (Resolve-Path $DIST).Path
     $outputDir = (Resolve-Path "dist").Path
+    Assert-WindowsBundleComponentPolicy $sourceDir
 
     Write-Info "Running Inno Setup compiler..."
     & $iscc /DAppVersion="$CargoVersion" /DSourceDir="$sourceDir" /DOutputDir="$outputDir" /DTargetArch="$InnoArch" $issFile
@@ -511,14 +716,21 @@ Write-Info "Bundling GTK4 DLLs and resources into $DIST ..."
 # every build, saving significant time on incremental rebuilds.
 function Copy-IfNewer {
     param([string]$Src, [string]$Dst)
+    $sourceItem = Get-Item -LiteralPath $Src -Force -ErrorAction Stop
+    if (($sourceItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw "Refusing to copy filesystem reparse point into the Windows bundle: $($sourceItem.FullName)"
+    }
+    if (Test-ForbiddenBundledComponentName $sourceItem.Name) {
+        throw "Refusing to copy forbidden bundled component: $($sourceItem.Name)"
+    }
     if (-not (Test-Path $Dst)) {
-        Copy-Item $Src $Dst
+        Copy-Item $sourceItem.FullName $Dst
         return $true
     }
-    $srcTime = (Get-Item $Src).LastWriteTimeUtc
+    $srcTime = $sourceItem.LastWriteTimeUtc
     $dstTime = (Get-Item $Dst).LastWriteTimeUtc
     if ($srcTime -gt $dstTime) {
-        Copy-Item $Src $Dst -Force
+        Copy-Item $sourceItem.FullName $Dst -Force
         return $true
     }
     return $false
@@ -526,14 +738,49 @@ function Copy-IfNewer {
 
 # Helper: recursively sync a directory tree, copying only newer files.
 function Sync-Directory {
-    param([string]$SrcDir, [string]$DstDir)
+    param(
+        [string]$SrcDir,
+        [string]$DstDir,
+        [switch]$SkipForbiddenComponents
+    )
     $copied = 0
-    Get-ChildItem -Path $SrcDir -Recurse -File | ForEach-Object {
-        $relPath = $_.FullName.Substring($SrcDir.Length)
+    $sourceRoot = (Get-Item -LiteralPath $SrcDir -Force -ErrorAction Stop).FullName.TrimEnd(
+        [char[]]@('\', '/')
+    )
+    if ($SkipForbiddenComponents -and
+        (Test-Path -LiteralPath $DstDir -PathType Container)) {
+        $null = Remove-ForbiddenWindowsBundleMembers $DstDir
+    }
+    if (Test-Path -LiteralPath $DstDir -PathType Container) {
+        $destinationReparsePoints = @(Get-WindowsBundleReparsePointMembers $DstDir)
+        if ($destinationReparsePoints.Count -gt 0) {
+            throw "Refusing to sync into a Windows destination tree containing a filesystem reparse point: $($destinationReparsePoints[0].FullName)"
+        }
+    }
+    foreach ($sourceMember in @(Get-WindowsTreeMembersWithoutReparseTraversal $sourceRoot)) {
+        $relPath = $sourceMember.FullName.Substring($sourceRoot.Length).TrimStart(
+            [char[]]@('\', '/')
+        )
+        $isDirectory = ($sourceMember.Attributes -band [System.IO.FileAttributes]::Directory) -ne 0
+        $isReparsePoint = ($sourceMember.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0
+        if ($isReparsePoint) {
+            throw "Refusing to sync filesystem reparse point into the Windows bundle: $relPath"
+        }
+        if ($isDirectory) { continue }
+
+        $sourceFile = $sourceMember
         $destFile = Join-Path $DstDir $relPath
+        if (Test-ForbiddenBundledRelativePath $relPath) {
+            if (-not $SkipForbiddenComponents) {
+                throw "Refusing to sync forbidden bundled relative path: $relPath"
+            }
+            # Incremental bundles may retain a component copied by an older
+            # version of this script; the destination tree was purged above.
+            continue
+        }
         $destDir = Split-Path $destFile
         if (-not (Test-Path $destDir)) { New-Item -ItemType Directory -Force $destDir | Out-Null }
-        if (Copy-IfNewer $_.FullName $destFile) { $copied++ }
+        if (Copy-IfNewer $sourceFile.FullName $destFile) { $copied++ }
     }
     return $copied
 }
@@ -790,6 +1037,14 @@ function Add-PeImportDependencies {
         $dllName = Get-PeImportDependencyName ([string]$line)
         if (-not $dllName) { continue }
 
+        # Never satisfy an import with a prohibited copy-control/DRM runtime.
+        # Failing here, rather than silently omitting the DLL, preserves the
+        # bundle's strict dependency-closure contract and identifies the
+        # remaining importer that must be excluded.
+        if (Test-ForbiddenBundledComponentName $dllName) {
+            throw "Forbidden bundled dependency $dllName reported for $SourceLabel"
+        }
+
         # Copy only exact imports that exist in the selected architecture's
         # bin directory. Imports provided by Windows itself are intentionally
         # not bundled; API-set contract names need not have a physical file.
@@ -823,7 +1078,19 @@ New-Item -ItemType Directory -Force $DIST | Out-Null
 # ProviderPath returns the physical path even when $PWD uses a custom
 # FileSystem PSDrive; repository paths containing spaces remain intact.
 $DIST = (Resolve-Path -LiteralPath $DIST).ProviderPath
+Assert-WindowsBundleRootIsNotReparsePoint $DIST
 New-Item -ItemType Directory -Force "$DIST\lib" | Out-Null
+
+# Remove policy members left by an older incremental bundle before copying or
+# inspecting anything. The same policy is asserted again after all copy paths,
+# so this cleanup cannot hide a newly introduced forbidden dependency.
+$staleForbiddenMemberCount = Remove-ForbiddenWindowsBundleMembers $DIST
+if ($staleForbiddenMemberCount -gt 0) {
+    Write-Info "Removed $staleForbiddenMemberCount forbidden component(s) from the incremental Windows bundle."
+}
+# Reject allowed-named reparse points before any incremental copy can write
+# through a junction into an external destination.
+Assert-WindowsBundleComponentPolicy $DIST
 
 # Always copy the executable (just built).
 Copy-Item $exePath $DIST -Force
@@ -834,13 +1101,15 @@ $totalCopied = 0
 
 $loadersSrc = Join-Path $MsysPath "lib\gdk-pixbuf-2.0"
 if (Test-Path $loadersSrc) {
-    $n = Sync-Directory $loadersSrc (Join-Path $DIST "lib\gdk-pixbuf-2.0")
+    $n = Sync-Directory $loadersSrc (Join-Path $DIST "lib\gdk-pixbuf-2.0") `
+        -SkipForbiddenComponents
     $totalCopied += $n
 }
 
 $gstPluginSrc = Join-Path $MsysPath "lib\gstreamer-1.0"
 if (Test-Path $gstPluginSrc) {
-    $n = Sync-Directory $gstPluginSrc (Join-Path $DIST "lib\gstreamer-1.0")
+    $n = Sync-Directory $gstPluginSrc (Join-Path $DIST "lib\gstreamer-1.0") `
+        -SkipForbiddenComponents
     $totalCopied += $n
 }
 
@@ -873,9 +1142,12 @@ if (-not [System.IO.Path]::IsPathRooted($peImportInspector) -or
 
 Write-Info "Resolving required DLLs for executable and plugins..."
 
-# Seed the dependency closure with Tributary, every copied plugin, and the
-# exact scanner. Every MSYS2 runtime DLL discovered below is copied to the
-# bundle root and enqueued in turn, so transitive dependencies reach closure.
+# Seed the dependency closure with every PE DLL and executable already present
+# anywhere in the bundle, including hidden and stale incremental members. The
+# same hidden-inclusive enumerator used by the final policy scan avoids a
+# visible-lib-only gap. Every MSYS2 runtime DLL discovered below is copied to
+# the bundle root and enqueued in turn, so transitive dependencies reach
+# closure.
 $requiredSoupPluginDest = Join-Path $DIST "lib\gstreamer-1.0\$requiredSoupPluginName"
 if (-not (Test-Path -LiteralPath $requiredSoupPluginDest -PathType Leaf)) {
     Write-Err "Required souphttpsrc plugin was not copied into the Windows bundle."
@@ -891,9 +1163,12 @@ $peInspectorClosureDeadlineMs = 300000
 $dllScanQueue = [System.Collections.Queue]::new()
 $knownDllScanTargets = @{}
 $scannedDllTargets = @{}
-$initialDllScanTargets = @(Join-Path $DIST (Split-Path $exePath -Leaf))
-$initialDllScanTargets += Get-ChildItem -Path "$DIST\lib" -Recurse -Filter *.dll | Select-Object -ExpandProperty FullName
-$initialDllScanTargets += $gstScannerDest
+$initialDllScanTargets = @(Get-WindowsTreeMembersWithoutReparseTraversal $DIST | Where-Object {
+    $isDirectory = ($_.Attributes -band [System.IO.FileAttributes]::Directory) -ne 0
+    $isReparsePoint = ($_.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0
+    $isPeCandidate = $_.Extension -ieq '.dll' -or $_.Extension -ieq '.exe'
+    -not $isDirectory -and -not $isReparsePoint -and $isPeCandidate
+} | Select-Object -ExpandProperty FullName)
 foreach ($bin in $initialDllScanTargets) {
     Add-DllScanTarget $dllScanQueue $knownDllScanTargets $bin $maxDllScanTargets
 }
@@ -1033,7 +1308,7 @@ foreach ($theme in @("hicolor", "Adwaita")) {
     $src = Join-Path $MsysPath "share\icons\$theme"
     $dest = Join-Path $DIST   "share\icons\$theme"
     if (Test-Path $src) {
-        $n = Sync-Directory $src $dest
+        $n = Sync-Directory $src $dest -SkipForbiddenComponents
         $totalCopied += $n
     }
 }
@@ -1042,7 +1317,8 @@ foreach ($theme in @("hicolor", "Adwaita")) {
 $appIconsSrc = "data\icons\hicolor"
 if (Test-Path $appIconsSrc) {
     $appIconsDest = Join-Path $DIST "share\icons\hicolor"
-    $n = Sync-Directory (Resolve-Path $appIconsSrc).Path $appIconsDest
+    $n = Sync-Directory (Resolve-Path $appIconsSrc).Path $appIconsDest `
+        -SkipForbiddenComponents
     $totalCopied += $n
     Write-Info "Bundled app icons: $n file(s) synced."
 
@@ -1074,6 +1350,10 @@ if (Test-Path $schemasSrc) {
 }
 
 Write-Info "Total incremental sync: $totalCopied file(s) updated."
+
+# Do not execute a bundle that violated the shared packaging policy. This also
+# catches stale or indirectly copied files outside the GStreamer plugin tree.
+Assert-WindowsBundleComponentPolicy $DIST
 
 # ── Packaged Runtime Probe ──────────────────────────────────────────────────
 # Run the bundled executable itself before archiving it. The child receives no
@@ -1249,10 +1529,14 @@ if ($probeFailure) { Write-Err "Packaged Windows runtime probe failed: $probeFai
 Write-Info "Packaged Windows runtime probe passed."
 
 # ── Zip Archive ──────────────────────────────────────────────────────────────
+# Recheck immediately before archiving so the emitted artifact, rather than
+# merely the earlier dependency-closure snapshot, is covered by the policy.
+Assert-WindowsBundleComponentPolicy $DIST
 Write-Info "Creating zip archive..."
 $zipPath = "dist\tributary-windows.zip"
 Remove-Item $zipPath -ErrorAction SilentlyContinue
 Compress-Archive -Path $DIST -DestinationPath $zipPath
+Assert-WindowsZipComponentPolicy $zipPath
 Write-Info "Archive created: $((Get-Item $zipPath).FullName)"
 
 # ── Inno Setup Installer (optional) ─────────────────────────────────────────
@@ -1285,6 +1569,7 @@ if ($InnoSetup) {
     $issFile = "build-aux\inno\tributary.iss"
     $sourceDir = (Resolve-Path $DIST).Path
     $outputDir = (Resolve-Path "dist").Path
+    Assert-WindowsBundleComponentPolicy $sourceDir
 
     Write-Info "Running Inno Setup compiler..."
     & $iscc /DAppVersion="$CargoVersion" /DSourceDir="$sourceDir" /DOutputDir="$outputDir" /DTargetArch="$InnoArch" $issFile

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -407,6 +407,365 @@ function Stop-ProbeProcessTree {
     Stop-BoundedProcessTree $Process "packaged runtime probe"
 }
 
+# Extract one dependency basename from llvm-readobj's PE import-table form:
+#   Import {
+#     Name: libfoo.dll
+#   }
+# --coff-imports includes ordinary and delay-load imports. Reject path
+# separators and other invalid filename characters so inspector output can
+# never redirect a copy outside the selected MSYS2 architecture's bin folder.
+function Get-PeImportDependencyName {
+    param([string]$Line)
+    if ($Line -notmatch '^\s*Name:\s*([^\\/:*?"<>|\x00-\x1F]+\.dll)\s*$') { return $null }
+    return $matches[1]
+}
+
+# Render an untrusted target path in a bounded, single-line diagnostic. The
+# import inspector only receives paths assembled by this script, but keeping
+# this formatter bounded prevents a malformed filesystem entry from flooding
+# CI logs or injecting a second diagnostic line.
+function Format-PeImportTargetForDiagnostic {
+    param(
+        [AllowNull()][string]$Target,
+        [int]$Limit = 192
+    )
+    if ($null -eq $Target) { return "<null>" }
+
+    $safe = [System.Text.RegularExpressions.Regex]::Replace(
+        $Target,
+        '[\p{Cc}\p{Zl}\p{Zp}"]',
+        '?'
+    )
+    if ($safe.Length -gt $Limit) {
+        $safe = $safe.Substring(0, $Limit) + "...[truncated]"
+    }
+    return "'$safe'"
+}
+
+# Validate and quote one strongly typed target batch. The exact-host failure
+# persisted after named parameter binding, so the collection shape cannot stay
+# implicit at this boundary. A List[string] crosses it as one object, while
+# each normalized member is still passed to llvm-readobj as a separately
+# quoted argument.
+function ConvertTo-BoundedPeImportArgumentBatch {
+    param(
+        [AllowNull()][System.Collections.Generic.List[string]]$TargetBatch,
+        [int]$ArgumentCharacterLimit
+    )
+    if ($null -eq $TargetBatch) {
+        throw "PE import-inspection target batch was null"
+    }
+
+    $quotedTargets = [System.Collections.Generic.List[string]]::new()
+    $targetNames = [System.Collections.Generic.List[string]]::new()
+    for ($targetIndex = 0; $targetIndex -lt $TargetBatch.Count; $targetIndex++) {
+        $target = $TargetBatch[$targetIndex]
+        $targetNumber = $targetIndex + 1
+        $targetLabel = Format-PeImportTargetForDiagnostic $target
+
+        if ([string]::IsNullOrWhiteSpace($target)) {
+            throw "PE import-inspection target #$targetNumber was empty ($targetLabel)"
+        }
+        if ([System.Text.RegularExpressions.Regex]::IsMatch(
+                $target,
+                '[\p{Cc}\p{Zl}\p{Zp}"]'
+            )) {
+            throw "PE import-inspection target #$targetNumber contains an unsupported quote or control character ($targetLabel)"
+        }
+        if (-not [System.IO.Path]::IsPathRooted($target)) {
+            throw "PE import-inspection target #$targetNumber is not absolute ($targetLabel)"
+        }
+
+        try {
+            $normalizedTarget = [System.IO.Path]::GetFullPath($target)
+        }
+        catch {
+            throw "PE import-inspection target #$targetNumber is not a valid filesystem path ($targetLabel)"
+        }
+        $extension = [System.IO.Path]::GetExtension($normalizedTarget)
+        if ($extension -ine ".dll" -and $extension -ine ".exe") {
+            throw "PE import-inspection target #$targetNumber is not a DLL or EXE ($targetLabel)"
+        }
+        if (-not [System.IO.File]::Exists($normalizedTarget)) {
+            throw "PE import-inspection target #$targetNumber is not an existing file ($targetLabel)"
+        }
+
+        $quotedTargets.Add('"' + $normalizedTarget + '"')
+        if ($targetNames.Count -lt 3) {
+            $targetNames.Add([System.IO.Path]::GetFileName($normalizedTarget))
+        }
+    }
+
+    $arguments = "--coff-imports " + ($quotedTargets -join " ")
+    if ($arguments.Length -gt $ArgumentCharacterLimit) {
+        throw "PE import-inspection batch exceeded its $ArgumentCharacterLimit-character command-line limit"
+    }
+
+    $batchLabel = $targetNames -join ", "
+    if ($TargetBatch.Count -gt $targetNames.Count) { $batchLabel += ", ..." }
+    return [PSCustomObject]@{
+        Arguments = $arguments
+        Label = $batchLabel
+    }
+}
+
+# Inspect a bounded batch without ever loading or executing a target DLL.
+# Start-Process redirects both streams straight to files, avoiding deadlocks
+# from synchronous whole-stream pipe reads. File sizes are polled while the
+# process runs and checked again after exit; only then is the capped stdout
+# read into memory for parsing.
+function Invoke-BoundedPeImportBatch {
+    param(
+        [string]$Inspector,
+        [AllowNull()][System.Collections.Generic.List[string]]$TargetBatch,
+        [System.Diagnostics.Stopwatch]$ClosureClock,
+        [int]$ClosureDeadlineMs,
+        [int]$ProcessDeadlineMs,
+        [int64]$OutputByteLimit,
+        [int]$ArgumentCharacterLimit
+    )
+    if ($null -eq $TargetBatch) {
+        throw "PE import-inspection target batch was null"
+    }
+    if ($TargetBatch.Count -eq 0) { return @() }
+
+    $argumentBatch = ConvertTo-BoundedPeImportArgumentBatch `
+        -TargetBatch $TargetBatch `
+        -ArgumentCharacterLimit $ArgumentCharacterLimit
+    $arguments = $argumentBatch.Arguments
+    $batchLabel = $argumentBatch.Label
+
+    $token = [Guid]::NewGuid().ToString("N")
+    $tempRoot = [System.IO.Path]::GetTempPath()
+    $stdoutPath = Join-Path $tempRoot "tributary-readobj-$token.stdout"
+    $stderrPath = Join-Path $tempRoot "tributary-readobj-$token.stderr"
+    $process = $null
+    $processClock = [System.Diagnostics.Stopwatch]::StartNew()
+    $failure = $null
+    $diagnostic = ""
+    $stdoutLines = @()
+
+    try {
+        $process = Start-Process -FilePath $Inspector -ArgumentList $arguments `
+            -RedirectStandardOutput $stdoutPath -RedirectStandardError $stderrPath `
+            -NoNewWindow -PassThru
+
+        while (-not $process.WaitForExit(50)) {
+            $stdoutLength = if (Test-Path -LiteralPath $stdoutPath -PathType Leaf) {
+                (Get-Item -LiteralPath $stdoutPath).Length
+            } else { 0 }
+            $stderrLength = if (Test-Path -LiteralPath $stderrPath -PathType Leaf) {
+                (Get-Item -LiteralPath $stderrPath).Length
+            } else { 0 }
+            if (($stdoutLength + $stderrLength) -gt $OutputByteLimit) {
+                throw "PE import inspector output crossed its $OutputByteLimit-byte batch limit ($batchLabel)"
+            }
+            if ($processClock.ElapsedMilliseconds -ge $ProcessDeadlineMs) {
+                throw "PE import inspector exceeded its $ProcessDeadlineMs-millisecond batch deadline ($batchLabel)"
+            }
+            if ($ClosureClock.ElapsedMilliseconds -ge $ClosureDeadlineMs) {
+                throw "PE import dependency closure exceeded its $ClosureDeadlineMs-millisecond deadline"
+            }
+        }
+
+        $stdoutLength = if (Test-Path -LiteralPath $stdoutPath -PathType Leaf) {
+            (Get-Item -LiteralPath $stdoutPath).Length
+        } else { 0 }
+        $stderrLength = if (Test-Path -LiteralPath $stderrPath -PathType Leaf) {
+            (Get-Item -LiteralPath $stderrPath).Length
+        } else { 0 }
+        if (($stdoutLength + $stderrLength) -gt $OutputByteLimit) {
+            throw "PE import inspector output crossed its $OutputByteLimit-byte batch limit ($batchLabel)"
+        }
+        if ($processClock.ElapsedMilliseconds -ge $ProcessDeadlineMs) {
+            throw "PE import inspector exceeded its $ProcessDeadlineMs-millisecond batch deadline ($batchLabel)"
+        }
+        if ($ClosureClock.ElapsedMilliseconds -ge $ClosureDeadlineMs) {
+            throw "PE import dependency closure exceeded its $ClosureDeadlineMs-millisecond deadline"
+        }
+        if ($process.ExitCode -ne 0) {
+            throw "PE import inspector exited with status $($process.ExitCode) ($batchLabel)"
+        }
+        $stdoutLines = @([System.IO.File]::ReadAllLines($stdoutPath))
+    }
+    catch {
+        $failure = $_.Exception.Message
+    }
+    finally {
+        try {
+            Stop-BoundedProcessTree $process "PE import inspector"
+        }
+        catch {
+            if ($failure) { $failure += "; $($_.Exception.Message)" }
+            else { $failure = $_.Exception.Message }
+        }
+        if ($failure) {
+            $diagnostic = Get-BoundedProbeDiagnostic $stderrPath "PE inspector stderr" 8192
+            if (-not $diagnostic) {
+                $diagnostic = Get-BoundedProbeDiagnostic $stdoutPath "PE inspector stdout" 8192
+            }
+        }
+        if ($null -ne $process) { $process.Dispose() }
+        Remove-Item -LiteralPath $stdoutPath, $stderrPath -Force -ErrorAction SilentlyContinue
+    }
+
+    if ($failure) {
+        if ($diagnostic) { throw "$failure`n$diagnostic" }
+        throw $failure
+    }
+    return $stdoutLines
+}
+
+# Reinspect the completed application tree without copying or repairing
+# anything. This final gate runs after every normal-mode writer (including the
+# packaged runtime probe) and is also available to installer-only mode, whose
+# existing tree must be treated as untrusted stale input.
+function Assert-WindowsBundlePeImportPolicy {
+    param(
+        [string]$Root,
+        [string]$Inspector
+    )
+
+    if (-not (Test-Path -LiteralPath $Root -PathType Container)) {
+        throw "Windows bundle was not found for final PE import validation: $Root"
+    }
+    $rootFull = (Get-Item -LiteralPath $Root -Force -ErrorAction Stop).FullName.TrimEnd(
+        [char[]]@('\', '/')
+    )
+    Assert-WindowsBundleComponentPolicy $rootFull
+
+    if ([string]::IsNullOrWhiteSpace($Inspector) -or
+        -not [System.IO.Path]::IsPathRooted($Inspector)) {
+        throw "Final PE import inspector path must be absolute"
+    }
+    $inspectorFull = [System.IO.Path]::GetFullPath($Inspector)
+    if (-not (Test-Path -LiteralPath $inspectorFull -PathType Leaf)) {
+        throw "Required final PE import inspector was not found: $inspectorFull"
+    }
+    $inspectorItem = Get-Item -LiteralPath $inspectorFull -Force -ErrorAction Stop
+    if (($inspectorItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw "Final PE import inspector must not be a filesystem reparse point: $inspectorFull"
+    }
+
+    $targetItems = @(Get-WindowsTreeMembersWithoutReparseTraversal $rootFull | Where-Object {
+        $isDirectory = ($_.Attributes -band [System.IO.FileAttributes]::Directory) -ne 0
+        $isReparsePoint = ($_.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0
+        $isPeCandidate = $_.Extension -ieq '.dll' -or $_.Extension -ieq '.exe'
+        -not $isDirectory -and -not $isReparsePoint -and $isPeCandidate
+    } | Sort-Object FullName)
+    if ($targetItems.Count -eq 0) {
+        throw "Windows bundle contains no DLL or EXE targets for final PE import validation"
+    }
+
+    $maxTargets = 4096
+    if ($targetItems.Count -gt $maxTargets) {
+        throw "Final PE import validation exceeded its $maxTargets-binary safety limit"
+    }
+
+    $targets = [System.Collections.Generic.List[string]]::new()
+    $targetSnapshot = @{}
+    foreach ($targetItem in $targetItems) {
+        $stream = [System.IO.File]::Open(
+            $targetItem.FullName,
+            [System.IO.FileMode]::Open,
+            [System.IO.FileAccess]::Read,
+            [System.IO.FileShare]::Read
+        )
+        try {
+            if ($stream.Length -lt 2 -or $stream.ReadByte() -ne 0x4D -or
+                $stream.ReadByte() -ne 0x5A) {
+                throw "Final PE import target does not have an MZ header: $($targetItem.Name)"
+            }
+        }
+        finally {
+            $stream.Dispose()
+        }
+        $fullPath = [System.IO.Path]::GetFullPath($targetItem.FullName)
+        $targets.Add($fullPath)
+        $targetSnapshot[$fullPath] = "$($targetItem.Length):$($targetItem.LastWriteTimeUtc.Ticks)"
+    }
+
+    $maxOutputLines = 131072
+    $maxBatchTargets = 28
+    $maxArgumentCharacters = 24000
+    $maxBatchOutputBytes = 8388608
+    $batchDeadlineMs = 45000
+    $validationDeadlineMs = 300000
+    $outputLineCount = 0
+    $validationClock = [System.Diagnostics.Stopwatch]::StartNew()
+    $offset = 0
+    $batchNumber = 0
+
+    while ($offset -lt $targets.Count) {
+        if ($validationClock.ElapsedMilliseconds -ge $validationDeadlineMs) {
+            throw "Final PE import validation exceeded its $validationDeadlineMs-millisecond deadline"
+        }
+        $batchNumber++
+        $batchTargets = [System.Collections.Generic.List[string]]::new()
+        $batchArgumentCharacters = "--coff-imports ".Length
+        while ($offset -lt $targets.Count -and
+            $batchTargets.Count -lt $maxBatchTargets) {
+            $candidate = [string]$targets[$offset]
+            $candidateCharacters = $candidate.Length + 3
+            if (($batchArgumentCharacters + $candidateCharacters) -gt $maxArgumentCharacters) {
+                if ($batchTargets.Count -eq 0) {
+                    throw "Final PE import target exceeds the command-line safety limit: $([System.IO.Path]::GetFileName($candidate))"
+                }
+                break
+            }
+            $batchTargets.Add($candidate)
+            $batchArgumentCharacters += $candidateCharacters
+            $offset++
+        }
+
+        $lines = @(Invoke-BoundedPeImportBatch `
+            -Inspector $inspectorFull `
+            -TargetBatch $batchTargets `
+            -ClosureClock $validationClock `
+            -ClosureDeadlineMs $validationDeadlineMs `
+            -ProcessDeadlineMs $batchDeadlineMs `
+            -OutputByteLimit $maxBatchOutputBytes `
+            -ArgumentCharacterLimit $maxArgumentCharacters)
+        foreach ($line in $lines) {
+            $outputLineCount++
+            if ($outputLineCount -gt $maxOutputLines) {
+                throw "Final PE import validation exceeded its $maxOutputLines-line safety limit"
+            }
+            if ([string]$line -notmatch '^\s*Name\s*:') { continue }
+
+            $dllName = Get-PeImportDependencyName ([string]$line)
+            if (-not $dllName) {
+                throw "Final PE import inspector returned an unsupported dependency spelling in batch $batchNumber"
+            }
+            if (Test-ForbiddenBundledComponentName $dllName) {
+                $dependencyLabel = Format-PeImportTargetForDiagnostic $dllName
+                throw "Forbidden bundled dependency $dependencyLabel reported during final PE import validation"
+            }
+        }
+    }
+
+    # No writer is expected during this gate. Recheck the policy and the cheap
+    # path/size/write-time snapshot so a late member cannot miss inspection.
+    Assert-WindowsBundleComponentPolicy $rootFull
+    $finalTargets = @(Get-WindowsTreeMembersWithoutReparseTraversal $rootFull | Where-Object {
+        $isDirectory = ($_.Attributes -band [System.IO.FileAttributes]::Directory) -ne 0
+        $isReparsePoint = ($_.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0
+        $isPeCandidate = $_.Extension -ieq '.dll' -or $_.Extension -ieq '.exe'
+        -not $isDirectory -and -not $isReparsePoint -and $isPeCandidate
+    })
+    if ($finalTargets.Count -ne $targetSnapshot.Count) {
+        throw "Windows bundle PE target set changed during final import validation"
+    }
+    foreach ($finalTarget in $finalTargets) {
+        $finalPath = [System.IO.Path]::GetFullPath($finalTarget.FullName)
+        $finalSignature = "$($finalTarget.Length):$($finalTarget.LastWriteTimeUtc.Ticks)"
+        if (-not $targetSnapshot.ContainsKey($finalPath) -or
+            $targetSnapshot[$finalPath] -ne $finalSignature) {
+            throw "Windows bundle PE target changed during final import validation: $($finalTarget.Name)"
+        }
+    }
+}
+
 # Auto-detect ARM64 when env vars are not explicitly set.
 $NativeArch = if ([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture -eq [System.Runtime.InteropServices.Architecture]::Arm64) {
     "arm64"
@@ -467,6 +826,15 @@ if ($InnoSetup -and $SkipBundle) {
     $sourceDir = (Resolve-Path $DIST).Path
     $outputDir = (Resolve-Path "dist").Path
     Assert-WindowsBundleComponentPolicy $sourceDir
+    $installerPeImportInspector = [System.IO.Path]::GetFullPath(
+        (Join-Path $MsysPath "bin\llvm-readobj.exe")
+    )
+    try {
+        Assert-WindowsBundlePeImportPolicy $sourceDir $installerPeImportInspector
+    }
+    catch {
+        Write-Err "Installer source PE import validation failed: $($_.Exception.Message)"
+    }
 
     Write-Info "Running Inno Setup compiler..."
     & $iscc /DAppVersion="$CargoVersion" /DSourceDir="$sourceDir" /DOutputDir="$outputDir" /DTargetArch="$InnoArch" $issFile
@@ -711,26 +1079,63 @@ if ($SkipBundle) {
 # ── DLL Bundle ───────────────────────────────────────────────────────────────
 Write-Info "Bundling GTK4 DLLs and resources into $DIST ..."
 
-# Helper: copy a single file only if the destination doesn't exist or the
-# source is newer.  This avoids re-copying hundreds of unchanged DLLs on
-# every build, saving significant time on incremental rebuilds.
-function Copy-IfNewer {
-    param([string]$Src, [string]$Dst)
+# Reject source aliases before Copy-Item can follow them and turn a forbidden
+# target into a safe-named regular destination. Keep the same guard on every
+# incremental and unconditional bundle copy.
+function Get-ValidatedWindowsBundleCopySourceItem {
+    param([string]$Src)
     $sourceItem = Get-Item -LiteralPath $Src -Force -ErrorAction Stop
+    if (($sourceItem.Attributes -band [System.IO.FileAttributes]::Directory) -ne 0) {
+        throw "Refusing to copy a directory as a Windows bundle file: $($sourceItem.FullName)"
+    }
     if (($sourceItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
         throw "Refusing to copy filesystem reparse point into the Windows bundle: $($sourceItem.FullName)"
     }
     if (Test-ForbiddenBundledComponentName $sourceItem.Name) {
         throw "Refusing to copy forbidden bundled component: $($sourceItem.Name)"
     }
-    if (-not (Test-Path $Dst)) {
-        Copy-Item $sourceItem.FullName $Dst
+    return $sourceItem
+}
+
+function Get-ValidatedWindowsBundleCopyDestinationItem {
+    param([string]$Dst)
+    if (Test-ForbiddenBundledComponentName ([System.IO.Path]::GetFileName($Dst))) {
+        throw "Refusing to write forbidden Windows bundle destination: $Dst"
+    }
+
+    $destinationItem = Get-Item -LiteralPath $Dst -Force -ErrorAction SilentlyContinue
+    if ($null -eq $destinationItem) { return $null }
+    if (($destinationItem.Attributes -band [System.IO.FileAttributes]::Directory) -ne 0) {
+        throw "Refusing to overwrite a directory as a Windows bundle file: $($destinationItem.FullName)"
+    }
+    if (($destinationItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw "Refusing to overwrite filesystem reparse point in the Windows bundle: $($destinationItem.FullName)"
+    }
+    return $destinationItem
+}
+
+function Copy-WindowsBundleFileForced {
+    param([string]$Src, [string]$Dst)
+    $sourceItem = Get-ValidatedWindowsBundleCopySourceItem $Src
+    $null = Get-ValidatedWindowsBundleCopyDestinationItem $Dst
+    Copy-Item -LiteralPath $sourceItem.FullName -Destination $Dst -Force
+}
+
+# Helper: copy a single file only if the destination doesn't exist or the
+# source is newer. This avoids re-copying hundreds of unchanged DLLs on every
+# build, saving significant time on incremental rebuilds.
+function Copy-IfNewer {
+    param([string]$Src, [string]$Dst)
+    $sourceItem = Get-ValidatedWindowsBundleCopySourceItem $Src
+    $destinationItem = Get-ValidatedWindowsBundleCopyDestinationItem $Dst
+    if ($null -eq $destinationItem) {
+        Copy-Item -LiteralPath $sourceItem.FullName -Destination $Dst
         return $true
     }
     $srcTime = $sourceItem.LastWriteTimeUtc
-    $dstTime = (Get-Item $Dst).LastWriteTimeUtc
+    $dstTime = $destinationItem.LastWriteTimeUtc
     if ($srcTime -gt $dstTime) {
-        Copy-Item $sourceItem.FullName $Dst -Force
+        Copy-Item -LiteralPath $sourceItem.FullName -Destination $Dst -Force
         return $true
     }
     return $false
@@ -785,19 +1190,6 @@ function Sync-Directory {
     return $copied
 }
 
-# Extract one dependency basename from llvm-readobj's PE import-table form:
-#   Import {
-#     Name: libfoo.dll
-#   }
-# --coff-imports includes ordinary and delay-load imports. Reject path
-# separators and other invalid filename characters so inspector output can
-# never redirect a copy outside the selected MSYS2 architecture's bin folder.
-function Get-PeImportDependencyName {
-    param([string]$Line)
-    if ($Line -notmatch '^\s*Name:\s*([^\\/:*?"<>|\x00-\x1F]+\.dll)\s*$') { return $null }
-    return $matches[1]
-}
-
 function Add-DllScanTarget {
     param(
         [System.Collections.Queue]$Queue,
@@ -812,202 +1204,6 @@ function Add-DllScanTarget {
     }
     $Known[$fullPath] = $true
     $Queue.Enqueue($fullPath)
-}
-
-# Render an untrusted target path in a bounded, single-line diagnostic. The
-# import inspector only receives paths assembled by this script, but keeping
-# this formatter bounded prevents a malformed filesystem entry from flooding
-# CI logs or injecting a second diagnostic line.
-function Format-PeImportTargetForDiagnostic {
-    param(
-        [AllowNull()][string]$Target,
-        [int]$Limit = 192
-    )
-    if ($null -eq $Target) { return "<null>" }
-
-    $safe = [System.Text.RegularExpressions.Regex]::Replace(
-        $Target,
-        '[\p{Cc}\p{Zl}\p{Zp}"]',
-        '?'
-    )
-    if ($safe.Length -gt $Limit) {
-        $safe = $safe.Substring(0, $Limit) + "...[truncated]"
-    }
-    return "'$safe'"
-}
-
-# Validate and quote one strongly typed target batch. The exact-host failure
-# persisted after named parameter binding, so the collection shape cannot stay
-# implicit at this boundary. A List[string] crosses it as one object, while
-# each normalized member is still passed to llvm-readobj as a separately
-# quoted argument.
-function ConvertTo-BoundedPeImportArgumentBatch {
-    param(
-        [AllowNull()][System.Collections.Generic.List[string]]$TargetBatch,
-        [int]$ArgumentCharacterLimit
-    )
-    if ($null -eq $TargetBatch) {
-        throw "PE import-inspection target batch was null"
-    }
-
-    $quotedTargets = [System.Collections.Generic.List[string]]::new()
-    $targetNames = [System.Collections.Generic.List[string]]::new()
-    for ($targetIndex = 0; $targetIndex -lt $TargetBatch.Count; $targetIndex++) {
-        $target = $TargetBatch[$targetIndex]
-        $targetNumber = $targetIndex + 1
-        $targetLabel = Format-PeImportTargetForDiagnostic $target
-
-        if ([string]::IsNullOrWhiteSpace($target)) {
-            throw "PE import-inspection target #$targetNumber was empty ($targetLabel)"
-        }
-        if ([System.Text.RegularExpressions.Regex]::IsMatch(
-                $target,
-                '[\p{Cc}\p{Zl}\p{Zp}"]'
-            )) {
-            throw "PE import-inspection target #$targetNumber contains an unsupported quote or control character ($targetLabel)"
-        }
-        if (-not [System.IO.Path]::IsPathRooted($target)) {
-            throw "PE import-inspection target #$targetNumber is not absolute ($targetLabel)"
-        }
-
-        try {
-            $normalizedTarget = [System.IO.Path]::GetFullPath($target)
-        }
-        catch {
-            throw "PE import-inspection target #$targetNumber is not a valid filesystem path ($targetLabel)"
-        }
-        $extension = [System.IO.Path]::GetExtension($normalizedTarget)
-        if ($extension -ine ".dll" -and $extension -ine ".exe") {
-            throw "PE import-inspection target #$targetNumber is not a DLL or EXE ($targetLabel)"
-        }
-        if (-not [System.IO.File]::Exists($normalizedTarget)) {
-            throw "PE import-inspection target #$targetNumber is not an existing file ($targetLabel)"
-        }
-
-        $quotedTargets.Add('"' + $normalizedTarget + '"')
-        if ($targetNames.Count -lt 3) {
-            $targetNames.Add([System.IO.Path]::GetFileName($normalizedTarget))
-        }
-    }
-
-    $arguments = "--coff-imports " + ($quotedTargets -join " ")
-    if ($arguments.Length -gt $ArgumentCharacterLimit) {
-        throw "PE import-inspection batch exceeded its $ArgumentCharacterLimit-character command-line limit"
-    }
-
-    $batchLabel = $targetNames -join ", "
-    if ($TargetBatch.Count -gt $targetNames.Count) { $batchLabel += ", ..." }
-    return [PSCustomObject]@{
-        Arguments = $arguments
-        Label = $batchLabel
-    }
-}
-
-# Inspect a bounded batch without ever loading or executing a target DLL.
-# Start-Process redirects both streams straight to files, avoiding deadlocks
-# from synchronous whole-stream pipe reads. File sizes
-# are polled while the process runs and checked again after exit; only then is
-# the capped stdout read into memory for parsing.
-function Invoke-BoundedPeImportBatch {
-    param(
-        [string]$Inspector,
-        [AllowNull()][System.Collections.Generic.List[string]]$TargetBatch,
-        [System.Diagnostics.Stopwatch]$ClosureClock,
-        [int]$ClosureDeadlineMs,
-        [int]$ProcessDeadlineMs,
-        [int64]$OutputByteLimit,
-        [int]$ArgumentCharacterLimit
-    )
-    if ($null -eq $TargetBatch) {
-        throw "PE import-inspection target batch was null"
-    }
-    if ($TargetBatch.Count -eq 0) { return @() }
-
-    $argumentBatch = ConvertTo-BoundedPeImportArgumentBatch `
-        -TargetBatch $TargetBatch `
-        -ArgumentCharacterLimit $ArgumentCharacterLimit
-    $arguments = $argumentBatch.Arguments
-    $batchLabel = $argumentBatch.Label
-
-    $token = [Guid]::NewGuid().ToString("N")
-    $tempRoot = [System.IO.Path]::GetTempPath()
-    $stdoutPath = Join-Path $tempRoot "tributary-readobj-$token.stdout"
-    $stderrPath = Join-Path $tempRoot "tributary-readobj-$token.stderr"
-    $process = $null
-    $processClock = [System.Diagnostics.Stopwatch]::StartNew()
-    $failure = $null
-    $diagnostic = ""
-    $stdoutLines = @()
-
-    try {
-        $process = Start-Process -FilePath $Inspector -ArgumentList $arguments `
-            -RedirectStandardOutput $stdoutPath -RedirectStandardError $stderrPath `
-            -NoNewWindow -PassThru
-
-        while (-not $process.WaitForExit(50)) {
-            $stdoutLength = if (Test-Path -LiteralPath $stdoutPath -PathType Leaf) {
-                (Get-Item -LiteralPath $stdoutPath).Length
-            } else { 0 }
-            $stderrLength = if (Test-Path -LiteralPath $stderrPath -PathType Leaf) {
-                (Get-Item -LiteralPath $stderrPath).Length
-            } else { 0 }
-            if (($stdoutLength + $stderrLength) -gt $OutputByteLimit) {
-                throw "PE import inspector output crossed its $OutputByteLimit-byte batch limit ($batchLabel)"
-            }
-            if ($processClock.ElapsedMilliseconds -ge $ProcessDeadlineMs) {
-                throw "PE import inspector exceeded its $ProcessDeadlineMs-millisecond batch deadline ($batchLabel)"
-            }
-            if ($ClosureClock.ElapsedMilliseconds -ge $ClosureDeadlineMs) {
-                throw "PE import dependency closure exceeded its $ClosureDeadlineMs-millisecond deadline"
-            }
-        }
-
-        $stdoutLength = if (Test-Path -LiteralPath $stdoutPath -PathType Leaf) {
-            (Get-Item -LiteralPath $stdoutPath).Length
-        } else { 0 }
-        $stderrLength = if (Test-Path -LiteralPath $stderrPath -PathType Leaf) {
-            (Get-Item -LiteralPath $stderrPath).Length
-        } else { 0 }
-        if (($stdoutLength + $stderrLength) -gt $OutputByteLimit) {
-            throw "PE import inspector output crossed its $OutputByteLimit-byte batch limit ($batchLabel)"
-        }
-        if ($processClock.ElapsedMilliseconds -ge $ProcessDeadlineMs) {
-            throw "PE import inspector exceeded its $ProcessDeadlineMs-millisecond batch deadline ($batchLabel)"
-        }
-        if ($ClosureClock.ElapsedMilliseconds -ge $ClosureDeadlineMs) {
-            throw "PE import dependency closure exceeded its $ClosureDeadlineMs-millisecond deadline"
-        }
-        if ($process.ExitCode -ne 0) {
-            throw "PE import inspector exited with status $($process.ExitCode) ($batchLabel)"
-        }
-        $stdoutLines = @([System.IO.File]::ReadAllLines($stdoutPath))
-    }
-    catch {
-        $failure = $_.Exception.Message
-    }
-    finally {
-        try {
-            Stop-BoundedProcessTree $process "PE import inspector"
-        }
-        catch {
-            if ($failure) { $failure += "; $($_.Exception.Message)" }
-            else { $failure = $_.Exception.Message }
-        }
-        if ($failure) {
-            $diagnostic = Get-BoundedProbeDiagnostic $stderrPath "PE inspector stderr" 8192
-            if (-not $diagnostic) {
-                $diagnostic = Get-BoundedProbeDiagnostic $stdoutPath "PE inspector stdout" 8192
-            }
-        }
-        if ($null -ne $process) { $process.Dispose() }
-        Remove-Item -LiteralPath $stdoutPath, $stderrPath -Force -ErrorAction SilentlyContinue
-    }
-
-    if ($failure) {
-        if ($diagnostic) { throw "$failure`n$diagnostic" }
-        throw $failure
-    }
-    return $stdoutLines
 }
 
 function Add-PeImportDependencies {
@@ -1034,8 +1230,11 @@ function Add-PeImportDependencies {
             throw "PE import dependency closure exceeded its $OutputLineLimit-line safety limit"
         }
 
+        if ([string]$line -notmatch '^\s*Name\s*:') { continue }
         $dllName = Get-PeImportDependencyName ([string]$line)
-        if (-not $dllName) { continue }
+        if (-not $dllName) {
+            throw "PE import inspector returned an unsupported dependency spelling for $SourceLabel"
+        }
 
         # Never satisfy an import with a prohibited copy-control/DRM runtime.
         # Failing here, rather than silently omitting the DLL, preserves the
@@ -1093,7 +1292,8 @@ if ($staleForbiddenMemberCount -gt 0) {
 Assert-WindowsBundleComponentPolicy $DIST
 
 # Always copy the executable (just built).
-Copy-Item $exePath $DIST -Force
+$exeBundleDest = Join-Path $DIST (Split-Path $exePath -Leaf)
+Copy-WindowsBundleFileForced $exePath $exeBundleDest
 
 # Copy dynamic plugin folders (incremental — only newer files).
 Write-Info "Syncing GTK plugins and GStreamer codecs (incremental)..."
@@ -1126,7 +1326,7 @@ if (-not (Test-Path -LiteralPath $gstScannerSrc -PathType Leaf)) {
     Write-Err "Required GStreamer plugin scanner not found at $gstScannerSrc"
 }
 Remove-Item -LiteralPath $legacyGstScannerDest -Force -ErrorAction SilentlyContinue
-Copy-Item -LiteralPath $gstScannerSrc -Destination $gstScannerDest -Force
+Copy-WindowsBundleFileForced $gstScannerSrc $gstScannerDest
 Write-Info "Bundled gst-plugin-scanner.exe (unconditional overwrite)."
 
 # Resolve all transitive dependencies for the EXE and plugins without loading
@@ -1532,6 +1732,12 @@ Write-Info "Packaged Windows runtime probe passed."
 # Recheck immediately before archiving so the emitted artifact, rather than
 # merely the earlier dependency-closure snapshot, is covered by the policy.
 Assert-WindowsBundleComponentPolicy $DIST
+try {
+    Assert-WindowsBundlePeImportPolicy $DIST $peImportInspector
+}
+catch {
+    Write-Err "Final Windows PE import validation failed: $($_.Exception.Message)"
+}
 Write-Info "Creating zip archive..."
 $zipPath = "dist\tributary-windows.zip"
 Remove-Item $zipPath -ErrorAction SilentlyContinue

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -411,12 +411,14 @@ function Stop-ProbeProcessTree {
 #   Import {
 #     Name: libfoo.dll
 #   }
-# --coff-imports includes ordinary and delay-load imports. Reject path
-# separators and other invalid filename characters so inspector output can
-# never redirect a copy outside the selected MSYS2 architecture's bin folder.
+# Windows also exposes a small number of legacy system modules with a .drv
+# suffix, notably WINSPOOL.DRV imported by current GTK packages. --coff-imports includes
+# ordinary and delay-load imports. Reject every other suffix, path separator,
+# and invalid filename character so inspector output can never redirect a copy
+# outside the selected MSYS2 architecture's bin folder.
 function Get-PeImportDependencyName {
     param([string]$Line)
-    if ($Line -notmatch '^\s*Name:\s*([^\\/:*?"<>|\x00-\x1F]+\.dll)\s*$') { return $null }
+    if ($Line -notmatch '^\s*Name:\s*([^\\/:*?"<>|\x00-\x1F]+\.(?:dll|drv))\s*$') { return $null }
     return $matches[1]
 }
 
@@ -483,8 +485,9 @@ function ConvertTo-BoundedPeImportArgumentBatch {
             throw "PE import-inspection target #$targetNumber is not a valid filesystem path ($targetLabel)"
         }
         $extension = [System.IO.Path]::GetExtension($normalizedTarget)
-        if ($extension -ine ".dll" -and $extension -ine ".exe") {
-            throw "PE import-inspection target #$targetNumber is not a DLL or EXE ($targetLabel)"
+        if ($extension -ine ".dll" -and $extension -ine ".drv" -and
+            $extension -ine ".exe") {
+            throw "PE import-inspection target #$targetNumber is not a DLL, DRV, or EXE ($targetLabel)"
         }
         if (-not [System.IO.File]::Exists($normalizedTarget)) {
             throw "PE import-inspection target #$targetNumber is not an existing file ($targetLabel)"
@@ -650,11 +653,12 @@ function Assert-WindowsBundlePeImportPolicy {
     $targetItems = @(Get-WindowsTreeMembersWithoutReparseTraversal $rootFull | Where-Object {
         $isDirectory = ($_.Attributes -band [System.IO.FileAttributes]::Directory) -ne 0
         $isReparsePoint = ($_.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0
-        $isPeCandidate = $_.Extension -ieq '.dll' -or $_.Extension -ieq '.exe'
+        $isPeCandidate = $_.Extension -ieq '.dll' -or $_.Extension -ieq '.drv' -or
+            $_.Extension -ieq '.exe'
         -not $isDirectory -and -not $isReparsePoint -and $isPeCandidate
     } | Sort-Object FullName)
     if ($targetItems.Count -eq 0) {
-        throw "Windows bundle contains no DLL or EXE targets for final PE import validation"
+        throw "Windows bundle contains no DLL, DRV, or EXE targets for final PE import validation"
     }
 
     $maxTargets = 4096
@@ -750,7 +754,8 @@ function Assert-WindowsBundlePeImportPolicy {
     $finalTargets = @(Get-WindowsTreeMembersWithoutReparseTraversal $rootFull | Where-Object {
         $isDirectory = ($_.Attributes -band [System.IO.FileAttributes]::Directory) -ne 0
         $isReparsePoint = ($_.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0
-        $isPeCandidate = $_.Extension -ieq '.dll' -or $_.Extension -ieq '.exe'
+        $isPeCandidate = $_.Extension -ieq '.dll' -or $_.Extension -ieq '.drv' -or
+            $_.Extension -ieq '.exe'
         -not $isDirectory -and -not $isReparsePoint -and $isPeCandidate
     })
     if ($finalTargets.Count -ne $targetSnapshot.Count) {
@@ -1342,7 +1347,7 @@ if (-not [System.IO.Path]::IsPathRooted($peImportInspector) -or
 
 Write-Info "Resolving required DLLs for executable and plugins..."
 
-# Seed the dependency closure with every PE DLL and executable already present
+# Seed the dependency closure with every PE DLL, DRV, and executable already present
 # anywhere in the bundle, including hidden and stale incremental members. The
 # same hidden-inclusive enumerator used by the final policy scan avoids a
 # visible-lib-only gap. Every MSYS2 runtime DLL discovered below is copied to
@@ -1366,7 +1371,8 @@ $scannedDllTargets = @{}
 $initialDllScanTargets = @(Get-WindowsTreeMembersWithoutReparseTraversal $DIST | Where-Object {
     $isDirectory = ($_.Attributes -band [System.IO.FileAttributes]::Directory) -ne 0
     $isReparsePoint = ($_.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0
-    $isPeCandidate = $_.Extension -ieq '.dll' -or $_.Extension -ieq '.exe'
+    $isPeCandidate = $_.Extension -ieq '.dll' -or $_.Extension -ieq '.drv' -or
+        $_.Extension -ieq '.exe'
     -not $isDirectory -and -not $isReparsePoint -and $isPeCandidate
 } | Select-Object -ExpandProperty FullName)
 foreach ($bin in $initialDllScanTargets) {

--- a/scripts/macos-package-policy.sh
+++ b/scripts/macos-package-policy.sh
@@ -1,0 +1,382 @@
+#!/usr/bin/env bash
+# Shared helpers for enforcing Tributary's macOS bundle component policy.
+# This file is sourced by build-macos.sh and by its deterministic policy tests.
+
+MACOS_PACKAGE_POLICY_REASON=""
+MACOS_PACKAGE_POLICY_RESULT=""
+MACOS_PACKAGE_POLICY_MATCHED_TOKEN=""
+MACOS_FORBIDDEN_COMPONENT_TOKENS=()
+
+macos_package_policy_default_file() {
+  local helper_dir
+  helper_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  printf '%s\n' "${helper_dir}/../build-aux/packaging/forbidden-bundled-components.txt"
+}
+
+macos_package_policy_load() {
+  local policy_file="${1:-${TRIBUTARY_FORBIDDEN_COMPONENTS_FILE:-}}"
+  local line token canonical_token known_token
+  local LC_ALL=C
+
+  if [[ -z "$policy_file" ]]; then
+    policy_file="$(macos_package_policy_default_file)"
+  fi
+
+  MACOS_FORBIDDEN_COMPONENT_TOKENS=()
+  MACOS_PACKAGE_POLICY_REASON=""
+  MACOS_PACKAGE_POLICY_RESULT=""
+  MACOS_PACKAGE_POLICY_MATCHED_TOKEN=""
+
+  if [[ ! -f "$policy_file" ]]; then
+    MACOS_PACKAGE_POLICY_REASON="Required bundled-component policy is missing: ${policy_file}"
+    MACOS_PACKAGE_POLICY_RESULT="error"
+    return 1
+  fi
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    token="$(printf '%s' "$line" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+    [[ -z "$token" || "$token" == \#* ]] && continue
+
+    if [[ ! "$token" =~ ^[A-Za-z0-9][A-Za-z0-9._+-]*$ ]]; then
+      MACOS_FORBIDDEN_COMPONENT_TOKENS=()
+      MACOS_PACKAGE_POLICY_REASON="Bundled-component policy contains an invalid filename token: '${token}'"
+      MACOS_PACKAGE_POLICY_RESULT="error"
+      return 1
+    fi
+
+    canonical_token="$(printf '%s' "$token" | tr '[:upper:]' '[:lower:]')"
+    for known_token in "${MACOS_FORBIDDEN_COMPONENT_TOKENS[@]}"; do
+      if [[ "$known_token" == "$canonical_token" ]]; then
+        MACOS_FORBIDDEN_COMPONENT_TOKENS=()
+        MACOS_PACKAGE_POLICY_REASON="Bundled-component policy contains a duplicate filename token: '${token}'"
+        MACOS_PACKAGE_POLICY_RESULT="error"
+        return 1
+      fi
+    done
+    MACOS_FORBIDDEN_COMPONENT_TOKENS+=("$canonical_token")
+  done < "$policy_file"
+
+  if [[ ${#MACOS_FORBIDDEN_COMPONENT_TOKENS[@]} -eq 0 ]]; then
+    MACOS_PACKAGE_POLICY_REASON="Bundled-component policy contains no filename tokens: ${policy_file}"
+    MACOS_PACKAGE_POLICY_RESULT="error"
+    return 1
+  fi
+
+  MACOS_PACKAGE_POLICY_RESULT="loaded"
+  return 0
+}
+
+macos_copy_control_path_is_prohibited() {
+  local path="$1"
+  local filename token
+
+  filename="$(basename "$path" | tr '[:upper:]' '[:lower:]')"
+  MACOS_PACKAGE_POLICY_MATCHED_TOKEN=""
+
+  for token in "${MACOS_FORBIDDEN_COMPONENT_TOKENS[@]}"; do
+    if [[ "$filename" == *"$token"* ]]; then
+      MACOS_PACKAGE_POLICY_MATCHED_TOKEN="$token"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+macos_copy_control_relative_path_is_prohibited() {
+  local relative_path="$1"
+  local remaining component
+
+  remaining="$relative_path"
+  while :; do
+    component="${remaining%%/*}"
+    if [[ -n "$component" ]] \
+      && macos_copy_control_path_is_prohibited "$component"; then
+      return 0
+    fi
+
+    [[ "$remaining" == */* ]] || break
+    remaining="${remaining#*/}"
+  done
+
+  return 1
+}
+
+macos_validate_macho_copy_control() {
+  local artifact="$1"
+  local otool_output line dependency
+
+  MACOS_PACKAGE_POLICY_REASON=""
+  MACOS_PACKAGE_POLICY_RESULT=""
+
+  if [[ ${#MACOS_FORBIDDEN_COMPONENT_TOKENS[@]} -eq 0 ]]; then
+    MACOS_PACKAGE_POLICY_REASON="bundled-component policy has not been loaded"
+    MACOS_PACKAGE_POLICY_RESULT="uninspectable"
+    return 2
+  fi
+
+  if macos_copy_control_path_is_prohibited "$artifact"; then
+    MACOS_PACKAGE_POLICY_REASON="$(basename "$artifact") matches forbidden token '${MACOS_PACKAGE_POLICY_MATCHED_TOKEN}'"
+    MACOS_PACKAGE_POLICY_RESULT="prohibited"
+    return 1
+  fi
+
+  if ! otool_output="$("${MACOS_OTOOL_COMMAND:-otool}" -L "$artifact" 2>&1)"; then
+    MACOS_PACKAGE_POLICY_REASON="could not inspect Mach-O imports for ${artifact}"
+    MACOS_PACKAGE_POLICY_RESULT="uninspectable"
+    return 2
+  fi
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ "$line" == *' (compatibility version '* ]] || continue
+
+    dependency="$line"
+    while [[ "$dependency" == ' '* || "$dependency" == $'\t'* ]]; do
+      dependency="${dependency#?}"
+    done
+    dependency="${dependency%% \(*}"
+    [[ -z "$dependency" ]] && continue
+
+    if macos_copy_control_path_is_prohibited "$dependency"; then
+      MACOS_PACKAGE_POLICY_REASON="$(basename "$artifact") imports forbidden component $(basename "$dependency") (token '${MACOS_PACKAGE_POLICY_MATCHED_TOKEN}')"
+      MACOS_PACKAGE_POLICY_RESULT="prohibited"
+      return 1
+    fi
+  done <<< "$otool_output"
+
+  MACOS_PACKAGE_POLICY_RESULT="allowed"
+  return 0
+}
+
+macos_stage_gstreamer_plugin() {
+  local source="$1"
+  local destination_dir="$2"
+  local validation_status=0
+
+  macos_validate_macho_copy_control "$source" || validation_status=$?
+  case "$validation_status" in
+    0)
+      ;;
+    1)
+      MACOS_PACKAGE_POLICY_RESULT="excluded"
+      return 0
+      ;;
+    *)
+      MACOS_PACKAGE_POLICY_RESULT="error"
+      return "$validation_status"
+      ;;
+  esac
+
+  if ! cp "$source" "$destination_dir/"; then
+    MACOS_PACKAGE_POLICY_REASON="could not copy GStreamer plugin ${source}"
+    MACOS_PACKAGE_POLICY_RESULT="error"
+    return 1
+  fi
+
+  MACOS_PACKAGE_POLICY_RESULT="copied"
+  return 0
+}
+
+macos_bundle_artifact_requires_import_scan() {
+  local bundle_root="$1"
+  local artifact="$2"
+  local bundle_name basename magic_output magic
+
+  bundle_name="$(basename "$bundle_root")"
+  bundle_name="${bundle_name%.app}"
+  basename="$(basename "$artifact")"
+
+  case "$basename" in
+    *.dylib|*.so)
+      return 0
+      ;;
+  esac
+
+  case "$artifact" in
+    "$bundle_root"/Contents/MacOS/*)
+      # build-macos.sh creates this one shell wrapper. Every other regular
+      # executable in Contents/MacOS is a copied or built Mach-O artifact.
+      [[ "$artifact" == "$bundle_root/Contents/MacOS/$bundle_name" ]] && return 1
+      return 0
+      ;;
+    "$bundle_root"/Contents/Frameworks/*)
+      [[ -x "$artifact" ]]
+      return
+      ;;
+  esac
+
+  # Mach-O payloads are not required to use a conventional extension or
+  # executable bit. Recognize thin and universal binaries by their on-disk
+  # magic so an allowed-named helper under Resources cannot hide an import.
+  [[ -f "$artifact" && ! -L "$artifact" ]] || return 1
+  if ! magic_output="$("${MACOS_OD_COMMAND:-od}" -An -tx1 -N4 < "$artifact" 2>/dev/null)"; then
+    MACOS_PACKAGE_POLICY_REASON="could not inspect file magic for ${artifact}"
+    MACOS_PACKAGE_POLICY_RESULT="uninspectable"
+    return 2
+  fi
+  if ! magic="$(printf '%s' "$magic_output" | tr -d '[:space:]')"; then
+    MACOS_PACKAGE_POLICY_REASON="could not normalize file magic for ${artifact}"
+    MACOS_PACKAGE_POLICY_RESULT="uninspectable"
+    return 2
+  fi
+  magic="$(printf '%s' "$magic" | tr '[:upper:]' '[:lower:]')"
+  case "$magic" in
+    feedface|cefaedfe|feedfacf|cffaedfe|cafebabe|bebafeca|cafebabf|bfbafeca)
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
+macos_validate_bundle_member_manifest() {
+  local bundle_root="$1"
+  local manifest="$2"
+  local artifact relative_path link_target
+
+  # Check every member name, including directories and symlinks. This catches
+  # forbidden frameworks, plugin directories, versioned dylibs, and CDMs even
+  # when a member is not itself a Mach-O executable.
+  while IFS= read -r -d '' artifact; do
+    relative_path="${artifact#"$bundle_root"/}"
+    if macos_copy_control_relative_path_is_prohibited "$relative_path"; then
+      MACOS_PACKAGE_POLICY_REASON="bundle member ${relative_path} has a path component matching forbidden token '${MACOS_PACKAGE_POLICY_MATCHED_TOKEN}'"
+      MACOS_PACKAGE_POLICY_RESULT="prohibited"
+      return 1
+    fi
+
+    if [[ -L "$artifact" ]]; then
+      if ! link_target="$(readlink "$artifact")"; then
+        MACOS_PACKAGE_POLICY_REASON="could not inspect bundle symlink ${artifact#"$bundle_root"/}"
+        MACOS_PACKAGE_POLICY_RESULT="uninspectable"
+        return 2
+      fi
+      if macos_copy_control_relative_path_is_prohibited "$link_target"; then
+        MACOS_PACKAGE_POLICY_REASON="bundle symlink ${relative_path} targets a path with forbidden component ${link_target} (token '${MACOS_PACKAGE_POLICY_MATCHED_TOKEN}')"
+        MACOS_PACKAGE_POLICY_RESULT="prohibited"
+        return 1
+      fi
+    fi
+  done < "$manifest"
+
+  return 0
+}
+
+macos_validate_bundle_import_manifest() {
+  local bundle_root="$1"
+  local manifest="$2"
+  local artifact candidate_status validation_status
+
+  # Filename filtering alone is insufficient: an innocuously named plugin can
+  # import a prohibited library. Inspect all copied dylibs/plugins and every
+  # executable that the bundle will launch. Failure to inspect is fatal.
+  while IFS= read -r -d '' artifact; do
+    candidate_status=0
+    macos_bundle_artifact_requires_import_scan "$bundle_root" "$artifact" \
+      || candidate_status=$?
+    case "$candidate_status" in
+      0) ;;
+      1) continue ;;
+      *) return "$candidate_status" ;;
+    esac
+
+    validation_status=0
+    macos_validate_macho_copy_control "$artifact" || validation_status=$?
+    if [[ $validation_status -ne 0 ]]; then
+      return "$validation_status"
+    fi
+  done < "$manifest"
+
+  return 0
+}
+
+macos_validate_bundle_copy_control() {
+  local bundle_root="$1"
+  local manifest_dir members_before imports members_after validation_status
+
+  MACOS_PACKAGE_POLICY_REASON=""
+  MACOS_PACKAGE_POLICY_RESULT=""
+
+  if [[ ${#MACOS_FORBIDDEN_COMPONENT_TOKENS[@]} -eq 0 ]]; then
+    MACOS_PACKAGE_POLICY_REASON="bundled-component policy has not been loaded"
+    MACOS_PACKAGE_POLICY_RESULT="uninspectable"
+    return 2
+  fi
+
+  if [[ ! -d "$bundle_root/Contents" ]]; then
+    MACOS_PACKAGE_POLICY_REASON="macOS bundle Contents directory does not exist: ${bundle_root}/Contents"
+    MACOS_PACKAGE_POLICY_RESULT="error"
+    return 1
+  fi
+
+  if ! manifest_dir="$(mktemp -d "${TMPDIR:-/tmp}/tributary-macos-bundle-policy.XXXXXX")"; then
+    MACOS_PACKAGE_POLICY_REASON="could not create a private macOS bundle-policy manifest directory"
+    MACOS_PACKAGE_POLICY_RESULT="uninspectable"
+    return 2
+  fi
+  members_before="${manifest_dir}/members-before.nul"
+  imports="${manifest_dir}/imports.nul"
+  members_after="${manifest_dir}/members-after.nul"
+
+  # Do not consume find through process substitution: Bash cannot observe that
+  # producer's status. Materialize each NUL-delimited pass privately, check the
+  # traversal itself, and only then consume its complete result.
+  if ! "${MACOS_FIND_COMMAND:-find}" "$bundle_root" -mindepth 1 -print0 > "$members_before"; then
+    rm -rf "$manifest_dir"
+    MACOS_PACKAGE_POLICY_REASON="could not enumerate macOS bundle members: ${bundle_root}"
+    MACOS_PACKAGE_POLICY_RESULT="uninspectable"
+    return 2
+  fi
+
+  validation_status=0
+  macos_validate_bundle_member_manifest "$bundle_root" "$members_before" \
+    || validation_status=$?
+  if [[ $validation_status -ne 0 ]]; then
+    rm -rf "$manifest_dir"
+    return "$validation_status"
+  fi
+
+  if ! "${MACOS_FIND_COMMAND:-find}" "$bundle_root/Contents" -type f -print0 > "$imports"; then
+    rm -rf "$manifest_dir"
+    MACOS_PACKAGE_POLICY_REASON="could not enumerate macOS bundle import candidates: ${bundle_root}/Contents"
+    MACOS_PACKAGE_POLICY_RESULT="uninspectable"
+    return 2
+  fi
+
+  validation_status=0
+  macos_validate_bundle_import_manifest "$bundle_root" "$imports" \
+    || validation_status=$?
+  if [[ $validation_status -ne 0 ]]; then
+    rm -rf "$manifest_dir"
+    return "$validation_status"
+  fi
+
+  # A second checked snapshot makes concurrent additions, removals, or renames
+  # fail closed. Recheck names and symlink targets from that snapshot as well.
+  if ! "${MACOS_FIND_COMMAND:-find}" "$bundle_root" -mindepth 1 -print0 > "$members_after"; then
+    rm -rf "$manifest_dir"
+    MACOS_PACKAGE_POLICY_REASON="could not re-enumerate macOS bundle members: ${bundle_root}"
+    MACOS_PACKAGE_POLICY_RESULT="uninspectable"
+    return 2
+  fi
+
+  validation_status=0
+  macos_validate_bundle_member_manifest "$bundle_root" "$members_after" \
+    || validation_status=$?
+  if [[ $validation_status -ne 0 ]]; then
+    rm -rf "$manifest_dir"
+    return "$validation_status"
+  fi
+
+  if ! cmp -s "$members_before" "$members_after"; then
+    rm -rf "$manifest_dir"
+    MACOS_PACKAGE_POLICY_REASON="macOS bundle changed during component-policy validation: ${bundle_root}"
+    MACOS_PACKAGE_POLICY_RESULT="uninspectable"
+    return 2
+  fi
+
+  rm -rf "$manifest_dir"
+
+  MACOS_PACKAGE_POLICY_RESULT="allowed"
+  return 0
+}

--- a/scripts/macos-package-policy.sh
+++ b/scripts/macos-package-policy.sh
@@ -6,6 +6,7 @@ MACOS_PACKAGE_POLICY_REASON=""
 MACOS_PACKAGE_POLICY_RESULT=""
 MACOS_PACKAGE_POLICY_MATCHED_TOKEN=""
 MACOS_FORBIDDEN_COMPONENT_TOKENS=()
+MACOS_FORBIDDEN_COMPONENT_TOKEN_COUNT=0
 
 macos_package_policy_default_file() {
   local helper_dir
@@ -17,12 +18,14 @@ macos_package_policy_load() {
   local policy_file="${1:-${TRIBUTARY_FORBIDDEN_COMPONENTS_FILE:-}}"
   local line token canonical_token known_token
   local LC_ALL=C
+  export LC_ALL
 
   if [[ -z "$policy_file" ]]; then
     policy_file="$(macos_package_policy_default_file)"
   fi
 
   MACOS_FORBIDDEN_COMPONENT_TOKENS=()
+  MACOS_FORBIDDEN_COMPONENT_TOKEN_COUNT=0
   MACOS_PACKAGE_POLICY_REASON=""
   MACOS_PACKAGE_POLICY_RESULT=""
   MACOS_PACKAGE_POLICY_MATCHED_TOKEN=""
@@ -45,18 +48,20 @@ macos_package_policy_load() {
     fi
 
     canonical_token="$(printf '%s' "$token" | tr '[:upper:]' '[:lower:]')"
-    for known_token in "${MACOS_FORBIDDEN_COMPONENT_TOKENS[@]}"; do
+    for known_token in ${MACOS_FORBIDDEN_COMPONENT_TOKENS[@]+"${MACOS_FORBIDDEN_COMPONENT_TOKENS[@]}"}; do
       if [[ "$known_token" == "$canonical_token" ]]; then
         MACOS_FORBIDDEN_COMPONENT_TOKENS=()
+        MACOS_FORBIDDEN_COMPONENT_TOKEN_COUNT=0
         MACOS_PACKAGE_POLICY_REASON="Bundled-component policy contains a duplicate filename token: '${token}'"
         MACOS_PACKAGE_POLICY_RESULT="error"
         return 1
       fi
     done
     MACOS_FORBIDDEN_COMPONENT_TOKENS+=("$canonical_token")
+    MACOS_FORBIDDEN_COMPONENT_TOKEN_COUNT=$((MACOS_FORBIDDEN_COMPONENT_TOKEN_COUNT + 1))
   done < "$policy_file"
 
-  if [[ ${#MACOS_FORBIDDEN_COMPONENT_TOKENS[@]} -eq 0 ]]; then
+  if [[ $MACOS_FORBIDDEN_COMPONENT_TOKEN_COUNT -eq 0 ]]; then
     MACOS_PACKAGE_POLICY_REASON="Bundled-component policy contains no filename tokens: ${policy_file}"
     MACOS_PACKAGE_POLICY_RESULT="error"
     return 1
@@ -69,11 +74,13 @@ macos_package_policy_load() {
 macos_copy_control_path_is_prohibited() {
   local path="$1"
   local filename token
+  local LC_ALL=C
+  export LC_ALL
 
   filename="$(basename "$path" | tr '[:upper:]' '[:lower:]')"
   MACOS_PACKAGE_POLICY_MATCHED_TOKEN=""
 
-  for token in "${MACOS_FORBIDDEN_COMPONENT_TOKENS[@]}"; do
+  for token in ${MACOS_FORBIDDEN_COMPONENT_TOKENS[@]+"${MACOS_FORBIDDEN_COMPONENT_TOKENS[@]}"}; do
     if [[ "$filename" == *"$token"* ]]; then
       MACOS_PACKAGE_POLICY_MATCHED_TOKEN="$token"
       return 0
@@ -104,18 +111,28 @@ macos_copy_control_relative_path_is_prohibited() {
 
 macos_validate_macho_copy_control() {
   local artifact="$1"
-  local otool_output line dependency
+  local inspect_source_path="${2:-true}"
+  local otool_output otool_load_commands line dependency load_reference
+  local LC_ALL=C
+  export LC_ALL
 
   MACOS_PACKAGE_POLICY_REASON=""
   MACOS_PACKAGE_POLICY_RESULT=""
 
-  if [[ ${#MACOS_FORBIDDEN_COMPONENT_TOKENS[@]} -eq 0 ]]; then
+  if [[ $MACOS_FORBIDDEN_COMPONENT_TOKEN_COUNT -eq 0 ]]; then
     MACOS_PACKAGE_POLICY_REASON="bundled-component policy has not been loaded"
     MACOS_PACKAGE_POLICY_RESULT="uninspectable"
     return 2
   fi
 
-  if macos_copy_control_path_is_prohibited "$artifact"; then
+  if [[ "$inspect_source_path" == true ]] \
+    && macos_copy_control_relative_path_is_prohibited "$artifact"; then
+    MACOS_PACKAGE_POLICY_REASON="source path ${artifact} matches forbidden token '${MACOS_PACKAGE_POLICY_MATCHED_TOKEN}'"
+    MACOS_PACKAGE_POLICY_RESULT="prohibited"
+    return 1
+  fi
+  if [[ "$inspect_source_path" != true ]] \
+    && macos_copy_control_path_is_prohibited "$artifact"; then
     MACOS_PACKAGE_POLICY_REASON="$(basename "$artifact") matches forbidden token '${MACOS_PACKAGE_POLICY_MATCHED_TOKEN}'"
     MACOS_PACKAGE_POLICY_RESULT="prohibited"
     return 1
@@ -137,12 +154,39 @@ macos_validate_macho_copy_control() {
     dependency="${dependency%% \(*}"
     [[ -z "$dependency" ]] && continue
 
-    if macos_copy_control_path_is_prohibited "$dependency"; then
-      MACOS_PACKAGE_POLICY_REASON="$(basename "$artifact") imports forbidden component $(basename "$dependency") (token '${MACOS_PACKAGE_POLICY_MATCHED_TOKEN}')"
+    if macos_copy_control_relative_path_is_prohibited "$dependency"; then
+      MACOS_PACKAGE_POLICY_REASON="$(basename "$artifact") imports forbidden component path ${dependency} (token '${MACOS_PACKAGE_POLICY_MATCHED_TOKEN}')"
       MACOS_PACKAGE_POLICY_RESULT="prohibited"
       return 1
     fi
   done <<< "$otool_output"
+
+  # -L covers linked dylibs, while -l also exposes LC_RPATH,
+  # LC_LOAD_DYLINKER, and other load-command name/path fields that can redirect
+  # an allowed basename through a recognizable denied directory.
+  if ! otool_load_commands="$("${MACOS_OTOOL_COMMAND:-otool}" -l "$artifact" 2>&1)"; then
+    MACOS_PACKAGE_POLICY_REASON="could not inspect Mach-O load commands for ${artifact}"
+    MACOS_PACKAGE_POLICY_RESULT="uninspectable"
+    return 2
+  fi
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    while [[ "$line" == ' '* || "$line" == $'\t'* ]]; do
+      line="${line#?}"
+    done
+    case "$line" in
+      name\ *\ \(offset\ *|path\ *\ \(offset\ *)
+        load_reference="${line#* }"
+        load_reference="${load_reference%% \(offset *}"
+        [[ -z "$load_reference" ]] && continue
+        if macos_copy_control_relative_path_is_prohibited "$load_reference"; then
+          MACOS_PACKAGE_POLICY_REASON="$(basename "$artifact") contains forbidden Mach-O load path ${load_reference} (token '${MACOS_PACKAGE_POLICY_MATCHED_TOKEN}')"
+          MACOS_PACKAGE_POLICY_RESULT="prohibited"
+          return 1
+        fi
+        ;;
+    esac
+  done <<< "$otool_load_commands"
 
   MACOS_PACKAGE_POLICY_RESULT="allowed"
   return 0
@@ -181,6 +225,8 @@ macos_bundle_artifact_requires_import_scan() {
   local bundle_root="$1"
   local artifact="$2"
   local bundle_name basename magic_output magic
+  local LC_ALL=C
+  export LC_ALL
 
   bundle_name="$(basename "$bundle_root")"
   bundle_name="${bundle_name%.app}"
@@ -195,13 +241,16 @@ macos_bundle_artifact_requires_import_scan() {
   case "$artifact" in
     "$bundle_root"/Contents/MacOS/*)
       # build-macos.sh creates this one shell wrapper. Every other regular
-      # executable in Contents/MacOS is a copied or built Mach-O artifact.
-      [[ "$artifact" == "$bundle_root/Contents/MacOS/$bundle_name" ]] && return 1
-      return 0
+      # file in Contents/MacOS is a copied or built Mach-O artifact. Let the
+      # wrapper fall through to magic inspection so a future Mach-O wrapper
+      # cannot bypass import validation merely by retaining the same name.
+      [[ "$artifact" == "$bundle_root/Contents/MacOS/$bundle_name" ]] || return 0
       ;;
     "$bundle_root"/Contents/Frameworks/*)
-      [[ -x "$artifact" ]]
-      return
+      # Framework members are not guaranteed to retain an executable bit.
+      # Scan executable members directly and use magic detection for all
+      # remaining regular files.
+      [[ -x "$artifact" ]] && return 0
       ;;
   esac
 
@@ -281,7 +330,7 @@ macos_validate_bundle_import_manifest() {
     esac
 
     validation_status=0
-    macos_validate_macho_copy_control "$artifact" || validation_status=$?
+    macos_validate_macho_copy_control "$artifact" false || validation_status=$?
     if [[ $validation_status -ne 0 ]]; then
       return "$validation_status"
     fi
@@ -297,7 +346,7 @@ macos_validate_bundle_copy_control() {
   MACOS_PACKAGE_POLICY_REASON=""
   MACOS_PACKAGE_POLICY_RESULT=""
 
-  if [[ ${#MACOS_FORBIDDEN_COMPONENT_TOKENS[@]} -eq 0 ]]; then
+  if [[ $MACOS_FORBIDDEN_COMPONENT_TOKEN_COUNT -eq 0 ]]; then
     MACOS_PACKAGE_POLICY_REASON="bundled-component policy has not been loaded"
     MACOS_PACKAGE_POLICY_RESULT="uninspectable"
     return 2

--- a/scripts/test-macos-package-policy.sh
+++ b/scripts/test-macos-package-policy.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=macos-package-policy.sh
+source "${SCRIPT_DIR}/macos-package-policy.sh"
+
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/tributary-macos-policy.XXXXXX")"
+POLICY_TMPDIR="${TEST_ROOT}/Policy Temp"
+mkdir -p "$POLICY_TMPDIR"
+TMPDIR="$POLICY_TMPDIR"
+export TMPDIR
+cleanup() {
+  rm -rf "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "not ok - $*" >&2
+  exit 1
+}
+
+assert_status() {
+  local expected="$1"
+  shift
+  local actual=0
+  "$@" || actual=$?
+  [[ "$actual" -eq "$expected" ]] \
+    || fail "expected status ${expected}, got ${actual}: $*"
+}
+
+assert_prohibited_name() {
+  macos_copy_control_path_is_prohibited "$1" \
+    || fail "expected forbidden filename: $1"
+}
+
+assert_allowed_name() {
+  if macos_copy_control_path_is_prohibited "$1"; then
+    fail "ordinary runtime was overmatched by '${MACOS_PACKAGE_POLICY_MATCHED_TOKEN}': $1"
+  fi
+}
+
+assert_no_policy_manifests() {
+  local manifest
+  for manifest in "$POLICY_TMPDIR"/tributary-macos-bundle-policy.*; do
+    [[ ! -e "$manifest" ]] || fail "bundle-policy manifest was not cleaned up: $manifest"
+  done
+}
+
+POLICY_FILE="$(macos_package_policy_default_file)"
+
+EMPTY_POLICY="${TEST_ROOT}/empty-policy.txt"
+INVALID_POLICY="${TEST_ROOT}/invalid-policy.txt"
+DUPLICATE_POLICY="${TEST_ROOT}/duplicate-policy.txt"
+MIXED_CASE_POLICY="${TEST_ROOT}/mixed-case-policy.txt"
+printf '%s\n' '# comments do not constitute a policy' '   ' > "$EMPTY_POLICY"
+printf '%s\n' 'dvdcss' 'not/a-token' > "$INVALID_POLICY"
+printf '%s\n' 'aacs' 'AACS' > "$DUPLICATE_POLICY"
+printf '%s\n' 'AaCs' > "$MIXED_CASE_POLICY"
+assert_status 1 macos_package_policy_load "${TEST_ROOT}/missing-policy.txt"
+assert_status 1 macos_package_policy_load "$EMPTY_POLICY"
+assert_status 1 macos_package_policy_load "$INVALID_POLICY"
+[[ "$MACOS_PACKAGE_POLICY_REASON" == *'invalid filename token'* ]] \
+  || fail "invalid policy token did not produce a useful diagnostic"
+assert_status 1 macos_package_policy_load "$DUPLICATE_POLICY"
+[[ "$MACOS_PACKAGE_POLICY_REASON" == *'duplicate filename token'* ]] \
+  || fail "case-insensitive duplicate did not produce a useful diagnostic"
+assert_status 0 macos_package_policy_load "$MIXED_CASE_POLICY"
+[[ "${MACOS_FORBIDDEN_COMPONENT_TOKENS[0]}" == aacs ]] \
+  || fail "mixed-case policy token was not canonicalized"
+assert_status 0 macos_package_policy_load "$POLICY_FILE"
+
+for prohibited in \
+  'libDVDcss.2.dylib' \
+  'libdvdread.8.dylib' \
+  'libdvdnav.4.dylib' \
+  'libaacs.0.dylib' \
+  'libbdplus.0.dylib' \
+  'libbluray.2.dylib' \
+  'libmmbd64.dylib' \
+  'libgstresindvd.dylib' \
+  'WidevineCDM.framework' \
+  'FairPlayRuntime'; do
+  assert_prohibited_name "$prohibited"
+done
+
+for ordinary_runtime in \
+  'libgstlibav.dylib' \
+  'libavcodec.61.dylib' \
+  'libgstfdkaac.dylib' \
+  'libgstaudioparsers.dylib' \
+  'libgstdvdlpcmdec.dylib' \
+  'libgstdvdsub.dylib' \
+  'libsoup-3.0.dylib' \
+  'libssl.3.dylib' \
+  'libcrypto.3.dylib'; do
+  assert_allowed_name "$ordinary_runtime"
+done
+
+# External dependency/source paths intentionally use leaf-only matching. A
+# formula directory name must not hide an otherwise ordinary codec library.
+assert_allowed_name '/opt/homebrew/Cellar/libbluray/1.3.4/lib/libgstlibav.dylib'
+macos_copy_control_relative_path_is_prohibited '../WidevineCDM/helper.dylib' \
+  || fail "forbidden intermediate relative-path component was not detected"
+if macos_copy_control_relative_path_is_prohibited '../ordinary-codecs/helper.dylib'; then
+  fail "benign intermediate relative-path component was overmatched"
+fi
+
+FAKE_OTOOL="${TEST_ROOT}/fake-otool"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'artifact=""' \
+  'for argument in "$@"; do artifact="$argument"; done' \
+  '[[ -e "${artifact}.otool-fail" ]] && exit 1' \
+  'printf "%s:\n" "$artifact"' \
+  'if [[ -f "${artifact}.deps" ]]; then' \
+  '  while IFS= read -r dependency || [[ -n "$dependency" ]]; do' \
+  '    printf "\t%s (compatibility version 1.0.0, current version 1.0.0)\n" "$dependency"' \
+  '  done < "${artifact}.deps"' \
+  'else' \
+  '  printf "\t/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1.0.0)\n"' \
+  'fi' > "$FAKE_OTOOL"
+chmod +x "$FAKE_OTOOL"
+MACOS_OTOOL_COMMAND="$FAKE_OTOOL"
+export MACOS_OTOOL_COMMAND
+
+PLUGIN_SOURCE="${TEST_ROOT}/plugins"
+PLUGIN_DEST="${TEST_ROOT}/staged"
+mkdir -p "$PLUGIN_SOURCE" "$PLUGIN_DEST"
+
+touch "${PLUGIN_SOURCE}/libgstordinary.dylib"
+printf '%s\n' \
+  '/opt/homebrew/lib/libavcodec.61.dylib' \
+  '/opt/homebrew/lib/libcrypto.3.dylib' \
+  > "${PLUGIN_SOURCE}/libgstordinary.dylib.deps"
+assert_status 0 macos_stage_gstreamer_plugin \
+  "${PLUGIN_SOURCE}/libgstordinary.dylib" "$PLUGIN_DEST"
+[[ "$MACOS_PACKAGE_POLICY_RESULT" == copied ]] || fail "ordinary plugin was not copied"
+[[ -f "${PLUGIN_DEST}/libgstordinary.dylib" ]] || fail "ordinary plugin copy is missing"
+
+touch "${PLUGIN_SOURCE}/libgstaacs.dylib"
+assert_status 0 macos_stage_gstreamer_plugin \
+  "${PLUGIN_SOURCE}/libgstaacs.dylib" "$PLUGIN_DEST"
+[[ "$MACOS_PACKAGE_POLICY_RESULT" == excluded ]] || fail "named decrypt plugin was not excluded"
+[[ ! -e "${PLUGIN_DEST}/libgstaacs.dylib" ]] || fail "excluded plugin reached staging"
+
+touch "${PLUGIN_SOURCE}/libgstinnocent.dylib"
+printf '%s\n' '@rpath/libaacs.0.dylib' \
+  > "${PLUGIN_SOURCE}/libgstinnocent.dylib.deps"
+assert_status 0 macos_stage_gstreamer_plugin \
+  "${PLUGIN_SOURCE}/libgstinnocent.dylib" "$PLUGIN_DEST"
+[[ "$MACOS_PACKAGE_POLICY_RESULT" == excluded ]] || fail "decrypt-linked plugin was not excluded"
+[[ ! -e "${PLUGIN_DEST}/libgstinnocent.dylib" ]] || fail "decrypt-linked plugin reached staging"
+
+touch "${PLUGIN_SOURCE}/libgstuninspectable.dylib"
+touch "${PLUGIN_SOURCE}/libgstuninspectable.dylib.otool-fail"
+assert_status 2 macos_stage_gstreamer_plugin \
+  "${PLUGIN_SOURCE}/libgstuninspectable.dylib" "$PLUGIN_DEST"
+[[ ! -e "${PLUGIN_DEST}/libgstuninspectable.dylib" ]] || fail "uninspectable plugin reached staging"
+
+make_bundle() {
+  local root="$1"
+  mkdir -p \
+    "$root/Contents/MacOS" \
+    "$root/Contents/Frameworks" \
+    "$root/Contents/Resources/lib/gstreamer-1.0"
+  printf '%s\n' '#!/bin/bash' 'exit 0' > "$root/Contents/MacOS/$(basename "${root%.app}")"
+}
+
+SAFE_BUNDLE="${TEST_ROOT}/Safe.app"
+make_bundle "$SAFE_BUNDLE"
+touch "$SAFE_BUNDLE/Contents/MacOS/Safe-bin"
+touch "$SAFE_BUNDLE/Contents/Frameworks/libavcodec.61.dylib"
+touch "$SAFE_BUNDLE/Contents/Resources/lib/gstreamer-1.0/libgstlibav.dylib"
+mkdir -p "$SAFE_BUNDLE/Contents/Resources/ordinary-codecs"
+touch "$SAFE_BUNDLE/Contents/Resources/ordinary-codecs/helper.dat"
+ln -s 'ordinary-codecs/helper.dat' \
+  "$SAFE_BUNDLE/Contents/Resources/ordinary-runtime-link"
+assert_status 0 macos_validate_bundle_copy_control "$SAFE_BUNDLE"
+assert_no_policy_manifests
+
+REAL_FIND_COMMAND="$(command -v find)"
+FAKE_FIND="${TEST_ROOT}/fake-find"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'root="${1:-}"' \
+  'if [[ "${MACOS_FIND_FAIL_SCOPE:-}" == all ]]; then exit 71; fi' \
+  'if [[ "${MACOS_FIND_FAIL_SCOPE:-}" == imports && "$root" == */Contents ]]; then exit 72; fi' \
+  'exec "$REAL_FIND_COMMAND" "$@"' > "$FAKE_FIND"
+chmod +x "$FAKE_FIND"
+export REAL_FIND_COMMAND
+MACOS_FIND_COMMAND="$FAKE_FIND"
+export MACOS_FIND_COMMAND
+
+MACOS_FIND_FAIL_SCOPE=all
+export MACOS_FIND_FAIL_SCOPE
+assert_status 2 macos_validate_bundle_copy_control "$SAFE_BUNDLE"
+[[ "$MACOS_PACKAGE_POLICY_REASON" == *'could not enumerate macOS bundle members'* ]] \
+  || fail "failed member enumeration did not produce a useful diagnostic"
+assert_no_policy_manifests
+
+MACOS_FIND_FAIL_SCOPE=imports
+export MACOS_FIND_FAIL_SCOPE
+assert_status 2 macos_validate_bundle_copy_control "$SAFE_BUNDLE"
+[[ "$MACOS_PACKAGE_POLICY_REASON" == *'could not enumerate macOS bundle import candidates'* ]] \
+  || fail "failed import enumeration did not produce a useful diagnostic"
+assert_no_policy_manifests
+
+unset MACOS_FIND_FAIL_SCOPE
+MACOS_FIND_COMMAND="$REAL_FIND_COMMAND"
+
+NAMED_BUNDLE="${TEST_ROOT}/Named.app"
+make_bundle "$NAMED_BUNDLE"
+touch "$NAMED_BUNDLE/Contents/Frameworks/libDVDcss.2.dylib"
+assert_status 1 macos_validate_bundle_copy_control "$NAMED_BUNDLE"
+
+DIRECTORY_BUNDLE="${TEST_ROOT}/Directory.app"
+make_bundle "$DIRECTORY_BUNDLE"
+mkdir -p "$DIRECTORY_BUNDLE/Contents/Resources/WidevineCDM"
+touch "$DIRECTORY_BUNDLE/Contents/Resources/WidevineCDM/helper.dat"
+assert_status 1 macos_validate_bundle_copy_control "$DIRECTORY_BUNDLE"
+
+IMPORTED_BUNDLE="${TEST_ROOT}/Imported.app"
+make_bundle "$IMPORTED_BUNDLE"
+touch "$IMPORTED_BUNDLE/Contents/Frameworks/libinnocent.dylib"
+printf '%s\n' '@rpath/libbdplus.0.dylib' \
+  > "$IMPORTED_BUNDLE/Contents/Frameworks/libinnocent.dylib.deps"
+assert_status 1 macos_validate_bundle_copy_control "$IMPORTED_BUNDLE"
+
+RESOURCE_MACHO_BUNDLE="${TEST_ROOT}/ResourceMachO.app"
+make_bundle "$RESOURCE_MACHO_BUNDLE"
+printf '\xcf\xfa\xed\xfe' \
+  > "$RESOURCE_MACHO_BUNDLE/Contents/Resources/allowed-helper.dat"
+printf '%s\n' '@rpath/libaacs.0.dylib' \
+  > "$RESOURCE_MACHO_BUNDLE/Contents/Resources/allowed-helper.dat.deps"
+assert_status 1 macos_validate_bundle_copy_control "$RESOURCE_MACHO_BUNDLE"
+
+SYMLINK_BUNDLE="${TEST_ROOT}/Symlink.app"
+make_bundle "$SYMLINK_BUNDLE"
+ln -s '../WidevineCDM/helper.dylib' "$SYMLINK_BUNDLE/Contents/Resources/runtime-link"
+assert_status 1 macos_validate_bundle_copy_control "$SYMLINK_BUNDLE"
+
+UNINSPECTABLE_BUNDLE="${TEST_ROOT}/Uninspectable.app"
+make_bundle "$UNINSPECTABLE_BUNDLE"
+touch "$UNINSPECTABLE_BUNDLE/Contents/Frameworks/libordinary.dylib"
+touch "$UNINSPECTABLE_BUNDLE/Contents/Frameworks/libordinary.dylib.otool-fail"
+assert_status 2 macos_validate_bundle_copy_control "$UNINSPECTABLE_BUNDLE"
+
+echo "ok - macOS packaging policy rejects decrypt components without hiding ordinary codecs"

--- a/scripts/test-macos-package-policy.sh
+++ b/scripts/test-macos-package-policy.sh
@@ -72,11 +72,12 @@ assert_status 0 macos_package_policy_load "$POLICY_FILE"
 
 for prohibited in \
   'libDVDcss.2.dylib' \
+  'libdvd-pkg-installer' \
   'libdvdread.8.dylib' \
   'libdvdnav.4.dylib' \
   'libaacs.0.dylib' \
   'libbdplus.0.dylib' \
-  'libbluray.2.dylib' \
+  'libgstbluray.dylib' \
   'libmmbd64.dylib' \
   'libgstresindvd.dylib' \
   'WidevineCDM.framework' \
@@ -91,15 +92,23 @@ for ordinary_runtime in \
   'libgstaudioparsers.dylib' \
   'libgstdvdlpcmdec.dylib' \
   'libgstdvdsub.dylib' \
+  'libbluray.2.dylib' \
   'libsoup-3.0.dylib' \
   'libssl.3.dylib' \
   'libcrypto.3.dylib'; do
   assert_allowed_name "$ordinary_runtime"
 done
 
-# External dependency/source paths intentionally use leaf-only matching. A
-# formula directory name must not hide an otherwise ordinary codec library.
+# The generic, non-decrypting libbluray formula path remains allowed even when
+# every path component is checked; a denied source/dependency parent does not.
 assert_allowed_name '/opt/homebrew/Cellar/libbluray/1.3.4/lib/libgstlibav.dylib'
+if macos_copy_control_relative_path_is_prohibited \
+  '/opt/homebrew/Cellar/libbluray/1.3.4/lib/libgstlibav.dylib'; then
+  fail "generic libbluray formula path was overmatched"
+fi
+macos_copy_control_relative_path_is_prohibited \
+  '/opt/homebrew/Cellar/libdvdcss/1.4.3/lib/libinnocent.dylib' \
+  || fail "forbidden source parent path was not detected"
 macos_copy_control_relative_path_is_prohibited '../WidevineCDM/helper.dylib' \
   || fail "forbidden intermediate relative-path component was not detected"
 if macos_copy_control_relative_path_is_prohibited '../ordinary-codecs/helper.dylib'; then
@@ -109,9 +118,18 @@ fi
 FAKE_OTOOL="${TEST_ROOT}/fake-otool"
 printf '%s\n' \
   '#!/usr/bin/env bash' \
+  'mode="${1:-}"' \
   'artifact=""' \
   'for argument in "$@"; do artifact="$argument"; done' \
   '[[ -e "${artifact}.otool-fail" ]] && exit 1' \
+  'if [[ "$mode" == -l ]]; then' \
+  '  if [[ -f "${artifact}.load-commands" ]]; then' \
+  '    cat "${artifact}.load-commands"' \
+  '  else' \
+  '    printf "Load command 0\\n      cmd LC_RPATH\\n     path /usr/lib (offset 12)\\n"' \
+  '  fi' \
+  '  exit 0' \
+  'fi' \
   'printf "%s:\n" "$artifact"' \
   'if [[ -f "${artifact}.deps" ]]; then' \
   '  while IFS= read -r dependency || [[ -n "$dependency" ]]; do' \
@@ -152,6 +170,36 @@ assert_status 0 macos_stage_gstreamer_plugin \
 [[ "$MACOS_PACKAGE_POLICY_RESULT" == excluded ]] || fail "decrypt-linked plugin was not excluded"
 [[ ! -e "${PLUGIN_DEST}/libgstinnocent.dylib" ]] || fail "decrypt-linked plugin reached staging"
 
+touch "${PLUGIN_SOURCE}/libgstinnocent-path.dylib"
+printf '%s\n' '@rpath/WidevineCDM/libinnocent.dylib' \
+  > "${PLUGIN_SOURCE}/libgstinnocent-path.dylib.deps"
+assert_status 0 macos_stage_gstreamer_plugin \
+  "${PLUGIN_SOURCE}/libgstinnocent-path.dylib" "$PLUGIN_DEST"
+[[ "$MACOS_PACKAGE_POLICY_RESULT" == excluded ]] \
+  || fail "plugin linked through a forbidden dependency path was not excluded"
+[[ ! -e "${PLUGIN_DEST}/libgstinnocent-path.dylib" ]] \
+  || fail "plugin linked through a forbidden dependency path reached staging"
+
+FORBIDDEN_PLUGIN_SOURCE="${TEST_ROOT}/libdvdcss-source/libgstsource-path.dylib"
+mkdir -p "$(dirname "$FORBIDDEN_PLUGIN_SOURCE")"
+touch "$FORBIDDEN_PLUGIN_SOURCE"
+assert_status 0 macos_stage_gstreamer_plugin \
+  "$FORBIDDEN_PLUGIN_SOURCE" "$PLUGIN_DEST"
+[[ "$MACOS_PACKAGE_POLICY_RESULT" == excluded ]] \
+  || fail "plugin from a forbidden source path was not excluded"
+
+touch "${PLUGIN_SOURCE}/libgstload-command.dylib"
+printf '%s\n' \
+  'Load command 1' \
+  '          cmd LC_RPATH' \
+  '      cmdsize 48' \
+  '         path @loader_path/../WidevineCDM (offset 12)' \
+  > "${PLUGIN_SOURCE}/libgstload-command.dylib.load-commands"
+assert_status 0 macos_stage_gstreamer_plugin \
+  "${PLUGIN_SOURCE}/libgstload-command.dylib" "$PLUGIN_DEST"
+[[ "$MACOS_PACKAGE_POLICY_RESULT" == excluded ]] \
+  || fail "plugin with a forbidden Mach-O load-command path was not excluded"
+
 touch "${PLUGIN_SOURCE}/libgstuninspectable.dylib"
 touch "${PLUGIN_SOURCE}/libgstuninspectable.dylib.otool-fail"
 assert_status 2 macos_stage_gstreamer_plugin \
@@ -177,6 +225,15 @@ touch "$SAFE_BUNDLE/Contents/Resources/ordinary-codecs/helper.dat"
 ln -s 'ordinary-codecs/helper.dat' \
   "$SAFE_BUNDLE/Contents/Resources/ordinary-runtime-link"
 assert_status 0 macos_validate_bundle_copy_control "$SAFE_BUNDLE"
+assert_no_policy_manifests
+
+# A checkout/build ancestor is not part of the shipped bundle. Source-copy
+# validation remains component-wise, while the final gate uses bundle-relative
+# member paths and must not overmatch an external parent directory name.
+SAFE_PARENT_BUNDLE="${TEST_ROOT}/libdvdcss-parent/SafeParent.app"
+make_bundle "$SAFE_PARENT_BUNDLE"
+touch "$SAFE_PARENT_BUNDLE/Contents/Frameworks/libgstlibav.dylib"
+assert_status 0 macos_validate_bundle_copy_control "$SAFE_PARENT_BUNDLE"
 assert_no_policy_manifests
 
 REAL_FIND_COMMAND="$(command -v find)"
@@ -234,6 +291,22 @@ printf '\xcf\xfa\xed\xfe' \
 printf '%s\n' '@rpath/libaacs.0.dylib' \
   > "$RESOURCE_MACHO_BUNDLE/Contents/Resources/allowed-helper.dat.deps"
 assert_status 1 macos_validate_bundle_copy_control "$RESOURCE_MACHO_BUNDLE"
+
+FRAMEWORK_MACHO_BUNDLE="${TEST_ROOT}/FrameworkMachO.app"
+make_bundle "$FRAMEWORK_MACHO_BUNDLE"
+printf '\xcf\xfa\xed\xfe' \
+  > "$FRAMEWORK_MACHO_BUNDLE/Contents/Frameworks/allowed-helper.dat"
+printf '%s\n' '@rpath/libbdplus.0.dylib' \
+  > "$FRAMEWORK_MACHO_BUNDLE/Contents/Frameworks/allowed-helper.dat.deps"
+assert_status 1 macos_validate_bundle_copy_control "$FRAMEWORK_MACHO_BUNDLE"
+
+WRAPPER_MACHO_BUNDLE="${TEST_ROOT}/WrapperMachO.app"
+make_bundle "$WRAPPER_MACHO_BUNDLE"
+printf '\xcf\xfa\xed\xfe' \
+  > "$WRAPPER_MACHO_BUNDLE/Contents/MacOS/WrapperMachO"
+printf '%s\n' '@rpath/libaacs.0.dylib' \
+  > "$WRAPPER_MACHO_BUNDLE/Contents/MacOS/WrapperMachO.deps"
+assert_status 1 macos_validate_bundle_copy_control "$WRAPPER_MACHO_BUNDLE"
 
 SYMLINK_BUNDLE="${TEST_ROOT}/Symlink.app"
 make_bundle "$SYMLINK_BUNDLE"

--- a/src/audio/airplay_output.rs
+++ b/src/audio/airplay_output.rs
@@ -16,8 +16,8 @@
 //! spawned `shairport-sync`, which is an AirPlay *receiver* — it
 //! ignored the device the user selected and could never reach it
 //! (review finding M3, tracker item P2.9).  A missing `raopsink` now
-//! fails the load with a localized error naming the package to
-//! install instead of silently spawning a subprocess that cannot work.
+//! fails the load with a localized, honest unsupported message instead
+//! of silently spawning a subprocess that cannot work.
 //!
 //! A bus watch on the dedicated pipeline forwards EOS / errors / state
 //! changes into the same `PlayerEvent` channel the rest of the app
@@ -34,11 +34,10 @@
 //!   this output does not implement.  Such devices are filtered out
 //!   of the output selector by [`crate::ui::discovery_handler`] until
 //!   a sender-side AirPlay 2 implementation lands.
-//! - **Requires a working `raopsink` element.**  It ships in the
-//!   GStreamer "bad" plugins set (`gst-plugins-bad`); the exact
-//!   package name varies by distro.  The code probes the GStreamer
-//!   registry at runtime and surfaces an actionable error when the
-//!   element is absent.
+//! - **Requires a working external `raopsink` element.**  Current official
+//!   GStreamer, Homebrew, and MSYS2 packages do not ship that element. The
+//!   code retains the registry-gated integration seam but reports AirPlay 1
+//!   unavailable unless a compatible third-party element is already present.
 //! - **Seeking is not supported** for live RAOP streams.
 
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -164,7 +163,7 @@ impl AirPlayOutput {
         // Refuse a missing transmitter before any per-track proxy work:
         // otherwise a protected load would start a loopback route and mint
         // a ticket only to revoke it, and a preparation failure would mask
-        // the actionable install guidance with its generic message.
+        // the explicit unavailable-sender guidance with its generic message.
         Self::ensure_raopsink(Self::raopsink_available())?;
 
         // Prepare exactly once so the pipeline receives the credential-safe
@@ -275,8 +274,8 @@ impl AirPlayOutput {
     /// There is deliberately no fallback here: the one this module used to
     /// have piped PCM into `shairport-sync`, an AirPlay *receiver*, which
     /// ignored the device the user selected and could never reach it. A
-    /// missing `raopsink` is a hard error that tells the user what to
-    /// install instead.
+    /// missing `raopsink` is a hard error that accurately reports the
+    /// unsupported sender rather than recommending an unrelated package.
     fn ensure_raopsink(available: bool) -> Result<(), String> {
         if available {
             Ok(())
@@ -285,9 +284,8 @@ impl AirPlayOutput {
         }
     }
 
-    /// Localized "install gst-plugins-bad" guidance. `raopsink` and
-    /// `gst-plugins-bad` are technical identifiers and stay untranslated
-    /// inside every catalog entry.
+    /// Localized unsupported-sender guidance. `raopsink` is a technical
+    /// identifier and stays untranslated inside every catalog entry.
     fn raopsink_missing_message(locale: &str) -> String {
         rust_i18n::t!("errors.playback.airplay_raopsink_missing", locale = locale).into_owned()
     }
@@ -716,20 +714,20 @@ mod tests {
         ));
     }
 
-    /// P2.9's core guarantee: a missing `raopsink` is refused with guidance
-    /// naming both the element and the package that provides it — never
-    /// routed to a fallback that cannot transmit.
+    /// P2.9's core guarantee: a missing `raopsink` is refused explicitly and
+    /// never routed to a fallback that cannot transmit. No currently
+    /// supported package is misrepresented as providing the element.
     #[test]
-    fn a_missing_raopsink_is_refused_with_install_guidance() {
+    fn a_missing_raopsink_is_refused_with_honest_guidance() {
         assert!(AirPlayOutput::ensure_raopsink(true).is_ok());
 
         let error = AirPlayOutput::ensure_raopsink(false).unwrap_err();
         assert!(error.contains("raopsink"), "{error}");
-        assert!(error.contains("gst-plugins-bad"), "{error}");
+        assert!(!error.contains("gst-plugins-bad"), "{error}");
     }
 
     /// The guidance must be real in every catalog — present, mentioning the
-    /// exact technical identifiers, and not silently falling back to English.
+    /// exact technical identifier, and not silently falling back to English.
     #[test]
     fn raopsink_guidance_is_localized_for_every_catalog() {
         let english = AirPlayOutput::raopsink_missing_message("en");
@@ -739,7 +737,7 @@ mod tests {
             let localized = AirPlayOutput::raopsink_missing_message(&locale);
             assert!(localized.contains("raopsink"), "{locale}: {localized}");
             assert!(
-                localized.contains("gst-plugins-bad"),
+                !localized.contains("gst-plugins-bad"),
                 "{locale}: {localized}"
             );
             if locale != "en" {
@@ -749,7 +747,7 @@ mod tests {
     }
 
     /// A load without a transmitter must fail *loudly* — an `Error` event
-    /// carrying the actionable message followed by `Stopped` — never a
+    /// carrying the honest unavailable message followed by `Stopped` — never a
     /// silent no-op stream.
     #[test]
     fn a_missing_raopsink_load_fails_loudly_not_silently() {
@@ -767,9 +765,9 @@ mod tests {
             }) => {
                 assert_eq!(event_generation, generation);
                 assert!(message.contains("raopsink"), "{message}");
-                assert!(message.contains("gst-plugins-bad"), "{message}");
+                assert!(!message.contains("gst-plugins-bad"), "{message}");
             }
-            event => panic!("expected actionable error, got {event:?}"),
+            event => panic!("expected explicit sender error, got {event:?}"),
         }
         assert!(matches!(
             rx.try_recv(),
@@ -793,7 +791,7 @@ mod tests {
         output.set_event_generation(generation);
 
         // The transmitter gate runs before any per-track proxy work, so on
-        // a machine without `raopsink` the actionable install guidance wins.
+        // a machine without `raopsink` the honest unavailable guidance wins.
         // With `raopsink` registered, preparation is reached next and must
         // fail — a protected URI requires the app runtime to mint its
         // loopback ticket, and none is configured. Either way the failure

--- a/src/platform_runtime.rs
+++ b/src/platform_runtime.rs
@@ -1513,14 +1513,15 @@ mod tests {
             "$gstScannerDest = Join-Path $DIST \"libexec\\gstreamer-1.0\\gst-plugin-scanner.exe\""
         ));
         let scanner_copy = script
-            .find("Copy-Item -LiteralPath $gstScannerSrc -Destination $gstScannerDest -Force")
+            .find("Copy-WindowsBundleFileForced $gstScannerSrc $gstScannerDest")
             .expect("unconditional scanner copy");
         let scanner_scan = script
             .find("$initialDllScanTargets = @(Get-WindowsTreeMembersWithoutReparseTraversal $DIST")
             .expect("whole-bundle dependency scan");
-        let executable_filter = script
+        let executable_filter = script[scanner_scan..]
             .find("$_.Extension -ieq '.dll' -or $_.Extension -ieq '.exe'")
-            .expect("scanner executable inclusion");
+            .map(|offset| scanner_scan + offset)
+            .expect("scanner executable inclusion in the normal dependency closure");
         let runtime_probe = script
             .find("Write-Info \"Running packaged Windows runtime probe...\"")
             .expect("packaged runtime probe");
@@ -1719,11 +1720,11 @@ mod tests {
         let invocations = production_invocations(script);
         assert_eq!(
             invocations.len(),
-            2,
+            3,
             "every production PE-import batch call must be covered"
         );
 
-        let expected_shared_bindings = [
+        let expected_closure_bindings = [
             ("-Inspector", "$peImportInspector"),
             ("-ClosureClock", "$peInspectorClosureClock"),
             ("-ClosureDeadlineMs", "$peInspectorClosureDeadlineMs"),
@@ -1734,7 +1735,16 @@ mod tests {
                 "$maxPeInspectorArgumentCharacters",
             ),
         ];
-        let mut target_bindings = std::collections::BTreeSet::new();
+        let expected_final_bindings = [
+            ("-Inspector", "$inspectorFull"),
+            ("-ClosureClock", "$validationClock"),
+            ("-ClosureDeadlineMs", "$validationDeadlineMs"),
+            ("-ProcessDeadlineMs", "$batchDeadlineMs"),
+            ("-OutputByteLimit", "$maxBatchOutputBytes"),
+            ("-ArgumentCharacterLimit", "$maxArgumentCharacters"),
+        ];
+        let mut closure_target_bindings = std::collections::BTreeSet::new();
+        let mut final_invocations = 0usize;
         for (invocation_index, invocation) in invocations.iter().enumerate() {
             let tokens: Vec<_> = invocation.split_whitespace().collect();
             assert_eq!(tokens.first(), Some(&"Invoke-BoundedPeImportBatch"));
@@ -1756,6 +1766,13 @@ mod tests {
                     pair[0]
                 );
             }
+            let expected_shared_bindings = match bindings.get("-Inspector").copied() {
+                Some("$peImportInspector") => &expected_closure_bindings,
+                Some("$inspectorFull") => &expected_final_bindings,
+                inspector => panic!(
+                    "invocation {invocation_index} uses an unknown inspector binding: {inspector:?}"
+                ),
+            };
             assert_eq!(
                 bindings.len(),
                 expected_shared_bindings.len() + 1,
@@ -1764,20 +1781,28 @@ mod tests {
             for (parameter, value) in expected_shared_bindings {
                 assert_eq!(
                     bindings.get(parameter),
-                    Some(&value),
+                    Some(value),
                     "invocation {invocation_index} must bind {parameter} explicitly"
                 );
             }
-            target_bindings.insert(
-                *bindings.get("-TargetBatch").unwrap_or_else(|| {
-                    panic!("invocation {invocation_index} must bind -TargetBatch")
-                }),
-            );
+            let target_binding = *bindings
+                .get("-TargetBatch")
+                .unwrap_or_else(|| panic!("invocation {invocation_index} must bind -TargetBatch"));
+            if bindings.get("-Inspector") == Some(&"$inspectorFull") {
+                assert_eq!(target_binding, "$batchTargets");
+                final_invocations += 1;
+            } else {
+                closure_target_bindings.insert(target_binding);
+            }
         }
         assert_eq!(
-            target_bindings,
+            closure_target_bindings,
             std::collections::BTreeSet::from(["$batchTargets", "$soupInspectorTargets"]),
             "the singleton Soup proof and closure batches must each bind their own exact typed list"
+        );
+        assert_eq!(
+            final_invocations, 1,
+            "the completed-tree verifier must contribute one bounded batch call site"
         );
         assert!(!script.contains("[string[]]$Paths"));
         assert!(!script.contains("-Paths @($requiredSoupPluginFull)"));
@@ -1790,7 +1815,7 @@ mod tests {
             .find("function Format-PeImportTargetForDiagnostic")
             .expect("bounded PE target formatter");
         let helpers_end = script[helpers_start..]
-            .find("function Add-PeImportDependencies")
+            .find("function Assert-WindowsBundlePeImportPolicy")
             .expect("PE target helper boundary")
             + helpers_start;
         let helpers = &script[helpers_start..helpers_end];
@@ -1960,6 +1985,7 @@ Assert-TargetFailure $newlineTarget "target #1 contains an unsupported quote or 
         assert!(create < resolve);
         assert!(resolve < soup_inspection);
         assert!(!script[resolve..soup_inspection].contains("$DIST = \"dist\\tributary-windows\""));
+        let resolved_closure = &script[resolve..soup_inspection];
         for fragment in [
             "$gstScannerDest = Join-Path $DIST \"gst-plugin-scanner.exe\"",
             "$requiredSoupPluginDest = Join-Path $DIST",
@@ -1967,13 +1993,10 @@ Assert-TargetFailure $newlineTarget "target #1 contains an unsupported quote or 
             "$_.Extension -ieq '.dll' -or $_.Extension -ieq '.exe'",
             "$requiredSoupRuntimeDest = Join-Path $DIST",
         ] {
-            let target = script
+            let target = resolved_closure
                 .find(fragment)
-                .unwrap_or_else(|| panic!("missing distribution-rooted PE target: {fragment}"));
-            assert!(
-                resolve < target,
-                "PE target was constructed before distribution resolution: {fragment}"
-            );
+                .unwrap_or_else(|| panic!("missing post-resolution PE target: {fragment}"));
+            assert!(target < resolved_closure.len());
         }
     }
 

--- a/src/platform_runtime.rs
+++ b/src/platform_runtime.rs
@@ -1516,8 +1516,11 @@ mod tests {
             .find("Copy-Item -LiteralPath $gstScannerSrc -Destination $gstScannerDest -Force")
             .expect("unconditional scanner copy");
         let scanner_scan = script
-            .find("$initialDllScanTargets += $gstScannerDest")
-            .expect("scanner dependency scan");
+            .find("$initialDllScanTargets = @(Get-WindowsTreeMembersWithoutReparseTraversal $DIST")
+            .expect("whole-bundle dependency scan");
+        let executable_filter = script
+            .find("$_.Extension -ieq '.dll' -or $_.Extension -ieq '.exe'")
+            .expect("scanner executable inclusion");
         let runtime_probe = script
             .find("Write-Info \"Running packaged Windows runtime probe...\"")
             .expect("packaged runtime probe");
@@ -1525,7 +1528,8 @@ mod tests {
             .find("Write-Info \"Creating zip archive...\"")
             .expect("zip creation");
         assert!(scanner_copy < scanner_scan);
-        assert!(scanner_scan < runtime_probe);
+        assert!(scanner_scan < executable_filter);
+        assert!(executable_filter < runtime_probe);
         assert!(runtime_probe < archive);
         assert!(!script.contains("Copy-IfNewer $gstScannerSrc"));
         assert!(script.contains(
@@ -1959,8 +1963,8 @@ Assert-TargetFailure $newlineTarget "target #1 contains an unsupported quote or 
         for fragment in [
             "$gstScannerDest = Join-Path $DIST \"gst-plugin-scanner.exe\"",
             "$requiredSoupPluginDest = Join-Path $DIST",
-            "$initialDllScanTargets = @(Join-Path $DIST",
-            "$initialDllScanTargets += Get-ChildItem -Path \"$DIST\\lib\"",
+            "$initialDllScanTargets = @(Get-WindowsTreeMembersWithoutReparseTraversal $DIST",
+            "$_.Extension -ieq '.dll' -or $_.Extension -ieq '.exe'",
             "$requiredSoupRuntimeDest = Join-Path $DIST",
         ] {
             let target = script

--- a/src/platform_runtime.rs
+++ b/src/platform_runtime.rs
@@ -1519,7 +1519,7 @@ mod tests {
             .find("$initialDllScanTargets = @(Get-WindowsTreeMembersWithoutReparseTraversal $DIST")
             .expect("whole-bundle dependency scan");
         let executable_filter = script[scanner_scan..]
-            .find("$_.Extension -ieq '.dll' -or $_.Extension -ieq '.exe'")
+            .find("$_.Extension -ieq '.dll' -or $_.Extension -ieq '.drv'")
             .map(|offset| scanner_scan + offset)
             .expect("scanner executable inclusion in the normal dependency closure");
         let runtime_probe = script
@@ -1548,8 +1548,9 @@ mod tests {
             "$PkgPrefix-libsoup3 packages",
             "function Get-PeImportDependencyName",
             "Name: libfoo.dll",
-            "--coff-imports includes ordinary and delay-load imports",
-            "if ($Line -notmatch '^\\s*Name:\\s*([^\\\\/:*?\"<>|\\x00-\\x1F]+\\.dll)\\s*$')",
+            "WINSPOOL.DRV imported by current GTK packages",
+            "ordinary and delay-load imports. Reject every other suffix",
+            "if ($Line -notmatch '^\\s*Name:\\s*([^\\\\/:*?\"<>|\\x00-\\x1F]+\\.(?:dll|drv))\\s*$')",
             "$peImportInspector = [System.IO.Path]::GetFullPath((Join-Path $MsysPath \"bin\\llvm-readobj.exe\"))",
             "[System.IO.Path]::IsPathRooted($peImportInspector)",
             "Required PE import inspector not found",
@@ -1560,7 +1561,7 @@ mod tests {
             "[System.Collections.Generic.List[string]]$TargetBatch",
             "function Invoke-BoundedPeImportBatch",
             "PE import-inspection target #$targetNumber is not absolute",
-            "PE import-inspection target #$targetNumber is not a DLL or EXE",
+            "PE import-inspection target #$targetNumber is not a DLL, DRV, or EXE",
             "PE import-inspection target #$targetNumber is not an existing file",
             "[System.IO.File]::Exists($normalizedTarget)",
             "Start-Process -FilePath $Inspector -ArgumentList $arguments",
@@ -1812,8 +1813,8 @@ mod tests {
     fn powershell_pe_import_target_batch_preserves_lists_and_bounds_diagnostics() {
         let script = include_str!("../scripts/build-windows.ps1");
         let helpers_start = script
-            .find("function Format-PeImportTargetForDiagnostic")
-            .expect("bounded PE target formatter");
+            .find("function Get-PeImportDependencyName")
+            .expect("bounded PE import-name parser");
         let helpers_end = script[helpers_start..]
             .find("function Assert-WindowsBundlePeImportPolicy")
             .expect("PE target helper boundary")
@@ -1822,10 +1823,12 @@ mod tests {
 
         let temp = tempfile::tempdir().unwrap();
         let valid_dll = temp.path().join("valid target with spaces.dll");
+        let valid_drv = temp.path().join("valid-system-style.DRV");
         let valid_exe = temp.path().join("valid-target.exe");
         let wrong_extension = temp.path().join("wrong-extension.txt");
         let missing_dll = temp.path().join("missing-target.dll");
         fs::write(&valid_dll, b"not executed").unwrap();
+        fs::write(&valid_drv, b"not executed").unwrap();
         fs::write(&valid_exe, b"not executed").unwrap();
         fs::write(&wrong_extension, b"not executed").unwrap();
 
@@ -1890,12 +1893,29 @@ function Assert-InvokeTargetFailure {
     }
 }
 
+if ((Get-PeImportDependencyName "  Name: libfoo.dll") -cne "libfoo.dll") {
+    throw "ordinary DLL import spelling was not preserved"
+}
+if ((Get-PeImportDependencyName "  Name: WINSPOOL.DRV") -cne "WINSPOOL.DRV") {
+    throw "legacy Windows DRV import spelling was not preserved"
+}
+foreach ($invalidImport in @(
+    "  Name: ../libdvdcss.dll",
+    "  Name: plugin.ocx",
+    "  Name: extensionless"
+)) {
+    if ($null -ne (Get-PeImportDependencyName $invalidImport)) {
+        throw "unsafe or unsupported import spelling was accepted: $invalidImport"
+    }
+}
+
 $validTargets = [System.Collections.Generic.List[string]]::new()
 $validTargets.Add($env:TRIBUTARY_VALID_DLL)
+$validTargets.Add($env:TRIBUTARY_VALID_DRV)
 $validTargets.Add($env:TRIBUTARY_VALID_EXE)
 $batch = ConvertTo-BoundedPeImportArgumentBatch `
     -TargetBatch $validTargets -ArgumentCharacterLimit 4096
-if ($batch.Label -ne "valid target with spaces.dll, valid-target.exe") {
+if ($batch.Label -ne "valid target with spaces.dll, valid-system-style.DRV, valid-target.exe") {
     throw "typed target list changed shape: $($batch.Label)"
 }
 foreach ($target in $validTargets) {
@@ -1915,7 +1935,7 @@ Assert-InvokeTargetFailure $relativeTarget "target #1 is not absolute"
 
 $wrongExtension = [System.Collections.Generic.List[string]]::new()
 $wrongExtension.Add($env:TRIBUTARY_WRONG_EXTENSION)
-Assert-TargetFailure $wrongExtension "target #1 is not a DLL or EXE"
+Assert-TargetFailure $wrongExtension "target #1 is not a DLL, DRV, or EXE"
 
 $missingTarget = [System.Collections.Generic.List[string]]::new()
 $missingTarget.Add($env:TRIBUTARY_MISSING_DLL)
@@ -1932,6 +1952,7 @@ Assert-TargetFailure $newlineTarget "target #1 contains an unsupported quote or 
             std::process::Command::new(program)
                 .args(["-NoProfile", "-NonInteractive", "-Command", &command])
                 .env("TRIBUTARY_VALID_DLL", &valid_dll)
+                .env("TRIBUTARY_VALID_DRV", &valid_drv)
                 .env("TRIBUTARY_VALID_EXE", &valid_exe)
                 .env("TRIBUTARY_WRONG_EXTENSION", &wrong_extension)
                 .env("TRIBUTARY_MISSING_DLL", &missing_dll)
@@ -1990,7 +2011,7 @@ Assert-TargetFailure $newlineTarget "target #1 contains an unsupported quote or 
             "$gstScannerDest = Join-Path $DIST \"gst-plugin-scanner.exe\"",
             "$requiredSoupPluginDest = Join-Path $DIST",
             "$initialDllScanTargets = @(Get-WindowsTreeMembersWithoutReparseTraversal $DIST",
-            "$_.Extension -ieq '.dll' -or $_.Extension -ieq '.exe'",
+            "$_.Extension -ieq '.dll' -or $_.Extension -ieq '.drv'",
             "$requiredSoupRuntimeDest = Join-Path $DIST",
         ] {
             let target = resolved_closure

--- a/tests/packaging_metadata.rs
+++ b/tests/packaging_metadata.rs
@@ -10,6 +10,8 @@ const README: &str = include_str!("../README.md");
 const BUILD_LINUX: &str = include_str!("../scripts/build-linux.sh");
 const BUILD_MACOS: &str = include_str!("../scripts/build-macos.sh");
 const BUILD_WINDOWS: &str = include_str!("../scripts/build-windows.ps1");
+const FORBIDDEN_BUNDLED_COMPONENTS: &str =
+    include_str!("../build-aux/packaging/forbidden-bundled-components.txt");
 
 fn manifest() -> Value {
     toml::from_str(MANIFEST).expect("Cargo.toml must parse")
@@ -105,6 +107,280 @@ fn workflow_job<'a>(source: &'a str, name: &str) -> &'a str {
 
     let start = body_start.unwrap_or_else(|| panic!("workflow job {name} must exist"));
     &source[start..]
+}
+
+fn forbidden_bundle_tokens() -> Vec<&'static str> {
+    FORBIDDEN_BUNDLED_COMPONENTS
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .collect()
+}
+
+fn bundle_policy_matches(filename: &str, tokens: &[&str]) -> bool {
+    let filename = filename.to_ascii_lowercase();
+    tokens
+        .iter()
+        .any(|token| filename.contains(&token.to_ascii_lowercase()))
+}
+
+fn bundle_policy_matches_relative_path(path: &str, tokens: &[&str]) -> bool {
+    path.split(['/', '\\'])
+        .filter(|component| !component.is_empty())
+        .any(|component| bundle_policy_matches(component, tokens))
+}
+
+#[test]
+fn bundled_component_policy_blocks_disc_decryption_without_hiding_codecs() {
+    let tokens = forbidden_bundle_tokens();
+    assert!(
+        !tokens.is_empty(),
+        "the shared bundle policy must not be empty"
+    );
+
+    let mut unique = std::collections::HashSet::new();
+    for token in &tokens {
+        assert_eq!(
+            *token,
+            token.to_ascii_lowercase(),
+            "policy tokens must use a canonical lowercase spelling"
+        );
+        assert!(
+            token
+                .chars()
+                .all(|character| character.is_ascii_alphanumeric()
+                    || matches!(character, '.' | '_' | '+' | '-')),
+            "policy token contains a character rejected by the packaging scripts: {token}"
+        );
+        assert!(unique.insert(*token), "duplicate policy token: {token}");
+    }
+
+    for required in [
+        "dvdcss",
+        "dvdread",
+        "dvdnav",
+        "aacs",
+        "bdplus",
+        "bluray",
+        "mmbd",
+        "makemkv",
+        "decss",
+        "dvdcpxm",
+        "resindvd",
+        "dvdspu",
+        "widevinecdm",
+        "playready",
+        "fairplay",
+        "keydb.cfg",
+    ] {
+        assert!(tokens.contains(&required), "policy is missing {required}");
+    }
+
+    for forbidden in [
+        "libdvdcss-2.dll",
+        "LIBDVDCSS-2.DLL",
+        "libdvdread-8.dll",
+        "libdvdnav-4.dll",
+        "libaacs-0.dll",
+        "aacs.dll",
+        "vendor-AaCs-runtime-helper.dll",
+        "libbdplus-0.dll",
+        "bdplus.dll",
+        "prefix-libbdplus-0-suffix.dll",
+        "libbluray-2.dll",
+        "libmmbd64.dll",
+        "MakeMKVcon.exe",
+        "libdecss.dll",
+        "libdvdcpxm.dll",
+        "libgstresindvd.dll",
+        "libgstdvdspu.dll",
+        "widevinecdm.dll",
+        "playready.dll",
+        "FairPlayRuntime.dll",
+        "KEYDB.CFG",
+    ] {
+        assert!(
+            bundle_policy_matches(forbidden, &tokens),
+            "forbidden component escaped the filename policy: {forbidden}"
+        );
+    }
+
+    for ordinary_runtime in [
+        "libgstlibav.dll",
+        "libgstfdkaac.dll",
+        "libgstaudioparsers.dll",
+        "libgstaes.dll",
+        "libgstdvdlpcmdec.dll",
+        "libgstdvdsub.dll",
+        "libsoup-3.0-0.dll",
+        "libssl-3-x64.dll",
+        "libcrypto-3-x64.dll",
+    ] {
+        assert!(
+            !bundle_policy_matches(ordinary_runtime, &tokens),
+            "ordinary codec/runtime is overmatched by the policy: {ordinary_runtime}"
+        );
+    }
+    assert!(
+        bundle_policy_matches_relative_path(r"plugins\WidevineCDM\helper.dll", &tokens),
+        "an innocuous leaf beneath a forbidden directory must still be rejected"
+    );
+    assert!(
+        !bundle_policy_matches_relative_path(r"plugins\audio\helper.dll", &tokens),
+        "ordinary relative path components must remain eligible"
+    );
+}
+
+#[test]
+fn windows_bundle_loads_policy_and_rejects_reparse_points() {
+    let build_windows = BUILD_WINDOWS.replace("\r\n", "\n");
+    assert!(
+        build_windows.contains("build-aux\\packaging\\forbidden-bundled-components.txt")
+            && build_windows.contains("Required bundled-component policy is missing")
+            && build_windows.contains("Bundled-component policy contains no filename tokens")
+            && build_windows
+                .contains("Bundled-component policy contains an invalid filename token")
+            && build_windows
+                .contains("Bundled-component policy contains a duplicate filename token")
+            && build_windows.contains("[System.StringComparison]::OrdinalIgnoreCase"),
+        "Windows packaging must load the shared policy fail-closed and match it case-insensitively"
+    );
+    assert!(
+        build_windows.contains("-SkipForbiddenComponents")
+            && build_windows.contains("Test-ForbiddenBundledRelativePath $relPath")
+            && build_windows.contains("Remove-ForbiddenWindowsBundleMembers $DstDir")
+            && build_windows.contains("Remove-ForbiddenWindowsBundleMembers $DIST"),
+        "the plugin sync must reject forbidden relative components and purge stale destinations"
+    );
+    assert!(
+        build_windows.contains("Get-WindowsTreeMembersWithoutReparseTraversal")
+            && build_windows.contains("Get-ChildItem -LiteralPath $directory -Force -ErrorAction Stop")
+            && build_windows.contains("[System.IO.FileAttributes]::ReparsePoint")
+            && build_windows.contains("Sort-Object")
+            && build_windows.contains("$_.FullName.Length")
+            && build_windows.contains("$member.Delete()"),
+        "stale/final scans must include directories and hidden members, avoid reparse traversal, and delete deepest-first without recursion"
+    );
+    assert!(
+        build_windows.contains("Get-WindowsBundleReparsePointMembers")
+            && build_windows.contains("$reparsePointMembers")
+            && build_windows.contains("$rootIsReparsePoint")
+            && build_windows.contains("filesystem reparse point(s)")
+            && build_windows.contains(
+                "Refusing to sync filesystem reparse point into the Windows bundle"
+            )
+            && build_windows.contains(
+                "Refusing to sync into a Windows destination tree containing a filesystem reparse point"
+            )
+            && build_windows.contains(
+                "Refusing to copy filesystem reparse point into the Windows bundle"
+            ),
+        "final artifacts and every recursive copy path must reject reparse points"
+    );
+    assert!(
+        build_windows.contains(
+            "$initialDllScanTargets = @(Get-WindowsTreeMembersWithoutReparseTraversal $DIST"
+        ) && build_windows.contains("$_.Extension -ieq '.dll' -or $_.Extension -ieq '.exe'")
+            && !build_windows.contains("Get-ChildItem -Path \"$DIST\\lib\" -Recurse -Filter *.dll"),
+        "PE import scanning must seed every hidden-inclusive DLL/EXE in the complete bundle"
+    );
+    let root_reparse_assertion = build_windows
+        .find("Assert-WindowsBundleRootIsNotReparsePoint $DIST")
+        .expect("the bundle root must receive an early reparse check");
+    let lib_directory_creation = build_windows
+        .find("New-Item -ItemType Directory -Force \"$DIST\\lib\"")
+        .expect("the first bundle child-directory write must remain recognizable");
+    assert!(
+        root_reparse_assertion < lib_directory_creation,
+        "the bundle root must be rejected before creating its first child"
+    );
+    let first_dist_assertion = build_windows
+        .find("Assert-WindowsBundleComponentPolicy $DIST")
+        .expect("the incremental dist tree must be validated");
+    let executable_copy = build_windows
+        .find("Copy-Item $exePath $DIST -Force")
+        .expect("the executable copy boundary must remain recognizable");
+    assert!(
+        first_dist_assertion < executable_copy,
+        "an existing destination reparse point must fail before any bundle write"
+    );
+}
+
+#[test]
+fn windows_bundle_applies_policy_at_copy_and_installer_boundaries() {
+    let build_windows = BUILD_WINDOWS.replace("\r\n", "\n");
+    let closure_rejection = build_windows
+        .find("if (Test-ForbiddenBundledComponentName $dllName)")
+        .expect("the recursive PE closure must reject a forbidden import");
+    let closure_copy = build_windows[closure_rejection..]
+        .find("$srcPath = Join-Path $ArchitectureBin $dllName")
+        .map(|offset| closure_rejection + offset)
+        .expect("the PE closure copy boundary must remain recognizable");
+    assert!(
+        closure_rejection < closure_copy,
+        "the closure must reject a forbidden DLL before resolving or copying it"
+    );
+
+    let installer_only = build_windows
+        .find("# ── Inno Setup only mode")
+        .expect("the installer-only path must exist");
+    let installer_assertion = build_windows[installer_only..]
+        .find("Assert-WindowsBundleComponentPolicy $sourceDir")
+        .map(|offset| installer_only + offset)
+        .expect("the installer-only path must validate its existing dist tree");
+    let installer_compile = build_windows[installer_assertion..]
+        .find("& $iscc")
+        .map(|offset| installer_assertion + offset)
+        .expect("the Inno compiler invocation must remain recognizable");
+    assert!(installer_assertion < installer_compile);
+    assert_eq!(
+        build_windows
+            .matches("Assert-WindowsBundleComponentPolicy $sourceDir")
+            .count(),
+        2,
+        "both installer-only and normal Inno paths must validate their source tree"
+    );
+
+    let runtime_probe = build_windows
+        .find("# ── Packaged Runtime Probe")
+        .expect("the packaged runtime probe must exist");
+    assert!(
+        build_windows[..runtime_probe].ends_with("Assert-WindowsBundleComponentPolicy $DIST\n\n"),
+        "the dist tree must pass policy immediately before the packaged executable is run"
+    );
+}
+
+#[test]
+fn windows_bundle_validates_the_completed_zip_and_ci_parser() {
+    let build_windows = BUILD_WINDOWS.replace("\r\n", "\n");
+    let windows_ci = workflow_job(CI_WORKFLOW, "build-windows");
+    let archive = build_windows
+        .find("Write-Info \"Creating zip archive...\"")
+        .expect("the Windows ZIP boundary must exist");
+    assert!(
+        build_windows[..archive].ends_with("Assert-WindowsBundleComponentPolicy $DIST\n"),
+        "the dist tree must pass policy immediately before ZIP creation"
+    );
+    let zip_creation = build_windows
+        .find("Compress-Archive -Path $DIST -DestinationPath $zipPath")
+        .expect("the ZIP creation call must remain recognizable");
+    let zip_validation = build_windows
+        .find("Assert-WindowsZipComponentPolicy $zipPath")
+        .expect("the completed ZIP must be reopened for validation");
+    assert!(
+        zip_creation < zip_validation
+            && build_windows.contains("[System.IO.Compression.ZipFile]::OpenRead")
+            && build_windows.contains("Test-ForbiddenBundledRelativePath $entryPath"),
+        "the completed ZIP entry names must pass the shared component policy"
+    );
+    assert!(
+        windows_ci.contains("name: Parse bundler with Windows PowerShell 5.1")
+            && windows_ci.contains("if: matrix.arch == 'x86_64'")
+            && windows_ci.contains("shell: powershell")
+            && windows_ci.contains("System.Management.Automation.Language.Parser]::ParseFile")
+            && windows_ci.contains("if (@($parseErrors).Count -gt 0)"),
+        "Windows CI must prove that the bundler parses under inbox Windows PowerShell 5.1"
+    );
 }
 
 #[test]

--- a/tests/packaging_metadata.rs
+++ b/tests/packaging_metadata.rs
@@ -282,9 +282,9 @@ fn windows_bundle_loads_policy_and_rejects_reparse_points() {
     assert!(
         build_windows.contains(
             "$initialDllScanTargets = @(Get-WindowsTreeMembersWithoutReparseTraversal $DIST"
-        ) && build_windows.contains("$_.Extension -ieq '.dll' -or $_.Extension -ieq '.exe'")
+        ) && build_windows.contains("$_.Extension -ieq '.dll' -or $_.Extension -ieq '.drv'")
             && !build_windows.contains("Get-ChildItem -Path \"$DIST\\lib\" -Recurse -Filter *.dll"),
-        "PE import scanning must seed every hidden-inclusive DLL/EXE in the complete bundle"
+        "PE import scanning must seed every hidden-inclusive DLL/DRV/EXE in the complete bundle"
     );
     let root_reparse_assertion = build_windows
         .find("Assert-WindowsBundleRootIsNotReparsePoint $DIST")
@@ -428,7 +428,7 @@ fn windows_bundle_validates_the_completed_zip_and_ci_parser() {
                 "Final PE import inspector returned an unsupported dependency spelling"
             )
             && build_windows.contains("$targetSnapshot.ContainsKey($finalPath)"),
-        "the final gate must inspect every hidden DLL/EXE as bounded PE data, reject malformed imports, and detect a changing target set"
+        "the final gate must inspect every hidden DLL/DRV/EXE as bounded PE data, reject malformed imports, and detect a changing target set"
     );
     assert!(
         windows_ci.contains("name: Parse bundler with Windows PowerShell 5.1")

--- a/tests/packaging_metadata.rs
+++ b/tests/packaging_metadata.rs
@@ -157,11 +157,12 @@ fn bundled_component_policy_blocks_disc_decryption_without_hiding_codecs() {
 
     for required in [
         "dvdcss",
+        "dvd-pkg",
         "dvdread",
         "dvdnav",
         "aacs",
         "bdplus",
-        "bluray",
+        "gstbluray",
         "mmbd",
         "makemkv",
         "decss",
@@ -187,7 +188,7 @@ fn bundled_component_policy_blocks_disc_decryption_without_hiding_codecs() {
         "libbdplus-0.dll",
         "bdplus.dll",
         "prefix-libbdplus-0-suffix.dll",
-        "libbluray-2.dll",
+        "libgstbluray.dll",
         "libmmbd64.dll",
         "MakeMKVcon.exe",
         "libdecss.dll",
@@ -212,6 +213,7 @@ fn bundled_component_policy_blocks_disc_decryption_without_hiding_codecs() {
         "libgstaes.dll",
         "libgstdvdlpcmdec.dll",
         "libgstdvdsub.dll",
+        "libbluray-3.dll",
         "libsoup-3.0-0.dll",
         "libssl-3-x64.dll",
         "libcrypto-3-x64.dll",
@@ -275,7 +277,7 @@ fn windows_bundle_loads_policy_and_rejects_reparse_points() {
             && build_windows.contains(
                 "Refusing to copy filesystem reparse point into the Windows bundle"
             ),
-        "final artifacts and every recursive copy path must reject reparse points"
+        "final artifacts and every copy path must reject reparse points"
     );
     assert!(
         build_windows.contains(
@@ -298,11 +300,31 @@ fn windows_bundle_loads_policy_and_rejects_reparse_points() {
         .find("Assert-WindowsBundleComponentPolicy $DIST")
         .expect("the incremental dist tree must be validated");
     let executable_copy = build_windows
-        .find("Copy-Item $exePath $DIST -Force")
+        .find("Copy-WindowsBundleFileForced $exePath $exeBundleDest")
         .expect("the executable copy boundary must remain recognizable");
     assert!(
         first_dist_assertion < executable_copy,
         "an existing destination reparse point must fail before any bundle write"
+    );
+    let validated_source = build_windows
+        .find("function Get-ValidatedWindowsBundleCopySourceItem")
+        .expect("all Windows bundle copies must share a validated source boundary");
+    let forced_copy = build_windows
+        .find("function Copy-WindowsBundleFileForced")
+        .expect("unconditional Windows bundle copies must use a guarded helper");
+    let scanner_copy = build_windows
+        .find("Copy-WindowsBundleFileForced $gstScannerSrc $gstScannerDest")
+        .expect("the GStreamer scanner copy must use the guarded helper");
+    assert!(validated_source < forced_copy && forced_copy < executable_copy);
+    assert!(forced_copy < scanner_copy);
+    assert!(
+        build_windows
+            .contains("Refusing to overwrite filesystem reparse point in the Windows bundle")
+            && !build_windows.contains("Copy-Item $exePath $DIST -Force")
+            && !build_windows.contains(
+                "Copy-Item -LiteralPath $gstScannerSrc -Destination $gstScannerDest -Force"
+            ),
+        "the executable and scanner must not bypass source/destination reparse validation"
     );
 }
 
@@ -332,7 +354,12 @@ fn windows_bundle_applies_policy_at_copy_and_installer_boundaries() {
         .find("& $iscc")
         .map(|offset| installer_assertion + offset)
         .expect("the Inno compiler invocation must remain recognizable");
-    assert!(installer_assertion < installer_compile);
+    let installer_pe_assertion = build_windows[installer_assertion..]
+        .find("Assert-WindowsBundlePeImportPolicy $sourceDir $installerPeImportInspector")
+        .map(|offset| installer_assertion + offset)
+        .expect("installer-only mode must recheck every PE import in its stale source tree");
+    assert!(installer_assertion < installer_pe_assertion);
+    assert!(installer_pe_assertion < installer_compile);
     assert_eq!(
         build_windows
             .matches("Assert-WindowsBundleComponentPolicy $sourceDir")
@@ -348,6 +375,13 @@ fn windows_bundle_applies_policy_at_copy_and_installer_boundaries() {
         build_windows[..runtime_probe].ends_with("Assert-WindowsBundleComponentPolicy $DIST\n\n"),
         "the dist tree must pass policy immediately before the packaged executable is run"
     );
+    assert!(
+        build_windows.contains("if ([string]$line -notmatch '^\\s*Name\\s*:') { continue }")
+            && build_windows.contains(
+                "PE import inspector returned an unsupported dependency spelling for $SourceLabel"
+            ),
+        "the recursive closure must fail closed on an import spelling it cannot safely resolve"
+    );
 }
 
 #[test]
@@ -357,9 +391,20 @@ fn windows_bundle_validates_the_completed_zip_and_ci_parser() {
     let archive = build_windows
         .find("Write-Info \"Creating zip archive...\"")
         .expect("the Windows ZIP boundary must exist");
+    let archive_section = build_windows
+        .find("# ── Zip Archive")
+        .expect("the Windows ZIP section must exist");
+    let final_component_assertion = build_windows[archive_section..]
+        .find("Assert-WindowsBundleComponentPolicy $DIST")
+        .map(|offset| archive_section + offset)
+        .expect("the final dist tree must pass the filename/reparse policy");
+    let final_pe_assertion = build_windows[archive_section..]
+        .find("Assert-WindowsBundlePeImportPolicy $DIST $peImportInspector")
+        .map(|offset| archive_section + offset)
+        .expect("the final dist tree must pass a fresh PE import inspection");
     assert!(
-        build_windows[..archive].ends_with("Assert-WindowsBundleComponentPolicy $DIST\n"),
-        "the dist tree must pass policy immediately before ZIP creation"
+        final_component_assertion < final_pe_assertion && final_pe_assertion < archive,
+        "both final source-tree gates must run after the runtime probe and before ZIP creation"
     );
     let zip_creation = build_windows
         .find("Compress-Archive -Path $DIST -DestinationPath $zipPath")
@@ -372,6 +417,18 @@ fn windows_bundle_validates_the_completed_zip_and_ci_parser() {
             && build_windows.contains("[System.IO.Compression.ZipFile]::OpenRead")
             && build_windows.contains("Test-ForbiddenBundledRelativePath $entryPath"),
         "the completed ZIP entry names must pass the shared component policy"
+    );
+    assert!(
+        build_windows.contains("function Assert-WindowsBundlePeImportPolicy")
+            && build_windows.contains("$targetItems = @(Get-WindowsTreeMembersWithoutReparseTraversal $rootFull")
+            && build_windows.contains("$stream.ReadByte() -ne 0x4D")
+            && build_windows.contains("$stream.ReadByte() -ne 0x5A")
+            && build_windows.contains("Invoke-BoundedPeImportBatch")
+            && build_windows.contains(
+                "Final PE import inspector returned an unsupported dependency spelling"
+            )
+            && build_windows.contains("$targetSnapshot.ContainsKey($finalPath)"),
+        "the final gate must inspect every hidden DLL/EXE as bounded PE data, reject malformed imports, and detect a changing target set"
     );
     assert!(
         windows_ci.contains("name: Parse bundler with Windows PowerShell 5.1")


### PR DESCRIPTION
## What changed

- add one shared, case-insensitive deny policy for unused DVD/Blu-ray access stacks, dedicated CSS/AACS/BD+/MakeMKV-style decrypt bridges, conventional AACS key databases, and proprietary content-decryption modules
- enforce that policy before plugin/dependency traversal and again at each supported release boundary
- document the conservative release-engineering boundary, ordinary-codec/transport-crypto distinction, review triggers, and deliberate limits
- correct the AirPlay 1 dependency record: current official GStreamer, Homebrew, and MSYS2 packages do not provide `raopsink`, so Tributary now reports the sender as unavailable instead of recommending `gst-plugins-bad`

## Root cause and impact

The Windows helper mirrored the installed GStreamer plugin directory broadly, then copied each plugin's native dependency closure. An unrelated host plugin could therefore pull `libdvdread`/`libdvdnav` and the observed `libdvdcss-2.dll` into Tributary even though Tributary has no optical-disc or protected-media feature. macOS had the same ambient broad-copy risk, and the native/Flatpak release paths lacked an equivalent artifact gate.

The new boundary keeps ordinary audio codecs, container parsers, TLS, authenticated protocol encryption, and general-purpose cryptography available. It is a conservative accidental-bundling safeguard, not a legal-status classifier or legal-compliance claim.

## Enforcement

- **Windows:** purge stale denied members; reject source/destination reparse points; filter plugins; reject denied PE imports; inspect every hidden-inclusive DLL/EXE in the complete bundle; revalidate before runtime execution, ZIP, and both Inno paths; reopen the completed ZIP and reject denied entry paths.
- **macOS:** filter plugins before copy; reject denied Mach-O imports during dependency closure; inspect final member/link paths and every Mach-O recognized by format, including unconventional Resource helpers; revalidate before signing and DMG creation.
- **Native Linux:** validate build inputs, direct ELF dependencies, Debian control/maintainer scripts, RPM strong/weak relationships and scriptlets, Arch installer metadata, extracted package payloads, RPM buildroots, and Arch installed trees even with `--nocheck`; validate completed release packages before upload.
- **Flatpak:** validate `/app` during the build, then import the completed bundle into an isolated OSTree repository and inspect the single complete app commit, exports, and metadata before upload. The separately delivered shared runtime remains outside Tributary's bundle claim.

## AirPlay provenance finding

Current supported packages contain no `raopsink`. GStreamer's historical, differently named `apexsink` was removed after remaining unported; its legacy code contained an RSA public modulus/exponent used to encrypt a generated outbound session key, not a private key or protected-media decryptor. Tributary does not bundle it. The maintained AirPlay sender decision, key provenance, packaging, and real-device validation remain explicit P2.4 work.

## Deliberate limits

- recognizable filenames and declared native dependencies are checked; arbitrarily renamed binaries are not semantically classified
- newly introduced innocuously named nested archives require separate review and are not recursively unpacked
- native distro packages and Flatpak runtimes resolved outside Tributary's payload are documented but not attested
- the final DMG/Inno containers trust their packaging tools after immediate source-tree validation; Windows ZIP and Linux/Flatpak artifacts are reopened

## Validation

- `cargo test --all-targets --all-features --locked` (1,419 tests)
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `build-aux/linux/test-package-compliance.sh`
- `scripts/test-macos-package-policy.sh`
- Linux metadata and host ELF validators
- Bash/POSIX syntax, all locale/workflow/manifest YAML parsing, Windows PowerShell 5.1-compatible AST parsing, and `git diff --check`

Platform-native Windows, macOS, Flatpak, and package artifact builds remain covered by their CI runners.
