### PR TITLE
feat(mpd): optional detectable exclusive-control mode before orphan cleanup (tr-cem)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Build and run helpers** — Add `--run` on Linux and macOS to build with locked
   dependencies, validate the native binary, and launch it with logs in the terminal.
   The macOS development route uses Homebrew libraries and skips app packaging.
+- **MPD outputs can now be supervised while under the user's explicit exclusive-control
+  confirmation** (`src/audio/mpd_output.rs`, `src/ui/output_dialogs.rs`,
+  `src/ui/output_switch.rs`, `locales/*.yml`). The user's explicit confirmation remains the
+  ONLY grant of partition authority: automatic authority is declared infeasible because MPD
+  offers no ownership lock, lease, token, or atomic conditional partition mutation. The
+  `detection_enabled` persisted field now opts an exclusive output into a revoke-only
+  supervisor: a foreign current song, any of `repeat`/`random`/`single`/`consume` flipped away
+  from the enforced defaults, or an observation gap beyond `MAX_SUPERVISION_GAP = 2 s` lapses
+  the supervisor, which revokes playback control — loads and partition-global playback
+  controls are refused with the exclusive-control-required error and orphan cleanup retains
+  the queue entry — until the user explicitly reconfirms by re-selecting the output. Quiet
+  status polling never grants or restores authority, and a lapsed supervisor is terminal for
+  the output instance. The `exclusive_control: false` default, the fail-closed load gate, the
+  refuse-before-Buffering/epoch/enqueue ordering, and the relinquish-without-racy-stop rule
+  for a foreign current song are all preserved; legacy `outputs.json` entries continue to
+  deserialize with `detection_enabled: false`, and a legacy `detection_enabled: true` entry
+  without the exclusive confirmation fails closed to `Unconfirmed`. The Add Output dialog
+  saves supervision only together with the exclusive confirmation, paired with a localized
+  warning/confirmation message in every supported catalog (13 locales).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   controls are refused with the exclusive-control-required error and orphan cleanup retains
   the queue entry — until the user explicitly reconfirms by re-selecting the output. Quiet
   status polling never grants or restores authority, and a lapsed supervisor is terminal for
-  the output instance. The `exclusive_control: false` default, the fail-closed load gate, the
+  the output instance. The 2 s supervision age is enforced eagerly at every authority gate —
+  public loads, public playback controls, worker commands, and orphan cleanup — so a
+  confirmation whose clean evidence has gone stale is refused immediately (and lapses the
+  supervisor) instead of staying valid until the next poll observes the gap, and a `status`
+  reply that omits any of the four partition-option fields fails the poll rather than
+  defaulting the omission to a clean `false`. The `exclusive_control: false` default, the fail-closed load gate, the
   refuse-before-Buffering/epoch/enqueue ordering, and the relinquish-without-racy-stop rule
   for a foreign current song are all preserved; legacy `outputs.json` entries continue to
   deserialize with `detection_enabled: false`, and a legacy `detection_enabled: true` entry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Supervised MPD control TOCTOU** (`src/audio/mpd_output.rs`) — A playback
+  control (play/pause/toggle/seek) whose own pre-control `status` observed
+  partition-option drift or a foreign current song lapsed the supervisor yet was
+  still issued. Authority is now rechecked immediately after the authoritative
+  status is applied and before the control goes to the wire; a just-lapsed
+  supervisor receives the exclusive-control-required error and no command, the
+  same refusal shape as the worker gate.
+- **Supervised MPD cleanup rechecks authority on fresh evidence**
+  (`src/audio/mpd_output.rs`) — The shutdown-time `status` in
+  `cleanup_unconditionally` (and the `status` fetched by the Stop command's
+  `StopOwned` cleanup in `cleanup_session`) is now applied to the supervisor
+  before any mutation decision, and authority is rechecked before the teardown
+  `stop` and again before the targeted `delete`. A supervisor that is fresh at
+  the initial gate but whose own teardown observation (option drift, foreign
+  song, or the round-trip time past the 2 s window) supplies disqualifying
+  evidence now retains the orphan and issues neither command.
+- **Lapsed supervised MPD outputs rebuild on same-target reselection**
+  (`src/audio/output.rs`, `src/audio/mpd_output.rs`, `src/ui/output_switch.rs`)
+  — After supervision lapsed, the documented recovery — re-select the output —
+  never reached the constructor, because clicking the already-active row was
+  swallowed as a non-perturbing no-op and every later command stayed refused.
+  The selector now detects a lapsed supervisor on the active MPD row and routes
+  the reselection through a dedicated same-target rebuild that keeps the
+  committed-switch ordering (session proof cleared before coordinator ingress,
+  predecessor retired, stopped, replaced) while re-arming authority via the
+  fresh construction. Healthy supervisors and non-MPD targets keep the old
+  no-op behavior.
+
 - **macOS local playback** — Bundle the dynamically loaded libsoup runtime and its
   dependencies so protected streams can use the required HTTP source on Macs without
   Homebrew. The signed package probe now verifies direct HTTP routing, audio decoding,

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -145,6 +145,8 @@ dialogs:
   output_port: "Port"
   output_exclusive_control_warning: "MPD-Befehle für Pause, Stopp, Wiederholen, Zufall, Einzelwiedergabe und Verbrauch betreffen die gesamte Wiedergabepartition. Teilen Sie sie nicht mit einem anderen Controller oder einer anderen Tributary-Instanz."
   output_exclusive_control_confirmation: "Ich bestätige, dass Tributary die exklusive Kontrolle über diese MPD-Wiedergabepartition hat."
+  output_detection_warning: "With supervision enabled, Tributary keeps observing the partition while it plays: a foreign current song, a foreign option change, or a lost observation window revokes playback control and keeps any orphaned queue entry. Supervision can only revoke, never grant: after such evidence the output refuses commands until you re-select it to confirm again."
+  output_detection_confirmation: "Supervise this exclusive output and revoke its control on evidence of another controller."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -145,8 +145,8 @@ dialogs:
   output_port: "Port"
   output_exclusive_control_warning: "MPD-Befehle für Pause, Stopp, Wiederholen, Zufall, Einzelwiedergabe und Verbrauch betreffen die gesamte Wiedergabepartition. Teilen Sie sie nicht mit einem anderen Controller oder einer anderen Tributary-Instanz."
   output_exclusive_control_confirmation: "Ich bestätige, dass Tributary die exklusive Kontrolle über diese MPD-Wiedergabepartition hat."
-  output_detection_warning: "With supervision enabled, Tributary keeps observing the partition while it plays: a foreign current song, a foreign option change, or a lost observation window revokes playback control and keeps any orphaned queue entry. Supervision can only revoke, never grant: after such evidence the output refuses commands until you re-select it to confirm again."
-  output_detection_confirmation: "Supervise this exclusive output and revoke its control on evidence of another controller."
+  output_detection_warning: "Mit aktivierter Überwachung beobachtet Tributary die Partition während der Wiedergabe weiter: Ein fremder aktueller Titel, eine fremde Optionsänderung oder ein verloren gegangenes Beobachtungsfenster entzieht die Wiedergabesteuerung und behält jeden verwaisten Warteschlangeneintrag. Überwachung kann nur entziehen, nie gewähren: Nach solchen Hinweisen verweigert die Ausgabe Befehle, bis du sie erneut auswählst, um sie erneut zu bestätigen."
+  output_detection_confirmation: "Diese exklusive Ausgabe überwachen und ihre Steuerung bei Anzeichen eines anderen Controllers entziehen."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -150,6 +150,8 @@ dialogs:
   output_port: "Port"
   output_exclusive_control_warning: "MPD pause, stop, repeat, random, single, and consume commands affect the entire playback partition. Do not share it with another controller or Tributary instance."
   output_exclusive_control_confirmation: "I confirm Tributary has exclusive control of this MPD playback partition."
+  output_detection_warning: "With supervision enabled, Tributary keeps observing the partition while it plays: a foreign current song, a foreign option change, or a lost observation window revokes playback control and keeps any orphaned queue entry. Supervision can only revoke, never grant: after such evidence the output refuses commands until you re-select it to confirm again."
+  output_detection_confirmation: "Supervise this exclusive output and revoke its control on evidence of another controller."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -145,8 +145,8 @@ dialogs:
   output_port: "Puerto"
   output_exclusive_control_warning: "Los comandos de MPD para pausar, detener, repetir, aleatorio, único y consumir afectan a toda la partición de reproducción. No la comparta con otro controlador ni con otra instancia de Tributary."
   output_exclusive_control_confirmation: "Confirmo que Tributary tiene el control exclusivo de esta partición de reproducción de MPD."
-  output_detection_warning: "With supervision enabled, Tributary keeps observing the partition while it plays: a foreign current song, a foreign option change, or a lost observation window revokes playback control and keeps any orphaned queue entry. Supervision can only revoke, never grant: after such evidence the output refuses commands until you re-select it to confirm again."
-  output_detection_confirmation: "Supervise this exclusive output and revoke its control on evidence of another controller."
+  output_detection_warning: "Con la supervisión activada, Tributary sigue observando la partición mientras reproduce: una canción actual ajena, un cambio de opción ajeno o una ventana de observación perdida revoca el control de reproducción y conserva cualquier entrada huérfana de la cola. La supervisión solo puede revocar, nunca otorgar: tras dicha evidencia, la salida rechaza comandos hasta que la vuelvas a seleccionar para confirmarla de nuevo."
+  output_detection_confirmation: "Supervisa esta salida exclusiva y revoca su control ante evidencia de otro controlador."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -145,6 +145,8 @@ dialogs:
   output_port: "Puerto"
   output_exclusive_control_warning: "Los comandos de MPD para pausar, detener, repetir, aleatorio, único y consumir afectan a toda la partición de reproducción. No la comparta con otro controlador ni con otra instancia de Tributary."
   output_exclusive_control_confirmation: "Confirmo que Tributary tiene el control exclusivo de esta partición de reproducción de MPD."
+  output_detection_warning: "With supervision enabled, Tributary keeps observing the partition while it plays: a foreign current song, a foreign option change, or a lost observation window revokes playback control and keeps any orphaned queue entry. Supervision can only revoke, never grant: after such evidence the output refuses commands until you re-select it to confirm again."
+  output_detection_confirmation: "Supervise this exclusive output and revoke its control on evidence of another controller."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -145,6 +145,8 @@ dialogs:
   output_port: "Port"
   output_exclusive_control_warning: "Les commandes MPD de pause, arrêt, répétition, lecture aléatoire, lecture unique et consommation affectent toute la partition de lecture. Ne la partagez pas avec un autre contrôleur ou une autre instance de Tributary."
   output_exclusive_control_confirmation: "Je confirme que Tributary contrôle exclusivement cette partition de lecture MPD."
+  output_detection_warning: "With supervision enabled, Tributary keeps observing the partition while it plays: a foreign current song, a foreign option change, or a lost observation window revokes playback control and keeps any orphaned queue entry. Supervision can only revoke, never grant: after such evidence the output refuses commands until you re-select it to confirm again."
+  output_detection_confirmation: "Supervise this exclusive output and revoke its control on evidence of another controller."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -145,8 +145,8 @@ dialogs:
   output_port: "Port"
   output_exclusive_control_warning: "Les commandes MPD de pause, arrêt, répétition, lecture aléatoire, lecture unique et consommation affectent toute la partition de lecture. Ne la partagez pas avec un autre contrôleur ou une autre instance de Tributary."
   output_exclusive_control_confirmation: "Je confirme que Tributary contrôle exclusivement cette partition de lecture MPD."
-  output_detection_warning: "With supervision enabled, Tributary keeps observing the partition while it plays: a foreign current song, a foreign option change, or a lost observation window revokes playback control and keeps any orphaned queue entry. Supervision can only revoke, never grant: after such evidence the output refuses commands until you re-select it to confirm again."
-  output_detection_confirmation: "Supervise this exclusive output and revoke its control on evidence of another controller."
+  output_detection_warning: "Avec la supervision activée, Tributary continue d'observer la partition pendant la lecture : une chanson actuelle étrangère, un changement d'option étranger ou une fenêtre d'observation perdue révoque le contrôle de la lecture et conserve toute entrée de file orpheline. La supervision ne peut que révoquer, jamais accorder : après de telles preuves, la sortie refuse les commandes jusqu'à ce que vous la resélectionniez pour la confirmer à nouveau."
+  output_detection_confirmation: "Superviser cette sortie exclusive et révoquer son contrôle en cas de preuve d'un autre contrôleur."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -145,6 +145,8 @@ dialogs:
   output_port: "Porta"
   output_exclusive_control_warning: "I comandi MPD pausa, arresto, ripetizione, casuale, singolo e consumo influiscono sull'intera partizione di riproduzione. Non condividerla con un altro controller o un'altra istanza di Tributary."
   output_exclusive_control_confirmation: "Confermo che Tributary ha il controllo esclusivo di questa partizione di riproduzione MPD."
+  output_detection_warning: "With supervision enabled, Tributary keeps observing the partition while it plays: a foreign current song, a foreign option change, or a lost observation window revokes playback control and keeps any orphaned queue entry. Supervision can only revoke, never grant: after such evidence the output refuses commands until you re-select it to confirm again."
+  output_detection_confirmation: "Supervise this exclusive output and revoke its control on evidence of another controller."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -145,8 +145,8 @@ dialogs:
   output_port: "Porta"
   output_exclusive_control_warning: "I comandi MPD pausa, arresto, ripetizione, casuale, singolo e consumo influiscono sull'intera partizione di riproduzione. Non condividerla con un altro controller o un'altra istanza di Tributary."
   output_exclusive_control_confirmation: "Confermo che Tributary ha il controllo esclusivo di questa partizione di riproduzione MPD."
-  output_detection_warning: "With supervision enabled, Tributary keeps observing the partition while it plays: a foreign current song, a foreign option change, or a lost observation window revokes playback control and keeps any orphaned queue entry. Supervision can only revoke, never grant: after such evidence the output refuses commands until you re-select it to confirm again."
-  output_detection_confirmation: "Supervise this exclusive output and revoke its control on evidence of another controller."
+  output_detection_warning: "Con la supervisione attiva, Tributary continua a osservare la partizione durante la riproduzione: un brano corrente estraneo, una modifica di opzione estranea o una finestra di osservazione mancante revoca il controllo della riproduzione e conserva qualsiasi voce di coda orfana. La supervisione può solo revocare, mai concedere: dopo tali evidenze l'uscita rifiuta i comandi finché non la riselezioni per confermarla di nuovo."
+  output_detection_confirmation: "Sorveglia questa uscita esclusiva e ne revoca il controllo in caso di evidenza di un altro controller."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -145,6 +145,8 @@ dialogs:
   output_port: "ポート"
   output_exclusive_control_warning: "MPD の一時停止、停止、リピート、ランダム、シングル、consume コマンドは再生パーティション全体に影響します。別のコントローラーや Tributary インスタンスと共有しないでください。"
   output_exclusive_control_confirmation: "Tributary がこの MPD 再生パーティションを排他的に制御することを確認します。"
+  output_detection_warning: "With supervision enabled, Tributary keeps observing the partition while it plays: a foreign current song, a foreign option change, or a lost observation window revokes playback control and keeps any orphaned queue entry. Supervision can only revoke, never grant: after such evidence the output refuses commands until you re-select it to confirm again."
+  output_detection_confirmation: "Supervise this exclusive output and revoke its control on evidence of another controller."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -145,8 +145,8 @@ dialogs:
   output_port: "ポート"
   output_exclusive_control_warning: "MPD の一時停止、停止、リピート、ランダム、シングル、consume コマンドは再生パーティション全体に影響します。別のコントローラーや Tributary インスタンスと共有しないでください。"
   output_exclusive_control_confirmation: "Tributary がこの MPD 再生パーティションを排他的に制御することを確認します。"
-  output_detection_warning: "With supervision enabled, Tributary keeps observing the partition while it plays: a foreign current song, a foreign option change, or a lost observation window revokes playback control and keeps any orphaned queue entry. Supervision can only revoke, never grant: after such evidence the output refuses commands until you re-select it to confirm again."
-  output_detection_confirmation: "Supervise this exclusive output and revoke its control on evidence of another controller."
+  output_detection_warning: "監視を有効にすると、Tributary は再生中もパーティションを監視し続けます。外部の現在の曲、オプションの変更、または監視の途切れが検知されると、再生操作の権限を取り消し、孤立したキューエントリを保持します。監視は取り消しのみを行い、権限を付与することはありません。そのような証拠が検知された後は、再度選択して確認するまで、この出力はコマンドを拒否します。"
+  output_detection_confirmation: "この排他出力を監視し、他のコントローラーの兆候を検知した場合にその制御を取り消します。"
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -145,8 +145,8 @@ dialogs:
   output_port: "포트"
   output_exclusive_control_warning: "MPD의 일시 정지, 정지, 반복, 무작위, 단일 및 consume 명령은 전체 재생 파티션에 영향을 줍니다. 다른 컨트롤러나 Tributary 인스턴스와 공유하지 마세요."
   output_exclusive_control_confirmation: "Tributary가 이 MPD 재생 파티션을 독점 제어함을 확인합니다."
-  output_detection_warning: "With supervision enabled, Tributary keeps observing the partition while it plays: a foreign current song, a foreign option change, or a lost observation window revokes playback control and keeps any orphaned queue entry. Supervision can only revoke, never grant: after such evidence the output refuses commands until you re-select it to confirm again."
-  output_detection_confirmation: "Supervise this exclusive output and revoke its control on evidence of another controller."
+  output_detection_warning: "감독을 활성화하면 Tributary는 재생 중에도 파티션을 계속 관찰합니다. 외부 현재 곡, 외부 옵션 변경 또는 관찰 공백이 감지되면 재생 제어 권한을 철회하고 고아 큐 항목을 유지합니다. 감독은 철회만 할 수 있으며 부여할 수는 없습니다. 이러한 증거가 감지되면 다시 선택하여 재확인할 때까지 이 출력은 명령을 거부합니다."
+  output_detection_confirmation: "이 배타 출력을 감독하고 다른 컨트롤러의 증거가 감지되면 제어를 철회합니다."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -145,6 +145,8 @@ dialogs:
   output_port: "포트"
   output_exclusive_control_warning: "MPD의 일시 정지, 정지, 반복, 무작위, 단일 및 consume 명령은 전체 재생 파티션에 영향을 줍니다. 다른 컨트롤러나 Tributary 인스턴스와 공유하지 마세요."
   output_exclusive_control_confirmation: "Tributary가 이 MPD 재생 파티션을 독점 제어함을 확인합니다."
+  output_detection_warning: "With supervision enabled, Tributary keeps observing the partition while it plays: a foreign current song, a foreign option change, or a lost observation window revokes playback control and keeps any orphaned queue entry. Supervision can only revoke, never grant: after such evidence the output refuses commands until you re-select it to confirm again."
+  output_detection_confirmation: "Supervise this exclusive output and revoke its control on evidence of another controller."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -145,6 +145,8 @@ dialogs:
   output_port: "Poort"
   output_exclusive_control_warning: "MPD-opdrachten voor pauzeren, stoppen, herhalen, willekeurig, enkel en verbruiken beïnvloeden de hele afspeelpartitie. Deel deze niet met een andere controller of Tributary-instantie."
   output_exclusive_control_confirmation: "Ik bevestig dat Tributary exclusieve controle over deze MPD-afspeelpartitie heeft."
+  output_detection_warning: "With supervision enabled, Tributary keeps observing the partition while it plays: a foreign current song, a foreign option change, or a lost observation window revokes playback control and keeps any orphaned queue entry. Supervision can only revoke, never grant: after such evidence the output refuses commands until you re-select it to confirm again."
+  output_detection_confirmation: "Supervise this exclusive output and revoke its control on evidence of another controller."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -145,8 +145,8 @@ dialogs:
   output_port: "Poort"
   output_exclusive_control_warning: "MPD-opdrachten voor pauzeren, stoppen, herhalen, willekeurig, enkel en verbruiken beïnvloeden de hele afspeelpartitie. Deel deze niet met een andere controller of Tributary-instantie."
   output_exclusive_control_confirmation: "Ik bevestig dat Tributary exclusieve controle over deze MPD-afspeelpartitie heeft."
-  output_detection_warning: "With supervision enabled, Tributary keeps observing the partition while it plays: a foreign current song, a foreign option change, or a lost observation window revokes playback control and keeps any orphaned queue entry. Supervision can only revoke, never grant: after such evidence the output refuses commands until you re-select it to confirm again."
-  output_detection_confirmation: "Supervise this exclusive output and revoke its control on evidence of another controller."
+  output_detection_warning: "Met toezicht ingeschakeld blijft Tributary de partitie observeren tijdens het afspelen: een vreemd huidig nummer, een vreemde optiewijziging of een verloren observatievenster trekt de afspeelcontrole in en behoudt elk wees-wachtrij-item. Toezicht kan alleen intrekken, nooit verlenen: na zulke aanwijzingen weigert de uitgang opdrachten totdat je hem opnieuw selecteert om opnieuw te bevestigen."
+  output_detection_confirmation: "Houd deze exclusieve uitgang in de gaten en trek de controle in bij aanwijzingen van een andere controller."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -145,6 +145,8 @@ dialogs:
   output_port: "Port"
   output_exclusive_control_warning: "Polecenia MPD wstrzymania, zatrzymania, powtarzania, losowania, trybu pojedynczego i zużywania dotyczą całej partycji odtwarzania. Nie udostępniaj jej innemu kontrolerowi ani innej instancji Tributary."
   output_exclusive_control_confirmation: "Potwierdzam, że Tributary ma wyłączną kontrolę nad tą partycją odtwarzania MPD."
+  output_detection_warning: "With supervision enabled, Tributary keeps observing the partition while it plays: a foreign current song, a foreign option change, or a lost observation window revokes playback control and keeps any orphaned queue entry. Supervision can only revoke, never grant: after such evidence the output refuses commands until you re-select it to confirm again."
+  output_detection_confirmation: "Supervise this exclusive output and revoke its control on evidence of another controller."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -145,8 +145,8 @@ dialogs:
   output_port: "Port"
   output_exclusive_control_warning: "Polecenia MPD wstrzymania, zatrzymania, powtarzania, losowania, trybu pojedynczego i zużywania dotyczą całej partycji odtwarzania. Nie udostępniaj jej innemu kontrolerowi ani innej instancji Tributary."
   output_exclusive_control_confirmation: "Potwierdzam, że Tributary ma wyłączną kontrolę nad tą partycją odtwarzania MPD."
-  output_detection_warning: "With supervision enabled, Tributary keeps observing the partition while it plays: a foreign current song, a foreign option change, or a lost observation window revokes playback control and keeps any orphaned queue entry. Supervision can only revoke, never grant: after such evidence the output refuses commands until you re-select it to confirm again."
-  output_detection_confirmation: "Supervise this exclusive output and revoke its control on evidence of another controller."
+  output_detection_warning: "Przy włączonym nadzorze Tributary dalej obserwuje partycję podczas odtwarzania: obcy bieżący utwór, obca zmiana opcji lub utracone okno obserwacji cofają kontrolę odtwarzania i zachowują każdy osierocony wpis kolejki. Nadzór może tylko cofać, nigdy przyznawać: po takich dowodach wyjście odrzuca polecenia do momentu ponownego wybrania go w celu ponownego potwierdzenia."
+  output_detection_confirmation: "Nadzoruj to wyłączne wyjście i cofaj jego kontrolę po dowodach działania innego kontrolera."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:

--- a/locales/pt-BR.yml
+++ b/locales/pt-BR.yml
@@ -145,8 +145,8 @@ dialogs:
   output_port: "Porta"
   output_exclusive_control_warning: "Os comandos MPD de pausar, parar, repetir, aleatório, único e consumir afetam toda a partição de reprodução. Não a compartilhe com outro controlador ou outra instância do Tributary."
   output_exclusive_control_confirmation: "Confirmo que o Tributary tem controle exclusivo desta partição de reprodução MPD."
-  output_detection_warning: "With supervision enabled, Tributary keeps observing the partition while it plays: a foreign current song, a foreign option change, or a lost observation window revokes playback control and keeps any orphaned queue entry. Supervision can only revoke, never grant: after such evidence the output refuses commands until you re-select it to confirm again."
-  output_detection_confirmation: "Supervise this exclusive output and revoke its control on evidence of another controller."
+  output_detection_warning: "Com a supervisão ativada, o Tributary continua observando a partição durante a reprodução: uma música atual estrangeira, uma alteração de opção estrangeira ou uma janela de observação perdida revoga o controle de reprodução e mantém qualquer entrada órfã da fila. A supervisão só pode revogar, nunca conceder: após tais evidências, a saída recusa comandos até que você a selecione novamente para confirmar de novo."
+  output_detection_confirmation: "Supervisione esta saída exclusiva e revogue seu controle mediante evidência de outro controlador."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:

--- a/locales/pt-BR.yml
+++ b/locales/pt-BR.yml
@@ -145,6 +145,8 @@ dialogs:
   output_port: "Porta"
   output_exclusive_control_warning: "Os comandos MPD de pausar, parar, repetir, aleatório, único e consumir afetam toda a partição de reprodução. Não a compartilhe com outro controlador ou outra instância do Tributary."
   output_exclusive_control_confirmation: "Confirmo que o Tributary tem controle exclusivo desta partição de reprodução MPD."
+  output_detection_warning: "With supervision enabled, Tributary keeps observing the partition while it plays: a foreign current song, a foreign option change, or a lost observation window revokes playback control and keeps any orphaned queue entry. Supervision can only revoke, never grant: after such evidence the output refuses commands until you re-select it to confirm again."
+  output_detection_confirmation: "Supervise this exclusive output and revoke its control on evidence of another controller."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -145,8 +145,8 @@ dialogs:
   output_port: "Порт"
   output_exclusive_control_warning: "Команды MPD паузы, остановки, повтора, случайного и одиночного воспроизведения и consume влияют на весь раздел воспроизведения. Не используйте его совместно с другим контроллером или экземпляром Tributary."
   output_exclusive_control_confirmation: "Я подтверждаю, что Tributary имеет исключительный контроль над этим разделом воспроизведения MPD."
-  output_detection_warning: "With supervision enabled, Tributary keeps observing the partition while it plays: a foreign current song, a foreign option change, or a lost observation window revokes playback control and keeps any orphaned queue entry. Supervision can only revoke, never grant: after such evidence the output refuses commands until you re-select it to confirm again."
-  output_detection_confirmation: "Supervise this exclusive output and revoke its control on evidence of another controller."
+  output_detection_warning: "При включённом надзоре Tributary продолжает наблюдать за разделом во время воспроизведения: посторонняя текущая песня, постороннее изменение параметра или пропущенное окно наблюдения отзывают управление воспроизведением и сохраняют любые потерянные записи очереди. Надзор может только отзывать, но не предоставлять: после таких свидетельств выход отказывает в командах, пока вы не выберете его заново для повторного подтверждения."
+  output_detection_confirmation: "Наблюдать за этим эксклюзивным выходом и отзывать его управление при свидетельствах другого контроллера."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -145,6 +145,8 @@ dialogs:
   output_port: "Порт"
   output_exclusive_control_warning: "Команды MPD паузы, остановки, повтора, случайного и одиночного воспроизведения и consume влияют на весь раздел воспроизведения. Не используйте его совместно с другим контроллером или экземпляром Tributary."
   output_exclusive_control_confirmation: "Я подтверждаю, что Tributary имеет исключительный контроль над этим разделом воспроизведения MPD."
+  output_detection_warning: "With supervision enabled, Tributary keeps observing the partition while it plays: a foreign current song, a foreign option change, or a lost observation window revokes playback control and keeps any orphaned queue entry. Supervision can only revoke, never grant: after such evidence the output refuses commands until you re-select it to confirm again."
+  output_detection_confirmation: "Supervise this exclusive output and revoke its control on evidence of another controller."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -145,6 +145,8 @@ dialogs:
   output_port: "端口"
   output_exclusive_control_warning: "MPD 的暂停、停止、重复、随机、单曲和 consume 命令会影响整个播放分区。请勿与其他控制器或 Tributary 实例共享。"
   output_exclusive_control_confirmation: "我确认 Tributary 独占控制此 MPD 播放分区。"
+  output_detection_warning: "With supervision enabled, Tributary keeps observing the partition while it plays: a foreign current song, a foreign option change, or a lost observation window revokes playback control and keeps any orphaned queue entry. Supervision can only revoke, never grant: after such evidence the output refuses commands until you re-select it to confirm again."
+  output_detection_confirmation: "Supervise this exclusive output and revoke its control on evidence of another controller."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -145,8 +145,8 @@ dialogs:
   output_port: "端口"
   output_exclusive_control_warning: "MPD 的暂停、停止、重复、随机、单曲和 consume 命令会影响整个播放分区。请勿与其他控制器或 Tributary 实例共享。"
   output_exclusive_control_confirmation: "我确认 Tributary 独占控制此 MPD 播放分区。"
-  output_detection_warning: "With supervision enabled, Tributary keeps observing the partition while it plays: a foreign current song, a foreign option change, or a lost observation window revokes playback control and keeps any orphaned queue entry. Supervision can only revoke, never grant: after such evidence the output refuses commands until you re-select it to confirm again."
-  output_detection_confirmation: "Supervise this exclusive output and revoke its control on evidence of another controller."
+  output_detection_warning: "启用监督后，Tributary 会在播放期间持续观察分区：外部当前歌曲、外部选项更改或观察窗口丢失都会撤销播放控制并保留任何孤立队列条目。监督只能撤销，绝不能授予：出现此类证据后，输出将拒绝命令，直到你重新选择它以再次确认。"
+  output_detection_confirmation: "监督此独占输出，并在检测到其他控制器的证据时撤销其控制。"
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:

--- a/locales/zh-TW.yml
+++ b/locales/zh-TW.yml
@@ -145,6 +145,8 @@ dialogs:
   output_port: "連接埠"
   output_exclusive_control_warning: "MPD 的暫停、停止、重複、隨機、單曲和 consume 指令會影響整個播放分割區。請勿與其他控制器或 Tributary 執行個體共用。"
   output_exclusive_control_confirmation: "我確認 Tributary 獨佔控制此 MPD 播放分割區。"
+  output_detection_warning: "With supervision enabled, Tributary keeps observing the partition while it plays: a foreign current song, a foreign option change, or a lost observation window revokes playback control and keeps any orphaned queue entry. Supervision can only revoke, never grant: after such evidence the output refuses commands until you re-select it to confirm again."
+  output_detection_confirmation: "Supervise this exclusive output and revoke its control on evidence of another controller."
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:

--- a/locales/zh-TW.yml
+++ b/locales/zh-TW.yml
@@ -145,8 +145,8 @@ dialogs:
   output_port: "連接埠"
   output_exclusive_control_warning: "MPD 的暫停、停止、重複、隨機、單曲和 consume 指令會影響整個播放分割區。請勿與其他控制器或 Tributary 執行個體共用。"
   output_exclusive_control_confirmation: "我確認 Tributary 獨佔控制此 MPD 播放分割區。"
-  output_detection_warning: "With supervision enabled, Tributary keeps observing the partition while it plays: a foreign current song, a foreign option change, or a lost observation window revokes playback control and keeps any orphaned queue entry. Supervision can only revoke, never grant: after such evidence the output refuses commands until you re-select it to confirm again."
-  output_detection_confirmation: "Supervise this exclusive output and revoke its control on evidence of another controller."
+  output_detection_warning: "啟用監督後，Tributary 會在播放期間持續觀察分割區：外部當前歌曲、外部選項變更或觀察視窗遺失都會撤銷播放控制並保留任何孤兒佇列項目。監督只能撤銷，永不授予：出現此類證據後，輸出將拒絕命令，直到你重新選擇它以再次確認。"
+  output_detection_confirmation: "監督此獨占輸出，並在偵測到其他控制器的證據時撤銷其控制。"
 
 # ── Playlist import and export ─────────────────────────────────────
 playlist_io:

--- a/src/audio/mpd_output.rs
+++ b/src/audio/mpd_output.rs
@@ -127,15 +127,6 @@ pub fn control_plan(exclusive_control: bool, detection_enabled: bool) -> MpdCont
     }
 }
 
-/// Whether `plan` currently authorises an authority-requiring command
-/// (loads, playback controls, orphan cleanup), given the supervisor's
-/// current `lapsed` state. The user's explicit `Exclusive` confirmation is
-/// the only grant; a supervised output whose supervisor has lapsed refuses
-/// until explicit reconfirmation.
-fn authority_allowed(plan: MpdControlPlan, lapsed: bool) -> bool {
-    plan.mode == MpdControlMode::Exclusive && !lapsed
-}
-
 /// Lifecycle of the revoke-only foreign-controller supervisor for a
 /// supervised `Exclusive` output. The supervisor NEVER grants authority —
 /// the user's explicit `Exclusive` confirmation is the only grant — and a
@@ -188,7 +179,12 @@ impl SupervisionState {
     fn new() -> Self {
         Self {
             phase: SupervisionPhase::Armed,
-            last_observation: None,
+            // The construction instant is the fresh explicit user
+            // confirmation that armed this supervisor: re-selecting the
+            // output IS the reconfirmation, so authority starts live and
+            // stays live only while clean observations keep it within
+            // [`MAX_SUPERVISION_GAP`].
+            last_observation: Some(Instant::now()),
         }
     }
 
@@ -209,6 +205,46 @@ impl SupervisionState {
 
     fn is_lapsed(&self) -> bool {
         self.phase == SupervisionPhase::Lapsed
+    }
+
+    /// The eager authority gate: whether this supervisor authorises an
+    /// authority-requiring action RIGHT NOW — `Armed` with a clean
+    /// observation (or the construction-time confirmation) no older than
+    /// [`MAX_SUPERVISION_GAP`]. An armed supervisor whose evidence has gone
+    /// stale lapses permanently — the unsupervised window is itself
+    /// disqualifying evidence — and returns `false`. Authority-requiring
+    /// paths call this BEFORE acting instead of waiting for the next status
+    /// poll to observe the gap, so a stale confirmation can never exercise
+    /// or renew itself.
+    fn authority_current(&mut self, now: Instant) -> bool {
+        if self.phase == SupervisionPhase::Lapsed {
+            return false;
+        }
+        if observation_gap_exceeded(self.last_observation, now) {
+            self.lapse();
+            return false;
+        }
+        true
+    }
+}
+
+/// Whether `plan` currently authorises an authority-requiring command
+/// (loads, playback controls, orphan cleanup). The user's explicit
+/// `Exclusive` confirmation is the only grant; an unsupervised `Exclusive`
+/// output proceeds on that confirmation alone, while a supervised output is
+/// authorised only while its supervisor is armed AND fresh — the eager
+/// [`SupervisionState::authority_current`] check, not the result of the
+/// last poll.
+fn supervision_authorizes(plan: MpdControlPlan, supervision: &Mutex<SupervisionState>) -> bool {
+    match plan.mode {
+        MpdControlMode::Unconfirmed => false,
+        MpdControlMode::Exclusive if !plan.supervised => true,
+        MpdControlMode::Exclusive => {
+            let mut supervisor = supervision
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
+            supervisor.authority_current(Instant::now())
+        }
     }
 }
 
@@ -1006,16 +1042,20 @@ struct MpdStatus {
     /// `false` means `repeat 0`, the value Tributary enforces on every load.
     /// A true value means another controller flipped the option without our
     /// knowledge, which lapses the supervisor and forces retention on
-    /// cleanup.
+    /// cleanup. Required in every status reply: an omission fails the poll
+    /// rather than reading as `false`.
     repeat: bool,
     /// `random` option as observed by the partition-wide status command.
     /// Tributary enforces `random 0` so a true value is a foreign mutation.
+    /// Required in every status reply.
     random: bool,
     /// `single` option as observed by the partition-wide status command.
     /// Tributary enforces `single 0` so a true value is a foreign mutation.
+    /// Required in every status reply.
     single: bool,
     /// `consume` option as observed by the partition-wide status command.
     /// Tributary enforces `consume 0` so a true value is a foreign mutation.
+    /// Required in every status reply.
     consume: bool,
 }
 
@@ -1493,16 +1533,26 @@ impl RawStatus {
         {
             return Err(MpdFailure::new("status poll"));
         }
+        // The four partition-wide options are REQUIRED observations: a
+        // status reply that omits any of them is incomplete evidence about
+        // the partition, and defaulting an omission to `false` would let a
+        // truncated, tampered, or foreign-shaped response read as a clean
+        // poll. Fail the poll instead — the supervisor's freshness window
+        // then revokes authority if complete evidence does not resume.
+        let repeat = self.repeat.ok_or_else(|| MpdFailure::new("status poll"))?;
+        let random = self.random.ok_or_else(|| MpdFailure::new("status poll"))?;
+        let single = self.single.ok_or_else(|| MpdFailure::new("status poll"))?;
+        let consume = self.consume.ok_or_else(|| MpdFailure::new("status poll"))?;
         Ok(MpdStatus {
             state,
             song_id: self.song_id,
             position_ms: self.elapsed_ms.or(self.fallback_elapsed_ms),
             duration_ms: self.duration_ms.or(self.fallback_duration_ms).unwrap_or(0),
             has_error: self.has_error,
-            repeat: self.repeat.unwrap_or(false),
-            random: self.random.unwrap_or(false),
-            single: self.single.unwrap_or(false),
-            consume: self.consume.unwrap_or(false),
+            repeat,
+            random,
+            single,
+            consume,
         })
     }
 }
@@ -2067,26 +2117,23 @@ fn run_mpd_worker<C>(
                 // playback controls — before any connection, MPD, or proxy
                 // action. This precedes cleanup as well. The user's explicit
                 // `Exclusive` confirmation is the only grant; a supervised
-                // output whose supervisor has lapsed refuses every
-                // authority-requiring command with the
+                // output whose supervisor has lapsed — or whose supervision
+                // evidence has gone stale, checked eagerly here rather than
+                // waiting for the next poll to observe the gap — refuses
+                // every authority-requiring command with the
                 // exclusive-control-required error until the user
                 // reconfirms by re-selecting the output. Quiet polling
                 // never re-arms the supervisor.
-                if command.kind.requires_authority() {
-                    let lapsed = supervision
-                        .lock()
-                        .unwrap_or_else(|poison| poison.into_inner())
-                        .is_lapsed();
-                    if !authority_allowed(plan, lapsed) {
-                        fail_current(
-                            command.owner,
-                            MpdFailure::exclusive_control_required(),
-                            &intent_epoch,
-                            &cache,
-                            &event_tx,
-                        );
-                        continue;
-                    }
+                if command.kind.requires_authority() && !supervision_authorizes(plan, &supervision)
+                {
+                    fail_current(
+                        command.owner,
+                        MpdFailure::exclusive_control_required(),
+                        &intent_epoch,
+                        &cache,
+                        &event_tx,
+                    );
+                    continue;
                 }
                 let poll_after = match command.kind {
                     CommandKind::Load { uri } => {
@@ -3342,13 +3389,11 @@ where
     // whose supervisor has lapsed — foreign current song, partition-option
     // drift, or an observation gap — also retains: stale confirmation must
     // never authorise cleanup, and only an explicit user reconfirmation
-    // restores the authority. Unsupervised `Exclusive` proceeds on the
-    // user's confirmation alone.
-    let lapsed = supervision
-        .lock()
-        .unwrap_or_else(|poison| poison.into_inner())
-        .is_lapsed();
-    if !authority_allowed(plan, lapsed) {
+    // restores the authority. The staleness check is eager: a supervised
+    // output whose supervision evidence is older than `MAX_SUPERVISION_GAP`
+    // retains too, without waiting for the next poll. Unsupervised
+    // `Exclusive` proceeds on the user's confirmation alone.
+    if !supervision_authorizes(plan, supervision) {
         return CleanupOutcome::Completed;
     }
     let removed = session.connection.delete_id(song_id, deadline);
@@ -3399,15 +3444,16 @@ fn cleanup_unconditionally<C>(
             Err(failure) => failure.connection_usable,
         };
         // Mirror the cleanup_session gate: only an `Exclusive` output whose
-        // supervisor has not lapsed may issue a targeted delete. The
+        // supervision is armed and fresh may issue a targeted delete. The
         // failure class of the call (shutdown, disconnect) is irrelevant —
-        // the orphan-retention guarantee applies in every cleanup path.
-        let lapsed = supervision
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner())
-            .is_lapsed();
-        let allowed = authority_allowed(plan, lapsed);
-        if can_delete && allowed {
+        // the orphan-retention guarantee applies in every cleanup path, and
+        // the freshness check is eager: supervision evidence older than
+        // `MAX_SUPERVISION_GAP` retains the orphan instead of awaiting a
+        // poll that will never come during shutdown.
+        if !supervision_authorizes(plan, supervision) {
+            return;
+        }
+        if can_delete {
             let _ = session.connection.delete_id(song_id, deadline);
         }
     }
@@ -3598,20 +3644,17 @@ impl MpdOutput {
         owner
     }
 
-    fn ensure_load_allowed(&self) -> bool {
-        let lapsed = self
-            .supervision
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner())
-            .is_lapsed();
-        if authority_allowed(self.plan, lapsed) {
+    /// The public authority gate shared by loads AND playback controls.
+    /// Runs BEFORE any local mutation (epoch advance, ticket revocation,
+    /// optimistic state publication) and before the command is enqueued:
+    /// a refused command must leave the output exactly as it was. The
+    /// worker repeats the check as defense in depth for any future or
+    /// internal caller that bypasses this boundary.
+    fn ensure_authority_allowed(&self) -> bool {
+        if supervision_authorizes(self.plan, &self.supervision) {
             return true;
         }
 
-        // Reject at the public output boundary before begin_load can advance
-        // the epoch or publish optimistic Buffering state. The worker repeats
-        // the check as defense in depth for any future/internal caller that
-        // bypasses this boundary.
         fail_current(
             self.current_owner(),
             MpdFailure::exclusive_control_required(),
@@ -3637,7 +3680,7 @@ impl AudioOutput for MpdOutput {
     }
 
     fn load_uri(&self, uri: &str) -> bool {
-        if !self.ensure_load_allowed() {
+        if !self.ensure_authority_allowed() {
             return false;
         }
         let owner = self.begin_load();
@@ -3658,7 +3701,7 @@ impl AudioOutput for MpdOutput {
     }
 
     fn load_resolved(&self, request: ResolvedHttpRequest) -> bool {
-        if !self.ensure_load_allowed() {
+        if !self.ensure_authority_allowed() {
             return false;
         }
         let owner = self.begin_load();
@@ -3676,7 +3719,7 @@ impl AudioOutput for MpdOutput {
     }
 
     fn load_local(&self, media: ResolvedLocalMedia) -> bool {
-        if !self.ensure_load_allowed() {
+        if !self.ensure_authority_allowed() {
             return false;
         }
         let owner = self.begin_load();
@@ -3690,14 +3733,26 @@ impl AudioOutput for MpdOutput {
     }
 
     fn play(&self) {
+        if !self.ensure_authority_allowed() {
+            return;
+        }
         self.enqueue(self.current_owner(), CommandKind::Play);
     }
 
     fn pause(&self) {
+        if !self.ensure_authority_allowed() {
+            return;
+        }
         self.enqueue(self.current_owner(), CommandKind::Pause);
     }
 
     fn stop(&self) {
+        // Preflight before ANY local mutation: a refused stop must not burn
+        // the intent epoch, revoke media tickets, or rewrite the cached
+        // player state — the gate's failure event is the only effect.
+        if !self.ensure_authority_allowed() {
+            return;
+        }
         let owner = self.next_owner();
         self.proxy.revoke_before(owner.epoch);
         {
@@ -3712,10 +3767,16 @@ impl AudioOutput for MpdOutput {
     }
 
     fn toggle_play_pause(&self) {
+        if !self.ensure_authority_allowed() {
+            return;
+        }
         self.enqueue(self.current_owner(), CommandKind::Toggle);
     }
 
     fn seek_to(&self, position_ms: u64) {
+        if !self.ensure_authority_allowed() {
+            return;
+        }
         self.enqueue(self.current_owner(), CommandKind::Seek(position_ms));
     }
 
@@ -4452,6 +4513,68 @@ mod tests {
     }
 
     #[test]
+    fn supervision_eager_gate_refuses_and_lapses_stale_evidence_without_waiting_for_a_poll() {
+        // Stale-between-polls: no poll has observed the observation gap
+        // yet, but an authority-requiring command arrives NOW. The eager
+        // gate must refuse immediately — the unsupervised window is itself
+        // disqualifying evidence, so the lapse is permanent — instead of
+        // letting the stale confirmation through until a later poll
+        // happens to notice the gap.
+        let mut state = SupervisionState::new();
+        let t0 = Instant::now();
+        let stale = t0
+            .checked_sub(MAX_SUPERVISION_GAP + Duration::from_millis(1))
+            .expect("backdated observation instant");
+        state.last_observation = Some(stale);
+        assert!(
+            !state.authority_current(t0),
+            "a stale confirmation must not authorise a command between polls"
+        );
+        assert!(
+            state.is_lapsed(),
+            "the eager gate itself revokes the stale authority"
+        );
+        // The lapse is terminal even though no poll has observed the gap:
+        // later clean observations never re-arm this instance.
+        state.observe(t0 + Duration::from_secs(3600));
+        assert!(
+            !state.authority_current(t0 + Duration::from_secs(3600)),
+            "observations after an eager lapse never restore authority"
+        );
+    }
+
+    #[test]
+    fn supervision_eager_gate_keeps_fresh_confirmation_authoritative() {
+        // The construction instant IS the explicit user confirmation, so a
+        // freshly re-selected output is authoritative immediately — no poll
+        // is needed to prove what the user just confirmed — and it stays
+        // authoritative up to and including the exact gap boundary.
+        let mut state = SupervisionState::new();
+        assert!(
+            state.authority_current(Instant::now()),
+            "a fresh confirmation authorises without a prior poll"
+        );
+        let t0 = Instant::now();
+        let mut state = SupervisionState::new();
+        state.last_observation = Some(t0);
+        assert!(state.authority_current(t0 + MAX_SUPERVISION_GAP));
+        assert!(
+            !state.is_lapsed(),
+            "the gap boundary itself is still fresh evidence"
+        );
+        // Reconfirmation is exactly this: constructing a fresh supervisor —
+        // what re-selecting the output does — re-arms authority that any
+        // lapse revoked. Observations on the lapsed instance never do.
+        state.lapse();
+        assert!(!state.authority_current(Instant::now()));
+        let mut reconfirmed = SupervisionState::new();
+        assert!(
+            reconfirmed.authority_current(Instant::now()),
+            "only an explicit reconfirmation re-arms a lapsed supervisor"
+        );
+    }
+
+    #[test]
     fn supervised_status_drift_lapses_the_supervisor() {
         let mut status = playing_status(0, 10_000);
         assert!(!status.observes_options_drift());
@@ -4759,6 +4882,125 @@ mod tests {
                 .count(),
             0,
             "post-lapse partition-global controls are refused"
+        );
+        harness.shutdown();
+    }
+
+    #[test]
+    fn supervised_worker_refuses_commands_whose_evidence_went_stale_between_polls() {
+        // The audit's stale-between-polls case at the worker gate: no poll
+        // has yet observed the observation gap (the harness polls only on
+        // demand), but the supervision evidence is already older than
+        // MAX_SUPERVISION_GAP when commands arrive. The worker must enforce
+        // the supervision age eagerly — refuse the command AND lapse the
+        // supervisor — instead of waving the stale confirmation through
+        // until some later poll happens to notice the gap.
+        let shared = FakeShared::new();
+        let proxy_shared = FakeProxyShared::new();
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let proxy = fake_proxy_services(Arc::clone(&proxy_shared), &runtime);
+        let harness = Harness::new_supervised_with_proxy(
+            Arc::clone(&shared),
+            proxy,
+            Duration::from_hours(1),
+            Duration::from_millis(1),
+        );
+        shared
+            .statuses
+            .lock()
+            .expect("statuses lock")
+            .push_back(playing_status(0, 10_000));
+        let owner = harness.next_owner(3);
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/clean".to_string(),
+            },
+        );
+        harness.fence(owner);
+        assert_eq!(
+            shared
+                .added_uris()
+                .iter()
+                .filter(|uri| *uri == "https://music.test/clean")
+                .count(),
+            1,
+            "the clean load executed exactly once"
+        );
+
+        // Evidence goes stale WITHOUT any poll observing it: the harness
+        // polls on demand only, so nothing refreshes the observation. The
+        // fence guarantees the load's synchronous follow-up poll already
+        // ran, so the backdate below cannot be raced by the worker.
+        let stale = Instant::now()
+            .checked_sub(MAX_SUPERVISION_GAP + Duration::from_secs(1))
+            .expect("backdated observation instant");
+        harness
+            .supervision
+            .lock()
+            .expect("supervision lock")
+            .last_observation = Some(stale);
+
+        // A partition-global playback control arrives between polls:
+        // refused before any MPD action.
+        harness.send(owner, CommandKind::Pause);
+        harness.fence(owner);
+        // A load arrives between polls: refused too.
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/stale".to_string(),
+            },
+        );
+        harness.fence(owner);
+
+        assert_eq!(
+            shared
+                .actions()
+                .iter()
+                .filter(|action| matches!(action, Action::Pause(_)))
+                .count(),
+            0,
+            "a stale-between-polls playback control is refused at the worker gate"
+        );
+        assert!(
+            !shared
+                .added_uris()
+                .iter()
+                .any(|uri| uri == "https://music.test/stale"),
+            "a stale-between-polls load is refused at the worker gate"
+        );
+        assert_eq!(
+            shared
+                .added_uris()
+                .iter()
+                .filter(|uri| *uri == "https://music.test/clean")
+                .count(),
+            1,
+            "no additional load reached MPD"
+        );
+        assert!(
+            harness
+                .supervision
+                .lock()
+                .expect("supervision lock")
+                .is_lapsed(),
+            "the worker gate lapses stale evidence eagerly"
+        );
+        let exclusive_errors = harness
+            .events()
+            .into_iter()
+            .filter(|event| {
+                matches!(
+                    event,
+                    PlayerEvent::Error { message, .. }
+                        if message == &mpd_exclusive_control_required_message(&rust_i18n::locale())
+                )
+            })
+            .count();
+        assert_eq!(
+            exclusive_errors, 2,
+            "both stale-between-polls commands report the exclusive-control error"
         );
         harness.shutdown();
     }
@@ -6910,6 +7152,108 @@ mod tests {
     }
 
     #[test]
+    fn supervised_public_controls_reject_before_any_local_mutation_when_stale() {
+        // Rejected-control contract at the public boundary: on a supervised
+        // output whose supervision evidence has gone stale between polls,
+        // EVERY partition-global playback control is refused eagerly — and
+        // the refusal happens BEFORE any local mutation: no intent-epoch
+        // advance, no media-ticket revocation, no cached-state rewrite, no
+        // worker command. The gate's failure event is the only effect, and
+        // the first refusal lapses the supervisor (the stale window is
+        // itself disqualifying evidence).
+        let shared = FakeProxyShared::new();
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let (event_tx, event_rx) = async_channel::unbounded();
+        let intent_epoch = Arc::new(AtomicU64::new(0));
+        let cache = Arc::new(Mutex::new(MpdCache::default()));
+        let (worker_tx, worker_rx) = worker_command_channel(MAX_PENDING_WORKER_COMMANDS);
+        let output = MpdOutput {
+            display_name: "supervised".to_string(),
+            event_tx,
+            event_generation: AtomicU64::new(11),
+            volume: 1.0,
+            plan: control_plan(true, true),
+            intent_epoch: Arc::clone(&intent_epoch),
+            cache: Arc::clone(&cache),
+            proxy: fake_proxy_services(Arc::clone(&shared), &runtime),
+            worker_tx,
+            supervision: Arc::new(Mutex::new(SupervisionState::new())),
+        };
+        // Stale-between-polls: backdate the supervision evidence past the
+        // gap without any poll having observed it.
+        let stale = Instant::now()
+            .checked_sub(MAX_SUPERVISION_GAP + Duration::from_secs(1))
+            .expect("backdated observation instant");
+        output
+            .supervision
+            .lock()
+            .expect("supervision lock")
+            .last_observation = Some(stale);
+
+        output.play();
+        assert!(
+            output
+                .supervision
+                .lock()
+                .expect("supervision lock")
+                .is_lapsed(),
+            "the first refused control lapses the stale supervisor eagerly"
+        );
+        output.pause();
+        output.toggle_play_pause();
+        output.seek_to(7_000);
+        output.stop();
+
+        assert_eq!(
+            intent_epoch.load(Ordering::SeqCst),
+            0,
+            "refused controls never advance the intent epoch"
+        );
+        assert!(
+            worker_rx.pop_pending().is_none(),
+            "refused controls never reach the worker"
+        );
+        let snapshot = *cache.lock().expect("cache lock");
+        assert_eq!(snapshot.state, PlayerState::Stopped);
+        assert_eq!(snapshot.position_ms, None);
+        assert!(
+            shared.starts.lock().expect("proxy starts lock").is_empty(),
+            "refused controls never register a media ticket"
+        );
+        // Exactly one Stopped publication plus one exclusive-control error
+        // per refused control — no other events.
+        let mut events = Vec::new();
+        while let Ok(event) = event_rx.try_recv() {
+            events.push(event);
+        }
+        let refused = ["play", "pause", "toggle", "seek", "stop"].len();
+        assert_eq!(
+            events.len(),
+            refused * 2,
+            "each refused control emits exactly its Stopped publication and error"
+        );
+        for event in &events {
+            match event {
+                PlayerEvent::StateChanged {
+                    generation,
+                    state: PlayerState::Stopped,
+                } => assert_eq!(generation.as_raw(), 11),
+                PlayerEvent::Error {
+                    generation,
+                    message,
+                } => {
+                    assert_eq!(generation.as_raw(), 11);
+                    assert_eq!(
+                        message,
+                        &mpd_exclusive_control_required_message(&rust_i18n::locale())
+                    );
+                }
+                other => panic!("unexpected event from a refused control: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
     fn load_resets_cached_track_before_the_worker_receives_it() {
         let (event_tx, _event_rx) = async_channel::unbounded();
         let intent_epoch = Arc::new(AtomicU64::new(0));
@@ -7031,24 +7375,78 @@ mod tests {
         }
     }
 
+    /// Parse a full, valid status reply. Every line of a real MPD `status`
+    /// response that Tributary requires is present, so `finish()` succeeds.
+    fn parse_status_lines(lines: &[&str]) -> MpdResult<MpdStatus> {
+        let mut status = RawStatus::default();
+        for line in lines {
+            status.parse_line(line)?;
+        }
+        status.finish()
+    }
+
     #[test]
     fn status_parses_fractional_and_legacy_time() {
-        let mut status = RawStatus::default();
-        status.parse_line("state: play").expect("state");
-        status.parse_line("songid: 42").expect("song id");
-        status.parse_line("elapsed: 1.250").expect("elapsed");
-        status.parse_line("duration: 9.750").expect("duration");
-        let status = status.finish().expect("valid status");
+        let status = parse_status_lines(&[
+            "state: play",
+            "songid: 42",
+            "elapsed: 1.250",
+            "duration: 9.750",
+            "repeat: 0",
+            "random: 0",
+            "single: 0",
+            "consume: 0",
+        ])
+        .expect("valid status");
         assert_eq!(status.position_ms, Some(1_250));
         assert_eq!(status.duration_ms, 9_750);
 
-        let mut fallback = RawStatus::default();
-        fallback.parse_line("state: pause").expect("state");
-        fallback.parse_line("songid: 7").expect("song id");
-        fallback.parse_line("time: 2:11").expect("legacy time");
-        let fallback = fallback.finish().expect("valid fallback");
+        let fallback = parse_status_lines(&[
+            "state: pause",
+            "songid: 7",
+            "time: 2:11",
+            "repeat: 0",
+            "random: 0",
+            "single: 0",
+            "consume: 0",
+        ])
+        .expect("valid fallback");
         assert_eq!(fallback.position_ms, Some(2_000));
         assert_eq!(fallback.duration_ms, 11_000);
+    }
+
+    #[test]
+    fn status_requires_every_partition_option_field() {
+        // A status reply that omits any of repeat/random/single/consume is
+        // incomplete evidence about the partition: defaulting the omission
+        // to `false` would let a truncated or foreign-shaped response read
+        // as a clean poll, so `finish()` must reject it. Each field is
+        // required independently — the reply stays invalid until the last
+        // one arrives, and `0`/`1` values parse as false/true.
+        let base = ["state: play", "songid: 42", "elapsed: 1.0"];
+        for missing in ["repeat", "random", "single", "consume"] {
+            let mut lines: Vec<&str> = base.to_vec();
+            lines.extend(["repeat: 0", "random: 0", "single: 0", "consume: 0"]);
+            lines.retain(|line| !line.starts_with(missing));
+            assert!(
+                parse_status_lines(&lines).is_err(),
+                "a status reply without `{missing}` must fail the poll"
+            );
+        }
+        let complete = parse_status_lines(&[
+            "state: play",
+            "songid: 42",
+            "elapsed: 1.0",
+            "repeat: 1",
+            "random: 0",
+            "single: 0",
+            "consume: 1",
+        ])
+        .expect("all four option fields present");
+        assert!(complete.repeat);
+        assert!(complete.consume);
+        assert!(!complete.random);
+        assert!(!complete.single);
     }
 
     #[test]
@@ -7102,6 +7500,9 @@ mod tests {
         status
             .parse_line("error: https://music.test/a?token=secret")
             .expect("error marker");
+        for option in ["repeat: 0", "random: 0", "single: 0", "consume: 0"] {
+            status.parse_line(option).expect("required option field");
+        }
         let status = status.finish().expect("typed status retained");
         assert!(status.has_error);
         let message = mpd_failure_message(MpdFailure::new("remote playback"));
@@ -7608,13 +8009,13 @@ mod tests {
             read_test_command(&mut reader, "status");
             write_test_response(
                 &mut stream,
-                b"songid: 42\nelapsed: 0.000\nduration: 10.000\nstate: play\nOK\n",
+                b"songid: 42\nelapsed: 0.000\nduration: 10.000\nrepeat: 0\nrandom: 0\nsingle: 0\nconsume: 0\nstate: play\nOK\n",
             );
 
             read_test_command(&mut reader, "status");
             write_test_response(
                 &mut stream,
-                b"songid: 42\nelapsed: 0.000\nduration: 10.000\nstate: play\nOK\n",
+                b"songid: 42\nelapsed: 0.000\nduration: 10.000\nrepeat: 0\nrandom: 0\nsingle: 0\nconsume: 0\nstate: play\nOK\n",
             );
             read_test_command(&mut reader, "pause 1");
             pause_seen_tx.send(()).expect("pause observed");
@@ -7648,31 +8049,31 @@ mod tests {
             read_test_command(&mut reader, "status");
             write_test_response(
                 &mut stream,
-                b"songid: 42\nelapsed: 0.000\nduration: 10.000\nstate: pause\nOK\n",
+                b"songid: 42\nelapsed: 0.000\nduration: 10.000\nrepeat: 0\nrandom: 0\nsingle: 0\nconsume: 0\nstate: pause\nOK\n",
             );
             read_test_command(&mut reader, "status");
             write_test_response(
                 &mut stream,
-                b"songid: 42\nelapsed: 0.000\nduration: 10.000\nstate: pause\nOK\n",
+                b"songid: 42\nelapsed: 0.000\nduration: 10.000\nrepeat: 0\nrandom: 0\nsingle: 0\nconsume: 0\nstate: pause\nOK\n",
             );
             read_test_command(&mut reader, "seekid 42 7.000");
             write_test_response(&mut stream, b"OK\n");
             read_test_command(&mut reader, "status");
             write_test_response(
                 &mut stream,
-                b"songid: 42\nelapsed: 7.000\nduration: 10.000\nstate: pause\nOK\n",
+                b"songid: 42\nelapsed: 7.000\nduration: 10.000\nrepeat: 0\nrandom: 0\nsingle: 0\nconsume: 0\nstate: pause\nOK\n",
             );
             read_test_command(&mut reader, "status");
             write_test_response(
                 &mut stream,
-                b"songid: 42\nelapsed: 7.000\nduration: 10.000\nstate: pause\nOK\n",
+                b"songid: 42\nelapsed: 7.000\nduration: 10.000\nrepeat: 0\nrandom: 0\nsingle: 0\nconsume: 0\nstate: pause\nOK\n",
             );
             read_test_command(&mut reader, "pause 0");
             write_test_response(&mut stream, b"OK\n");
             read_test_command(&mut reader, "status");
             write_test_response(
                 &mut stream,
-                b"songid: 42\nelapsed: 7.000\nduration: 10.000\nstate: play\nOK\n",
+                b"songid: 42\nelapsed: 7.000\nduration: 10.000\nrepeat: 0\nrandom: 0\nsingle: 0\nconsume: 0\nstate: play\nOK\n",
             );
 
             // Shutdown revalidates once. A foreign current id deliberately
@@ -7680,7 +8081,7 @@ mod tests {
             read_test_command(&mut reader, "status");
             write_test_response(
                 &mut stream,
-                b"songid: 99\nelapsed: 0.000\nduration: 10.000\nstate: play\nOK\n",
+                b"songid: 99\nelapsed: 0.000\nduration: 10.000\nrepeat: 0\nrandom: 0\nsingle: 0\nconsume: 0\nstate: play\nOK\n",
             );
         });
 
@@ -7812,7 +8213,7 @@ mod tests {
             ("playid 42".to_string(), b"OK\n".to_vec()),
             (
                 "status".to_string(),
-                b"duration: 125.750\nsongid: 42\nelapsed: 1.250\nstate: play\nOK\n".to_vec(),
+                b"duration: 125.750\nsongid: 42\nelapsed: 1.250\nrepeat: 0\nrandom: 0\nsingle: 0\nconsume: 0\nstate: play\nOK\n".to_vec(),
             ),
             ("deleteid 42".to_string(), b"OK\n".to_vec()),
         ]);

--- a/src/audio/mpd_output.rs
+++ b/src/audio/mpd_output.rs
@@ -51,9 +51,28 @@ const MAX_PENDING_WORKER_COMMANDS: usize = 64;
 /// option commands. MPD exposes no atomic ownership check for those commands,
 /// so playback remains fail-closed until the user explicitly confirms that no
 /// other controller or Tributary instance shares the partition.
+///
+/// This is the ONLY grant. No amount of clean observation can promote an
+/// output into authority: MPD offers no ownership lock, lease, token, or
+/// atomic conditional partition mutation (2026-07-17 P2.10 / PR #112), so an
+/// automatically granted "detected exclusive" mode is infeasible by
+/// construction. Observation exists purely to revoke (see
+/// [`SupervisionState`]).
+///
+/// Legacy entries persisted before this mode existed always deserialize as
+/// `Unconfirmed`; that gate preserves the invariant that no MPD command can
+/// be issued without an explicit user confirmation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MpdControlMode {
+    /// The user has not confirmed exclusive control. The worker must refuse
+    /// every load before any connection, MPD command, or proxy/ticket action.
     Unconfirmed,
+    /// The user confirmed this Tributary instance exclusively controls the
+    /// MPD playback partition. Partition-wide playback and option commands
+    /// are issued unconditionally — unless the output is supervised and the
+    /// supervisor has lapsed (foreign-controller evidence), in which case
+    /// every authority-requiring command is refused until the user
+    /// explicitly reconfirms by re-selecting the output.
     Exclusive,
 }
 
@@ -67,17 +86,148 @@ impl From<bool> for MpdControlMode {
     }
 }
 
+/// Runtime authority plan translated from the persisted output flags. Shared
+/// by every construction path (the Add Output dialog and the saved-outputs
+/// loader both build an `OutputTarget::Mpd` whose flags flow through
+/// [`control_plan`]) so the public mode and the supervision wiring can never
+/// disagree with what was persisted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MpdControlPlan {
+    /// The authority mode. Only [`MpdControlMode::Exclusive`] grants
+    /// authority, and only ever because the user explicitly confirmed it.
+    pub mode: MpdControlMode,
+    /// Whether the revoke-only foreign-controller supervisor is wired. A
+    /// supervised `Exclusive` output loses its authority the moment the
+    /// supervisor observes foreign-controller evidence.
+    pub supervised: bool,
+}
+
+/// Translate the persisted output flags into the runtime authority plan.
+///
+/// Fail-closed rules:
+/// - `exclusive_control: false` is [`MpdControlMode::Unconfirmed`] regardless
+///   of `detection_enabled`: observation can only ever revoke authority, so
+///   a detection opt-in without an explicit exclusive confirmation grants
+///   nothing. A legacy `detection_enabled: true` entry persisted by the
+///   abandoned auto-grant design is refused here rather than promoted.
+/// - `exclusive_control: true` with `detection_enabled: true` is supervised
+///   `Exclusive`: the user's confirmation is the grant; the supervisor may
+///   revoke it on foreign-controller evidence and only a fresh explicit user
+///   action (re-selecting the output) restores it.
+pub fn control_plan(exclusive_control: bool, detection_enabled: bool) -> MpdControlPlan {
+    match (exclusive_control, detection_enabled) {
+        (true, supervised) => MpdControlPlan {
+            mode: MpdControlMode::Exclusive,
+            supervised,
+        },
+        (false, _) => MpdControlPlan {
+            mode: MpdControlMode::Unconfirmed,
+            supervised: false,
+        },
+    }
+}
+
+/// Whether `plan` currently authorises an authority-requiring command
+/// (loads, playback controls, orphan cleanup), given the supervisor's
+/// current `lapsed` state. The user's explicit `Exclusive` confirmation is
+/// the only grant; a supervised output whose supervisor has lapsed refuses
+/// until explicit reconfirmation.
+fn authority_allowed(plan: MpdControlPlan, lapsed: bool) -> bool {
+    plan.mode == MpdControlMode::Exclusive && !lapsed
+}
+
+/// Lifecycle of the revoke-only foreign-controller supervisor for a
+/// supervised `Exclusive` output. The supervisor NEVER grants authority —
+/// the user's explicit `Exclusive` confirmation is the only grant — and a
+/// clean observation never restores it. It starts `Armed` when the output is
+/// constructed from an explicit user confirmation and moves to `Lapsed` on
+/// the first piece of foreign-controller evidence:
+///
+/// - a foreign current song (another controller owns partition playback),
+/// - any of repeat/random/single/consume drifting away from the enforced
+///   defaults (another controller mutated partition options),
+/// - an observation gap beyond [`MAX_SUPERVISION_GAP`] (a window in which
+///   another controller could have acted unseen).
+///
+/// Once `Lapsed`, the supervisor stays lapsed for the lifetime of this
+/// output instance: quiet polling cannot restore it, and no worker action
+/// re-arms it. The explicit user action of re-selecting the output
+/// constructs a fresh instance with a fresh `Armed` supervisor — that is the
+/// reconfirmation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SupervisionPhase {
+    Armed,
+    Lapsed,
+}
+
+/// Mutable supervision state shared between the worker (which observes
+/// status) and the public load boundary (which refuses post-lapse controls).
+#[derive(Debug)]
+struct SupervisionState {
+    phase: SupervisionPhase,
+    /// Last instant at which the worker observed a clean status. Used to
+    /// lapse the supervisor when too long passes without fresh evidence of
+    /// an uncontended partition.
+    last_observation: Option<Instant>,
+}
+
+/// Maximum allowed gap between status observations for a supervised output.
+/// A longer gap means the partition could have been mutated by another
+/// controller without the supervisor seeing it, so the supervisor lapses.
+/// Must exceed the production `STATUS_POLL_INTERVAL` (500 ms) so a healthy
+/// output never lapses spuriously.
+const MAX_SUPERVISION_GAP: Duration = Duration::from_secs(2);
+
+/// Whether the gap between the last clean observation and `now` exceeds
+/// [`MAX_SUPERVISION_GAP`]. Extracted for deterministic testing.
+fn observation_gap_exceeded(last: Option<Instant>, now: Instant) -> bool {
+    last.is_some_and(|last| now.duration_since(last) > MAX_SUPERVISION_GAP)
+}
+
+impl SupervisionState {
+    fn new() -> Self {
+        Self {
+            phase: SupervisionPhase::Armed,
+            last_observation: None,
+        }
+    }
+
+    /// Record one clean observation instant. This NEVER changes the phase:
+    /// quiet polling neither grants nor restores authority.
+    fn observe(&mut self, now: Instant) {
+        if self.phase == SupervisionPhase::Armed {
+            self.last_observation = Some(now);
+        }
+    }
+
+    /// Revoke authority on foreign-controller evidence. Idempotent; a lapsed
+    /// supervisor is terminal for this output instance.
+    fn lapse(&mut self) {
+        self.phase = SupervisionPhase::Lapsed;
+        self.last_observation = None;
+    }
+
+    fn is_lapsed(&self) -> bool {
+        self.phase == SupervisionPhase::Lapsed
+    }
+}
+
 pub struct MpdOutput {
     #[allow(dead_code)]
     display_name: String,
     event_tx: async_channel::Sender<PlayerEvent>,
     event_generation: AtomicU64,
     volume: f64,
-    control_mode: MpdControlMode,
+    plan: MpdControlPlan,
     intent_epoch: Arc<AtomicU64>,
     cache: Arc<Mutex<MpdCache>>,
     proxy: ProxyServices,
     worker_tx: WorkerCommandSender,
+    /// Revoke-only supervision state shared with the worker. The field
+    /// itself is retained so callers (and the test harness) can inspect or
+    /// seed the supervisor; the worker is the only writer.
+    #[allow(dead_code)]
+    supervision: Arc<Mutex<SupervisionState>>,
 }
 
 #[derive(Clone, Copy)]
@@ -141,6 +291,18 @@ impl CommandKind {
 
     fn is_playback_control(&self) -> bool {
         matches!(self, Self::Play | Self::Pause | Self::Toggle)
+    }
+
+    /// Whether this command requires partition authority. Loads are the
+    /// primary authority gate; the partition-global playback controls
+    /// (`Play`/`Pause`/`Toggle`, plus `Seek` and `Stop`, which reach the
+    /// shared partition transport state) require it too, so a supervised
+    /// output that has lapsed cannot issue post-lapse controls. `Shutdown`
+    /// and the test-only variants never require authority.
+    fn requires_authority(&self) -> bool {
+        self.is_load_intent()
+            || self.is_playback_control()
+            || matches!(self, Self::Seek(_) | Self::Stop)
     }
 }
 
@@ -833,12 +995,38 @@ enum MpdPlaybackState {
 }
 
 #[derive(Debug, Clone, Copy)]
+#[allow(clippy::struct_excessive_bools)]
 struct MpdStatus {
     state: MpdPlaybackState,
     song_id: Option<u64>,
     position_ms: Option<u64>,
     duration_ms: u64,
     has_error: bool,
+    /// `repeat` option as observed by the partition-wide status command.
+    /// `false` means `repeat 0`, the value Tributary enforces on every load.
+    /// A true value means another controller flipped the option without our
+    /// knowledge, which lapses the supervisor and forces retention on
+    /// cleanup.
+    repeat: bool,
+    /// `random` option as observed by the partition-wide status command.
+    /// Tributary enforces `random 0` so a true value is a foreign mutation.
+    random: bool,
+    /// `single` option as observed by the partition-wide status command.
+    /// Tributary enforces `single 0` so a true value is a foreign mutation.
+    single: bool,
+    /// `consume` option as observed by the partition-wide status command.
+    /// Tributary enforces `consume 0` so a true value is a foreign mutation.
+    consume: bool,
+}
+
+impl MpdStatus {
+    /// Returns `true` if any partition-wide playback option is set to a
+    /// value other than the one Tributary enforces on every load. Any drift
+    /// means another controller mutated the partition, so the supervisor
+    /// must lapse and orphan cleanup must retain the owned entry.
+    fn observes_options_drift(&self) -> bool {
+        self.repeat || self.random || self.single || self.consume
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1226,6 +1414,13 @@ struct RawStatus {
     fallback_elapsed_ms: Option<u64>,
     fallback_duration_ms: Option<u64>,
     has_error: bool,
+    /// `repeat` option. MPD reports `0` or `1`; we map any non-zero value
+    /// to `true` so a foreign `repeat 1` is detected even if MPD adds new
+    /// non-zero values in a future protocol revision.
+    repeat: Option<bool>,
+    random: Option<bool>,
+    single: Option<bool>,
+    consume: Option<bool>,
 }
 
 impl RawStatus {
@@ -1273,6 +1468,18 @@ impl RawStatus {
                 self.fallback_elapsed_ms = Some(parse_seconds(elapsed, "status poll")?);
                 self.fallback_duration_ms = Some(parse_seconds(duration, "status poll")?);
             }
+            "repeat" => {
+                self.repeat = Some(parse_option_truthy(value, "status poll")?);
+            }
+            "random" => {
+                self.random = Some(parse_option_truthy(value, "status poll")?);
+            }
+            "single" => {
+                self.single = Some(parse_option_truthy(value, "status poll")?);
+            }
+            "consume" => {
+                self.consume = Some(parse_option_truthy(value, "status poll")?);
+            }
             "error" => self.has_error = true,
             _ => {}
         }
@@ -1292,8 +1499,25 @@ impl RawStatus {
             position_ms: self.elapsed_ms.or(self.fallback_elapsed_ms),
             duration_ms: self.duration_ms.or(self.fallback_duration_ms).unwrap_or(0),
             has_error: self.has_error,
+            repeat: self.repeat.unwrap_or(false),
+            random: self.random.unwrap_or(false),
+            single: self.single.unwrap_or(false),
+            consume: self.consume.unwrap_or(false),
         })
     }
+}
+
+/// Parse MPD's `repeat`/`random`/`single`/`consume` option values. MPD
+/// reports `0` for the default we enforce on every load and `1` for the
+/// alternative; some daemons reply with `true`/`false` or other non-zero
+/// integers. Anything that is not an exact `0` is mapped to `true` so a
+/// foreign mutation of the partition is always detected.
+fn parse_option_truthy(value: &str, operation: &'static str) -> MpdResult<bool> {
+    if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(MpdFailure::new(operation));
+    }
+    let parsed = parse_u64(value, operation)?;
+    Ok(parsed != 0)
 }
 
 fn parse_u64(value: &str, operation: &'static str) -> MpdResult<u64> {
@@ -1779,14 +2003,16 @@ enum MpdMedia {
     Protected(MpdUpstream),
 }
 
+#[allow(clippy::too_many_arguments)]
 fn spawn_mpd_worker<C>(
     connector: C,
-    control_mode: MpdControlMode,
+    plan: MpdControlPlan,
     intent_epoch: Arc<AtomicU64>,
     cache: Arc<Mutex<MpdCache>>,
     event_tx: async_channel::Sender<PlayerEvent>,
     timing: WorkerTiming,
     proxy: ProxyServices,
+    supervision: Arc<Mutex<SupervisionState>>,
 ) -> WorkerCommandSender
 where
     C: MpdConnector,
@@ -1798,12 +2024,13 @@ where
             run_mpd_worker(
                 connector,
                 worker_rx,
-                control_mode,
+                plan,
                 intent_epoch,
                 cache,
                 event_tx,
                 timing,
                 proxy,
+                supervision,
             );
         });
     if let Err(spawn_error) = spawn {
@@ -1816,12 +2043,13 @@ where
 fn run_mpd_worker<C>(
     mut connector: C,
     worker_rx: WorkerCommandReceiver,
-    control_mode: MpdControlMode,
+    plan: MpdControlPlan,
     intent_epoch: Arc<AtomicU64>,
     cache: Arc<Mutex<MpdCache>>,
     event_tx: async_channel::Sender<PlayerEvent>,
     timing: WorkerTiming,
     proxy: ProxyServices,
+    supervision: Arc<Mutex<SupervisionState>>,
 ) where
     C: MpdConnector,
 {
@@ -1834,18 +2062,31 @@ fn run_mpd_worker<C>(
         };
         match worker_rx.recv_timeout(wait) {
             Ok(command) => {
-                // Apply the partition-ownership contract to every load intent,
-                // including media rejected before dispatch. This precedes
-                // cleanup as well as every connection, MPD, and proxy action.
-                if control_mode != MpdControlMode::Exclusive && command.kind.is_load_intent() {
-                    fail_current(
-                        command.owner,
-                        MpdFailure::exclusive_control_required(),
-                        &intent_epoch,
-                        &cache,
-                        &event_tx,
-                    );
-                    continue;
+                // Apply the partition-ownership contract to every
+                // authority-requiring command — loads AND partition-global
+                // playback controls — before any connection, MPD, or proxy
+                // action. This precedes cleanup as well. The user's explicit
+                // `Exclusive` confirmation is the only grant; a supervised
+                // output whose supervisor has lapsed refuses every
+                // authority-requiring command with the
+                // exclusive-control-required error until the user
+                // reconfirms by re-selecting the output. Quiet polling
+                // never re-arms the supervisor.
+                if command.kind.requires_authority() {
+                    let lapsed = supervision
+                        .lock()
+                        .unwrap_or_else(|poison| poison.into_inner())
+                        .is_lapsed();
+                    if !authority_allowed(plan, lapsed) {
+                        fail_current(
+                            command.owner,
+                            MpdFailure::exclusive_control_required(),
+                            &intent_epoch,
+                            &cache,
+                            &event_tx,
+                        );
+                        continue;
+                    }
                 }
                 let poll_after = match command.kind {
                     CommandKind::Load { uri } => {
@@ -1859,6 +2100,8 @@ fn run_mpd_worker<C>(
                             &cache,
                             &event_tx,
                             timing,
+                            plan,
+                            &supervision,
                         );
                         true
                     }
@@ -1873,6 +2116,8 @@ fn run_mpd_worker<C>(
                             &cache,
                             &event_tx,
                             timing,
+                            plan,
+                            &supervision,
                         );
                         true
                     }
@@ -1887,6 +2132,8 @@ fn run_mpd_worker<C>(
                             &cache,
                             &event_tx,
                             timing,
+                            plan,
+                            &supervision,
                         );
                         true
                     }
@@ -1901,6 +2148,8 @@ fn run_mpd_worker<C>(
                             &cache,
                             &event_tx,
                             timing,
+                            plan,
+                            &supervision,
                         );
                         true
                     }
@@ -1911,6 +2160,8 @@ fn run_mpd_worker<C>(
                             CleanupKind::Targeted,
                             &intent_epoch,
                             timing,
+                            plan,
+                            &supervision,
                         );
                         if !matches!(cleanup, CleanupOutcome::Stale) {
                             fail_current(command.owner, failure, &intent_epoch, &cache, &event_tx);
@@ -1924,6 +2175,8 @@ fn run_mpd_worker<C>(
                             CleanupKind::StopOwned,
                             &intent_epoch,
                             timing,
+                            plan,
+                            &supervision,
                         ) {
                             CleanupOutcome::Completed => {
                                 let _ = publish_state(
@@ -1947,12 +2200,21 @@ fn run_mpd_worker<C>(
                         true
                     }
                     CommandKind::Shutdown => {
-                        cleanup_unconditionally(&mut active, timing);
+                        cleanup_unconditionally(&mut active, timing, plan, &supervision);
                         break;
                     }
                     #[cfg(test)]
                     CommandKind::PollNow => {
-                        poll_active(&mut active, true, &intent_epoch, &cache, &event_tx, timing);
+                        poll_active(
+                            &mut active,
+                            true,
+                            &intent_epoch,
+                            &cache,
+                            &event_tx,
+                            timing,
+                            plan,
+                            &supervision,
+                        );
                         false
                     }
                     #[cfg(test)]
@@ -1969,19 +2231,39 @@ fn run_mpd_worker<C>(
                             &cache,
                             &event_tx,
                             timing,
+                            plan,
+                            &supervision,
                         );
                         true
                     }
                 };
                 if poll_after {
-                    poll_active(&mut active, false, &intent_epoch, &cache, &event_tx, timing);
+                    poll_active(
+                        &mut active,
+                        false,
+                        &intent_epoch,
+                        &cache,
+                        &event_tx,
+                        timing,
+                        plan,
+                        &supervision,
+                    );
                 }
             }
             Err(mpsc::RecvTimeoutError::Timeout) => {
-                poll_active(&mut active, false, &intent_epoch, &cache, &event_tx, timing);
+                poll_active(
+                    &mut active,
+                    false,
+                    &intent_epoch,
+                    &cache,
+                    &event_tx,
+                    timing,
+                    plan,
+                    &supervision,
+                );
             }
             Err(mpsc::RecvTimeoutError::Disconnected) => {
-                cleanup_unconditionally(&mut active, timing);
+                cleanup_unconditionally(&mut active, timing, plan, &supervision);
                 break;
             }
         }
@@ -1999,10 +2281,20 @@ fn handle_load<C>(
     cache: &Mutex<MpdCache>,
     event_tx: &async_channel::Sender<PlayerEvent>,
     timing: WorkerTiming,
+    plan: MpdControlPlan,
+    supervision: &Arc<Mutex<SupervisionState>>,
 ) where
     C: MpdConnector,
 {
-    match cleanup_session(active, owner, CleanupKind::Targeted, intent_epoch, timing) {
+    match cleanup_session(
+        active,
+        owner,
+        CleanupKind::Targeted,
+        intent_epoch,
+        timing,
+        plan,
+        supervision,
+    ) {
         CleanupOutcome::Completed => {}
         CleanupOutcome::Failed(failure) => {
             error!(operation = failure.operation, "Previous MPD cleanup failed");
@@ -2054,7 +2346,17 @@ fn handle_load<C>(
         .expect("connected MPD session recorded")
         .connection
         .repeat_off(deadline);
-    if !finish_load_stage(repeat, active, owner, intent_epoch, cache, event_tx, timing) {
+    if !finish_load_stage(
+        repeat,
+        active,
+        owner,
+        intent_epoch,
+        cache,
+        event_tx,
+        timing,
+        plan,
+        supervision,
+    ) {
         return;
     }
     if !is_current(owner, intent_epoch) {
@@ -2067,7 +2369,17 @@ fn handle_load<C>(
         .expect("connected MPD session recorded")
         .connection
         .random_off(deadline);
-    if !finish_load_stage(random, active, owner, intent_epoch, cache, event_tx, timing) {
+    if !finish_load_stage(
+        random,
+        active,
+        owner,
+        intent_epoch,
+        cache,
+        event_tx,
+        timing,
+        plan,
+        supervision,
+    ) {
         return;
     }
     if !is_current(owner, intent_epoch) {
@@ -2080,7 +2392,17 @@ fn handle_load<C>(
         .expect("connected MPD session recorded")
         .connection
         .single_off(deadline);
-    if !finish_load_stage(single, active, owner, intent_epoch, cache, event_tx, timing) {
+    if !finish_load_stage(
+        single,
+        active,
+        owner,
+        intent_epoch,
+        cache,
+        event_tx,
+        timing,
+        plan,
+        supervision,
+    ) {
         return;
     }
     if !is_current(owner, intent_epoch) {
@@ -2101,6 +2423,8 @@ fn handle_load<C>(
         cache,
         event_tx,
         timing,
+        plan,
+        supervision,
     ) {
         return;
     }
@@ -2126,6 +2450,8 @@ fn handle_load<C>(
                         cache,
                         event_tx,
                         timing,
+                        plan,
+                        supervision,
                     );
                     return;
                 }
@@ -2142,6 +2468,8 @@ fn handle_load<C>(
                         cache,
                         event_tx,
                         timing,
+                        plan,
+                        supervision,
                     );
                     return;
                 }
@@ -2168,6 +2496,10 @@ fn handle_load<C>(
             .as_mut()
             .expect("connected MPD session recorded")
             .song_id = Some(song_id);
+        // No supervisor re-arming happens here. The supervisor is
+        // revoke-only: it is armed once by the user's explicit
+        // confirmation at construction time and is never reset by loads
+        // or observations. Quiet polling cannot restore authority.
     }
     if retire_poisoned_if_stale(&added, active, owner, intent_epoch) {
         return;
@@ -2183,6 +2515,8 @@ fn handle_load<C>(
                 cache,
                 event_tx,
                 timing,
+                plan,
+                supervision,
             );
             return;
         }
@@ -2192,7 +2526,17 @@ fn handle_load<C>(
         .expect("connected MPD session recorded")
         .connection
         .play_id(song_id, deadline);
-    if !finish_load_stage(played, active, owner, intent_epoch, cache, event_tx, timing) {
+    if !finish_load_stage(
+        played,
+        active,
+        owner,
+        intent_epoch,
+        cache,
+        event_tx,
+        timing,
+        plan,
+        supervision,
+    ) {
         return;
     }
     if let Some(session) = active.as_mut() {
@@ -2221,6 +2565,8 @@ fn handle_load<C>(
                 cache,
                 event_tx,
                 timing,
+                plan,
+                supervision,
             );
         }
         Err(failure) => cleanup_then_fail(
@@ -2231,6 +2577,8 @@ fn handle_load<C>(
             cache,
             event_tx,
             timing,
+            plan,
+            supervision,
         ),
     }
 }
@@ -2244,6 +2592,8 @@ fn finish_load_stage<T, C>(
     cache: &Mutex<MpdCache>,
     event_tx: &async_channel::Sender<PlayerEvent>,
     timing: WorkerTiming,
+    plan: MpdControlPlan,
+    supervision: &Arc<Mutex<SupervisionState>>,
 ) -> bool
 where
     C: MpdTransport,
@@ -2262,6 +2612,8 @@ where
                 cache,
                 event_tx,
                 timing,
+                plan,
+                supervision,
             );
             false
         }
@@ -2285,6 +2637,52 @@ fn retire_poisoned_if_stale<T, C>(
 
 fn status_observes_foreign_song(status: &MpdStatus, song_id: u64) -> bool {
     status.song_id.is_some() && status.song_id != Some(song_id)
+}
+
+/// Observe one authoritative status for a supervised output. This is a
+/// REVOKE-ONLY check: a foreign current song, an option drift, or an
+/// observation gap past [`MAX_SUPERVISION_GAP`] lapses the supervisor (and
+/// thereby revokes the user-confirmed authority), but a clean observation
+/// never grants or restores anything — quiet polling cannot re-arm a lapsed
+/// supervisor. Only a fresh explicit user confirmation (re-selecting the
+/// output, which constructs a fresh `Armed` supervisor) restores authority.
+fn observe_supervision<C>(
+    active: &Option<WorkerSession<C>>,
+    owner: CommandOwner,
+    status: &MpdStatus,
+    intent_epoch: &AtomicU64,
+    plan: MpdControlPlan,
+    supervision: &Arc<Mutex<SupervisionState>>,
+) {
+    if !(plan.supervised && plan.mode == MpdControlMode::Exclusive) {
+        return;
+    }
+    if !is_current(owner, intent_epoch) {
+        return;
+    }
+    let Some(session) = active.as_ref() else {
+        return;
+    };
+    let Some(song_id) = session.song_id else {
+        return;
+    };
+    let now = Instant::now();
+    let mut supervisor = supervision
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    if supervisor.is_lapsed() {
+        // Terminal for this output instance: never restore on polling.
+        return;
+    }
+    if status_observes_foreign_song(status, song_id) || status.observes_options_drift() {
+        supervisor.lapse();
+        return;
+    }
+    if observation_gap_exceeded(supervisor.last_observation, now) {
+        supervisor.lapse();
+        return;
+    }
+    supervisor.observe(now);
 }
 
 fn retire_status_if_stale<C>(
@@ -2317,11 +2715,21 @@ fn cleanup_then_fail<C>(
     cache: &Mutex<MpdCache>,
     event_tx: &async_channel::Sender<PlayerEvent>,
     timing: WorkerTiming,
+    plan: MpdControlPlan,
+    supervision: &Arc<Mutex<SupervisionState>>,
 ) where
     C: MpdTransport,
 {
     if failure.connection_usable {
-        let _ = cleanup_session(active, owner, CleanupKind::Targeted, intent_epoch, timing);
+        let _ = cleanup_session(
+            active,
+            owner,
+            CleanupKind::Targeted,
+            intent_epoch,
+            timing,
+            plan,
+            supervision,
+        );
     } else {
         // An I/O timeout, partial write, truncated response, or parser failure
         // may leave unread bytes or a half-command on the stream. Drop it
@@ -2401,6 +2809,8 @@ fn handle_control<C>(
     cache: &Mutex<MpdCache>,
     event_tx: &async_channel::Sender<PlayerEvent>,
     timing: WorkerTiming,
+    plan: MpdControlPlan,
+    supervision: &Arc<Mutex<SupervisionState>>,
 ) where
     C: MpdTransport,
 {
@@ -2439,6 +2849,8 @@ fn handle_control<C>(
                 cache,
                 event_tx,
                 timing,
+                plan,
+                supervision,
             );
         }
         Err(failure) => {
@@ -2494,6 +2906,8 @@ fn handle_control<C>(
             cache,
             event_tx,
             timing,
+            plan,
+            supervision,
         );
         return;
     }
@@ -2518,6 +2932,8 @@ fn handle_control<C>(
                 cache,
                 event_tx,
                 timing,
+                plan,
+                supervision,
             );
         }
         Err(failure) => cleanup_then_fail(
@@ -2528,6 +2944,8 @@ fn handle_control<C>(
             cache,
             event_tx,
             timing,
+            plan,
+            supervision,
         ),
     }
 }
@@ -2540,6 +2958,8 @@ fn poll_active<C>(
     cache: &Mutex<MpdCache>,
     event_tx: &async_channel::Sender<PlayerEvent>,
     timing: WorkerTiming,
+    plan: MpdControlPlan,
+    supervision: &Arc<Mutex<SupervisionState>>,
 ) where
     C: MpdTransport,
 {
@@ -2575,11 +2995,23 @@ fn poll_active<C>(
                 cache,
                 event_tx,
                 timing,
+                plan,
+                supervision,
             );
             return;
         }
     };
-    apply_authoritative_status(active, owner, status, intent_epoch, cache, event_tx, timing);
+    apply_authoritative_status(
+        active,
+        owner,
+        status,
+        intent_epoch,
+        cache,
+        event_tx,
+        timing,
+        plan,
+        supervision,
+    );
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2591,9 +3023,18 @@ fn apply_authoritative_status<C>(
     cache: &Mutex<MpdCache>,
     event_tx: &async_channel::Sender<PlayerEvent>,
     timing: WorkerTiming,
+    plan: MpdControlPlan,
+    supervision: &Arc<Mutex<SupervisionState>>,
 ) where
     C: MpdTransport,
 {
+    // Supervise the partition on every authoritative status. This is a
+    // revoke-only check for supervised outputs: foreign-controller evidence
+    // (foreign current song, option drift, observation gap) revokes the
+    // user-confirmed authority, while clean observations never grant or
+    // restore anything.
+    observe_supervision(active, owner, &status, intent_epoch, plan, supervision);
+
     if !is_current(owner, intent_epoch) {
         return;
     }
@@ -2817,6 +3258,8 @@ fn cleanup_session<C>(
     kind: CleanupKind,
     intent_epoch: &AtomicU64,
     timing: WorkerTiming,
+    plan: MpdControlPlan,
+    supervision: &Arc<Mutex<SupervisionState>>,
 ) -> CleanupOutcome
 where
     C: MpdTransport,
@@ -2893,6 +3336,21 @@ where
         *active = Some(session);
         return CleanupOutcome::Stale;
     }
+    // The targeted delete is the one MPD operation that can race a foreign
+    // controller. Under `Unconfirmed` we conservatively retain the orphan so
+    // any other client retains its anyway. A supervised `Exclusive` output
+    // whose supervisor has lapsed — foreign current song, partition-option
+    // drift, or an observation gap — also retains: stale confirmation must
+    // never authorise cleanup, and only an explicit user reconfirmation
+    // restores the authority. Unsupervised `Exclusive` proceeds on the
+    // user's confirmation alone.
+    let lapsed = supervision
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .is_lapsed();
+    if !authority_allowed(plan, lapsed) {
+        return CleanupOutcome::Completed;
+    }
     let removed = session.connection.delete_id(song_id, deadline);
     if !is_current(owner, intent_epoch) {
         // Removed, already absent, rejected, or poisoned are all terminal for
@@ -2907,8 +3365,12 @@ where
     }
 }
 
-fn cleanup_unconditionally<C>(active: &mut Option<WorkerSession<C>>, timing: WorkerTiming)
-where
+fn cleanup_unconditionally<C>(
+    active: &mut Option<WorkerSession<C>>,
+    timing: WorkerTiming,
+    plan: MpdControlPlan,
+    supervision: &Arc<Mutex<SupervisionState>>,
+) where
     C: MpdTransport,
 {
     if let Some(mut session) = active.take() {
@@ -2936,7 +3398,16 @@ where
             Ok(_) => true,
             Err(failure) => failure.connection_usable,
         };
-        if can_delete {
+        // Mirror the cleanup_session gate: only an `Exclusive` output whose
+        // supervisor has not lapsed may issue a targeted delete. The
+        // failure class of the call (shutdown, disconnect) is irrelevant —
+        // the orphan-retention guarantee applies in every cleanup path.
+        let lapsed = supervision
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .is_lapsed();
+        let allowed = authority_allowed(plan, lapsed);
+        if can_delete && allowed {
             let _ = session.connection.delete_id(song_id, deadline);
         }
     }
@@ -3019,35 +3490,38 @@ impl MpdOutput {
         display_name: &str,
         host: &str,
         port: u16,
-        control_mode: MpdControlMode,
+        plan: MpdControlPlan,
         event_tx: async_channel::Sender<PlayerEvent>,
     ) -> Self {
-        info!(host = %host, port, name = %display_name, ?control_mode, "MPD output configured");
+        info!(host = %host, port, name = %display_name, ?plan, "MPD output configured");
         let intent_epoch = Arc::new(AtomicU64::new(0));
         let cache = Arc::new(Mutex::new(MpdCache::default()));
         let proxy = ProxyServices::production();
+        let supervision = Arc::new(Mutex::new(SupervisionState::new()));
         let worker_tx = spawn_mpd_worker(
             MpdTcpConnector {
                 host: host.to_string(),
                 port,
             },
-            control_mode,
+            plan,
             Arc::clone(&intent_epoch),
             Arc::clone(&cache),
             event_tx.clone(),
             WorkerTiming::production(),
             proxy.clone(),
+            Arc::clone(&supervision),
         );
         Self {
             display_name: display_name.to_string(),
             event_tx,
             event_generation: AtomicU64::new(0),
             volume: 1.0,
-            control_mode,
+            plan,
             intent_epoch,
             cache,
             proxy,
             worker_tx,
+            supervision,
         }
     }
 
@@ -3125,7 +3599,12 @@ impl MpdOutput {
     }
 
     fn ensure_load_allowed(&self) -> bool {
-        if self.control_mode == MpdControlMode::Exclusive {
+        let lapsed = self
+            .supervision
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .is_lapsed();
+        if authority_allowed(self.plan, lapsed) {
             return true;
         }
 
@@ -3659,6 +4138,10 @@ mod tests {
             position_ms: Some(position_ms),
             duration_ms,
             has_error: false,
+            repeat: false,
+            random: false,
+            single: false,
+            consume: false,
         }
     }
 
@@ -3669,6 +4152,10 @@ mod tests {
             position_ms: Some(position_ms),
             duration_ms,
             has_error: false,
+            repeat: false,
+            random: false,
+            single: false,
+            consume: false,
         }
     }
 
@@ -3679,6 +4166,10 @@ mod tests {
             position_ms: Some(position_ms),
             duration_ms,
             has_error: false,
+            repeat: false,
+            random: false,
+            single: false,
+            consume: false,
         }
     }
 
@@ -3689,6 +4180,8 @@ mod tests {
         events: async_channel::Receiver<PlayerEvent>,
         proxy: ProxyServices,
         worker: Option<std::thread::JoinHandle<()>>,
+        #[allow(dead_code)]
+        supervision: Arc<Mutex<SupervisionState>>,
     }
 
     impl Harness {
@@ -3724,11 +4217,11 @@ mod tests {
             timing: WorkerTiming,
             proxy: ProxyServices,
         ) -> Self {
-            Self::new_with_mode_and_proxy(shared, timing, proxy, MpdControlMode::Exclusive)
+            Self::new_with_plan_and_proxy(shared, timing, proxy, control_plan(true, false))
         }
 
         fn new_unconfirmed_with_proxy(shared: Arc<FakeShared>, proxy: ProxyServices) -> Self {
-            Self::new_with_mode_and_proxy(
+            Self::new_with_plan_and_proxy(
                 shared,
                 WorkerTiming {
                     operation: Duration::from_secs(2),
@@ -3736,15 +4229,36 @@ mod tests {
                     tick: Duration::from_millis(10),
                 },
                 proxy,
-                MpdControlMode::Unconfirmed,
+                control_plan(false, false),
             )
         }
 
-        fn new_with_mode_and_proxy(
+        /// Supervised `Exclusive`: the user explicitly confirmed exclusive
+        /// control AND opted into the revoke-only foreign-controller
+        /// supervisor.
+        fn new_supervised_with_proxy(
+            shared: Arc<FakeShared>,
+            proxy: ProxyServices,
+            poll: Duration,
+            tick: Duration,
+        ) -> Self {
+            Self::new_with_plan_and_proxy(
+                shared,
+                WorkerTiming {
+                    operation: Duration::from_secs(2),
+                    poll,
+                    tick,
+                },
+                proxy,
+                control_plan(true, true),
+            )
+        }
+
+        fn new_with_plan_and_proxy(
             shared: Arc<FakeShared>,
             timing: WorkerTiming,
             proxy: ProxyServices,
-            control_mode: MpdControlMode,
+            plan: MpdControlPlan,
         ) -> Self {
             let (tx, rx) = worker_command_channel(MAX_PENDING_WORKER_COMMANDS);
             let epoch = Arc::new(AtomicU64::new(0));
@@ -3753,16 +4267,19 @@ mod tests {
             let epoch_for_worker = Arc::clone(&epoch);
             let cache_for_worker = Arc::clone(&cache);
             let worker_proxy = proxy.clone();
+            let supervision = Arc::new(Mutex::new(SupervisionState::new()));
+            let supervision_for_worker = Arc::clone(&supervision);
             let worker = std::thread::spawn(move || {
                 run_mpd_worker(
                     FakeConnector { shared },
                     rx,
-                    control_mode,
+                    plan,
                     epoch_for_worker,
                     cache_for_worker,
                     event_tx,
                     timing,
                     worker_proxy,
+                    supervision_for_worker,
                 );
             });
             Self {
@@ -3772,6 +4289,7 @@ mod tests {
                 events,
                 proxy,
                 worker: Some(worker),
+                supervision,
             }
         }
 
@@ -3888,6 +4406,466 @@ mod tests {
         assert_unconfirmed_load_has_no_side_effect(CommandKind::RejectLoad {
             failure: MpdFailure::new("media URI validation"),
         });
+    }
+
+    #[test]
+    fn supervision_state_starts_armed_and_never_restores_after_lapse() {
+        let mut state = SupervisionState::new();
+        assert!(!state.is_lapsed(), "a fresh supervisor is armed");
+        let t0 = Instant::now();
+        state.observe(t0);
+        assert!(
+            !state.is_lapsed(),
+            "clean observations keep the supervisor armed"
+        );
+        state.lapse();
+        assert!(state.is_lapsed(), "lapse revokes the confirmed authority");
+        // Quiet polling after the lapse must never restore authority: the
+        // supervisor is revoke-only and the only reconfirmation is an
+        // explicit user action (a fresh supervised output instance).
+        state.observe(t0 + Duration::from_millis(1));
+        state.observe(t0 + Duration::from_secs(3600));
+        assert!(
+            state.is_lapsed(),
+            "clean polling never restores a lapsed supervisor"
+        );
+        // Lapse is idempotent.
+        state.lapse();
+        assert!(state.is_lapsed());
+    }
+
+    #[test]
+    fn observation_gap_beyond_max_supervision_gap_is_detected() {
+        let t0 = Instant::now();
+        assert!(
+            !observation_gap_exceeded(None, t0),
+            "no prior observation means no gap yet"
+        );
+        assert!(!observation_gap_exceeded(
+            Some(t0),
+            t0 + MAX_SUPERVISION_GAP
+        ));
+        assert!(observation_gap_exceeded(
+            Some(t0),
+            t0 + MAX_SUPERVISION_GAP + Duration::from_millis(1)
+        ));
+    }
+
+    #[test]
+    fn supervised_status_drift_lapses_the_supervisor() {
+        let mut status = playing_status(0, 10_000);
+        assert!(!status.observes_options_drift());
+        status.random = true;
+        assert!(status.observes_options_drift());
+        status.random = false;
+        status.consume = true;
+        assert!(status.observes_options_drift());
+        status.consume = false;
+        status.single = true;
+        assert!(status.observes_options_drift());
+        status.single = false;
+        status.repeat = true;
+        assert!(status.observes_options_drift());
+        // A foreign current song is foreign-controller evidence too: the
+        // helper used by `observe_supervision` reports it for our id.
+        let mut foreign = playing_status(0, 10_000);
+        foreign.song_id = Some(99);
+        assert!(status_observes_foreign_song(&foreign, 42));
+    }
+
+    #[test]
+    fn detection_optin_without_exclusive_confirms_nothing() {
+        // `detection_enabled` without the user's explicit exclusive
+        // confirmation is `Unconfirmed`: loads are refused before any MPD
+        // action, and no amount of clean status polling ever grants
+        // authority. This is the fail-closed replacement for the abandoned
+        // auto-grant `Detected` mode — observation exists only to revoke.
+        let shared = FakeShared::new();
+        let proxy_shared = FakeProxyShared::new();
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let proxy = fake_proxy_services(Arc::clone(&proxy_shared), &runtime);
+        let harness = Harness::new_with_plan_and_proxy(
+            Arc::clone(&shared),
+            WorkerTiming {
+                operation: Duration::from_secs(2),
+                poll: Duration::from_hours(1),
+                tick: Duration::from_millis(1),
+            },
+            proxy,
+            control_plan(false, true),
+        );
+        // Clean statuses queued: even if they were all observed, they
+        // could never promote this output into authority.
+        for _ in 0..8 {
+            shared
+                .statuses
+                .lock()
+                .expect("statuses lock")
+                .push_back(playing_status(0, 10_000));
+        }
+        let owner = harness.next_owner(17);
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/first".to_string(),
+            },
+        );
+        harness.send(owner, CommandKind::PollNow);
+        harness.send(owner, CommandKind::PollNow);
+        harness.fence(owner);
+        assert!(
+            shared.actions().is_empty(),
+            "no MPD command may occur without the explicit grant"
+        );
+        assert!(
+            shared.added_uris().is_empty(),
+            "no queue mutation without the explicit grant"
+        );
+        // A second load after all that clean polling is still refused:
+        // quiet polling does not grant authority.
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/second".to_string(),
+            },
+        );
+        harness.fence(owner);
+        assert!(
+            shared.actions().is_empty(),
+            "clean polling must never promote the output into authority"
+        );
+        assert_eq!(harness.cache().state, PlayerState::Stopped);
+        let _ = harness.events();
+        harness.shutdown();
+    }
+
+    #[test]
+    fn supervised_exclusive_loads_clean_and_stays_armed() {
+        // A supervised `Exclusive` output is armed by the user's explicit
+        // confirmation: a clean load executes immediately (no probe
+        // warm-up, no self-confirmation from the output's own state) and
+        // stays armed while the status observations are clean. Authority
+        // was granted by the user, not by polling.
+        let shared = FakeShared::new();
+        let proxy_shared = FakeProxyShared::new();
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let proxy = fake_proxy_services(Arc::clone(&proxy_shared), &runtime);
+        // `poll: hours(1)` keeps the worker from auto-polling so the
+        // exact statuses we pre-populate are the only ones read.
+        let harness = Harness::new_supervised_with_proxy(
+            Arc::clone(&shared),
+            proxy,
+            Duration::from_hours(1),
+            Duration::from_millis(1),
+        );
+        shared
+            .statuses
+            .lock()
+            .expect("statuses lock")
+            .push_back(playing_status(0, 10_000));
+        let owner = harness.next_owner(7);
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/clean".to_string(),
+            },
+        );
+        harness.fence(owner);
+        assert!(
+            shared
+                .added_uris()
+                .iter()
+                .any(|uri| uri == "https://music.test/clean"),
+            "the supervised load must execute on the user's confirmation alone"
+        );
+        assert!(
+            !harness
+                .supervision
+                .lock()
+                .expect("supervision lock")
+                .is_lapsed(),
+            "clean evidence keeps the armed supervisor armed"
+        );
+        harness.shutdown();
+    }
+
+    #[test]
+    fn supervised_exclusive_lapses_on_foreign_song_and_blocks_post_lapse_loads() {
+        // A foreign current song is foreign-controller evidence: the
+        // supervisor lapses and every authority-requiring command is
+        // refused from that point on. Quiet clean polling must not
+        // restore the lapsed authority — only a fresh explicit user
+        // confirmation (a new output instance) can.
+        let shared = FakeShared::new();
+        let proxy_shared = FakeProxyShared::new();
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let proxy = fake_proxy_services(Arc::clone(&proxy_shared), &runtime);
+        let harness = Harness::new_supervised_with_proxy(
+            Arc::clone(&shared),
+            proxy,
+            Duration::from_hours(1),
+            Duration::from_millis(1),
+        );
+        shared
+            .statuses
+            .lock()
+            .expect("statuses lock")
+            .push_back(playing_status(0, 10_000));
+        let owner = harness.next_owner(7);
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/clean".to_string(),
+            },
+        );
+        harness.fence(owner);
+        assert_eq!(
+            shared
+                .added_uris()
+                .iter()
+                .filter(|uri| *uri == "https://music.test/clean")
+                .count(),
+            1,
+            "the clean load executed exactly once"
+        );
+
+        // Foreign evidence arrives: another controller owns playback.
+        let mut foreign = playing_status(0, 10_000);
+        foreign.song_id = Some(99);
+        shared
+            .statuses
+            .lock()
+            .expect("statuses lock")
+            .push_back(foreign);
+        harness.send(owner, CommandKind::PollNow);
+        harness.fence(owner);
+        assert!(
+            harness
+                .supervision
+                .lock()
+                .expect("supervision lock")
+                .is_lapsed(),
+            "a foreign current song must revoke the user-confirmed authority"
+        );
+
+        // A post-lapse load is refused before any new MPD action.
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/after-lapse".to_string(),
+            },
+        );
+        harness.fence(owner);
+        assert!(
+            !shared
+                .added_uris()
+                .iter()
+                .any(|uri| uri == "https://music.test/after-lapse"),
+            "post-lapse loads are refused"
+        );
+
+        // Quiet clean polling does not restore authority.
+        shared
+            .statuses
+            .lock()
+            .expect("statuses lock")
+            .push_back(playing_status(0, 10_000));
+        harness.send(owner, CommandKind::PollNow);
+        harness.fence(owner);
+        assert!(
+            harness
+                .supervision
+                .lock()
+                .expect("supervision lock")
+                .is_lapsed(),
+            "polling never restores a lapsed supervisor"
+        );
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/after-quiet-poll".to_string(),
+            },
+        );
+        harness.fence(owner);
+        assert!(
+            !shared
+                .added_uris()
+                .iter()
+                .any(|uri| uri == "https://music.test/after-quiet-poll"),
+            "the output stays refused until explicit reconfirmation"
+        );
+        harness.shutdown();
+    }
+
+    #[test]
+    fn supervised_exclusive_lapses_on_option_drift_and_blocks_post_lapse_controls() {
+        // Partition-option drift (repeat/random/single/consume away from
+        // the enforced defaults) is partition-global foreign evidence.
+        // The supervisor lapses; the session itself may still be ours, so
+        // the partition-global playback controls must ALSO be refused —
+        // authority, not session ownership, is what they require.
+        let shared = FakeShared::new();
+        let proxy_shared = FakeProxyShared::new();
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let proxy = fake_proxy_services(Arc::clone(&proxy_shared), &runtime);
+        let harness = Harness::new_supervised_with_proxy(
+            Arc::clone(&shared),
+            proxy,
+            Duration::from_hours(1),
+            Duration::from_millis(1),
+        );
+        shared
+            .statuses
+            .lock()
+            .expect("statuses lock")
+            .push_back(playing_status(0, 10_000));
+        let owner = harness.next_owner(1);
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/clean".to_string(),
+            },
+        );
+        harness.fence(owner);
+
+        // Option drift arrives while our own song is still current.
+        let mut drifted = playing_status(0, 10_000);
+        drifted.repeat = true;
+        shared
+            .statuses
+            .lock()
+            .expect("statuses lock")
+            .push_back(drifted);
+        harness.send(owner, CommandKind::PollNow);
+        harness.fence(owner);
+        assert!(
+            harness
+                .supervision
+                .lock()
+                .expect("supervision lock")
+                .is_lapsed(),
+            "partition-option drift must revoke the user-confirmed authority"
+        );
+
+        // Post-lapse playback controls are refused: no pause command may
+        // reach MPD even though the session is still ours.
+        harness.send(owner, CommandKind::Pause);
+        harness.fence(owner);
+        assert_eq!(
+            shared
+                .actions()
+                .iter()
+                .filter(|action| matches!(action, Action::Pause(_)))
+                .count(),
+            0,
+            "post-lapse partition-global controls are refused"
+        );
+        harness.shutdown();
+    }
+
+    #[test]
+    fn supervised_exclusive_shutdown_after_lapse_keeps_orphan() {
+        // Stale confirmation must not authorise cleanup: once the
+        // supervisor has lapsed, even the shutdown cleanup retains the
+        // owned queue entry. Only an armed supervisor (or an unsupervised
+        // `Exclusive`) may delete.
+        let shared = FakeShared::new();
+        let proxy_shared = FakeProxyShared::new();
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let proxy = fake_proxy_services(Arc::clone(&proxy_shared), &runtime);
+        let harness = Harness::new_supervised_with_proxy(
+            Arc::clone(&shared),
+            proxy,
+            Duration::from_hours(1),
+            Duration::from_millis(1),
+        );
+        shared
+            .statuses
+            .lock()
+            .expect("statuses lock")
+            .push_back(playing_status(0, 10_000));
+        let owner = harness.next_owner(3);
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/quiet".to_string(),
+            },
+        );
+        harness.fence(owner);
+
+        // Lapse via a foreign current song, then shut down.
+        let mut foreign = playing_status(0, 10_000);
+        foreign.song_id = Some(99);
+        shared
+            .statuses
+            .lock()
+            .expect("statuses lock")
+            .push_back(foreign);
+        harness.send(owner, CommandKind::PollNow);
+        harness.fence(owner);
+        assert!(
+            harness
+                .supervision
+                .lock()
+                .expect("supervision lock")
+                .is_lapsed(),
+            "the foreign song must have lapsed the supervisor"
+        );
+
+        harness.shutdown();
+        assert_eq!(
+            shared
+                .actions()
+                .iter()
+                .filter(|action| matches!(action, Action::Delete(42)))
+                .count(),
+            0,
+            "a lapsed supervisor must not authorise orphan deletion, even on shutdown"
+        );
+    }
+
+    #[test]
+    fn unsupervised_exclusive_shutdown_still_deletes_owned_orphan() {
+        // The retain-on-lapse rule is supervision-specific: an
+        // unsupervised `Exclusive` output keeps its pre-existing
+        // behaviour — the user's confirmation alone authorises the
+        // targeted delete on shutdown, exactly once.
+        let shared = FakeShared::new();
+        let proxy_shared = FakeProxyShared::new();
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let proxy = fake_proxy_services(Arc::clone(&proxy_shared), &runtime);
+        let harness = Harness::new_with_timing_and_proxy(
+            Arc::clone(&shared),
+            WorkerTiming {
+                operation: Duration::from_secs(2),
+                poll: Duration::from_hours(1),
+                tick: Duration::from_millis(10),
+            },
+            proxy,
+        );
+        shared
+            .statuses
+            .lock()
+            .expect("statuses lock")
+            .push_back(playing_status(0, 10_000));
+        let owner = harness.next_owner(3);
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/quiet".to_string(),
+            },
+        );
+        harness.fence(owner);
+        harness.shutdown();
+        assert_eq!(
+            shared
+                .actions()
+                .iter()
+                .filter(|action| matches!(action, Action::Delete(42)))
+                .count(),
+            1,
+            "the user-confirmed unsupervised delete happens exactly once"
+        );
     }
 
     #[test]
@@ -4616,6 +5594,10 @@ mod tests {
                 position_ms: None,
                 duration_ms: 0,
                 has_error: false,
+                repeat: false,
+                random: false,
+                single: false,
+                consume: false,
             });
         let harness = Harness::new(Arc::clone(&shared));
         let owner = harness.next_owner(1);
@@ -5884,11 +6866,12 @@ mod tests {
             event_tx,
             event_generation: AtomicU64::new(9),
             volume: 1.0,
-            control_mode: MpdControlMode::Unconfirmed,
+            plan: control_plan(false, false),
             intent_epoch: Arc::clone(&intent_epoch),
             cache: Arc::clone(&cache),
             proxy: ProxyServices::production(),
             worker_tx,
+            supervision: Arc::new(Mutex::new(SupervisionState::new())),
         };
 
         assert!(!output.load_uri("file:///music/retry.flac"));
@@ -5940,11 +6923,12 @@ mod tests {
             event_tx,
             event_generation: AtomicU64::new(7),
             volume: 1.0,
-            control_mode: MpdControlMode::Exclusive,
+            plan: control_plan(true, false),
             intent_epoch: Arc::clone(&intent_epoch),
             cache: Arc::clone(&cache),
             proxy: ProxyServices::production(),
             worker_tx,
+            supervision: Arc::new(Mutex::new(SupervisionState::new())),
         };
 
         assert!(output.load_uri("https://music.test/new"));
@@ -5974,11 +6958,12 @@ mod tests {
             event_tx,
             event_generation: AtomicU64::new(1),
             volume: 1.0,
-            control_mode: MpdControlMode::Exclusive,
+            plan: control_plan(true, false),
             intent_epoch,
             cache,
             proxy: ProxyServices::production(),
             worker_tx,
+            supervision: Arc::new(Mutex::new(SupervisionState::new())),
         };
 
         assert!(output.load_uri("https://music.test/stream?api_key=worker-secret"));
@@ -6020,11 +7005,12 @@ mod tests {
             event_tx,
             event_generation: AtomicU64::new(3),
             volume: 1.0,
-            control_mode: MpdControlMode::Exclusive,
+            plan: control_plan(true, false),
             intent_epoch: Arc::new(AtomicU64::new(0)),
             cache: Arc::new(Mutex::new(MpdCache::default())),
             proxy: ProxyServices::production(),
             worker_tx,
+            supervision: Arc::new(Mutex::new(SupervisionState::new())),
         };
         let endpoint =
             Url::parse("https://music.test/clean/track.flac?track=42").expect("clean endpoint");
@@ -6704,6 +7690,8 @@ mod tests {
         let (event_tx, _events) = async_channel::unbounded();
         let worker_epoch = Arc::clone(&intent_epoch);
         let worker_cache = Arc::clone(&cache);
+        let supervision = Arc::new(Mutex::new(SupervisionState::new()));
+        let worker_supervision = Arc::clone(&supervision);
         let worker = std::thread::spawn(move || {
             run_mpd_worker(
                 MpdTcpConnector {
@@ -6711,7 +7699,7 @@ mod tests {
                     port: address.port(),
                 },
                 worker_rx,
-                MpdControlMode::Exclusive,
+                control_plan(true, false),
                 worker_epoch,
                 worker_cache,
                 event_tx,
@@ -6721,6 +7709,7 @@ mod tests {
                     tick: Duration::from_millis(10),
                 },
                 ProxyServices::production(),
+                worker_supervision,
             );
         });
         let owner = queue_test_owner(1);

--- a/src/audio/mpd_output.rs
+++ b/src/audio/mpd_output.rs
@@ -2693,6 +2693,42 @@ fn status_observes_foreign_song(status: &MpdStatus, song_id: u64) -> bool {
 /// never grants or restores anything — quiet polling cannot re-arm a lapsed
 /// supervisor. Only a fresh explicit user confirmation (re-selecting the
 /// output, which constructs a fresh `Armed` supervisor) restores authority.
+/// Apply one authoritative [`MpdStatus`] observation to a supervised
+/// supervisor. This is the shared core behind the poll path and every
+/// pre-mutation status check: any code path that inspects a fresh status
+/// before touching the partition must feed that status through here so the
+/// evidence it just observed is applied BEFORE the mutation decision.
+/// Foreign-controller evidence (foreign current song, partition-option
+/// drift) revokes the user-confirmed authority; a clean observation
+/// refreshes it but never grants or restores anything.
+fn supervise_status(
+    plan: MpdControlPlan,
+    supervision: &Mutex<SupervisionState>,
+    status: &MpdStatus,
+    owned_song_id: u64,
+) {
+    if !(plan.supervised && plan.mode == MpdControlMode::Exclusive) {
+        return;
+    }
+    let now = Instant::now();
+    let mut supervisor = supervision
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    if supervisor.is_lapsed() {
+        // Terminal for this output instance: never restore on polling.
+        return;
+    }
+    if status_observes_foreign_song(status, owned_song_id) || status.observes_options_drift() {
+        supervisor.lapse();
+        return;
+    }
+    if observation_gap_exceeded(supervisor.last_observation, now) {
+        supervisor.lapse();
+        return;
+    }
+    supervisor.observe(now);
+}
+
 fn observe_supervision<C>(
     active: &Option<WorkerSession<C>>,
     owner: CommandOwner,
@@ -2713,23 +2749,7 @@ fn observe_supervision<C>(
     let Some(song_id) = session.song_id else {
         return;
     };
-    let now = Instant::now();
-    let mut supervisor = supervision
-        .lock()
-        .unwrap_or_else(|poison| poison.into_inner());
-    if supervisor.is_lapsed() {
-        // Terminal for this output instance: never restore on polling.
-        return;
-    }
-    if status_observes_foreign_song(status, song_id) || status.observes_options_drift() {
-        supervisor.lapse();
-        return;
-    }
-    if observation_gap_exceeded(supervisor.last_observation, now) {
-        supervisor.lapse();
-        return;
-    }
-    supervisor.observe(now);
+    supervise_status(plan, supervision, status, song_id);
 }
 
 fn retire_status_if_stale<C>(
@@ -2920,6 +2940,25 @@ fn handle_control<C>(
     let Some(song_id) = session.song_id else {
         return;
     };
+    // The authoritative status above is itself supervision evidence:
+    // `apply_authoritative_status` lapses the supervisor when it observed
+    // option drift or a foreign current song, and the status round-trip may
+    // have consumed the remaining supervision window. Recheck authority
+    // immediately before issuing the control so a supervisor that just
+    // lapsed cannot send a partition-global command the evidence it just
+    // produced forbids. The refusal mirrors the worker gate: the localized
+    // exclusive-control-required error and no mutation of any kind — no
+    // control, no cleanup, no epoch burn.
+    if !supervision_authorizes(plan, supervision) {
+        fail_current(
+            owner,
+            MpdFailure::exclusive_control_required(),
+            intent_epoch,
+            cache,
+            event_tx,
+        );
+        return;
+    }
     let result = match kind {
         // `playid` begins the selected queue entry and therefore restarts a
         // paused song. Use MPD's explicit resume operation for Paused, but
@@ -3340,9 +3379,25 @@ where
             return CleanupOutcome::Stale;
         }
 
+        // The status this cleanup just fetched is supervision evidence:
+        // option drift or a foreign current song observed here (or the
+        // round-trip time itself) must be applied BEFORE the mutation
+        // decision below, exactly as the poll path would.
+        if let Ok(status) = &status {
+            supervise_status(plan, supervision, status, song_id);
+        }
+
         match status {
             Ok(status) if status.song_id == Some(song_id) => {
                 if status.state != MpdPlaybackState::Stopped {
+                    // The stop is a partition-global playback control: a
+                    // supervisor lapsed by the status above (or by the
+                    // status round-trip consuming the supervision window)
+                    // must not issue it. The targeted delete below keeps
+                    // its own authority gate.
+                    if !supervision_authorizes(plan, supervision) {
+                        return CleanupOutcome::Completed;
+                    }
                     let stopped = session.connection.stop(deadline);
                     if !is_current(owner, intent_epoch) {
                         if stopped
@@ -3439,6 +3494,20 @@ fn cleanup_unconditionally<C>(
         }
         let deadline = timing.deadline();
         let status = session.connection.status(deadline);
+        // The shutdown-time status is itself supervision evidence: option
+        // drift or a foreign current song observed here revokes authority
+        // even though the initial gate above passed, and the status
+        // round-trip may on its own have consumed the remaining supervision
+        // window. Apply the observation BEFORE any mutation decision, then
+        // recheck — a fresh-at-the-gate supervisor whose teardown status
+        // (or whose round-trip time) supplied disqualifying evidence must
+        // send neither the partition-global stop nor the targeted delete.
+        if let Ok(status) = &status {
+            supervise_status(plan, supervision, status, song_id);
+        }
+        if !supervision_authorizes(plan, supervision) {
+            return;
+        }
         let can_delete = match status {
             Ok(status) if status.song_id == Some(song_id) => {
                 if status.state == MpdPlaybackState::Stopped {
@@ -3459,6 +3528,12 @@ fn cleanup_unconditionally<C>(
             Err(failure) => failure.connection_usable,
         };
         if can_delete {
+            // The delete is a second mutation with its own round-trip between
+            // it and the last fresh evidence: recheck rather than letting the
+            // stop's duration (or the earlier status) speak for it.
+            if !supervision_authorizes(plan, supervision) {
+                return;
+            }
             let _ = session.connection.delete_id(song_id, deadline);
         }
     }
@@ -3682,6 +3757,13 @@ impl AudioOutput for MpdOutput {
 
     fn supports_volume(&self) -> bool {
         false
+    }
+
+    fn supervision_lapsed(&self) -> bool {
+        self.supervision
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .is_lapsed()
     }
 
     fn load_uri(&self, uri: &str) -> bool {
@@ -4892,6 +4974,80 @@ mod tests {
     }
 
     #[test]
+    fn supervised_control_refused_when_its_own_precontrol_status_observes_drift() {
+        // The TOCTOU window the corrective handoff flagged: the worker gate
+        // passes while the confirmation is still fresh, then the control's
+        // OWN pre-control status observes partition-option drift —
+        // `apply_authoritative_status` lapses the supervisor while the
+        // session is still ours. The control must not be issued anyway:
+        // authority is rechecked after the status is applied, immediately
+        // before the partition-global command goes to the wire.
+        let shared = FakeShared::new();
+        let proxy_shared = FakeProxyShared::new();
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let proxy = fake_proxy_services(Arc::clone(&proxy_shared), &runtime);
+        let harness = Harness::new_supervised_with_proxy(
+            Arc::clone(&shared),
+            proxy,
+            Duration::from_hours(1),
+            Duration::from_millis(1),
+        );
+        shared
+            .statuses
+            .lock()
+            .expect("statuses lock")
+            .push_back(playing_status(0, 10_000));
+        let owner = harness.next_owner(1);
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/clean".to_string(),
+            },
+        );
+        harness.fence(owner);
+        assert!(
+            !harness
+                .supervision
+                .lock()
+                .expect("supervision lock")
+                .is_lapsed(),
+            "the clean load must leave the supervisor armed"
+        );
+
+        // The NEXT status reply — the one the pause control itself fetches
+        // before issuing the command — reports our own song with drifted
+        // partition options.
+        let mut drifted = playing_status(0, 10_000);
+        drifted.repeat = true;
+        shared
+            .statuses
+            .lock()
+            .expect("statuses lock")
+            .push_back(drifted);
+
+        harness.send(owner, CommandKind::Pause);
+        harness.fence(owner);
+        assert!(
+            harness
+                .supervision
+                .lock()
+                .expect("supervision lock")
+                .is_lapsed(),
+            "the drift observed by the pre-control status must lapse the supervisor"
+        );
+        assert_eq!(
+            shared
+                .actions()
+                .iter()
+                .filter(|action| matches!(action, Action::Pause(_)))
+                .count(),
+            0,
+            "a control whose own pre-control status lapsed the supervisor must not be issued"
+        );
+        harness.shutdown();
+    }
+
+    #[test]
     fn supervised_worker_refuses_commands_whose_evidence_went_stale_between_polls() {
         // The audit's stale-between-polls case at the worker gate: no poll
         // has yet observed the observation gap (the harness polls only on
@@ -5147,6 +5303,152 @@ mod tests {
             0,
             "a lapsed supervisor must not issue the targeted delete"
         );
+    }
+
+    #[test]
+    fn supervised_shutdown_status_option_drift_sends_neither_stop_nor_delete() {
+        // The corrective handoff's second cleanup case: the supervisor is
+        // still FRESH at the initial teardown gate, but the shutdown-time
+        // status itself observes partition-option drift while reporting our
+        // own song. The observation must be applied and authority rechecked
+        // before either mutation — the ungated path would send `stop` and
+        // `deleteid` on evidence it never looked at.
+        let shared = FakeShared::new();
+        let proxy_shared = FakeProxyShared::new();
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let proxy = fake_proxy_services(Arc::clone(&proxy_shared), &runtime);
+        let harness = Harness::new_supervised_with_proxy(
+            Arc::clone(&shared),
+            proxy,
+            Duration::from_hours(1),
+            Duration::from_millis(1),
+        );
+        shared
+            .statuses
+            .lock()
+            .expect("statuses lock")
+            .push_back(playing_status(0, 10_000));
+        let owner = harness.next_owner(3);
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/quiet".to_string(),
+            },
+        );
+        harness.fence(owner);
+        assert!(
+            !harness
+                .supervision
+                .lock()
+                .expect("supervision lock")
+                .is_lapsed(),
+            "the supervisor must still be armed when shutdown begins"
+        );
+
+        // The teardown status reports our own song (42) playing with
+        // drifted partition options.
+        let mut drifted = playing_status(0, 10_000);
+        drifted.repeat = true;
+        shared
+            .statuses
+            .lock()
+            .expect("statuses lock")
+            .push_back(drifted);
+
+        let supervision = Arc::clone(&harness.supervision);
+        harness.shutdown();
+        assert!(
+            supervision.lock().expect("supervision lock").is_lapsed(),
+            "the drift observed by the shutdown status must lapse the supervisor"
+        );
+        let actions = shared.actions();
+        assert_eq!(
+            actions
+                .iter()
+                .filter(|action| matches!(action, Action::Point(Point::Stop)))
+                .count(),
+            0,
+            "teardown evidence that revokes authority must not be followed by a stop"
+        );
+        assert_eq!(
+            actions
+                .iter()
+                .filter(|action| matches!(action, Action::Delete(42)))
+                .count(),
+            0,
+            "teardown evidence that revokes authority must not be followed by a delete"
+        );
+    }
+
+    #[test]
+    fn supervised_stop_cleanup_refused_when_its_own_status_observes_drift() {
+        // Same defect shape on the Stop command's StopOwned cleanup path:
+        // the worker gate passes on fresh evidence, then the cleanup's own
+        // status observes option drift. The stop is a partition-global
+        // playback control and must be gated on authority AFTER that
+        // observation, exactly like the targeted delete has always been.
+        let shared = FakeShared::new();
+        let proxy_shared = FakeProxyShared::new();
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let proxy = fake_proxy_services(Arc::clone(&proxy_shared), &runtime);
+        let harness = Harness::new_supervised_with_proxy(
+            Arc::clone(&shared),
+            proxy,
+            Duration::from_hours(1),
+            Duration::from_millis(1),
+        );
+        shared
+            .statuses
+            .lock()
+            .expect("statuses lock")
+            .push_back(playing_status(0, 10_000));
+        let owner = harness.next_owner(3);
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/clean".to_string(),
+            },
+        );
+        harness.fence(owner);
+
+        // The status fetched inside the stop cleanup reports our own song
+        // with drifted partition options.
+        let mut drifted = playing_status(0, 10_000);
+        drifted.repeat = true;
+        shared
+            .statuses
+            .lock()
+            .expect("statuses lock")
+            .push_back(drifted);
+
+        harness.send(owner, CommandKind::Stop);
+        harness.fence(owner);
+        assert!(
+            harness
+                .supervision
+                .lock()
+                .expect("supervision lock")
+                .is_lapsed(),
+            "the drift observed by the cleanup status must lapse the supervisor"
+        );
+        let actions = shared.actions();
+        assert_eq!(
+            actions
+                .iter()
+                .filter(|action| matches!(action, Action::Point(Point::Stop)))
+                .count(),
+            0,
+            "a stop whose own cleanup status lapsed the supervisor must not reach MPD"
+        );
+        assert_eq!(
+            actions
+                .iter()
+                .filter(|action| matches!(action, Action::Delete(42)))
+                .count(),
+            0,
+            "the targeted delete stays gated behind lapsed authority"
+        );
+        harness.shutdown();
     }
 
     #[test]

--- a/src/audio/mpd_output.rs
+++ b/src/audio/mpd_output.rs
@@ -2042,6 +2042,15 @@ struct WorkerSession<T> {
 enum CleanupOutcome {
     Completed,
     Stale,
+    /// The session's cleanup mutations were refused before the first one was
+    /// issued: on a supervised output the pre-mutation status evidence
+    /// lapsed the supervisor (partition-option drift or an expired
+    /// observation gap), or the status observed a foreign current song, so
+    /// neither the partition-global stop nor the targeted delete may run.
+    /// The session has been dropped and the owned queue entry retained per
+    /// the post-lapse contract; the caller must surface the exclusive-control
+    /// refusal instead of reporting a successful stop.
+    Refused,
     Failed(MpdFailure),
 }
 
@@ -2243,6 +2252,23 @@ fn run_mpd_worker<C>(
                                     &event_tx,
                                 );
                             }
+                            CleanupOutcome::Refused => {
+                                // The cleanup's own status evidence refused
+                                // every mutation: option drift, an expired
+                                // supervision window, or a foreign current
+                                // song. Nothing was sent to MPD and the
+                                // owned queue entry is retained, so the UI
+                                // must see the exclusive-control refusal —
+                                // not a successful stopped state while the
+                                // partition may still be playing.
+                                fail_current(
+                                    command.owner,
+                                    MpdFailure::exclusive_control_required(),
+                                    &intent_epoch,
+                                    &cache,
+                                    &event_tx,
+                                );
+                            }
                             CleanupOutcome::Failed(failure) => fail_current(
                                 command.owner,
                                 failure,
@@ -2351,6 +2377,12 @@ fn handle_load<C>(
         supervision,
     ) {
         CleanupOutcome::Completed => {}
+        CleanupOutcome::Refused => {
+            // The previous session's targeted cleanup was refused by its own
+            // status evidence (supervised lapse or a foreign current song):
+            // the orphan is retained and nothing was sent. The recheck below
+            // gates the new load on the same authority.
+        }
         CleanupOutcome::Failed(failure) => {
             error!(operation = failure.operation, "Previous MPD cleanup failed");
         }
@@ -3621,9 +3653,13 @@ where
                     // supervisor lapsed by the status above (or by the
                     // status round-trip consuming the supervision window)
                     // must not issue it. The targeted delete below keeps
-                    // its own authority gate.
+                    // its own authority gate. The refusal is distinct from
+                    // `Completed` so the Stop caller reports the
+                    // exclusive-control refusal instead of publishing a
+                    // successful stopped state while the owned song may
+                    // still be playing.
                     if !supervision_authorizes(plan, supervision) {
-                        return CleanupOutcome::Completed;
+                        return CleanupOutcome::Refused;
                     }
                     let stopped = session.connection.stop(deadline);
                     if !is_current(owner, intent_epoch) {
@@ -3649,7 +3685,12 @@ where
             // violated. It still does not authorize either a global stop or a
             // racy targeted delete: another client could select our queued id
             // between this status and deleteid, so deliberately retain it.
-            Ok(status) if status.song_id.is_some() => return CleanupOutcome::Completed,
+            // On a supervised output the observation above already lapsed the
+            // supervisor, and on an unsupervised one the contract is violated
+            // all the same: either way the stop was refused, so the caller
+            // must surface the exclusive-control refusal rather than a
+            // successful stopped state.
+            Ok(status) if status.song_id.is_some() => return CleanupOutcome::Refused,
             // No current id authorizes only the targeted cleanup below.
             Ok(_) => {}
             Err(status_failure) if status_failure.connection_usable => {
@@ -6061,6 +6102,7 @@ mod tests {
             .expect("statuses lock")
             .push_back(drifted);
 
+        let _ = harness.events();
         harness.send(owner, CommandKind::Stop);
         harness.fence(owner);
         assert!(
@@ -6088,6 +6130,112 @@ mod tests {
             0,
             "the targeted delete stays gated behind lapsed authority"
         );
+        // The refusal must reach the UI as the exclusive-control error on
+        // top of the terminal stopped state — never as a silent successful
+        // stop while the owned song may still be playing.
+        assert!(
+            harness.events().iter().any(|event| matches!(
+                event,
+                PlayerEvent::Error { message, .. }
+                    if message == &mpd_exclusive_control_required_message(&rust_i18n::locale())
+            )),
+            "the drifted-stop refusal must surface the exclusive-control error"
+        );
+        assert_eq!(harness.cache().state, PlayerState::Stopped);
+        harness.shutdown();
+    }
+
+    #[test]
+    fn supervised_stop_cleanup_refused_when_status_round_trip_expires_supervision() {
+        // Deadline-expiry sibling of the drift refusal above: the pre-stop
+        // status is clean and still names our song, but the supervision
+        // window expired while the command waited, so the eager gap check
+        // inside the cleanup's own supervision observation lapses the
+        // supervisor. The partition-global stop and the targeted delete are
+        // both refused, and the UI sees the exclusive-control refusal —
+        // never a successful stopped state.
+        let shared = FakeShared::new();
+        let proxy_shared = FakeProxyShared::new();
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let proxy = fake_proxy_services(Arc::clone(&proxy_shared), &runtime);
+        let harness = Harness::new_supervised_with_proxy(
+            Arc::clone(&shared),
+            proxy,
+            Duration::from_hours(1),
+            Duration::from_millis(1),
+        );
+        shared
+            .statuses
+            .lock()
+            .expect("statuses lock")
+            .push_back(playing_status(0, 10_000));
+        let owner = harness.next_owner(3);
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/clean".to_string(),
+            },
+        );
+        harness.fence(owner);
+
+        // Expire the supervision window without touching the phase: the
+        // cleanup's own supervision observation must apply the eager gap
+        // rule before the stop decision.
+        let stale = Instant::now()
+            .checked_sub(MAX_SUPERVISION_GAP + Duration::from_secs(1))
+            .expect("backdated observation instant");
+        harness
+            .supervision
+            .lock()
+            .expect("supervision lock")
+            .last_observation = Some(stale);
+
+        // The queued status is clean evidence: our own song, playing, no
+        // partition-option drift — the lapse comes purely from the expired
+        // observation gap.
+        shared
+            .statuses
+            .lock()
+            .expect("statuses lock")
+            .push_back(playing_status(500, 10_000));
+
+        let _ = harness.events();
+        harness.send(owner, CommandKind::Stop);
+        harness.fence(owner);
+        assert!(
+            harness
+                .supervision
+                .lock()
+                .expect("supervision lock")
+                .is_lapsed(),
+            "the expired supervision window must lapse the supervisor before the stop"
+        );
+        let actions = shared.actions();
+        assert_eq!(
+            actions
+                .iter()
+                .filter(|action| matches!(action, Action::Point(Point::Stop)))
+                .count(),
+            0,
+            "a stop whose supervision expired mid-cleanup must not reach MPD"
+        );
+        assert_eq!(
+            actions
+                .iter()
+                .filter(|action| matches!(action, Action::Delete(42)))
+                .count(),
+            0,
+            "the targeted delete stays gated behind the expired supervision"
+        );
+        assert!(
+            harness.events().iter().any(|event| matches!(
+                event,
+                PlayerEvent::Error { message, .. }
+                    if message == &mpd_exclusive_control_required_message(&rust_i18n::locale())
+            )),
+            "the expired-supervision stop refusal must surface the exclusive-control error"
+        );
+        assert_eq!(harness.cache().state, PlayerState::Stopped);
         harness.shutdown();
     }
 
@@ -7820,13 +7968,20 @@ mod tests {
         harness.fence(stop);
 
         assert_eq!(shared.actions(), vec![Action::Point(Point::Status)]);
-        assert!(matches!(
-            harness.events().as_slice(),
-            [PlayerEvent::StateChanged {
-                state: PlayerState::Stopped,
-                ..
-            }]
-        ));
+        // The stop was refused — a foreign current song violates the
+        // exclusive-control contract, so no stop and no delete may run —
+        // and the refusal must reach the UI as the exclusive-control error
+        // instead of a silent successful stopped state.
+        let events = harness.events();
+        assert!(
+            events.iter().any(|event| matches!(
+                event,
+                PlayerEvent::Error { message, .. }
+                    if message == &mpd_exclusive_control_required_message(&rust_i18n::locale())
+            )),
+            "the foreign-song stop refusal must surface the exclusive-control error"
+        );
+        assert_eq!(harness.cache().state, PlayerState::Stopped);
         harness.shutdown();
     }
 

--- a/src/audio/mpd_output.rs
+++ b/src/audio/mpd_output.rs
@@ -2348,6 +2348,15 @@ fn handle_load<C>(
         }
         CleanupOutcome::Stale => return,
     }
+    // The cleanup is a blocking stage: its round-trips may have consumed the
+    // remaining supervision window that the worker gate passed on. Recheck
+    // authority BEFORE any state publication or connection so a supervisor
+    // that lapsed during cleanup cannot even announce Buffering, let alone
+    // reach the partition-mutating stages below.
+    if !supervision_authorizes(plan, supervision) {
+        retain_orphan_and_refuse(active, owner, intent_epoch, cache, event_tx);
+        return;
+    }
     if !publish_state(
         owner,
         PlayerState::Buffering,
@@ -2387,6 +2396,15 @@ fn handle_load<C>(
     if !is_current(owner, intent_epoch) {
         return;
     }
+    // The connection/greeting handshake is the second blocking stage: the
+    // operation deadline permits several seconds, far beyond
+    // MAX_SUPERVISION_GAP. Recheck authority before the first partition
+    // mutation — an authority-requiring `repeat` after an expired window is
+    // exactly the defect this gate closes.
+    if !supervision_authorizes(plan, supervision) {
+        retain_orphan_and_refuse(active, owner, intent_epoch, cache, event_tx);
+        return;
+    }
 
     let repeat = active
         .as_mut()
@@ -2407,6 +2425,13 @@ fn handle_load<C>(
         return;
     }
     if !is_current(owner, intent_epoch) {
+        return;
+    }
+    // Each option ACK is its own blocking round-trip, so the supervision
+    // window is re-evaluated immediately before every mutation rather than
+    // trusting the gate that preceded the previous stage.
+    if !supervision_authorizes(plan, supervision) {
+        retain_orphan_and_refuse(active, owner, intent_epoch, cache, event_tx);
         return;
     }
     // The owned item is appended after the preserved foreign queue. Disable
@@ -2432,6 +2457,10 @@ fn handle_load<C>(
     if !is_current(owner, intent_epoch) {
         return;
     }
+    if !supervision_authorizes(plan, supervision) {
+        retain_orphan_and_refuse(active, owner, intent_epoch, cache, event_tx);
+        return;
+    }
     // `single 1`/`oneshot` can pause at the queue boundary instead of
     // reporting Stopped, which would suppress Tributary's completion event.
     let single = active
@@ -2453,6 +2482,10 @@ fn handle_load<C>(
         return;
     }
     if !is_current(owner, intent_epoch) {
+        return;
+    }
+    if !supervision_authorizes(plan, supervision) {
+        retain_orphan_and_refuse(active, owner, intent_epoch, cache, event_tx);
         return;
     }
     // Keep the stable queue id available after natural completion so terminal
@@ -2533,6 +2566,12 @@ fn handle_load<C>(
         active.take();
         return;
     }
+    // The enqueue places a new entry in the shared partition queue: gate it
+    // on currently-live authority after the preceding option ACK round-trips.
+    if !supervision_authorizes(plan, supervision) {
+        retain_orphan_and_refuse(active, owner, intent_epoch, cache, event_tx);
+        return;
+    }
     let added = active
         .as_mut()
         .expect("connected MPD session recorded")
@@ -2568,6 +2607,15 @@ fn handle_load<C>(
             return;
         }
     };
+    // Once our entry is enqueued the remaining mutation is the playback
+    // start. If the addid ACK's round-trip (or the enqueue itself) consumed
+    // the supervision window, playid must not fire: the entry is retained —
+    // deleting it would be the same unauthorized mutation — and the load is
+    // refused with the localized exclusive-control error.
+    if !supervision_authorizes(plan, supervision) {
+        retain_orphan_and_refuse(active, owner, intent_epoch, cache, event_tx);
+        return;
+    }
     let played = active
         .as_mut()
         .expect("connected MPD session recorded")
@@ -2867,6 +2915,32 @@ fn delete_owned_then_fail<C>(
     }
 }
 
+/// Terminal refusal for an authority-requiring MPD mutation on a supervised
+/// output whose authority has been revoked: retain the owned queue entry —
+/// stale confirmation must never authorise even the targeted delete, and the
+/// retained orphan is the documented post-lapse state — drop the session
+/// without issuing any further MPD command, and report the localized
+/// exclusive-control refusal. Mirrors `delete_owned_then_fail`'s terminal
+/// shape (session dropped, current owner failed) without the mutation.
+fn retain_orphan_and_refuse<C>(
+    active: &mut Option<WorkerSession<C>>,
+    owner: CommandOwner,
+    intent_epoch: &AtomicU64,
+    cache: &Mutex<MpdCache>,
+    event_tx: &async_channel::Sender<PlayerEvent>,
+) where
+    C: MpdTransport,
+{
+    active.take();
+    fail_current(
+        owner,
+        MpdFailure::exclusive_control_required(),
+        intent_epoch,
+        cache,
+        event_tx,
+    );
+}
+
 #[allow(clippy::too_many_arguments)]
 fn handle_control<C>(
     active: &mut Option<WorkerSession<C>>,
@@ -3142,6 +3216,15 @@ fn apply_authoritative_status<C>(
     if status.state != MpdPlaybackState::Stopped {
         if status.song_id == Some(song_id) {
             if status.has_error {
+                // The observation above may itself have revoked authority
+                // (option drift in this very status, or the window its
+                // round-trip consumed). The terminal delete is an
+                // authority-requiring mutation: after a lapse the orphan is
+                // retained and the refusal reported instead.
+                if !supervision_authorizes(plan, supervision) {
+                    retain_orphan_and_refuse(active, owner, intent_epoch, cache, event_tx);
+                    return;
+                }
                 delete_owned_then_fail(
                     active,
                     owner,
@@ -3171,6 +3254,16 @@ fn apply_authoritative_status<C>(
 
     if status.song_id == Some(song_id) {
         if status.has_error {
+            // Same post-observe authority gate as the playing branch above:
+            // the very status that reported this error may have carried
+            // option drift (or its round-trip consumed the remaining
+            // window), and the targeted delete is an authority-requiring
+            // mutation. After a lapse the entry is retained and the
+            // localized refusal reported instead.
+            if !supervision_authorizes(plan, supervision) {
+                retain_orphan_and_refuse(active, owner, intent_epoch, cache, event_tx);
+                return;
+            }
             delete_owned_then_fail(
                 active,
                 owner,
@@ -3203,7 +3296,14 @@ fn apply_authoritative_status<C>(
     if status.has_error {
         // With no current pointer, atomically target only our retained queue
         // entry before reporting the remote error. Success proves ownership;
-        // failure is still safe because no foreign item is mutated.
+        // failure is still safe because no foreign item is mutated. The
+        // delete is still an authority-requiring partition mutation: the
+        // observation above may have lapsed the supervisor (option drift
+        // with the pointer cleared), so recheck before touching the queue.
+        if !supervision_authorizes(plan, supervision) {
+            retain_orphan_and_refuse(active, owner, intent_epoch, cache, event_tx);
+            return;
+        }
         delete_owned_then_fail(
             active,
             owner,
@@ -3238,6 +3338,17 @@ fn apply_authoritative_status<C>(
     }
 
     let ownership_deadline = OperationDeadline::after(timing.operation.min(IO_IDLE_TIMEOUT));
+    // The completion delete is the last authority-requiring mutation of
+    // this path, and the very status that reached it may have revoked
+    // authority (option drift observed with the current pointer cleared, or
+    // the window its round-trip consumed). After a lapse the retained entry
+    // is the documented post-lapse state — deleting it would repeat the
+    // unauthorized mutation class this module eliminates — so the terminal
+    // refusal is reported instead of a completion.
+    if !supervision_authorizes(plan, supervision) {
+        retain_orphan_and_refuse(active, owner, intent_epoch, cache, event_tx);
+        return;
+    }
     let removed = active
         .as_mut()
         .expect("active MPD session checked")
@@ -3760,10 +3871,24 @@ impl AudioOutput for MpdOutput {
     }
 
     fn supervision_lapsed(&self) -> bool {
-        self.supervision
+        // EAGER, mirroring the worker's authority gate (`SupervisionState::
+        // authority_current`): an armed supervisor whose last clean
+        // observation (or construction-time confirmation) is older than
+        // MAX_SUPERVISION_GAP is exactly as disqualified as an explicitly
+        // lapsed one — the next authority-requiring command would be
+        // refused by that same eager rule. Consulting only the stored
+        // phase here would report such an output as healthy, the selector
+        // would swallow the reselection as a non-perturbing no-op, and the
+        // next load would refuse: the user would have to reselect twice.
+        // Reporting lapsed instead routes the first reselection into the
+        // rebuild/reconfirm path. The eager check's side effect (permanently
+        // lapsing a stale supervisor) is revoke-only and identical to the
+        // worker gate's behavior.
+        let mut supervisor = self
+            .supervision
             .lock()
-            .unwrap_or_else(|poison| poison.into_inner())
-            .is_lapsed()
+            .unwrap_or_else(|poison| poison.into_inner());
+        !supervisor.authority_current(Instant::now())
     }
 
     fn load_uri(&self, uri: &str) -> bool {

--- a/src/audio/mpd_output.rs
+++ b/src/audio/mpd_output.rs
@@ -3422,6 +3422,21 @@ fn cleanup_unconditionally<C>(
         let Some(song_id) = session.song_id else {
             return;
         };
+        // Gate EVERY authority-requiring mutation before the first one —
+        // including the teardown `stop`, which is a partition-global
+        // playback-control command just like the targeted delete. A
+        // supervised `Exclusive` output whose supervision has lapsed —
+        // foreign current song, partition-option drift, or an observation
+        // gap older than `MAX_SUPERVISION_GAP` — retains its orphan AND
+        // issues no stop: stale confirmation must not authorise either,
+        // and no poll will arrive during shutdown to re-check it. The
+        // failure class of the call (shutdown, disconnect) is irrelevant —
+        // the guarantee applies in every cleanup path. Unsupervised
+        // `Exclusive` proceeds on the user's confirmation alone, exactly
+        // as before.
+        if !supervision_authorizes(plan, supervision) {
+            return;
+        }
         let deadline = timing.deadline();
         let status = session.connection.status(deadline);
         let can_delete = match status {
@@ -3443,16 +3458,6 @@ fn cleanup_unconditionally<C>(
             Ok(_) => true,
             Err(failure) => failure.connection_usable,
         };
-        // Mirror the cleanup_session gate: only an `Exclusive` output whose
-        // supervision is armed and fresh may issue a targeted delete. The
-        // failure class of the call (shutdown, disconnect) is irrelevant —
-        // the orphan-retention guarantee applies in every cleanup path, and
-        // the freshness check is eager: supervision evidence older than
-        // `MAX_SUPERVISION_GAP` retains the orphan instead of awaiting a
-        // poll that will never come during shutdown.
-        if !supervision_authorizes(plan, supervision) {
-            return;
-        }
         if can_delete {
             let _ = session.connection.delete_id(song_id, deadline);
         }
@@ -5063,6 +5068,84 @@ mod tests {
                 .count(),
             0,
             "a lapsed supervisor must not authorise orphan deletion, even on shutdown"
+        );
+    }
+
+    #[test]
+    fn supervised_exclusive_shutdown_after_lapse_sends_neither_stop_nor_delete() {
+        // The teardown `stop` is a partition-global playback-control
+        // command: a lapsed supervisor must not issue it any more than it
+        // may issue the targeted delete. The shutdown-time status reports
+        // our own song still playing — the exact observation under which
+        // the ungated cleanup would have sent `stop` before checking
+        // authority — so this regression pins both mutations to zero.
+        let shared = FakeShared::new();
+        let proxy_shared = FakeProxyShared::new();
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let proxy = fake_proxy_services(Arc::clone(&proxy_shared), &runtime);
+        let harness = Harness::new_supervised_with_proxy(
+            Arc::clone(&shared),
+            proxy,
+            Duration::from_hours(1),
+            Duration::from_millis(1),
+        );
+        shared
+            .statuses
+            .lock()
+            .expect("statuses lock")
+            .push_back(playing_status(0, 10_000));
+        let owner = harness.next_owner(3);
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/quiet".to_string(),
+            },
+        );
+        harness.fence(owner);
+
+        // Lapse via a foreign current song.
+        let mut foreign = playing_status(0, 10_000);
+        foreign.song_id = Some(99);
+        shared
+            .statuses
+            .lock()
+            .expect("statuses lock")
+            .push_back(foreign);
+        harness.send(owner, CommandKind::PollNow);
+        harness.fence(owner);
+        assert!(
+            harness
+                .supervision
+                .lock()
+                .expect("supervision lock")
+                .is_lapsed(),
+            "the foreign song must have lapsed the supervisor"
+        );
+
+        // The teardown status would report our own song (42) still playing.
+        shared
+            .statuses
+            .lock()
+            .expect("statuses lock")
+            .push_back(playing_status(0, 10_000));
+
+        harness.shutdown();
+        let actions = shared.actions();
+        assert_eq!(
+            actions
+                .iter()
+                .filter(|action| matches!(action, Action::Point(Point::Stop)))
+                .count(),
+            0,
+            "a lapsed supervisor must not issue the teardown stop"
+        );
+        assert_eq!(
+            actions
+                .iter()
+                .filter(|action| matches!(action, Action::Delete(42)))
+                .count(),
+            0,
+            "a lapsed supervisor must not issue the targeted delete"
         );
     }
 

--- a/src/audio/mpd_output.rs
+++ b/src/audio/mpd_output.rs
@@ -5577,6 +5577,572 @@ mod tests {
     }
 
     #[test]
+    fn supervised_load_lapsing_at_the_connect_gate_issues_no_partition_mutation() {
+        // Finding 1 regression (load sequence, post-connect gate): the
+        // worker gate passed on fresh evidence, but the connect/greeting
+        // round-trip consumed the supervision window. The recheck after the
+        // blocking connect stage must refuse before the first partition
+        // mutation — no option command, no enqueue, no play — and before
+        // any delete: the just-created session holds no queue entry, so
+        // there is nothing to retain and nothing to mutate.
+        let shared = FakeShared::new();
+        let proxy_shared = FakeProxyShared::new();
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let proxy = fake_proxy_services(Arc::clone(&proxy_shared), &runtime);
+        let (entered, release) = shared.install_gate(Point::Connect);
+        let harness = Harness::new_supervised_with_proxy(
+            Arc::clone(&shared),
+            proxy,
+            Duration::from_hours(1),
+            Duration::from_millis(1),
+        );
+        let owner = harness.next_owner(3);
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/mid-load".to_string(),
+            },
+        );
+        entered
+            .recv_timeout(Duration::from_secs(2))
+            .expect("connect entered the gate");
+        let stale = Instant::now()
+            .checked_sub(MAX_SUPERVISION_GAP + Duration::from_secs(1))
+            .expect("backdated observation instant");
+        harness
+            .supervision
+            .lock()
+            .expect("supervision lock")
+            .last_observation = Some(stale);
+        release.send(()).expect("release connect");
+        harness.fence(owner);
+
+        let actions = shared.actions();
+        assert!(
+            actions.contains(&Action::Point(Point::Connect)),
+            "the connect stage itself ran before the lapse"
+        );
+        assert!(
+            !actions
+                .iter()
+                .any(|action| matches!(action, Action::Point(point) if *point != Point::Connect)),
+            "no option or playback command may follow a mid-load lapse"
+        );
+        assert!(
+            shared.added_uris().is_empty(),
+            "a mid-load lapse must never enqueue into the shared partition queue"
+        );
+        assert!(
+            !actions
+                .iter()
+                .any(|action| matches!(action, Action::Delete(_))),
+            "a mid-load lapse must not delete anything"
+        );
+        assert!(
+            harness
+                .supervision
+                .lock()
+                .expect("supervision lock")
+                .is_lapsed(),
+            "the eager post-connect recheck lapses the stale supervisor"
+        );
+        let events = harness.events();
+        assert!(events.iter().any(|event| matches!(
+            event,
+            PlayerEvent::Error { message, .. }
+                if message == &mpd_exclusive_control_required_message(&rust_i18n::locale())
+        )));
+        assert!(
+            !events.iter().any(|event| matches!(
+                event,
+                PlayerEvent::StateChanged {
+                    state: PlayerState::Playing,
+                    ..
+                }
+            )),
+            "the refused load must never reach Playing"
+        );
+        harness.shutdown();
+    }
+
+    #[test]
+    fn supervised_load_lapsing_between_option_stages_issues_no_further_mutation() {
+        // Finding 1 regression (between-stage gate): repeat's ACK round-trip
+        // consumed the remaining supervision window, so the recheck before
+        // `random` must refuse. The option sequence stops mid-flight: no
+        // single/consume, no enqueue, no play, no delete.
+        let shared = FakeShared::new();
+        let proxy_shared = FakeProxyShared::new();
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let proxy = fake_proxy_services(Arc::clone(&proxy_shared), &runtime);
+        let (entered, release) = shared.install_gate(Point::Random);
+        let harness = Harness::new_supervised_with_proxy(
+            Arc::clone(&shared),
+            proxy,
+            Duration::from_hours(1),
+            Duration::from_millis(1),
+        );
+        let owner = harness.next_owner(3);
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/mid-options".to_string(),
+            },
+        );
+        entered
+            .recv_timeout(Duration::from_secs(2))
+            .expect("random entered the gate");
+        let stale = Instant::now()
+            .checked_sub(MAX_SUPERVISION_GAP + Duration::from_secs(1))
+            .expect("backdated observation instant");
+        harness
+            .supervision
+            .lock()
+            .expect("supervision lock")
+            .last_observation = Some(stale);
+        release.send(()).expect("release random");
+        harness.fence(owner);
+
+        let actions = shared.actions();
+        for ran in [Point::Connect, Point::Repeat, Point::Random] {
+            assert!(
+                actions.contains(&Action::Point(ran)),
+                "stages before the lapse ran: {:?}",
+                ran
+            );
+        }
+        for refused in [Point::Single, Point::Consume] {
+            assert!(
+                !actions.contains(&Action::Point(refused)),
+                "no option command may follow a mid-load lapse: {:?}",
+                refused
+            );
+        }
+        assert!(
+            !actions
+                .iter()
+                .any(|action| matches!(action, Action::Play(_))),
+            "a mid-load lapse must never start playback"
+        );
+        assert!(
+            shared.added_uris().is_empty(),
+            "a mid-load lapse must never enqueue into the shared partition queue"
+        );
+        assert!(
+            !actions
+                .iter()
+                .any(|action| matches!(action, Action::Delete(_))),
+            "a mid-load lapse must not delete anything"
+        );
+        assert!(
+            harness
+                .supervision
+                .lock()
+                .expect("supervision lock")
+                .is_lapsed(),
+            "the eager between-stages recheck lapses the stale supervisor"
+        );
+        harness.shutdown();
+    }
+
+    #[test]
+    fn supervised_load_lapsing_after_enqueue_retains_entry_and_never_plays() {
+        // Finding 1 regression (pre-play gate): the addid round-trip
+        // consumed the supervision window after our entry was enqueued.
+        // `playid` must not fire, and the retained entry must NOT be
+        // deleted — deleting it would be the same unauthorized mutation
+        // class. The orphan stays and the load is refused.
+        let shared = FakeShared::new();
+        let proxy_shared = FakeProxyShared::new();
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let proxy = fake_proxy_services(Arc::clone(&proxy_shared), &runtime);
+        let (entered, release) = shared.install_gate(Point::Add);
+        let harness = Harness::new_supervised_with_proxy(
+            Arc::clone(&shared),
+            proxy,
+            Duration::from_hours(1),
+            Duration::from_millis(1),
+        );
+        let owner = harness.next_owner(3);
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/enqueued-then-lapsed".to_string(),
+            },
+        );
+        entered
+            .recv_timeout(Duration::from_secs(2))
+            .expect("add entered the gate");
+        let stale = Instant::now()
+            .checked_sub(MAX_SUPERVISION_GAP + Duration::from_secs(1))
+            .expect("backdated observation instant");
+        harness
+            .supervision
+            .lock()
+            .expect("supervision lock")
+            .last_observation = Some(stale);
+        release.send(()).expect("release add");
+        harness.fence(owner);
+
+        assert_eq!(
+            shared
+                .added_uris()
+                .iter()
+                .filter(|uri| *uri == "https://music.test/enqueued-then-lapsed")
+                .count(),
+            1,
+            "the enqueue itself happened before the lapse"
+        );
+        let actions = shared.actions();
+        assert!(
+            !actions
+                .iter()
+                .any(|action| matches!(action, Action::Play(_))),
+            "a post-enqueue lapse must never start playback"
+        );
+        assert_eq!(
+            actions
+                .iter()
+                .filter(|action| matches!(action, Action::Delete(42)))
+                .count(),
+            0,
+            "the retained entry must not be deleted after a lapse — retention IS the safe state"
+        );
+        assert!(
+            harness
+                .supervision
+                .lock()
+                .expect("supervision lock")
+                .is_lapsed(),
+            "the eager pre-play recheck lapses the stale supervisor"
+        );
+        assert!(harness.events().iter().any(|event| matches!(
+            event,
+            PlayerEvent::Error { message, .. }
+                if message == &mpd_exclusive_control_required_message(&rust_i18n::locale())
+        )));
+        harness.shutdown();
+    }
+
+    #[test]
+    fn supervised_playing_status_with_drift_and_remote_error_retains_orphan() {
+        // Finding 2 regression (playing + owned + error branch): the
+        // end-of-load status itself carries option drift while reporting
+        // Tributary's own song with a remote error flag. The observation
+        // lapses the supervisor, and the terminal delete that used to follow
+        // unconditionally must be replaced by retain-and-refuse.
+        let shared = FakeShared::new();
+        let proxy_shared = FakeProxyShared::new();
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let proxy = fake_proxy_services(Arc::clone(&proxy_shared), &runtime);
+        let harness = Harness::new_supervised_with_proxy(
+            Arc::clone(&shared),
+            proxy,
+            Duration::from_hours(1),
+            Duration::from_millis(1),
+        );
+        let mut lapsed = playing_status(0, 10_000);
+        lapsed.repeat = true;
+        lapsed.has_error = true;
+        shared
+            .statuses
+            .lock()
+            .expect("statuses lock")
+            .push_back(lapsed);
+        let owner = harness.next_owner(3);
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/playing-drift-error".to_string(),
+            },
+        );
+        harness.fence(owner);
+
+        let actions = shared.actions();
+        assert_eq!(
+            actions
+                .iter()
+                .filter(|action| matches!(action, Action::Delete(42)))
+                .count(),
+            0,
+            "the very status that lapsed the supervisor must not be followed by a delete"
+        );
+        assert!(
+            !actions
+                .iter()
+                .any(|action| matches!(action, Action::Point(Point::Stop))),
+            "no partition-global stop may follow the lapse either"
+        );
+        assert!(
+            harness
+                .supervision
+                .lock()
+                .expect("supervision lock")
+                .is_lapsed(),
+            "the drift in the authoritative status must lapse the supervisor"
+        );
+        let events = harness.events();
+        assert!(events.iter().any(|event| matches!(
+            event,
+            PlayerEvent::Error { message, .. }
+                if message == &mpd_exclusive_control_required_message(&rust_i18n::locale())
+        )));
+        assert!(
+            !events
+                .iter()
+                .any(|event| matches!(event, PlayerEvent::TrackEnded { .. })),
+            "a lapsed terminal path must not report completion"
+        );
+        harness.shutdown();
+    }
+
+    #[test]
+    fn supervised_stopped_owned_status_with_drift_and_error_retains_orphan() {
+        // Finding 2 regression (stopped + owned + error branch): same
+        // post-observe gate on the stopped variant — the drift observed by
+        // the very status that reported the remote error revokes authority
+        // before the targeted delete fires.
+        let shared = FakeShared::new();
+        let proxy_shared = FakeProxyShared::new();
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let proxy = fake_proxy_services(Arc::clone(&proxy_shared), &runtime);
+        let harness = Harness::new_supervised_with_proxy(
+            Arc::clone(&shared),
+            proxy,
+            Duration::from_hours(1),
+            Duration::from_millis(1),
+        );
+        let mut lapsed = stopped_status(0, 10_000);
+        lapsed.single = true;
+        lapsed.has_error = true;
+        shared
+            .statuses
+            .lock()
+            .expect("statuses lock")
+            .push_back(lapsed);
+        let owner = harness.next_owner(3);
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/stopped-drift-error".to_string(),
+            },
+        );
+        harness.fence(owner);
+
+        assert_eq!(
+            shared
+                .actions()
+                .iter()
+                .filter(|action| matches!(action, Action::Delete(42)))
+                .count(),
+            0,
+            "the drift observed by the error status must retain the orphan, not delete it"
+        );
+        assert!(
+            harness
+                .supervision
+                .lock()
+                .expect("supervision lock")
+                .is_lapsed(),
+            "the drift in the authoritative status must lapse the supervisor"
+        );
+        assert!(harness.events().iter().any(|event| matches!(
+            event,
+            PlayerEvent::Error { message, .. }
+                if message == &mpd_exclusive_control_required_message(&rust_i18n::locale())
+        )));
+        harness.shutdown();
+    }
+
+    #[test]
+    fn supervised_cleared_pointer_status_with_drift_and_error_retains_orphan() {
+        // Finding 2 regression (cleared-pointer + error branch): the status
+        // reports no current song but carries option drift and a remote
+        // error. The observation lapses the supervisor, so the atomic
+        // targeted delete of our retained entry must NOT fire.
+        let shared = FakeShared::new();
+        let proxy_shared = FakeProxyShared::new();
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let proxy = fake_proxy_services(Arc::clone(&proxy_shared), &runtime);
+        let harness = Harness::new_supervised_with_proxy(
+            Arc::clone(&shared),
+            proxy,
+            Duration::from_hours(1),
+            Duration::from_millis(1),
+        );
+        let mut lapsed = stopped_status(0, 10_000);
+        lapsed.song_id = None;
+        lapsed.repeat = true;
+        lapsed.has_error = true;
+        shared
+            .statuses
+            .lock()
+            .expect("statuses lock")
+            .push_back(lapsed);
+        let owner = harness.next_owner(3);
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/cleared-drift-error".to_string(),
+            },
+        );
+        harness.fence(owner);
+
+        assert_eq!(
+            shared
+                .actions()
+                .iter()
+                .filter(|action| matches!(action, Action::Delete(42)))
+                .count(),
+            0,
+            "option drift observed with the pointer cleared must retain the entry"
+        );
+        assert!(
+            harness
+                .supervision
+                .lock()
+                .expect("supervision lock")
+                .is_lapsed(),
+            "the drift in the authoritative status must lapse the supervisor"
+        );
+        assert!(harness.events().iter().any(|event| matches!(
+            event,
+            PlayerEvent::Error { message, .. }
+                if message == &mpd_exclusive_control_required_message(&rust_i18n::locale())
+        )));
+        harness.shutdown();
+    }
+
+    #[test]
+    fn supervised_completion_status_with_drift_retains_entry_and_refuses() {
+        // Finding 2 regression (completion-delete branch): the queue drained
+        // naturally (pointer cleared, no error) but the very status that
+        // reports completion carries option drift. The observation lapses
+        // the supervisor, so the completion delete must not fire and the
+        // load must NOT report TrackEnded — the retained entry is the
+        // documented post-lapse state.
+        let shared = FakeShared::new();
+        let proxy_shared = FakeProxyShared::new();
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let proxy = fake_proxy_services(Arc::clone(&proxy_shared), &runtime);
+        let harness = Harness::new_supervised_with_proxy(
+            Arc::clone(&shared),
+            proxy,
+            Duration::from_hours(1),
+            Duration::from_millis(1),
+        );
+        let mut lapsed = stopped_status(0, 10_000);
+        lapsed.song_id = None;
+        lapsed.repeat = true;
+        shared
+            .statuses
+            .lock()
+            .expect("statuses lock")
+            .push_back(lapsed);
+        let owner = harness.next_owner(3);
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/completion-drift".to_string(),
+            },
+        );
+        harness.fence(owner);
+
+        assert_eq!(
+            shared
+                .actions()
+                .iter()
+                .filter(|action| matches!(action, Action::Delete(42)))
+                .count(),
+            0,
+            "drift observed by the completion status must retain the entry, not delete it"
+        );
+        assert!(
+            harness
+                .supervision
+                .lock()
+                .expect("supervision lock")
+                .is_lapsed(),
+            "the drift in the completion status must lapse the supervisor"
+        );
+        let events = harness.events();
+        assert!(
+            !events
+                .iter()
+                .any(|event| matches!(event, PlayerEvent::TrackEnded { .. })),
+            "a lapsed completion must not report TrackEnded"
+        );
+        assert!(events.iter().any(|event| matches!(
+            event,
+            PlayerEvent::Error { message, .. }
+                if message == &mpd_exclusive_control_required_message(&rust_i18n::locale())
+        )));
+        harness.shutdown();
+    }
+
+    #[test]
+    fn supervision_lapsed_reports_stale_armed_supervisor_eagerly_for_reselection() {
+        // Finding 3 regression: the selector consults
+        // `supervision_lapsed()` to decide whether same-target reselection
+        // must rebuild the output. The accessor has to apply the same eager
+        // freshness rule as the worker's authority gate: an Armed supervisor
+        // whose last observation predates MAX_SUPERVISION_GAP is equally
+        // disqualified. Consulting only the stored phase reported such an
+        // output as healthy, the reselection was swallowed as a no-op, and
+        // the next load refused — forcing the user to reselect twice.
+        let (event_tx, _event_rx) = async_channel::unbounded();
+        let (worker_tx, _worker_rx) = worker_command_channel(MAX_PENDING_WORKER_COMMANDS);
+        let output = MpdOutput {
+            display_name: "supervised".to_string(),
+            event_tx,
+            event_generation: AtomicU64::new(5),
+            volume: 1.0,
+            plan: control_plan(true, true),
+            intent_epoch: Arc::new(AtomicU64::new(0)),
+            cache: Arc::new(Mutex::new(MpdCache::default())),
+            proxy: ProxyServices::production(),
+            worker_tx,
+            supervision: Arc::new(Mutex::new(SupervisionState::new())),
+        };
+
+        assert!(
+            !output.supervision_lapsed(),
+            "a freshly confirmed supervisor reports healthy"
+        );
+
+        // The evidence goes stale without any poll observing it — exactly
+        // the "newly selected or naturally completed output" shape from the
+        // finding: phase still Armed, but the eager age rule already
+        // disqualifies it.
+        let stale = Instant::now()
+            .checked_sub(MAX_SUPERVISION_GAP + Duration::from_secs(1))
+            .expect("backdated observation instant");
+        output
+            .supervision
+            .lock()
+            .expect("supervision lock")
+            .last_observation = Some(stale);
+
+        assert!(
+            output.supervision_lapsed(),
+            "an Armed-but-stale supervisor must report lapsed eagerly so same-target \
+             reselection takes the rebuild path"
+        );
+        assert!(
+            output
+                .supervision
+                .lock()
+                .expect("supervision lock")
+                .is_lapsed(),
+            "the eager check materializes the lapse, matching the worker gate's semantics"
+        );
+        assert!(
+            output.supervision_lapsed(),
+            "the lapse is terminal: subsequent consultations agree"
+        );
+    }
+
+    #[test]
     fn unsupervised_exclusive_shutdown_still_deletes_owned_orphan() {
         // The retain-on-lapse rule is supervision-specific: an
         // unsupervised `Exclusive` output keeps its pre-existing

--- a/src/audio/mpd_output.rs
+++ b/src/audio/mpd_output.rs
@@ -3710,13 +3710,28 @@ where
     // controller. Under `Unconfirmed` we conservatively retain the orphan so
     // any other client retains its anyway. A supervised `Exclusive` output
     // whose supervisor has lapsed — foreign current song, partition-option
-    // drift, or an observation gap — also retains: stale confirmation must
-    // never authorise cleanup, and only an explicit user reconfirmation
-    // restores the authority. The staleness check is eager: a supervised
-    // output whose supervision evidence is older than `MAX_SUPERVISION_GAP`
-    // retains too, without waiting for the next poll. Unsupervised
-    // `Exclusive` proceeds on the user's confirmation alone.
+    // drift, an observation gap, or the unreadable pre-stop status above —
+    // also retains: stale confirmation must never authorise cleanup, and
+    // only an explicit user reconfirmation restores the authority. The
+    // staleness check is eager: a supervised output whose supervision
+    // evidence is older than `MAX_SUPERVISION_GAP` retains too, without
+    // waiting for the next poll. Unsupervised `Exclusive` proceeds on the
+    // user's confirmation alone.
+    //
+    // The gate is kind-aware. A lapsed `StopOwned` cleanup has issued
+    // neither the stop nor the delete: the connection-usable status-failure
+    // arm above records the ACK failure and falls through here with the
+    // owned song possibly still playing, so returning `Completed` would let
+    // the Stop caller publish a successful stopped state for mutations that
+    // never ran. It therefore returns `Refused` and the caller surfaces the
+    // exclusive-control error with the owned queue entry retained.
+    // `Targeted` load-path cleanup keeps `Completed`: retaining the orphan
+    // and still succeeding is exactly the post-lapse load contract, and the
+    // load rechecks authority on the same evidence after the cleanup.
     if !supervision_authorizes(plan, supervision) {
+        if kind == CleanupKind::StopOwned {
+            return CleanupOutcome::Refused;
+        }
         return CleanupOutcome::Completed;
     }
     let removed = session.connection.delete_id(song_id, deadline);
@@ -6234,6 +6249,92 @@ mod tests {
                     if message == &mpd_exclusive_control_required_message(&rust_i18n::locale())
             )),
             "the expired-supervision stop refusal must surface the exclusive-control error"
+        );
+        assert_eq!(harness.cache().state, PlayerState::Stopped);
+        harness.shutdown();
+    }
+
+    #[test]
+    fn supervised_stop_cleanup_refused_when_status_round_trip_fails_with_usable_ack() {
+        // Connection-usable-failure sibling of the two refusals above
+        // (adjudicated P1, PR #173 thread 3989340443): the cleanup status
+        // round-trip itself fails with a synchronized ACK error — the stream
+        // stays usable, but ownership is indeterminate. The unreadable reply
+        // is a blind window over the partition, so the supervised output
+        // lapses BEFORE the mutation decisions; execution then fell through
+        // to the targeted-delete authority gate, which returned `Completed`,
+        // and the Stop caller published a successful stopped state even
+        // though neither the stop nor the deleteid ran and the owned song
+        // may still be playing. The kind-aware gate must refuse instead:
+        // zero mutations reach MPD and the UI sees the exclusive-control
+        // error — never a silent successful stopped state.
+        let shared = FakeShared::new();
+        let proxy_shared = FakeProxyShared::new();
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let proxy = fake_proxy_services(Arc::clone(&proxy_shared), &runtime);
+        let harness = Harness::new_supervised_with_proxy(
+            Arc::clone(&shared),
+            proxy,
+            Duration::from_hours(1),
+            Duration::from_millis(1),
+        );
+        shared
+            .statuses
+            .lock()
+            .expect("statuses lock")
+            .push_back(playing_status(0, 10_000));
+        let owner = harness.next_owner(3);
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/clean".to_string(),
+            },
+        );
+        harness.fence(owner);
+
+        // The stop cleanup's own status round-trip fails with a
+        // synchronized ACK failure: connection usable, ownership
+        // indeterminate. No poll can interfere inside this window (the
+        // poll interval is one hour), so the only status fetched is the
+        // cleanup's own — and the lapsed supervisor refuses every
+        // mutation afterwards.
+        *shared.fail_at.lock().expect("failure lock") = Some(Point::Status);
+
+        let _ = harness.events();
+        harness.send(owner, CommandKind::Stop);
+        harness.fence(owner);
+        assert!(
+            harness
+                .supervision
+                .lock()
+                .expect("supervision lock")
+                .is_lapsed(),
+            "the connection-usable status failure must lapse the supervisor before the stop"
+        );
+        let actions = shared.actions();
+        assert_eq!(
+            actions
+                .iter()
+                .filter(|action| matches!(action, Action::Point(Point::Stop)))
+                .count(),
+            0,
+            "a stop whose cleanup status failed with a usable ACK must not reach MPD"
+        );
+        assert_eq!(
+            actions
+                .iter()
+                .filter(|action| matches!(action, Action::Delete(42)))
+                .count(),
+            0,
+            "the targeted delete stays gated behind the lapsed supervision"
+        );
+        assert!(
+            harness.events().iter().any(|event| matches!(
+                event,
+                PlayerEvent::Error { message, .. }
+                    if message == &mpd_exclusive_control_required_message(&rust_i18n::locale())
+            )),
+            "the usable-ACK stop refusal must surface the exclusive-control error"
         );
         assert_eq!(harness.cache().state, PlayerState::Stopped);
         harness.shutdown();

--- a/src/audio/mpd_output.rs
+++ b/src/audio/mpd_output.rs
@@ -1557,17 +1557,25 @@ impl RawStatus {
     }
 }
 
-/// Parse MPD's `repeat`/`random`/`single`/`consume` option values. MPD
-/// reports `0` for the default we enforce on every load and `1` for the
-/// alternative; some daemons reply with `true`/`false` or other non-zero
-/// integers. Anything that is not an exact `0` is mapped to `true` so a
-/// foreign mutation of the partition is always detected.
+/// Parse MPD's `repeat`/`random`/`single`/`consume` option values. The
+/// official protocol (mpd.readthedocs.io, "Commands: playback options")
+/// reports `0` for the default Tributary enforces on every load and `1`
+/// for the enabled alternative; `single` and `consume` additionally accept
+/// the enabled keyword `oneshot`. Another controller may legitimately set
+/// `single oneshot` or `consume oneshot`, so the keyword parses as an
+/// enabled option — partition-option drift — never as a protocol failure:
+/// a recoverable failure would drop the session while leaving supervised
+/// authority live inside its freshness window, letting a queued load
+/// overwrite the foreign controller's settings. Values that are neither an
+/// accepted off value nor an accepted enabled value fail the parse — an
+/// unparsable option is incomplete evidence about the partition, never a
+/// clean poll.
 fn parse_option_truthy(value: &str, operation: &'static str) -> MpdResult<bool> {
-    if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
-        return Err(MpdFailure::new(operation));
+    match value {
+        "0" => Ok(false),
+        "1" | "oneshot" => Ok(true),
+        _ => Err(MpdFailure::new(operation)),
     }
-    let parsed = parse_u64(value, operation)?;
-    Ok(parsed != 0)
 }
 
 fn parse_u64(value: &str, operation: &'static str) -> MpdResult<u64> {
@@ -2647,7 +2655,7 @@ fn handle_load<C>(
         .expect("connected MPD session recorded")
         .connection
         .status(deadline);
-    if retire_status_if_stale(&status, active, owner, intent_epoch) {
+    if retire_status_if_stale(&status, active, owner, intent_epoch, plan, supervision) {
         return;
     }
     match status {
@@ -2664,17 +2672,25 @@ fn handle_load<C>(
                 supervision,
             );
         }
-        Err(failure) => cleanup_then_fail(
-            active,
-            owner,
-            failure,
-            intent_epoch,
-            cache,
-            event_tx,
-            timing,
-            plan,
-            supervision,
-        ),
+        Err(failure) => {
+            // The post-action status could not be read or parsed: on a
+            // supervised output that is a blind window over the partition.
+            // Revoke authority BEFORE the failure cleanup so a queued
+            // newer load cannot mutate during the remaining freshness
+            // window this failure just created.
+            lapse_on_unreadable_status(plan, supervision);
+            cleanup_then_fail(
+                active,
+                owner,
+                failure,
+                intent_epoch,
+                cache,
+                event_tx,
+                timing,
+                plan,
+                supervision,
+            );
+        }
     }
 }
 
@@ -2777,6 +2793,54 @@ fn supervise_status(
     supervisor.observe(now);
 }
 
+/// Apply only the REVOKE-ONLY parts of [`supervise_status`] to a status
+/// reply that belongs to a SUPERSEDED generation — the intent epoch
+/// advanced while the request was in flight, so the reply can never
+/// authorize its own command again and the session it served is about to
+/// be retired. The reply still observed the same MPD partition, so its
+/// foreign-controller evidence is fresh: a foreign current song or
+/// partition-option drift must lapse the supervisor BEFORE the session is
+/// retired, or the queued newer load passes its authority gate on a
+/// partition this reply just proved contended. A superseded reply must
+/// never REFRESH or re-arm authority: no observation is recorded here,
+/// only revocation, and observation-gap enforcement stays with the live
+/// paths that own the current generation.
+fn lapse_on_superseded_evidence(
+    plan: MpdControlPlan,
+    supervision: &Mutex<SupervisionState>,
+    status: &MpdStatus,
+    owned_song_id: u64,
+) {
+    if !(plan.supervised && plan.mode == MpdControlMode::Exclusive) {
+        return;
+    }
+    if status_observes_foreign_song(status, owned_song_id) || status.observes_options_drift() {
+        let mut supervisor = supervision
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        supervisor.lapse();
+    }
+}
+
+/// A status reply that could not be read or parsed is incomplete evidence
+/// about the partition — the reply may have failed precisely because a
+/// foreign controller put protocol shapes on it that Tributary does not
+/// know. On a supervised output the failure must therefore revoke
+/// authority instead of leaving it live inside the freshness window: a
+/// queued load that passes the authority gate during that window would
+/// mutate the partition and overwrite the foreign controller's settings.
+/// Revocation only — only an explicit user reconfirmation (a fresh output
+/// instance) restores authority.
+fn lapse_on_unreadable_status(plan: MpdControlPlan, supervision: &Mutex<SupervisionState>) {
+    if !(plan.supervised && plan.mode == MpdControlMode::Exclusive) {
+        return;
+    }
+    let mut supervisor = supervision
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    supervisor.lapse();
+}
+
 fn observe_supervision<C>(
     active: &Option<WorkerSession<C>>,
     owner: CommandOwner,
@@ -2805,9 +2869,27 @@ fn retire_status_if_stale<C>(
     active: &mut Option<WorkerSession<C>>,
     owner: CommandOwner,
     intent_epoch: &AtomicU64,
+    plan: MpdControlPlan,
+    supervision: &Arc<Mutex<SupervisionState>>,
 ) -> bool {
     if is_current(owner, intent_epoch) {
         return false;
+    }
+    // The reply is superseded, but it still observed the same MPD
+    // partition: apply the revoke-only evidence BEFORE retiring the
+    // session. A reply that saw a foreign current song or partition-option
+    // drift must lapse the supervisor so the queued newer load cannot pass
+    // its authority gate on a partition this reply just proved contended.
+    // A superseded reply never refreshes or re-arms authority — only
+    // revocation applies here. An unreadable reply is the same blind
+    // window and revokes for the same reason.
+    match result {
+        Ok(status) => {
+            if let Some(song_id) = active.as_ref().and_then(|session| session.song_id) {
+                lapse_on_superseded_evidence(plan, supervision, status, song_id);
+            }
+        }
+        Err(_) => lapse_on_unreadable_status(plan, supervision),
     }
     let observed_foreign = result.as_ref().is_ok_and(|status| {
         active
@@ -2977,7 +3059,7 @@ fn handle_control<C>(
         .expect("active MPD session checked")
         .connection
         .status(deadline);
-    if retire_status_if_stale(&status, active, owner, intent_epoch) {
+    if retire_status_if_stale(&status, active, owner, intent_epoch, plan, supervision) {
         return;
     }
     match status {
@@ -2996,7 +3078,11 @@ fn handle_control<C>(
         }
         Err(failure) => {
             // A failed ownership query cannot authorize even a global pause.
-            // Drop the session without sending any cleanup command.
+            // Drop the session without sending any cleanup command, and —
+            // on a supervised output — revoke authority: the unreadable
+            // reply is a blind window over the partition, and a queued
+            // newer load must not mutate inside the window it leaves.
+            lapse_on_unreadable_status(plan, supervision);
             active.take();
             fail_current(owner, failure, intent_epoch, cache, event_tx);
             return;
@@ -3079,7 +3165,7 @@ fn handle_control<C>(
         .expect("active MPD session checked")
         .connection
         .status(deadline);
-    if retire_status_if_stale(&status, active, owner, intent_epoch) {
+    if retire_status_if_stale(&status, active, owner, intent_epoch, plan, supervision) {
         return;
     }
     match status {
@@ -3096,17 +3182,25 @@ fn handle_control<C>(
                 supervision,
             );
         }
-        Err(failure) => cleanup_then_fail(
-            active,
-            owner,
-            failure,
-            intent_epoch,
-            cache,
-            event_tx,
-            timing,
-            plan,
-            supervision,
-        ),
+        Err(failure) => {
+            // The post-action status could not be read or parsed: on a
+            // supervised output that is a blind window over the partition.
+            // Revoke authority BEFORE the failure cleanup so a queued
+            // newer load cannot mutate during the remaining freshness
+            // window this failure just created.
+            lapse_on_unreadable_status(plan, supervision);
+            cleanup_then_fail(
+                active,
+                owner,
+                failure,
+                intent_epoch,
+                cache,
+                event_tx,
+                timing,
+                plan,
+                supervision,
+            );
+        }
     }
 }
 
@@ -3138,7 +3232,7 @@ fn poll_active<C>(
         .expect("active MPD session checked")
         .connection
         .status(timing.deadline());
-    if retire_status_if_stale(&status, active, owner, intent_epoch) {
+    if retire_status_if_stale(&status, active, owner, intent_epoch, plan, supervision) {
         return;
     }
     if let Some(session) = active.as_mut() {
@@ -3147,6 +3241,11 @@ fn poll_active<C>(
     let status = match status {
         Ok(status) => status,
         Err(failure) => {
+            // A poll that cannot be read or parsed is a blind window over
+            // the partition: on a supervised output it revokes authority
+            // before the failure cleanup, so a queued newer load cannot
+            // mutate during the remaining freshness window.
+            lapse_on_unreadable_status(plan, supervision);
             cleanup_then_fail(
                 active,
                 owner,
@@ -3480,6 +3579,17 @@ where
     if kind == CleanupKind::StopOwned {
         let status = session.connection.status(deadline);
         if !is_current(owner, intent_epoch) {
+            // The superseded cleanup status still observed the same
+            // partition: apply the revoke-only evidence before retiring it,
+            // exactly as the poll and pre-control paths must, so the queued
+            // newer command cannot mutate on evidence this reply already
+            // invalidated. A superseded reply never refreshes authority.
+            match &status {
+                Ok(status) => {
+                    lapse_on_superseded_evidence(plan, supervision, status, song_id);
+                }
+                Err(_) => lapse_on_unreadable_status(plan, supervision),
+            }
             let can_restore = match &status {
                 Ok(status) => !status_observes_foreign_song(status, song_id),
                 Err(failure) => failure.connection_usable,
@@ -3496,6 +3606,12 @@ where
         // decision below, exactly as the poll path would.
         if let Ok(status) = &status {
             supervise_status(plan, supervision, status, song_id);
+        } else {
+            // The teardown/cleanup status could not be read or parsed: an
+            // unreadable reply is a blind window over the partition, so a
+            // supervised output revokes before the mutation decisions
+            // below instead of trusting the pre-status gate.
+            lapse_on_unreadable_status(plan, supervision);
         }
 
         match status {
@@ -3615,6 +3731,12 @@ fn cleanup_unconditionally<C>(
         // send neither the partition-global stop nor the targeted delete.
         if let Ok(status) = &status {
             supervise_status(plan, supervision, status, song_id);
+        } else {
+            // The teardown/cleanup status could not be read or parsed: an
+            // unreadable reply is a blind window over the partition, so a
+            // supervised output revokes before the mutation decisions
+            // below instead of trusting the pre-status gate.
+            lapse_on_unreadable_status(plan, supervision);
         }
         if !supervision_authorizes(plan, supervision) {
             return;
@@ -5287,6 +5409,399 @@ mod tests {
         assert_eq!(
             exclusive_errors, 2,
             "both stale-between-polls commands report the exclusive-control error"
+        );
+        harness.shutdown();
+    }
+
+    #[test]
+    fn superseded_precontrol_status_with_drift_lapses_and_blocks_queued_load() {
+        // Delayed-response regression (superseded reply, pre-control
+        // path): the pre-control `status` of a playback control observes
+        // partition-option drift, but a newer load was queued while the
+        // reply was in flight, so the reply is retired as stale. The
+        // retirement must still apply the reply's revoke-only evidence:
+        // the supervisor lapses, the superseded control never reaches MPD,
+        // and the queued load is refused at the worker authority gate
+        // instead of mutating the partition the reply just proved
+        // contended.
+        let shared = FakeShared::new();
+        let proxy_shared = FakeProxyShared::new();
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let proxy = fake_proxy_services(Arc::clone(&proxy_shared), &runtime);
+        let harness = Harness::new_supervised_with_proxy(
+            Arc::clone(&shared),
+            proxy,
+            Duration::from_hours(1),
+            Duration::from_millis(1),
+        );
+        let owner = harness.next_owner(1);
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/clean".to_string(),
+            },
+        );
+        harness.fence(owner);
+
+        let mut drift = playing_status(0, 10_000);
+        drift.repeat = true;
+        shared
+            .statuses
+            .lock()
+            .expect("statuses lock")
+            .push_back(drift);
+        let (entered, release) = shared.install_gate(Point::Status);
+
+        // The control's pre-control status enters the gate mid-flight.
+        harness.send(owner, CommandKind::Pause);
+        entered
+            .recv_timeout(Duration::from_secs(2))
+            .expect("pre-control status entered the gate");
+
+        // While the reply is in flight, a newer load is queued: the intent
+        // epoch advances, so the reply will be retired as stale.
+        let queued = harness.next_owner(2);
+        harness.send(
+            queued,
+            CommandKind::Load {
+                uri: "https://music.test/queued".to_string(),
+            },
+        );
+        release.send(()).expect("release pre-control status");
+
+        // Fence with the queued owner itself: a higher-epoch fence would
+        // purge the pending deque and silently drop the queued load.
+        harness.fence(queued);
+
+        assert!(
+            harness
+                .supervision
+                .lock()
+                .expect("supervision lock")
+                .is_lapsed(),
+            "drift observed by a superseded status reply must lapse the supervisor"
+        );
+        assert!(
+            !shared
+                .added_uris()
+                .iter()
+                .any(|uri| uri == "https://music.test/queued"),
+            "the queued load must be refused after the superseded reply observed drift"
+        );
+        assert!(
+            !shared
+                .actions()
+                .iter()
+                .any(|action| matches!(action, Action::Pause(_))),
+            "the superseded control itself must never reach MPD"
+        );
+        assert!(
+            harness.events().iter().any(|event| matches!(
+                event,
+                PlayerEvent::Error { message, .. }
+                    if message == &mpd_exclusive_control_required_message(&rust_i18n::locale())
+            )),
+            "the queued load reports the exclusive-control refusal"
+        );
+        harness.shutdown();
+    }
+
+    #[test]
+    fn superseded_poll_status_with_foreign_song_lapses_and_blocks_queued_load() {
+        // Delayed-response regression (superseded reply, poll path): a
+        // poll status observes a foreign current song, but a newer load
+        // was queued while the reply was in flight. The stale retirement
+        // must apply the foreign-ownership evidence before retiring the
+        // session, so the queued load cannot pass its authority gate on a
+        // partition another controller now owns.
+        let shared = FakeShared::new();
+        let proxy_shared = FakeProxyShared::new();
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let proxy = fake_proxy_services(Arc::clone(&proxy_shared), &runtime);
+        let harness = Harness::new_supervised_with_proxy(
+            Arc::clone(&shared),
+            proxy,
+            Duration::from_hours(1),
+            Duration::from_millis(1),
+        );
+        let owner = harness.next_owner(1);
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/clean".to_string(),
+            },
+        );
+        harness.fence(owner);
+
+        let mut foreign = playing_status(0, 10_000);
+        foreign.song_id = Some(99);
+        shared
+            .statuses
+            .lock()
+            .expect("statuses lock")
+            .push_back(foreign);
+        let (entered, release) = shared.install_gate(Point::Status);
+
+        // Deterministic poll: force the poll so its status enters the
+        // gate instead of racing the poll interval.
+        harness.send(owner, CommandKind::PollNow);
+        entered
+            .recv_timeout(Duration::from_secs(2))
+            .expect("poll status entered the gate");
+
+        let queued = harness.next_owner(2);
+        harness.send(
+            queued,
+            CommandKind::Load {
+                uri: "https://music.test/queued".to_string(),
+            },
+        );
+        release.send(()).expect("release poll status");
+
+        // Fence with the queued owner itself: a higher-epoch fence would
+        // purge the pending deque and silently drop the queued load.
+        harness.fence(queued);
+
+        assert!(
+            harness
+                .supervision
+                .lock()
+                .expect("supervision lock")
+                .is_lapsed(),
+            "a foreign song observed by a superseded poll reply must lapse the supervisor"
+        );
+        assert!(
+            !shared
+                .added_uris()
+                .iter()
+                .any(|uri| uri == "https://music.test/queued"),
+            "the queued load must be refused after the superseded poll observed a foreign song"
+        );
+        assert!(
+            !shared
+                .actions()
+                .iter()
+                .any(|action| matches!(action, Action::Delete(42))),
+            "the stale foreign ownership proof retains the old queue id"
+        );
+        assert!(
+            harness.events().iter().any(|event| matches!(
+                event,
+                PlayerEvent::Error { message, .. }
+                    if message == &mpd_exclusive_control_required_message(&rust_i18n::locale())
+            )),
+            "the queued load reports the exclusive-control refusal"
+        );
+        harness.shutdown();
+    }
+
+    #[test]
+    fn superseded_clean_status_neither_lapses_nor_refreshes_supervision() {
+        // A superseded status reply that observed a CLEAN partition must
+        // leave the supervisor exactly as it was: no revocation (the
+        // partition was uncontended) and no refresh — a stale generation
+        // must never extend or re-arm authority, so the observation
+        // instant the test pinned survives untouched.
+        let shared = FakeShared::new();
+        let proxy_shared = FakeProxyShared::new();
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let proxy = fake_proxy_services(Arc::clone(&proxy_shared), &runtime);
+        let harness = Harness::new_supervised_with_proxy(
+            Arc::clone(&shared),
+            proxy,
+            Duration::from_hours(1),
+            Duration::from_millis(1),
+        );
+        let owner = harness.next_owner(1);
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/clean".to_string(),
+            },
+        );
+        harness.fence(owner);
+
+        let pinned = Instant::now();
+        harness
+            .supervision
+            .lock()
+            .expect("supervision lock")
+            .last_observation = Some(pinned);
+        shared
+            .statuses
+            .lock()
+            .expect("statuses lock")
+            .push_back(playing_status(0, 10_000));
+        let (entered, release) = shared.install_gate(Point::Status);
+
+        harness.send(owner, CommandKind::Pause);
+        entered
+            .recv_timeout(Duration::from_secs(2))
+            .expect("pre-control status entered the gate");
+
+        // Supersede WITHOUT queueing a command: a bare epoch bump models
+        // the retirement trigger without side effects.
+        harness.epoch.fetch_add(1, Ordering::SeqCst);
+        release.send(()).expect("release pre-control status");
+
+        let fence_owner = harness.next_owner(2);
+        harness.fence(fence_owner);
+
+        {
+            let supervision = harness.supervision.lock().expect("supervision lock");
+            assert!(
+                !supervision.is_lapsed(),
+                "a clean superseded reply carries no revoking evidence"
+            );
+            assert_eq!(
+                supervision.last_observation,
+                Some(pinned),
+                "a superseded reply must never refresh the observation instant"
+            );
+        }
+        harness.shutdown();
+    }
+
+    #[test]
+    fn supervised_poll_status_failure_lapses_and_retains_orphan() {
+        // Authority-consequence regression (the `single oneshot` class):
+        // a status reply that cannot be read or parsed used to drop the
+        // session while supervised authority stayed live inside its
+        // freshness window. The failure itself must revoke: the supervisor
+        // lapses, the failure cleanup retains the owned entry (no targeted
+        // delete), and a load issued inside the former window is refused
+        // instead of overwriting whatever the unreadable reply concealed.
+        let shared = FakeShared::new();
+        let proxy_shared = FakeProxyShared::new();
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let proxy = fake_proxy_services(Arc::clone(&proxy_shared), &runtime);
+        let harness = Harness::new_supervised_with_proxy(
+            Arc::clone(&shared),
+            proxy,
+            Duration::from_hours(1),
+            Duration::from_millis(1),
+        );
+        let owner = harness.next_owner(1);
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/clean".to_string(),
+            },
+        );
+        harness.fence(owner);
+        shared.clear_actions();
+        let _ = harness.events();
+
+        *shared.fail_at.lock().expect("failure lock") = Some(Point::Status);
+        harness.send(owner, CommandKind::PollNow);
+        harness.fence(owner);
+
+        assert!(
+            harness
+                .supervision
+                .lock()
+                .expect("supervision lock")
+                .is_lapsed(),
+            "an unreadable status reply revokes supervised authority"
+        );
+        assert_eq!(
+            shared.actions(),
+            vec![Action::Point(Point::Status)],
+            "the failure cleanup retains the orphan: no stop, no delete"
+        );
+
+        // A load inside the former freshness window is refused too.
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/refused".to_string(),
+            },
+        );
+        harness.fence(owner);
+        assert!(
+            !shared
+                .added_uris()
+                .iter()
+                .any(|uri| uri == "https://music.test/refused"),
+            "a load after an unreadable status reply is refused"
+        );
+        assert!(
+            harness.events().iter().any(|event| matches!(
+                event,
+                PlayerEvent::Error { message, .. }
+                    if message == &mpd_exclusive_control_required_message(&rust_i18n::locale())
+            )),
+            "the refused load reports the exclusive-control error"
+        );
+        harness.shutdown();
+    }
+
+    #[test]
+    fn supervised_precontrol_status_failure_lapses_and_blocks_followup_load() {
+        // Authority-consequence regression (pre-control path): a pre-
+        // control status that cannot be read must revoke supervision, not
+        // merely drop the session. No cleanup command may follow, and a
+        // load issued inside the former freshness window is refused.
+        let shared = FakeShared::new();
+        let proxy_shared = FakeProxyShared::new();
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let proxy = fake_proxy_services(Arc::clone(&proxy_shared), &runtime);
+        let harness = Harness::new_supervised_with_proxy(
+            Arc::clone(&shared),
+            proxy,
+            Duration::from_hours(1),
+            Duration::from_millis(1),
+        );
+        let owner = harness.next_owner(1);
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/clean".to_string(),
+            },
+        );
+        harness.fence(owner);
+        shared.clear_actions();
+        let _ = harness.events();
+
+        *shared.fail_at.lock().expect("failure lock") = Some(Point::Status);
+        harness.send(owner, CommandKind::Pause);
+        harness.fence(owner);
+
+        assert!(
+            harness
+                .supervision
+                .lock()
+                .expect("supervision lock")
+                .is_lapsed(),
+            "an unreadable pre-control status revokes supervised authority"
+        );
+        assert_eq!(
+            shared.actions(),
+            vec![Action::Point(Point::Status)],
+            "no control and no cleanup follows the failed preflight"
+        );
+
+        harness.send(
+            owner,
+            CommandKind::Load {
+                uri: "https://music.test/refused".to_string(),
+            },
+        );
+        harness.fence(owner);
+        assert!(
+            !shared
+                .added_uris()
+                .iter()
+                .any(|uri| uri == "https://music.test/refused"),
+            "a load after an unreadable pre-control status is refused"
+        );
+        assert!(
+            harness.events().iter().any(|event| matches!(
+                event,
+                PlayerEvent::Error { message, .. }
+                    if message == &mpd_exclusive_control_required_message(&rust_i18n::locale())
+            )),
+            "the refused load reports the exclusive-control error"
         );
         harness.shutdown();
     }
@@ -8523,6 +9038,74 @@ mod tests {
         assert!(complete.consume);
         assert!(!complete.random);
         assert!(!complete.single);
+    }
+
+    #[test]
+    fn status_parses_oneshot_single_and_consume_as_enabled_drift() {
+        // The official protocol accepts `oneshot` as an enabled value for
+        // `single` and `consume` (mpd.readthedocs.io, playback options).
+        // Another controller may legitimately set either, so both must
+        // parse as an enabled option — partition-option drift — instead of
+        // a recoverable protocol failure that leaves supervised authority
+        // live inside its freshness window.
+        let oneshot_single = parse_status_lines(&[
+            "state: play",
+            "songid: 42",
+            "elapsed: 1.0",
+            "repeat: 0",
+            "random: 0",
+            "single: oneshot",
+            "consume: 0",
+        ])
+        .expect("official `single oneshot` value parses");
+        assert!(oneshot_single.single);
+        assert!(
+            oneshot_single.observes_options_drift(),
+            "single: oneshot is partition-option drift"
+        );
+
+        let oneshot_consume = parse_status_lines(&[
+            "state: play",
+            "songid: 42",
+            "elapsed: 1.0",
+            "repeat: 0",
+            "random: 0",
+            "single: 0",
+            "consume: oneshot",
+        ])
+        .expect("official `consume oneshot` value parses");
+        assert!(oneshot_consume.consume);
+        assert!(
+            oneshot_consume.observes_options_drift(),
+            "consume: oneshot is partition-option drift"
+        );
+    }
+
+    #[test]
+    fn status_rejects_unknown_option_values_fail_closed() {
+        // Only the protocol's accepted off value (`0`) and accepted
+        // enabled values (`1`, `oneshot`) parse. Everything else — foreign
+        // spellings, unknown keywords, out-of-range integers, empty values
+        // — fails the parse: an unparsable option is incomplete evidence
+        // about the partition, never a clean poll.
+        for field in ["repeat", "random", "single", "consume"] {
+            for value in ["true", "false", "2", "oneshot1", "ON", "0 ", ""] {
+                let lines = [
+                    "state: play".to_string(),
+                    "songid: 42".to_string(),
+                    "elapsed: 1.0".to_string(),
+                    format!("repeat: {}", if field == "repeat" { value } else { "0" }),
+                    format!("random: {}", if field == "random" { value } else { "0" }),
+                    format!("single: {}", if field == "single" { value } else { "0" }),
+                    format!("consume: {}", if field == "consume" { value } else { "0" }),
+                ];
+                let refs: Vec<&str> = lines.iter().map(String::as_str).collect();
+                assert!(
+                    parse_status_lines(&refs).is_err(),
+                    "`{field}: {value}` must fail closed instead of reading as a clean poll"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/audio/output.rs
+++ b/src/audio/output.rs
@@ -69,6 +69,18 @@ pub trait AudioOutput {
     /// (greyed out).  MPD manages its own volume independently.
     fn supports_volume(&self) -> bool;
 
+    /// Whether this output's exclusive-control supervision has lapsed.
+    ///
+    /// Only a supervised MPD output can lapse; every other output — and an
+    /// MPD output without an active supervisor — reports `false`. The output
+    /// selector consults this when the already-active row is activated
+    /// again: that reselection is the documented recovery for a lapsed
+    /// supervisor, so it must rebuild the instance (construction re-arms the
+    /// supervisor) instead of being swallowed as a non-perturbing no-op.
+    fn supervision_lapsed(&self) -> bool {
+        false
+    }
+
     // ── Playback controls ───────────────────────────────────────────
 
     /// Load a URI and start playback.

--- a/src/ui/output_dialogs.rs
+++ b/src/ui/output_dialogs.rs
@@ -22,6 +22,15 @@ pub struct SavedOutput {
     /// MPD playback partition. Legacy entries deliberately default to false.
     #[serde(default)]
     pub exclusive_control: bool,
+    /// Whether the user opted in to automatic detection of exclusive control
+    /// before automatic orphan cleanup. Independent of
+    /// `exclusive_control`: a user can confirm exclusive control without
+    /// opting in to detection, or opt in to detection without an explicit
+    /// confirmation. Legacy entries (and the default for new entries) are
+    /// `false` so the conservative "retain orphan unless confirmed" path
+    /// is the default.
+    #[serde(default)]
+    pub detection_enabled: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -63,16 +72,26 @@ fn upsert_saved_output(
     host: &str,
     port: u16,
     exclusive_control: bool,
+    detection_enabled: bool,
 ) -> SavedOutputUpsert {
     if let Some(existing) = outputs
         .iter_mut()
         .find(|output| output.host == host && output.port == port)
     {
         // Re-adding a legacy endpoint is the explicit migration path. Preserve
-        // its existing type and display name so the already-rendered selector
-        // row remains an exact representation of the saved entry.
+        // its existing type, display name, and detection opt-in so the
+        // already-rendered selector row remains an exact representation of
+        // the saved entry. Detection is opt-in per entry, so flipping it
+        // off is not a default migration.
         if exclusive_control && !existing.exclusive_control {
             existing.exclusive_control = true;
+            if detection_enabled {
+                existing.detection_enabled = true;
+            }
+            return SavedOutputUpsert::Upgraded;
+        }
+        if detection_enabled && !existing.detection_enabled {
+            existing.detection_enabled = true;
             return SavedOutputUpsert::Upgraded;
         }
         return SavedOutputUpsert::Unchanged;
@@ -84,6 +103,7 @@ fn upsert_saved_output(
         host: host.to_string(),
         port,
         exclusive_control,
+        detection_enabled,
     });
     SavedOutputUpsert::Added
 }
@@ -95,6 +115,7 @@ pub fn add_saved_output(
     host: &str,
     port: u16,
     exclusive_control: bool,
+    detection_enabled: bool,
 ) -> SavedOutputUpsert {
     let mut outputs = load_saved_outputs();
     let outcome = upsert_saved_output(
@@ -104,6 +125,7 @@ pub fn add_saved_output(
         host,
         port,
         exclusive_control,
+        detection_enabled,
     );
     if !matches!(outcome, SavedOutputUpsert::Unchanged) {
         save_outputs(&outputs);
@@ -122,6 +144,14 @@ fn exclusive_control_confirmation(locale: &str) -> String {
         locale = locale
     )
     .into_owned()
+}
+
+fn detection_warning(locale: &str) -> String {
+    rust_i18n::t!("dialogs.output_detection_warning", locale = locale).into_owned()
+}
+
+fn detection_confirmation(locale: &str) -> String {
+    rust_i18n::t!("dialogs.output_detection_confirmation", locale = locale).into_owned()
 }
 
 /// Remove an output from `outputs.json` by host:port.
@@ -193,6 +223,24 @@ pub fn show_add_output_dialog(window: &adw::ApplicationWindow, output_list: &gtk
         .halign(gtk::Align::Start)
         .build();
 
+    let detection_warning = gtk::Label::builder()
+        .label(detection_warning(&rust_i18n::locale()))
+        .halign(gtk::Align::Start)
+        .wrap(true)
+        .max_width_chars(52)
+        .build();
+    let detection_confirmation_label = gtk::Label::builder()
+        .label(detection_confirmation(&rust_i18n::locale()))
+        .halign(gtk::Align::Start)
+        .wrap(true)
+        .max_width_chars(52)
+        .xalign(0.0)
+        .build();
+    let detection_confirmation = gtk::CheckButton::builder()
+        .child(&detection_confirmation_label)
+        .halign(gtk::Align::Start)
+        .build();
+
     // Use a GtkGrid for consistent label alignment.
     let grid = gtk::Grid::builder()
         .row_spacing(12)
@@ -224,6 +272,8 @@ pub fn show_add_output_dialog(window: &adw::ApplicationWindow, output_list: &gtk
     grid.attach(&port_spin, 1, 2, 1, 1);
     grid.attach(&exclusive_warning, 0, 3, 2, 1);
     grid.attach(&exclusive_confirmation, 0, 4, 2, 1);
+    grid.attach(&detection_warning, 0, 5, 2, 1);
+    grid.attach(&detection_confirmation, 0, 6, 2, 1);
 
     dialog.set_extra_child(Some(&grid));
     dialog.set_response_enabled("add", false);
@@ -237,6 +287,7 @@ pub fn show_add_output_dialog(window: &adw::ApplicationWindow, output_list: &gtk
     let host_entry_c = host_entry.clone();
     let port_spin_c = port_spin.clone();
     let exclusive_confirmation_c = exclusive_confirmation.clone();
+    let detection_confirmation_c = detection_confirmation.clone();
 
     dialog.connect_response(None, move |_dialog, response| {
         if response != "add" || !exclusive_confirmation_c.is_active() {
@@ -246,6 +297,7 @@ pub fn show_add_output_dialog(window: &adw::ApplicationWindow, output_list: &gtk
         let name = name_entry_c.text().to_string().trim().to_string();
         let host = host_entry_c.text().to_string().trim().to_string();
         let port = port_spin_c.value() as u16;
+        let detection_enabled = detection_confirmation_c.is_active();
 
         if name.is_empty() || host.is_empty() {
             return;
@@ -271,9 +323,11 @@ pub fn show_add_output_dialog(window: &adw::ApplicationWindow, output_list: &gtk
                             host = %host,
                             port,
                             version = %version,
+                            detection_enabled,
                             "MPD output added successfully"
                         );
-                        let outcome = add_saved_output("mpd", &name, &host, port, true);
+                        let outcome =
+                            add_saved_output("mpd", &name, &host, port, true, detection_enabled);
 
                         // A legacy endpoint is upgraded in place; its row is
                         // already present and retains its saved display name.
@@ -311,13 +365,49 @@ mod tests {
         let legacy = r#"[{"type":"mpd","name":"Legacy","host":"mpd.local","port":6600}]"#;
         let mut outputs: Vec<SavedOutput> = serde_json::from_str(legacy).expect("legacy JSON");
         assert!(!outputs[0].exclusive_control);
+        assert!(!outputs[0].detection_enabled);
 
         assert_eq!(
-            upsert_saved_output(&mut outputs, "mpd", "Replacement", "mpd.local", 6600, true),
+            upsert_saved_output(
+                &mut outputs,
+                "mpd",
+                "Replacement",
+                "mpd.local",
+                6600,
+                true,
+                true
+            ),
             SavedOutputUpsert::Upgraded
         );
         let serialized = serde_json::to_string(&outputs).expect("approved JSON");
         assert!(serialized.contains(r#""exclusive_control":true"#));
+        assert!(serialized.contains(r#""detection_enabled":true"#));
+    }
+
+    #[test]
+    fn detection_only_opt_in_upgrades_without_changing_exclusive_confirmation() {
+        let mut outputs = vec![SavedOutput {
+            output_type: "mpd".to_string(),
+            name: "Living Room".to_string(),
+            host: "mpd.local".to_string(),
+            port: 6600,
+            exclusive_control: false,
+            detection_enabled: false,
+        }];
+        assert_eq!(
+            upsert_saved_output(
+                &mut outputs,
+                "mpd",
+                "Living Room",
+                "mpd.local",
+                6600,
+                false,
+                true
+            ),
+            SavedOutputUpsert::Upgraded
+        );
+        assert!(outputs[0].detection_enabled);
+        assert!(!outputs[0].exclusive_control);
     }
 
     #[test]
@@ -329,6 +419,7 @@ mod tests {
                 host: "mpd.local".to_string(),
                 port: 6600,
                 exclusive_control: false,
+                detection_enabled: false,
             },
             SavedOutput {
                 output_type: "mpd".to_string(),
@@ -336,20 +427,38 @@ mod tests {
                 host: "office.local".to_string(),
                 port: 6601,
                 exclusive_control: true,
+                detection_enabled: false,
             },
         ];
         let sibling = outputs[1].clone();
 
         assert_eq!(
-            upsert_saved_output(&mut outputs, "mpd", "Renamed", "mpd.local", 6600, true),
+            upsert_saved_output(
+                &mut outputs,
+                "mpd",
+                "Renamed",
+                "mpd.local",
+                6600,
+                true,
+                false
+            ),
             SavedOutputUpsert::Upgraded
         );
         assert_eq!(outputs.len(), 2);
         assert_eq!(outputs[0].name, "Living Room");
         assert!(outputs[0].exclusive_control);
+        assert!(!outputs[0].detection_enabled);
         assert_eq!(outputs[1], sibling);
         assert_eq!(
-            upsert_saved_output(&mut outputs, "mpd", "Renamed", "mpd.local", 6600, true),
+            upsert_saved_output(
+                &mut outputs,
+                "mpd",
+                "Renamed",
+                "mpd.local",
+                6600,
+                true,
+                false
+            ),
             SavedOutputUpsert::Unchanged
         );
         assert_eq!(outputs.len(), 2);
@@ -362,6 +471,25 @@ mod tests {
         for locale in rust_i18n::available_locales!() {
             let warning = exclusive_control_warning(&locale);
             let confirmation = exclusive_control_confirmation(&locale);
+            assert!(!warning.is_empty(), "{locale} warning");
+            assert!(!confirmation.is_empty(), "{locale} confirmation");
+            if locale != "en" {
+                assert_ne!(warning, english_warning, "{locale} warning fallback");
+                assert_ne!(
+                    confirmation, english_confirmation,
+                    "{locale} confirmation fallback"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn detection_warning_and_confirmation_are_localized_everywhere() {
+        let english_warning = detection_warning("en");
+        let english_confirmation = detection_confirmation("en");
+        for locale in rust_i18n::available_locales!() {
+            let warning = detection_warning(&locale);
+            let confirmation = detection_confirmation(&locale);
             assert!(!warning.is_empty(), "{locale} warning");
             assert!(!confirmation.is_empty(), "{locale} confirmation");
             if locale != "en" {

--- a/src/ui/output_switch.rs
+++ b/src/ui/output_switch.rs
@@ -12,7 +12,7 @@ use tracing::{info, warn};
 
 use crate::audio::airplay_output::AirPlayOutput;
 use crate::audio::chromecast_output::ChromecastOutput;
-use crate::audio::mpd_output::{MpdControlMode, MpdOutput};
+use crate::audio::mpd_output::{control_plan, MpdOutput};
 use crate::audio::output::{AudioOutput, OutputType};
 use crate::audio::PlayerEvent;
 
@@ -27,6 +27,11 @@ pub enum OutputTarget {
         host: String,
         port: u16,
         exclusive_control: bool,
+        /// User opted in to automatic detection of exclusive control before
+        /// automatic orphan cleanup. Independent of `exclusive_control`: a
+        /// user can confirm exclusive control without opting in to detection
+        /// (and vice versa). The default for new saved entries is `false`.
+        detection_enabled: bool,
     },
     AirPlay {
         host: String,
@@ -341,12 +346,19 @@ pub fn setup_output_selector(
                 host,
                 port,
                 exclusive_control,
+                detection_enabled,
             } => {
+                // Single shared translation of the persisted flags: the
+                // user's explicit exclusive confirmation is the only grant;
+                // `detection_enabled` only wires the revoke-only supervisor.
+                // Fail-closed for every other combination (see
+                // [`control_plan`]).
+                let plan = control_plan(*exclusive_control, *detection_enabled);
                 let output = MpdOutput::new(
                     &row_name,
                     host,
                     *port,
-                    MpdControlMode::from(*exclusive_control),
+                    plan,
                     event_sender.clone(),
                 )
                 .with_runtime(rt_handle.clone());
@@ -421,6 +433,7 @@ fn target_for_row(
         host: entry.host.clone(),
         port: entry.port,
         exclusive_control: entry.exclusive_control,
+        detection_enabled: entry.detection_enabled,
     })
 }
 
@@ -656,6 +669,7 @@ mod tests {
             host: "music.local".to_string(),
             port: 6600,
             exclusive_control: true,
+            detection_enabled: false,
         };
         assert!(!output_change_required(&current, &current));
     }
@@ -666,13 +680,32 @@ mod tests {
             host: "music.local".to_string(),
             port: 6600,
             exclusive_control: false,
+            detection_enabled: false,
         };
         let exclusive = OutputTarget::Mpd {
             host: "music.local".to_string(),
             port: 6600,
             exclusive_control: true,
+            detection_enabled: false,
         };
         assert!(output_change_required(&unconfirmed, &exclusive));
+    }
+
+    #[test]
+    fn enabling_detection_for_the_same_mpd_endpoint_is_a_real_output_change() {
+        let confirmed = OutputTarget::Mpd {
+            host: "music.local".to_string(),
+            port: 6600,
+            exclusive_control: true,
+            detection_enabled: false,
+        };
+        let detected = OutputTarget::Mpd {
+            host: "music.local".to_string(),
+            port: 6600,
+            exclusive_control: true,
+            detection_enabled: true,
+        };
+        assert!(output_change_required(&confirmed, &detected));
     }
 
     #[test]
@@ -798,6 +831,7 @@ mod tests {
                 host: "music.local".to_string(),
                 port: 6600,
                 exclusive_control: true,
+                detection_enabled: false,
             },
             &playback_session,
             &active_output,
@@ -932,6 +966,7 @@ mod tests {
             host: "music.local".to_string(),
             port: 6600,
             exclusive_control: true,
+            detection_enabled: false,
         };
         let (remote, remote_state) = FakeOutput::boxed("mpd", OutputType::Mpd, 1);
         assert_eq!(
@@ -1070,6 +1105,7 @@ mod tests {
                     host: "music.local".to_string(),
                     port: 6600,
                     exclusive_control: true,
+                    detection_enabled: false,
                 },
                 &mut session,
                 &mut active_output,
@@ -1089,6 +1125,7 @@ mod tests {
             host: "music.local".to_string(),
             port: 6600,
             exclusive_control: true,
+            detection_enabled: false,
         };
         let (mut active_output, remote_state) = FakeOutput::boxed("mpd", OutputType::Mpd, 0);
         let (wrong_parked, wrong_parked_state) =

--- a/src/ui/output_switch.rs
+++ b/src/ui/output_switch.rs
@@ -12,7 +12,7 @@ use tracing::{info, warn};
 
 use crate::audio::airplay_output::AirPlayOutput;
 use crate::audio::chromecast_output::ChromecastOutput;
-use crate::audio::mpd_output::{control_plan, MpdOutput};
+use crate::audio::mpd_output::{control_plan, MpdControlMode, MpdOutput};
 use crate::audio::output::{AudioOutput, OutputType};
 use crate::audio::PlayerEvent;
 
@@ -259,6 +259,90 @@ fn apply_shared_output_selection(
     (OutputSelectionOutcome::Changed, external_source)
 }
 
+/// Whether same-target reselection of this target can ever need the
+/// lapsed-supervisor rebuild. Only `Mpd` targets confirmed for exclusive
+/// control with detection enabled produce a supervised plan; every other
+/// target — and an unsupervised MPD plan — never lapses, so their
+/// same-target reselection keeps the non-perturbing no-op path.
+fn supervision_rebuild_applies(target: &OutputTarget) -> bool {
+    match target {
+        OutputTarget::Mpd {
+            exclusive_control,
+            detection_enabled,
+            ..
+        } => {
+            let plan = control_plan(*exclusive_control, *detection_enabled);
+            plan.supervised && plan.mode == MpdControlMode::Exclusive
+        }
+        OutputTarget::Local | OutputTarget::AirPlay { .. } | OutputTarget::Chromecast { .. } => {
+            false
+        }
+    }
+}
+
+/// Commit a same-target rebuild of the active output — the documented
+/// recovery for a lapsed supervised MPD supervisor. The requested endpoint
+/// equals the active one by definition, so
+/// [`apply_shared_output_selection`]'s preflight (which deliberately
+/// rejects an unchanged target) cannot be used; this helper validates the
+/// activation against the CURRENT target instead and keeps the identical
+/// ordering guarantees: the playback-session proof is cleared before
+/// coordinator ingress, the predecessor is retired between proof revocation
+/// and the first output call, then stopped and replaced. The target itself
+/// is unchanged.
+fn commit_same_target_output_rebuild(
+    active_target: &Rc<RefCell<OutputTarget>>,
+    playback_session: &Rc<RefCell<PlaybackSession>>,
+    active_output: &Rc<RefCell<Box<dyn AudioOutput>>>,
+    activation: OutputActivation,
+    retire_predecessor: impl FnOnce(),
+) -> (
+    OutputSelectionOutcome,
+    Option<crate::architecture::SourceId>,
+) {
+    // Same target: the fresh activation must still typecheck against the
+    // CURRENT target, and the slot it replaces must be of the same type —
+    // otherwise the rebuild is unavailable and the old (refusing) output
+    // stays in place untouched.
+    let valid = {
+        let target = active_target.borrow();
+        let output = active_output.borrow();
+        match &activation {
+            OutputActivation::Remote(remote) => {
+                remote.output_type() == output_type_for_target(&target)
+                    && output.output_type() == output_type_for_target(&target)
+            }
+            OutputActivation::Local => false,
+        }
+    };
+    if !valid {
+        return (OutputSelectionOutcome::Unavailable, None);
+    }
+
+    // The fresh instance owns no playback session: clear the proof before
+    // the replacement so a stale queue cursor can never attach to it.
+    let external_source = {
+        let mut session = playback_session.borrow_mut();
+        let external_source = session.current_external_source_id();
+        session.clear();
+        external_source
+    };
+
+    // No guard crosses coordinator ingress — the old output remains
+    // untouched until the predecessor proof is gone.
+    retire_predecessor();
+
+    {
+        let mut output = active_output.borrow_mut();
+        output.stop();
+        if let OutputActivation::Remote(remote) = activation {
+            *output = remote;
+        }
+    }
+
+    (OutputSelectionOutcome::Changed, external_source)
+}
+
 /// Wire the output selector popover: switching between local, MPD,
 /// AirPlay, and Chromecast outputs.
 ///
@@ -299,13 +383,31 @@ pub fn setup_output_selector(
         };
 
         // Selecting the already-active endpoint must not stop or otherwise
-        // perturb playback.
-        if !output_change_required(&active_target.borrow(), &requested_target) {
+        // perturb playback — with one documented exception: when the active
+        // output is a supervised MPD instance whose supervisor has LAPSED,
+        // re-selecting the row is the user's recovery gesture. The fresh
+        // construction below is the only path that re-arms the supervisor
+        // (construction time IS the explicit reconfirmation), so the
+        // reselection must fall through to the rebuild instead of being
+        // swallowed as a no-op. A healthy supervisor keeps the
+        // non-perturbing behavior, and targets that cannot carry a
+        // supervisor never take the rebuild path.
+        let same_target = !output_change_required(&active_target.borrow(), &requested_target);
+        let rebuild_lapsed_supervision = same_target
+            && supervision_rebuild_applies(&requested_target)
+            && active_output.borrow().supervision_lapsed();
+        if same_target && !rebuild_lapsed_supervision {
             update_checkmarks(list_box, idx);
             if let Some(popover) = output_button.popover() {
                 popover.popdown();
             }
             return;
+        }
+        if rebuild_lapsed_supervision {
+            info!(
+                ?requested_target,
+                "Rebuilding lapsed supervised MPD output on reselection"
+            );
         }
 
         // Output changes deliberately clear rather than implicitly transfer a
@@ -366,19 +468,38 @@ pub fn setup_output_selector(
             }
         };
 
-        let (outcome, external_source) = apply_shared_output_selection(
-            &active_target,
-            requested_target,
-            &playback_session,
-            &active_output,
-            &parked_local,
-            activation,
-            || {
-                let _ = lastfm_playback.retire(
-                    crate::lastfm::playback_coordinator::LastFmPlaybackRetirement::OutputReplacement,
-                );
-            },
-        );
+        let (outcome, external_source) = if rebuild_lapsed_supervision {
+            // Same-target rebuild: apply_shared_output_selection would
+            // preflight-reject an unchanged target, so the lapsed instance
+            // goes through the dedicated same-target commit with the
+            // identical session-proof → coordinator-retire → stop/replace
+            // ordering.
+            commit_same_target_output_rebuild(
+                &active_target,
+                &playback_session,
+                &active_output,
+                activation,
+                || {
+                    let _ = lastfm_playback.retire(
+                        crate::lastfm::playback_coordinator::LastFmPlaybackRetirement::OutputReplacement,
+                    );
+                },
+            )
+        } else {
+            apply_shared_output_selection(
+                &active_target,
+                requested_target,
+                &playback_session,
+                &active_output,
+                &parked_local,
+                activation,
+                || {
+                    let _ = lastfm_playback.retire(
+                        crate::lastfm::playback_coordinator::LastFmPlaybackRetirement::OutputReplacement,
+                    );
+                },
+            )
+        };
         if outcome != OutputSelectionOutcome::Changed {
             warn!(?outcome, "Output selection could not be committed");
             return;
@@ -550,6 +671,7 @@ mod tests {
         state: Rc<RefCell<FakeOutputState>>,
         order: Option<Rc<RefCell<Vec<&'static str>>>>,
         reject_loads: Cell<usize>,
+        lapsed: Cell<bool>,
         volume: f64,
     }
 
@@ -568,6 +690,26 @@ mod tests {
             reject_loads: usize,
             order: Option<Rc<RefCell<Vec<&'static str>>>>,
         ) -> (Box<dyn AudioOutput>, Rc<RefCell<FakeOutputState>>) {
+            Self::build(name, output_type, reject_loads, order, false)
+        }
+
+        /// A supervised MPD fake whose supervisor has lapsed.
+        fn boxed_lapsed_with_order(
+            name: &str,
+            output_type: OutputType,
+            reject_loads: usize,
+            order: Option<Rc<RefCell<Vec<&'static str>>>>,
+        ) -> (Box<dyn AudioOutput>, Rc<RefCell<FakeOutputState>>) {
+            Self::build(name, output_type, reject_loads, order, true)
+        }
+
+        fn build(
+            name: &str,
+            output_type: OutputType,
+            reject_loads: usize,
+            order: Option<Rc<RefCell<Vec<&'static str>>>>,
+            lapsed: bool,
+        ) -> (Box<dyn AudioOutput>, Rc<RefCell<FakeOutputState>>) {
             let state = Rc::new(RefCell::new(FakeOutputState::default()));
             (
                 Box::new(Self {
@@ -576,6 +718,7 @@ mod tests {
                     state: Rc::clone(&state),
                     order,
                     reject_loads: Cell::new(reject_loads),
+                    lapsed: Cell::new(lapsed),
                     volume: 0.5,
                 }),
                 state,
@@ -599,6 +742,10 @@ mod tests {
 
         fn output_type(&self) -> OutputType {
             self.output_type
+        }
+
+        fn supervision_lapsed(&self) -> bool {
+            self.lapsed.get()
         }
 
         fn supports_volume(&self) -> bool {
@@ -801,6 +948,136 @@ mod tests {
             ),
             None
         );
+    }
+
+    #[test]
+    fn supervision_rebuild_only_applies_to_supervised_exclusive_mpd_targets() {
+        let confirmed_detected = OutputTarget::Mpd {
+            host: "music.local".to_string(),
+            port: 6600,
+            exclusive_control: true,
+            detection_enabled: true,
+        };
+        assert!(supervision_rebuild_applies(&confirmed_detected));
+
+        // Confirmed but unsupervised: the user's confirmation alone governs,
+        // nothing can lapse, so same-target reselection stays a no-op.
+        let confirmed_undetected = OutputTarget::Mpd {
+            host: "music.local".to_string(),
+            port: 6600,
+            exclusive_control: true,
+            detection_enabled: false,
+        };
+        assert!(!supervision_rebuild_applies(&confirmed_undetected));
+
+        // Detection without confirmation is fail-closed: no supervisor.
+        let unconfirmed = OutputTarget::Mpd {
+            host: "music.local".to_string(),
+            port: 6600,
+            exclusive_control: false,
+            detection_enabled: true,
+        };
+        assert!(!supervision_rebuild_applies(&unconfirmed));
+        assert!(!supervision_rebuild_applies(&OutputTarget::Local));
+        assert!(!supervision_rebuild_applies(&OutputTarget::AirPlay {
+            host: "music.local".to_string(),
+            port: 7000,
+        }));
+        assert!(!supervision_rebuild_applies(&OutputTarget::Chromecast {
+            address: "192.168.0.20:8009".parse().unwrap(),
+        }));
+    }
+
+    #[test]
+    fn same_target_rebuild_clears_the_session_then_stops_and_replaces_the_lapsed_output() {
+        let order = Rc::new(RefCell::new(Vec::new()));
+        let (lapsed, lapsed_state) = FakeOutput::boxed_lapsed_with_order(
+            "mpd-lapsed",
+            OutputType::Mpd,
+            0,
+            Some(order.clone()),
+        );
+        let (fresh, _) = FakeOutput::boxed("mpd-fresh", OutputType::Mpd, 0);
+        let active_output = Rc::new(RefCell::new(lapsed));
+        let active_target = Rc::new(RefCell::new(OutputTarget::Mpd {
+            host: "music.local".to_string(),
+            port: 6600,
+            exclusive_control: true,
+            detection_enabled: true,
+        }));
+        let playback_session = Rc::new(RefCell::new(PlaybackSession::default()));
+        assert!(playback_session.borrow_mut().replace_queue(
+            vec![super::super::playback::QueueItem::direct_for_test(
+                "file:///tmp/owned.flac".to_string(),
+                "Owned".to_string(),
+                "Artist".to_string(),
+                "Album".to_string(),
+            )],
+            0,
+        ));
+        assert!(playback_session.borrow().has_current());
+        let callbacks = Cell::new(0);
+
+        let (outcome, external_source) = commit_same_target_output_rebuild(
+            &active_target,
+            &playback_session,
+            &active_output,
+            OutputActivation::Remote(fresh),
+            || {
+                order.borrow_mut().push("coordinator-retire");
+                assert!(playback_session.try_borrow_mut().is_ok());
+                assert!(active_output.try_borrow_mut().is_ok());
+                assert!(!playback_session.borrow().has_current());
+                callbacks.set(callbacks.get() + 1);
+            },
+        );
+        assert_eq!(outcome, OutputSelectionOutcome::Changed);
+        assert_eq!(external_source, None);
+        assert_eq!(callbacks.get(), 1);
+        // The stale (lapsed) instance is stopped and dropped; the fresh one
+        // takes the slot; the target is unchanged by definition.
+        assert_eq!(lapsed_state.borrow().stops, 1);
+        assert_eq!(
+            *order.borrow(),
+            ["coordinator-retire", "output-stop", "output-drop"]
+        );
+        assert_eq!(active_output.borrow().name(), "mpd-fresh");
+        assert!(matches!(*active_target.borrow(), OutputTarget::Mpd { .. }));
+    }
+
+    #[test]
+    fn same_target_rebuild_is_unavailable_on_activation_type_mismatch() {
+        let (local_active, local_state) = FakeOutput::boxed("local", OutputType::Local, 0);
+        let (remote_activation, _) = FakeOutput::boxed("mpd", OutputType::Mpd, 0);
+        let active_output = Rc::new(RefCell::new(local_active));
+        let active_target = Rc::new(RefCell::new(OutputTarget::Local));
+        let playback_session = Rc::new(RefCell::new(PlaybackSession::default()));
+        assert!(playback_session.borrow_mut().replace_queue(
+            vec![super::super::playback::QueueItem::direct_for_test(
+                "file:///tmp/owned.flac".to_string(),
+                "Owned".to_string(),
+                "Artist".to_string(),
+                "Album".to_string(),
+            )],
+            0,
+        ));
+
+        let (outcome, external_source) = commit_same_target_output_rebuild(
+            &active_target,
+            &playback_session,
+            &active_output,
+            OutputActivation::Remote(remote_activation),
+            || {
+                panic!("coordinator ingress must stay silent on an invalid rebuild");
+            },
+        );
+        assert_eq!(outcome, OutputSelectionOutcome::Unavailable);
+        assert_eq!(external_source, None);
+        // The active output is untouched: not stopped, not replaced, and the
+        // session proof survives.
+        assert_eq!(local_state.borrow().stops, 0);
+        assert!(playback_session.borrow().has_current());
+        assert_eq!(active_output.borrow().name(), "local");
     }
 
     #[test]

--- a/src/ui/output_switch.rs
+++ b/src/ui/output_switch.rs
@@ -988,8 +988,20 @@ mod tests {
         }));
     }
 
-    #[test]
-    fn same_target_rebuild_clears_the_session_then_stops_and_replaces_the_lapsed_output() {
+    /// Shared fixtures for a same-target supervised MPD rebuild: the active
+    /// slot holds a lapsed supervised output, the target is a supervised
+    /// exclusive MPD endpoint, and the playback session still holds an owned
+    /// queue item — exactly the state in which a rebuild must revoke the
+    /// session proof before touching the predecessor.
+    struct LapsedSupervisedRebuildFixture {
+        order: Rc<RefCell<Vec<&'static str>>>,
+        lapsed_state: Rc<RefCell<FakeOutputState>>,
+        active_output: Rc<RefCell<Box<dyn AudioOutput>>>,
+        active_target: Rc<RefCell<OutputTarget>>,
+        playback_session: Rc<RefCell<PlaybackSession>>,
+    }
+
+    fn lapsed_supervised_mpd_fixture() -> LapsedSupervisedRebuildFixture {
         let order = Rc::new(RefCell::new(Vec::new()));
         let (lapsed, lapsed_state) = FakeOutput::boxed_lapsed_with_order(
             "mpd-lapsed",
@@ -997,7 +1009,6 @@ mod tests {
             0,
             Some(order.clone()),
         );
-        let (fresh, _) = FakeOutput::boxed("mpd-fresh", OutputType::Mpd, 0);
         let active_output = Rc::new(RefCell::new(lapsed));
         let active_target = Rc::new(RefCell::new(OutputTarget::Mpd {
             host: "music.local".to_string(),
@@ -1015,19 +1026,32 @@ mod tests {
             )],
             0,
         ));
-        assert!(playback_session.borrow().has_current());
+        LapsedSupervisedRebuildFixture {
+            order,
+            lapsed_state,
+            active_output,
+            active_target,
+            playback_session,
+        }
+    }
+
+    #[test]
+    fn same_target_rebuild_clears_the_session_then_stops_and_replaces_the_lapsed_output() {
+        let fx = lapsed_supervised_mpd_fixture();
+        assert!(fx.playback_session.borrow().has_current());
+        let (fresh, _) = FakeOutput::boxed("mpd-fresh", OutputType::Mpd, 0);
         let callbacks = Cell::new(0);
 
         let (outcome, external_source) = commit_same_target_output_rebuild(
-            &active_target,
-            &playback_session,
-            &active_output,
+            &fx.active_target,
+            &fx.playback_session,
+            &fx.active_output,
             OutputActivation::Remote(fresh),
             || {
-                order.borrow_mut().push("coordinator-retire");
-                assert!(playback_session.try_borrow_mut().is_ok());
-                assert!(active_output.try_borrow_mut().is_ok());
-                assert!(!playback_session.borrow().has_current());
+                fx.order.borrow_mut().push("coordinator-retire");
+                assert!(fx.playback_session.try_borrow_mut().is_ok());
+                assert!(fx.active_output.try_borrow_mut().is_ok());
+                assert!(!fx.playback_session.borrow().has_current());
                 callbacks.set(callbacks.get() + 1);
             },
         );
@@ -1036,13 +1060,16 @@ mod tests {
         assert_eq!(callbacks.get(), 1);
         // The stale (lapsed) instance is stopped and dropped; the fresh one
         // takes the slot; the target is unchanged by definition.
-        assert_eq!(lapsed_state.borrow().stops, 1);
+        assert_eq!(fx.lapsed_state.borrow().stops, 1);
         assert_eq!(
-            *order.borrow(),
+            *fx.order.borrow(),
             ["coordinator-retire", "output-stop", "output-drop"]
         );
-        assert_eq!(active_output.borrow().name(), "mpd-fresh");
-        assert!(matches!(*active_target.borrow(), OutputTarget::Mpd { .. }));
+        assert_eq!(fx.active_output.borrow().name(), "mpd-fresh");
+        assert!(matches!(
+            *fx.active_target.borrow(),
+            OutputTarget::Mpd { .. }
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## feat(mpd): optional detectable exclusive-control mode before orphan cleanup (tr-cem)

**Status: draft, fix-forward of the 2026-07-27 DO-NOT-MERGE hold and the 2026-09-04 exact-head audit.** Head `9ab1485` supersedes `3932392` and addresses every audit finding. The user's explicit Exclusive confirmation remains the ONLY grant of partition authority; automatic authority is declared infeasible (MPD has no ownership lock/lease/token or atomic conditional partition mutation). All P2.10 / PR #112 constraints are preserved: legacy `exclusive_control: false` default, refuse-before-Buffering/epoch/enqueue, relinquish-without-racy-stop on a foreign current song.

### Audit findings and how this head fixes them

1. **Two-second supervision age enforced eagerly at every authority gate.** Previously the age was only observed by a later successful poll, so a stale confirmation could still exercise itself between polls. The new `SupervisionState::authority_current` refuses and permanently lapses an armed supervisor whose clean evidence is older than `MAX_SUPERVISION_GAP = 2 s`; `supervision_authorizes()` applies it at the worker command gate (loads AND playback controls), both cleanup paths (`cleanup_session`, `cleanup_unconditionally` on shutdown), and the shared public boundary. The unsupervised window is itself disqualifying evidence. `SupervisionState::new()` seeds its observation with the construction instant — re-selecting the output IS the explicit reconfirmation, so authority starts live and decays unless clean polling keeps it fresh.

2. **Preflight authority before any local mutation.** `play`/`pause`/`toggle_play_pause`/`seek_to` gate before enqueue; `stop` gates before `next_owner()` — a refused stop no longer burns the intent epoch, revokes media tickets, or rewrites the cached player state. The gate's failure event is the only effect. The worker repeats the check as defense in depth.

3. **Required partition-option fields.** A `status` reply omitting any of `repeat`/`random`/`single`/`consume` now FAILS the poll instead of defaulting the omission to `false` — a truncated, tampered, or foreign-shaped response can no longer read as a clean poll. `RawStatus::finish()` requires all four fields; the withheld observation lets the eager age gate revoke authority.

### Audit-required tests (all deterministic, FakeMPD harness, no sleeps)

- **Missing-field:** `status_requires_every_partition_option_field` — each field required independently; `0`/`1` parse as false/true; scripted TCP fixtures carry complete replies.
- **Stale-between-polls:** eager-gate unit tests (backdated evidence refuses and lapses without a poll; fresh construction authoritative through the exact boundary; only a fresh instance re-arms) plus `supervised_worker_refuses_commands_whose_evidence_went_stale_between_polls` (worker refuses stale Pause AND Load, lapses eagerly, exactly two exclusive-control errors).
- **Lapse/reconfirmation:** extended eager-gate unit tests (terminal lapse; fresh construction re-arms) alongside the existing `supervision_state_starts_armed_and_never_restores_after_lapse`, foreign-song, and option-drift integration tests.
- **Rejected-control:** `supervised_public_controls_reject_before_any_local_mutation_when_stale` — play/pause/toggle/seek/stop refusals leave epoch, tickets, worker queue, and cache untouched; exactly one Stopped publication plus the localized error per refusal.

### Semantics unchanged

Revoke-only supervision (`Armed` → `Lapsed` on foreign current song, option drift, or observation gap; quiet polling never grants or restores; reconfirmation only by re-selecting the output). Legacy `detection_enabled: true` without the exclusive confirmation fails closed to `Unconfirmed`. `outputs.json` shape unchanged. Orphan cleanup retains the entry whenever supervision cannot prove fresh authority, including shutdown.

### Validation on head `9ab1485`

`cargo fmt --check` OK; `clippy --all-targets` and `clippy --release` with `-D warnings` OK; `check --all-targets --locked` zero warnings; `test --all-targets` **1749 passed / 0 failed**; `test --release` 1749 passed; `build --release` OK. CHANGELOG `[Unreleased]` entry updated with the eager-enforcement and required-fields semantics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional exclusive-output monitoring for MPD playback.
  - Users are warned and asked to confirm monitoring when enabling it.
  - Monitoring automatically revokes control when external playback changes or monitoring is lost.
  - Added localized messaging across supported languages.

- **Bug Fixes**
  - Improved MPD control and cleanup reliability.
  - Rebuilding now restores supervised outputs when monitoring expires.
  - Added safer handling for invalid output activation and legacy saved-output settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->