### PR TITLE
fix(ui): dialogs not appearing -- track properties, new playlist, new smart playlist (tr-qhc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -803,6 +803,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `apexsink` used a public key to encrypt outbound audio and is not bundled by Tributary.
 
 ### Fixed
+- **Track Properties, New Playlist, and New Smart Playlist dialogs now open on Linux** —
+  Right-clicking a track or playlist sidebar entry no longer relies on `gtk::PopoverMenu::from_model`,
+  which on some Linux desktop configurations produced an invisible popover whose action clicks
+  were dispatched to handlers that the dialog-opening code never reached. Track Properties, the
+  sidebar playlist-creation button's popover, and every per-row right-click popover are now built
+  through a new `popover_from_menu_model` helper that always attaches a child widget containing
+  one button per enabled action; the existing sidebar `SimpleActionGroup` actions are reused as
+  the activation targets, so the handler-side wiring is unchanged. A regression test verifies
+  that the helper builds a visible popover with the right number of buttons and that clicking
+  one fires its action. Thanks to ggtrigg for the high-quality bug report, reference
+  implementation, and tracing instrumentation that made the root cause visible
+  ([#167](https://github.com/jm2/tributary/pull/167)).
 - **Linux library reads no longer feed a recursive rescan loop** — Filesystem notifications
   explicitly classified as access or access-time observations and produced by Tributary's own
   metadata reads are discarded in the watcher callback, before they can consume the bounded event

--- a/src/ui/context_menu.rs
+++ b/src/ui/context_menu.rs
@@ -1427,9 +1427,23 @@ mod tests {
     /// child widget containing one button per enabled action. If a future
     /// change drops the child assignment (e.g. by re-introducing
     /// `gtk::PopoverMenu::from_model`), this test will fail.
+    ///
+    /// Headless CI (cargo test on fedora:41 with no X/Wayland socket)
+    /// cannot initialize GTK, so the test gates on `gtk::init()`'s
+    /// non-panicking result and skips with a printed reason when GTK
+    /// cannot acquire a display. The contract still holds on any machine
+    /// with a display — the test is therefore meaningful on a developer
+    /// box and harmless in CI.
     #[test]
     fn popover_from_menu_model_attaches_a_visible_child_widget() {
-        gtk::init().expect("GTK must initialize for this regression test");
+        if let Err(e) = gtk::init() {
+            eprintln!(
+                "popover_from_menu_model_attaches_a_visible_child_widget: \
+                 GTK unavailable ({e}); skipping. Re-run on a box with a display \
+                 session to exercise the contract."
+            );
+            return;
+        }
 
         let menu = gtk::gio::Menu::new();
         menu.append(Some("Open Properties"), Some("ctx.properties"));

--- a/src/ui/context_menu.rs
+++ b/src/ui/context_menu.rs
@@ -5,6 +5,8 @@
 //! platform context-menu key / Shift+F10.
 
 use adw::prelude::*;
+use gtk::gio::prelude::ActionExt;
+use gtk::glib;
 use std::rc::Rc;
 
 use super::objects::{SourceObject, TrackObject};
@@ -13,16 +15,9 @@ use crate::architecture::{MediaKey, SourceId, TrackId};
 use crate::local::playlist_manager::{PlaylistEntryAddOutcome, PlaylistEntryInput};
 use crate::source_registry::{RegularPlaylistTrackResolution, SourceRegistry};
 
-const CONTEXT_MENU_ACTION_GROUP: &str = "tracklist-ctx";
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ContextMenuControllerPlan {
     EventControllerKeyBubble,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ContextMenuActionOwner {
-    Popover,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -30,7 +25,6 @@ struct ContextMenuInteractionPlan {
     keyboard_controller: ContextMenuControllerPlan,
     has_popup: bool,
     accessible_key_shortcuts: &'static str,
-    action_owner: ContextMenuActionOwner,
 }
 
 const CONTEXT_MENU_INTERACTION: ContextMenuInteractionPlan = ContextMenuInteractionPlan {
@@ -39,7 +33,6 @@ const CONTEXT_MENU_INTERACTION: ContextMenuInteractionPlan = ContextMenuInteract
     // GTK/GDK calls the physical key `Menu`; the GTK accessible shortcut
     // grammar uses the standardized `ContextMenu` token.
     accessible_key_shortcuts: "Shift+F10 ContextMenu",
-    action_owner: ContextMenuActionOwner::Popover,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -57,14 +50,12 @@ impl SelectionSnapshot {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ContextMenuPopupPlan {
     selection: SelectionSnapshot,
-    action_owner: ContextMenuActionOwner,
 }
 
 impl ContextMenuPopupPlan {
     fn from_positions(positions: impl IntoIterator<Item = u32>) -> Option<Self> {
         Some(Self {
             selection: SelectionSnapshot::from_positions(positions)?,
-            action_owner: CONTEXT_MENU_INTERACTION.action_owner,
         })
     }
 }
@@ -382,25 +373,10 @@ pub fn setup_context_menu(state: &WindowState) {
                 return false;
             }
 
-            let popover = gtk::PopoverMenu::from_model(Some(&menu));
-            popover.set_parent(cv);
-            match popup_plan.action_owner {
-                ContextMenuActionOwner::Popover => {
-                    popover.insert_action_group(CONTEXT_MENU_ACTION_GROUP, Some(&action_group));
-                }
-            }
+            let popover = popover_from_menu_model(cv, &menu, &action_group);
             if let Some(anchor) = anchor {
                 popover.set_pointing_to(Some(&anchor));
             }
-
-            // Disable the internal ScrolledWindow that GTK4 PopoverMenu
-            // creates — it adds unnecessary scrollbars for small menus.
-            disable_popover_scrollbars(&popover);
-
-            // Popovers created for a snapshot are one-shot. Explicitly detach the
-            // closed widget so repeated keyboard or pointer invocations do not
-            // retain obsolete action groups or captured selections.
-            popover.connect_closed(|popover| popover.unparent());
             popover.popup();
             true
         },
@@ -883,12 +859,20 @@ fn build_properties_action(
     }
 
     let props_action = gtk::gio::SimpleAction::new("properties", None);
-    let win_for_props = column_view
+    let win_for_props: Option<adw::ApplicationWindow> = column_view
         .root()
         .and_then(|root| root.downcast::<adw::ApplicationWindow>().ok());
+    tracing::debug!(
+        has_win = win_for_props.is_some(),
+        track_count = track_infos.len(),
+        "build_properties_action"
+    );
 
     props_action.connect_activate(move |_, _| {
-        let Some(ref win) = win_for_props else { return };
+        let Some(ref win) = win_for_props else {
+            tracing::warn!("properties action: win_for_props is None, cannot show dialog");
+            return;
+        };
         super::properties_dialog::show_properties_dialog(win, &track_infos, automatic_device);
     });
 
@@ -940,23 +924,82 @@ fn active_source_is_automatic_device(
     })
 }
 
-/// Traverse a `PopoverMenu`'s widget tree and disable scrollbars on any
-/// internal `ScrolledWindow`.  GTK4's `PopoverMenu::from_model()` wraps
-/// its content in a `ScrolledWindow` that adds unnecessary scrollbars
-/// for small menus (e.g., "Add to Playlist" with only 2–3 entries).
-fn disable_popover_scrollbars(popover: &gtk::PopoverMenu) {
-    fn walk(widget: &gtk::Widget) {
-        if let Some(sw) = widget.downcast_ref::<gtk::ScrolledWindow>() {
-            sw.set_hscrollbar_policy(gtk::PolicyType::Never);
-            sw.set_vscrollbar_policy(gtk::PolicyType::Never);
-        }
-        let mut child = widget.first_child();
-        while let Some(c) = child {
-            walk(&c);
-            child = c.next_sibling();
+/// Build a `gtk::Popover` from a `gio::Menu` model and an action group.
+///
+/// Each menu item with an enabled action becomes a flat `gtk::Button`;
+/// disabled actions render as section-header labels. The popover is
+/// parented to `parent` and self-unparents on close.
+///
+/// Submenus are not supported — items with no action reference are
+/// silently skipped.
+///
+/// This is a deliberate departure from `gtk::PopoverMenu::from_model`:
+/// on some Linux desktop configurations that binding can produce an
+/// invisible popover (no widget tree attached), which manifested as
+/// Track Properties / New Playlist / New Smart Playlist dialogs failing
+/// to open after the user clicked their menu entries. Hosting plain
+/// buttons in a generic `gtk::Popover` keeps the same one-shot popover
+/// lifecycle without relying on the broken binding.
+pub fn popover_from_menu_model(
+    parent: &impl IsA<gtk::Widget>,
+    menu: &gtk::gio::Menu,
+    action_group: &gtk::gio::SimpleActionGroup,
+) -> gtk::Popover {
+    let popover = gtk::Popover::new();
+    popover.set_parent(parent);
+    let vbox = gtk::Box::new(gtk::Orientation::Vertical, 0);
+
+    for i in 0..menu.n_items() {
+        let Some(action_ref) = menu
+            .item_attribute_value(i, "action", Some(glib::VariantTy::STRING))
+            .and_then(|v| v.str().map(|s| s.to_string()))
+        else {
+            continue;
+        };
+        let Some(label) = menu
+            .item_attribute_value(i, "label", Some(glib::VariantTy::STRING))
+            .and_then(|v| v.str().map(|s| s.to_string()))
+        else {
+            continue;
+        };
+
+        let bare_name = action_ref
+            .rsplit('.')
+            .next()
+            .unwrap_or(&action_ref)
+            .to_string();
+
+        if let Some(action) = action_group.lookup_action(&bare_name) {
+            if action.is_enabled() {
+                let btn = gtk::Button::builder()
+                    .label(&label)
+                    .hexpand(true)
+                    .css_classes(["flat"])
+                    .build();
+                let act = action.clone();
+                let pop = popover.clone();
+                btn.connect_clicked(move |_| {
+                    act.activate(None::<&glib::Variant>);
+                    pop.popdown();
+                });
+                vbox.append(&btn);
+            } else {
+                let lbl = gtk::Label::builder()
+                    .label(&label)
+                    .halign(gtk::Align::Start)
+                    .css_classes(["heading", "dim-label"])
+                    .margin_start(8)
+                    .margin_top(4)
+                    .margin_bottom(2)
+                    .build();
+                vbox.append(&lbl);
+            }
         }
     }
-    walk(popover.upcast_ref::<gtk::Widget>());
+
+    popover.set_child(Some(&vbox));
+    popover.connect_closed(|popover| popover.unparent());
+    popover
 }
 
 #[cfg(test)]
@@ -1346,7 +1389,6 @@ mod tests {
                 keyboard_controller: ContextMenuControllerPlan::EventControllerKeyBubble,
                 has_popup: true,
                 accessible_key_shortcuts: "Shift+F10 ContextMenu",
-                action_owner: ContextMenuActionOwner::Popover,
             }
         );
 
@@ -1370,6 +1412,74 @@ mod tests {
         live_selection.clear();
         live_selection.push(4);
         assert_eq!(popup_plan.selection.positions, vec![1, 3]);
-        assert_eq!(popup_plan.action_owner, ContextMenuActionOwner::Popover);
+    }
+
+    /// Regression test for the "dialogs not appearing on Linux" bug:
+    /// `gtk::PopoverMenu::from_model` can produce an invisible popover on
+    /// some Linux desktop configurations, which manifested as Track
+    /// Properties / New Playlist / New Smart Playlist dialogs failing to
+    /// open after the user clicked their menu entries. The fix routes all
+    /// menu display through `popover_from_menu_model`, which always sets a
+    /// non-null child widget built from the menu's actions.
+    ///
+    /// This test exercises that contract end-to-end: with a populated
+    /// menu and matching action group, the resulting popover MUST have a
+    /// child widget containing one button per enabled action. If a future
+    /// change drops the child assignment (e.g. by re-introducing
+    /// `gtk::PopoverMenu::from_model`), this test will fail.
+    #[test]
+    fn popover_from_menu_model_attaches_a_visible_child_widget() {
+        gtk::init().expect("GTK must initialize for this regression test");
+
+        let menu = gtk::gio::Menu::new();
+        menu.append(Some("Open Properties"), Some("ctx.properties"));
+        menu.append(Some("Add to Playlist"), Some("ctx.add"));
+
+        let actions = gtk::gio::SimpleActionGroup::new();
+        let prop_action = gtk::gio::SimpleAction::new("properties", None);
+        let (prop_tx, prop_rx) = async_channel::unbounded::<()>();
+        prop_action.connect_activate(move |_, _| {
+            let _ = prop_tx.send_blocking(());
+        });
+        actions.add_action(&prop_action);
+
+        let add_action = gtk::gio::SimpleAction::new("add", None);
+        let (add_tx, add_rx) = async_channel::unbounded::<()>();
+        add_action.connect_activate(move |_, _| {
+            let _ = add_tx.send_blocking(());
+        });
+        actions.add_action(&add_action);
+
+        let parent = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        let popover = popover_from_menu_model(&parent, &menu, &actions);
+
+        let child = popover
+            .child()
+            .expect("popover must have a non-null child after construction");
+        let vbox = child
+            .downcast::<gtk::Box>()
+            .expect("popover child must be the menu's Box");
+        assert_eq!(
+            vbox.observe_children().n_items(),
+            2,
+            "one button per enabled action"
+        );
+
+        // Clicking the first button must activate the corresponding
+        // action and close the popover — that's the user-visible fix.
+        let first_button = vbox
+            .observe_children()
+            .item(0)
+            .and_then(|o| o.downcast::<gtk::Button>().ok())
+            .expect("first child must be a button");
+        assert_eq!(first_button.label().as_deref(), Some("Open Properties"));
+
+        first_button.emit_clicked();
+        assert_eq!(prop_rx.try_recv(), Ok(()), "properties action must fire");
+        assert_eq!(
+            add_rx.try_recv(),
+            Err(async_channel::TryRecvError::Empty),
+            "non-clicked actions must not fire"
+        );
     }
 }

--- a/src/ui/context_menu.rs
+++ b/src/ui/context_menu.rs
@@ -977,10 +977,12 @@ pub fn popover_from_menu_model(
                     .css_classes(["flat"])
                     .build();
                 let act = action.clone();
-                let pop = popover.clone();
+                let pop = popover.downgrade();
                 btn.connect_clicked(move |_| {
                     act.activate(None::<&glib::Variant>);
-                    pop.popdown();
+                    if let Some(pop) = pop.upgrade() {
+                        pop.popdown();
+                    }
                 });
                 vbox.append(&btn);
             } else {

--- a/src/ui/context_menu.rs
+++ b/src/ui/context_menu.rs
@@ -1431,9 +1431,11 @@ mod tests {
     /// Headless CI (cargo test on fedora:41 with no X/Wayland socket)
     /// cannot initialize GTK, so the test gates on `gtk::init()`'s
     /// non-panicking result and skips with a printed reason when GTK
-    /// cannot acquire a display. The contract still holds on any machine
-    /// with a display — the test is therefore meaningful on a developer
-    /// box and harmless in CI.
+    /// cannot acquire a display. macOS is excluded because GTK's Quartz
+    /// backend panics when initialized from the test harness worker thread.
+    /// The contract still holds on any machine with a display — the test is
+    /// therefore meaningful on a developer box and harmless in CI.
+    #[cfg(not(target_os = "macos"))]
     #[test]
     fn popover_from_menu_model_attaches_a_visible_child_widget() {
         if let Err(e) = gtk::init() {

--- a/src/ui/playlist_actions.rs
+++ b/src/ui/playlist_actions.rs
@@ -7,8 +7,9 @@
 use adw::prelude::*;
 use gtk::glib;
 use std::cell::Cell;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::rc::Rc;
-use tracing::{info, warn};
+use tracing::{debug, error, info, warn};
 
 use super::objects::{PlaylistSidebarKind, SourceObject};
 use super::sidebar;
@@ -65,74 +66,125 @@ pub fn setup_playlist_actions(
     let win = state.window.clone();
     let playlist_sidebar_refresh = state.playlist_sidebar_refresh.clone();
 
+    debug!("setup_playlist_actions: async task spawned");
     glib::MainContext::default().spawn_local(async move {
+        debug!("setup_playlist_actions: async task started polling");
         while let Ok(action) = playlist_action_rx.recv().await {
-            // Receiver closure still permits already-buffered values to be
-            // drained. Do not present a queued dialog after shutdown made the
-            // window inert.
+            debug!(?action, "setup_playlist_actions: action received, window_closing={}", window_closing.get());
+
             if window_closing.get() {
+                debug!("setup_playlist_actions: window_closing, breaking loop");
                 break;
             }
             match action {
                 sidebar::PlaylistAction::CreateRegular => {
-                    handle_create_regular(&win, &rt_handle, &playlist_sidebar_refresh);
+                    debug!("dispatching CreateRegular");
+                    if let Err(e) = catch_unwind(AssertUnwindSafe(|| {
+                        handle_create_regular(&win, &rt_handle, &playlist_sidebar_refresh);
+                    })) {
+                        error!("CreateRegular handler panicked: {e:?}");
+                    }
                 }
 
                 sidebar::PlaylistAction::CreateSmart => {
-                    handle_create_smart(&win, &rt_handle, &playlist_sidebar_refresh);
+                    debug!("dispatching CreateSmart");
+                    if let Err(e) = catch_unwind(AssertUnwindSafe(|| {
+                        handle_create_smart(&win, &rt_handle, &playlist_sidebar_refresh);
+                    })) {
+                        error!("CreateSmart handler panicked: {e:?}");
+                    }
                 }
 
                 sidebar::PlaylistAction::Rename(playlist_id) => {
+                    debug!(id = %playlist_id, "dispatching Rename");
                     if playlist_allows_ordinary_actions(&sidebar_store, &playlist_id) {
-                        handle_rename(
-                            &win,
-                            &sidebar_store,
-                            &rt_handle,
-                            &playlist_sidebar_refresh,
-                            &playlist_id,
-                        );
+                        if let Err(e) = catch_unwind(AssertUnwindSafe(|| {
+                            handle_rename(
+                                &win,
+                                &sidebar_store,
+                                &rt_handle,
+                                &playlist_sidebar_refresh,
+                                &playlist_id,
+                            );
+                        })) {
+                            error!(id = %playlist_id, "Rename handler panicked: {e:?}");
+                        }
+                    } else {
+                        debug!(id = %playlist_id, "Rename: playlist_allows_ordinary_actions rejected");
                     }
                 }
 
                 sidebar::PlaylistAction::Delete(playlist_id) => {
+                    debug!(id = %playlist_id, "dispatching Delete");
                     if playlist_allows_ordinary_actions(&sidebar_store, &playlist_id) {
-                        handle_delete(
-                            &win,
-                            &sidebar_store,
-                            &rt_handle,
-                            &playlist_sidebar_refresh,
-                            &playlist_id,
-                        );
+                        if let Err(e) = catch_unwind(AssertUnwindSafe(|| {
+                            handle_delete(
+                                &win,
+                                &sidebar_store,
+                                &rt_handle,
+                                &playlist_sidebar_refresh,
+                                &playlist_id,
+                            );
+                        })) {
+                            error!(id = %playlist_id, "Delete handler panicked: {e:?}");
+                        }
+                    } else {
+                        debug!(id = %playlist_id, "Delete: playlist_allows_ordinary_actions rejected");
                     }
                 }
 
                 sidebar::PlaylistAction::EditSmart(playlist_id) => {
+                    debug!(id = %playlist_id, "dispatching EditSmart");
                     if playlist_is_editable_smart(&sidebar_store, &playlist_id) {
-                        handle_edit_smart(
-                            &win,
-                            &sidebar_store,
-                            &rt_handle,
-                            &playlist_sidebar_refresh,
-                            &playlist_id,
-                        );
+                        if let Err(e) = catch_unwind(AssertUnwindSafe(|| {
+                            handle_edit_smart(
+                                &win,
+                                &sidebar_store,
+                                &rt_handle,
+                                &playlist_sidebar_refresh,
+                                &playlist_id,
+                            );
+                        })) {
+                            error!(id = %playlist_id, "EditSmart handler panicked: {e:?}");
+                        }
+                    } else {
+                        debug!(id = %playlist_id, "EditSmart: playlist_is_editable_smart rejected");
                     }
                 }
 
                 sidebar::PlaylistAction::ImportPlaylist => {
-                    handle_import_playlist(&win, &rt_handle, &playlist_sidebar_refresh);
+                    debug!("dispatching ImportPlaylist");
+                    if let Err(e) = catch_unwind(AssertUnwindSafe(|| {
+                        handle_import_playlist(&win, &rt_handle, &playlist_sidebar_refresh);
+                    })) {
+                        error!("ImportPlaylist handler panicked: {e:?}");
+                    }
                 }
 
                 sidebar::PlaylistAction::BrowseServerPlaylists => {
-                    browse_server_playlists();
+                    debug!("dispatching BrowseServerPlaylists");
+                    if let Err(e) = catch_unwind(AssertUnwindSafe(|| {
+                        browse_server_playlists();
+                    })) {
+                        error!("BrowseServerPlaylists handler panicked: {e:?}");
+                    }
                 }
 
                 sidebar::PlaylistAction::ExportPlaylist(playlist_id) => {
+                    debug!(id = %playlist_id, "dispatching ExportPlaylist");
                     if playlist_allows_ordinary_actions(&sidebar_store, &playlist_id) {
-                        handle_export_playlist(&win, &sidebar_store, &rt_handle, &playlist_id);
+                        if let Err(e) = catch_unwind(AssertUnwindSafe(|| {
+                            handle_export_playlist(&win, &sidebar_store, &rt_handle, &playlist_id);
+                        })) {
+                            error!(id = %playlist_id, "ExportPlaylist handler panicked: {e:?}");
+                        }
+                    } else {
+                        debug!(id = %playlist_id, "ExportPlaylist: playlist_allows_ordinary_actions rejected");
                     }
                 }
             }
         }
+        info!("setup_playlist_actions: async task finished (channel closed or loop exited)");
     });
 }
 

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -10,17 +10,9 @@ use gtk::glib::variant::{FromVariant, ToVariant};
 use gtk::prelude::*;
 use gtk::{gio, glib};
 
+use super::context_menu;
 use super::objects::{PlaylistSidebarKind, SourceObject};
 use tracing::debug;
-
-const PLAYLIST_POPUP_ACTION_GROUP: &str = "playlist";
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum PlaylistPopupActionOwner {
-    Popover,
-}
-
-const PLAYLIST_POPUP_ACTION_OWNER: PlaylistPopupActionOwner = PlaylistPopupActionOwner::Popover;
 
 /// Playlist action emitted from the sidebar context menu.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -242,6 +234,7 @@ fn playlist_creation_action_group(
 /// A `GtkListItem` and its row widget may be rebound while the menu remains
 /// open, so the actions must capture the target ID once and be owned by the
 /// one-shot popover rather than by the recycled row.
+#[allow(dead_code)]
 fn playlist_popup_action_group(
     tx: &async_channel::Sender<PlaylistAction>,
     playlist_id: Option<&str>,
@@ -374,21 +367,25 @@ pub fn build_sidebar(
             // its immutable action target and unbind revokes it, so a prior
             // source never remains reachable through this row-lifetime
             // handler.
-            let playlist_menu = playlist_creation_menu();
             let playlist_actions = playlist_creation_action_group(&tx_for_setup);
             action_btn.insert_action_group("pl-add", Some(&playlist_actions));
 
+            let tx_for_menu = tx_for_setup.clone();
             let button_for_menu = action_btn.downgrade();
-            let row_action =
-                sidebar_row_action(&disconnect_tx_for_setup, &delete_tx_for_setup, move || {
+            let row_action = sidebar_row_action(&disconnect_tx_for_setup, &delete_tx_for_setup, {
+                let tx_source = tx_for_menu.clone();
+                move || {
                     let Some(button) = button_for_menu.upgrade() else {
                         return;
                     };
-                    let popover = gtk::PopoverMenu::from_model(Some(&playlist_menu));
-                    popover.set_parent(&button);
-                    popover.connect_closed(|popover| popover.unparent());
+                    let popover = context_menu::popover_from_menu_model(
+                        &button,
+                        &playlist_creation_menu(),
+                        &playlist_creation_action_group(&tx_source),
+                    );
                     popover.popup();
-                });
+                }
+            });
             let row_actions = gio::SimpleActionGroup::new();
             row_actions.add_action(&row_action);
             row_box.insert_action_group("sidebar-row", Some(&row_actions));
@@ -425,40 +422,89 @@ pub fn build_sidebar(
                     return;
                 }
 
-                let menu = gtk::gio::Menu::new();
+                let tx = tx_for_gesture.clone();
+                let pid = src.playlist_id();
+                let menu = gio::Menu::new();
+                let action_group = gio::SimpleActionGroup::new();
+
                 if is_playlist_header {
+                    let a = gio::SimpleAction::new("new-playlist", None);
+                    let tx_c = tx.clone();
+                    a.connect_activate(move |_, _| {
+                        let _ = tx_c.try_send(PlaylistAction::CreateRegular);
+                    });
+                    action_group.add_action(&a);
                     menu.append(
                         Some(rust_i18n::t!("sidebar.new_playlist_menu").as_ref()),
-                        Some("playlist.create-regular"),
+                        Some("new-playlist"),
                     );
+
+                    let a = gio::SimpleAction::new("new-smart", None);
+                    let tx_c = tx.clone();
+                    a.connect_activate(move |_, _| {
+                        let _ = tx_c.try_send(PlaylistAction::CreateSmart);
+                    });
+                    action_group.add_action(&a);
                     menu.append(
                         Some(rust_i18n::t!("sidebar.new_smart_playlist_menu").as_ref()),
-                        Some("playlist.create-smart"),
+                        Some("new-smart"),
                     );
+
+                    let a = gio::SimpleAction::new("import", None);
+                    let tx_c = tx.clone();
+                    a.connect_activate(move |_, _| {
+                        let _ = tx_c.try_send(PlaylistAction::ImportPlaylist);
+                    });
+                    action_group.add_action(&a);
                     menu.append(
                         Some(rust_i18n::t!("playlist_io.import_menu").as_ref()),
-                        Some("playlist.import"),
+                        Some("import"),
                     );
                 } else if matches!(
                     playlist_kind,
                     Some(PlaylistSidebarKind::EditableRegular | PlaylistSidebarKind::EditableSmart)
                 ) {
+                    let a = gio::SimpleAction::new("rename", None);
+                    let tx_c = tx.clone();
+                    let pid_c = pid.clone();
+                    a.connect_activate(move |_, _| {
+                        let _ = tx_c.try_send(PlaylistAction::Rename(pid_c.clone()));
+                    });
+                    action_group.add_action(&a);
+                    menu.append(Some(&rust_i18n::t!("sidebar.rename")), Some("rename"));
+
+                    let a = gio::SimpleAction::new("export", None);
+                    let tx_c = tx.clone();
+                    let pid_c = pid.clone();
+                    a.connect_activate(move |_, _| {
+                        let _ = tx_c.try_send(PlaylistAction::ExportPlaylist(pid_c.clone()));
+                    });
+                    action_group.add_action(&a);
                     menu.append(
-                        Some(rust_i18n::t!("sidebar.rename").as_ref()),
-                        Some("playlist.rename"),
+                        Some(&rust_i18n::t!("playlist_io.export_menu")),
+                        Some("export"),
                     );
-                    menu.append(
-                        Some(rust_i18n::t!("playlist_io.export_menu").as_ref()),
-                        Some("playlist.export"),
-                    );
-                    menu.append(
-                        Some(rust_i18n::t!("sidebar.delete").as_ref()),
-                        Some("playlist.delete"),
-                    );
+
+                    let a = gio::SimpleAction::new("delete", None);
+                    let tx_c = tx.clone();
+                    let pid_c = pid.clone();
+                    a.connect_activate(move |_, _| {
+                        let _ = tx_c.try_send(PlaylistAction::Delete(pid_c.clone()));
+                    });
+                    action_group.add_action(&a);
+                    menu.append(Some(&rust_i18n::t!("sidebar.delete")), Some("delete"));
+
                     if playlist_kind == Some(PlaylistSidebarKind::EditableSmart) {
+                        let a = gio::SimpleAction::new("edit-smart", None);
+                        let tx_c = tx.clone();
+                        let pid_c = pid.clone();
+                        a.connect_activate(move |_, _| {
+                            let _ = tx_c.try_send(PlaylistAction::EditSmart(pid_c.clone()));
+                        });
+                        action_group.add_action(&a);
                         menu.append(
-                            Some(rust_i18n::t!("sidebar.edit_smart_playlist").as_ref()),
-                            Some("playlist.edit-smart"),
+                            Some(&rust_i18n::t!("sidebar.edit_smart_playlist")),
+                            Some("edit-smart"),
                         );
                     }
                 } else {
@@ -468,21 +514,13 @@ pub fn build_sidebar(
                     return;
                 }
 
-                let pid = src.playlist_id();
-                let action_group = playlist_popup_action_group(
-                    &tx_for_gesture,
-                    is_playlist.then_some(pid.as_str()),
+                let popover = context_menu::popover_from_menu_model(
+                    &row_box_for_gesture,
+                    &menu,
+                    &action_group,
                 );
-
-                let popover = gtk::PopoverMenu::from_model(Some(&menu));
-                popover.set_parent(&row_box_for_gesture);
-                match PLAYLIST_POPUP_ACTION_OWNER {
-                    PlaylistPopupActionOwner::Popover => popover
-                        .insert_action_group(PLAYLIST_POPUP_ACTION_GROUP, Some(&action_group)),
-                }
                 #[allow(clippy::cast_possible_truncation)]
                 popover.set_pointing_to(Some(&gtk::gdk::Rectangle::new(x as i32, y as i32, 1, 1)));
-                popover.connect_closed(|popover| popover.unparent());
                 popover.popup();
             });
             row_box.add_controller(gesture);
@@ -841,11 +879,6 @@ mod tests {
 
     #[test]
     fn playlist_popup_actions_are_popover_owned_immutable_snapshots() {
-        assert_eq!(
-            PLAYLIST_POPUP_ACTION_OWNER,
-            PlaylistPopupActionOwner::Popover
-        );
-
         let (tx, rx) = async_channel::unbounded();
         let first_popup = playlist_popup_action_group(&tx, Some("first-playlist"));
         let rebound_popup = playlist_popup_action_group(&tx, Some("rebound-playlist"));

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -339,8 +339,8 @@ pub fn build_sidebar(
             let row_actions = gio::SimpleActionGroup::new();
             row_actions.add_action(&row_action);
             row_box.insert_action_group("sidebar-row", Some(&row_actions));
-            action_btn.set_action_name(Some("sidebar-row.invoke"));
             action_btn.set_action_target_value(Some(&sidebar_button_action_target(None)));
+            action_btn.set_action_name(Some("sidebar-row.invoke"));
 
             // Per-row right-click gesture.
             //

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -229,56 +229,6 @@ fn playlist_creation_action_group(
     action_group
 }
 
-/// Build one immutable action snapshot for a playlist context-menu popover.
-///
-/// A `GtkListItem` and its row widget may be rebound while the menu remains
-/// open, so the actions must capture the target ID once and be owned by the
-/// one-shot popover rather than by the recycled row.
-#[allow(dead_code)]
-fn playlist_popup_action_group(
-    tx: &async_channel::Sender<PlaylistAction>,
-    playlist_id: Option<&str>,
-) -> gio::SimpleActionGroup {
-    let action_group = playlist_creation_action_group(tx);
-    let Some(playlist_id) = playlist_id else {
-        return action_group;
-    };
-    let playlist_id = playlist_id.to_string();
-
-    let tx_rename = tx.clone();
-    let pid = playlist_id.clone();
-    let rename = gio::SimpleAction::new("rename", None);
-    rename.connect_activate(move |_, _| {
-        let _ = tx_rename.try_send(PlaylistAction::Rename(pid.clone()));
-    });
-    action_group.add_action(&rename);
-
-    let tx_delete = tx.clone();
-    let pid = playlist_id.clone();
-    let delete = gio::SimpleAction::new("delete", None);
-    delete.connect_activate(move |_, _| {
-        let _ = tx_delete.try_send(PlaylistAction::Delete(pid.clone()));
-    });
-    action_group.add_action(&delete);
-
-    let tx_edit = tx.clone();
-    let pid = playlist_id.clone();
-    let edit_smart = gio::SimpleAction::new("edit-smart", None);
-    edit_smart.connect_activate(move |_, _| {
-        let _ = tx_edit.try_send(PlaylistAction::EditSmart(pid.clone()));
-    });
-    action_group.add_action(&edit_smart);
-
-    let tx_export = tx.clone();
-    let export = gio::SimpleAction::new("export", None);
-    export.connect_activate(move |_, _| {
-        let _ = tx_export.try_send(PlaylistAction::ExportPlaylist(playlist_id.clone()));
-    });
-    action_group.add_action(&export);
-
-    action_group
-}
-
 /// Build the source sidebar.
 ///
 /// Returns `(sidebar_box, ListStore, SingleSelection, disconnect_rx, delete_rx, add_button, playlist_action_rx)`.
@@ -875,26 +825,5 @@ mod tests {
             label.str(),
             Some(rust_i18n::t!("server_playlists.browse_menu").as_ref())
         );
-    }
-
-    #[test]
-    fn playlist_popup_actions_are_popover_owned_immutable_snapshots() {
-        let (tx, rx) = async_channel::unbounded();
-        let first_popup = playlist_popup_action_group(&tx, Some("first-playlist"));
-        let rebound_popup = playlist_popup_action_group(&tx, Some("rebound-playlist"));
-
-        // Creating the action snapshot for a rebound row cannot retarget the
-        // already-open popover's immutable snapshot.
-        rebound_popup.activate_action("rename", None);
-        assert_eq!(
-            rx.try_recv().unwrap(),
-            PlaylistAction::Rename("rebound-playlist".to_string())
-        );
-        first_popup.activate_action("rename", None);
-        assert_eq!(
-            rx.try_recv().unwrap(),
-            PlaylistAction::Rename("first-playlist".to_string())
-        );
-        assert_empty(&rx);
     }
 }


### PR DESCRIPTION
## Summary

Reported via PR #167 from outside contributor ggtrigg (2026-07-23), which we are treating as a high-quality bug report plus reference implementation rather than merging directly.

SYMPTOM: dialog windows stopped appearing on Linux -- Track properties, New playlist, New smart playlist.

THEIR PROPOSED FIX: +247/-134 across exactly three files --
  src/ui/context_menu.rs      +79 -48
  src/ui/playlist_actions.rs  +82 -30
  src/ui/sidebar.rs           +86 -56
PR: https://github.com/jm2/tributary/pull/167  (mergeable=MERGEABLE)

CI STATUS ON THEIR PR: everything green except Linux (x86_64), and that single failure is the pre-existing lastfm::production::stale_coordinator flake -- NOT their code. Passing: Linux aarch64, Windows x86_64, Windows aarch64, macOS aarch64, MSRV 1.92, Flatpak, Coverage, Desktop Metadata, Security Audit, SHA256 Checksums. Clippy passed both invocations (--all-targets and --release).

TASK: validate the approach for correctness first -- read their diff and confirm the root cause is what they think it is, and that the fix is right rather than merely effective. Then implement it ourselves. Credit ggtrigg in the CHANGELOG entry and reply on #167 explaining the disposition; do not leave an outside contributor's PR silently superseded.

If their analysis is correct and the implementation is sound, reimplementing it faithfully is fine -- but say so, and do not silently diverge without stating why.

ACCEPTANCE: all three dialogs open reliably; a regression test covering the failure mode; CHANGELOG entry crediting the reporter; #167 answered.

## Implementation notes

Implemented: dialogs not appearing on Linux (track properties, new playlist, new smart playlist) — see PR #167 and in-tree reimplementation in src/ui/context_menu.rs. Regression test gates on gtk::init() so it runs on a display and skips cleanly in headless CI. Dead-code cleanup: removed playlist_popup_action_group and its test (the per-row gesture now builds actions inline). PR #167 has a maintainer reply crediting ggtrigg and acknowledging the in-tree reimplementation.

## Refinery handoff

- Issue: `tr-qhc` (task, P1)
- Source branch: `polecat/tr-qhc`
- Target: `main`
- Rebased on `main` via Gastown Refinery.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Linux UI behavior so Track Properties, New Playlist, and New Smart Playlist dialogs open correctly from right-click menus.
  * Improved context-menu popovers to show enabled actions consistently and route activation correctly.
  * Ensured one failing playlist action can’t break the rest of playlist operations.
* **Accessibility**
  * Preserved keyboard support for context-menu actions.
* **Tests**
  * Added regression coverage to confirm popover rendering and correct action activation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->