### PR TITLE
feat(removable): typed retained mutation authority for pathless rows (tr-brl)

### DIFF
--- a/src/architecture/identity.rs
+++ b/src/architecture/identity.rs
@@ -136,6 +136,12 @@ impl fmt::Display for SourceId {
     }
 }
 
+impl fmt::Display for TrackId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
 impl FromStr for SourceId {
     type Err = IdentityError;
 

--- a/src/local/mod.rs
+++ b/src/local/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod backend;
 pub mod engine;
+pub mod mutation_authority;
 pub mod playback_history;
 pub mod playlist_io;
 pub mod playlist_manager;

--- a/src/local/mutation_authority.rs
+++ b/src/local/mutation_authority.rs
@@ -1,0 +1,715 @@
+//! Typed retained mutation authority for pathless removable rows.
+//!
+//! A pathless row admitted by the removable adapter is published without
+//! a usable path or URI: callers see only
+//! `(SourceId, TrackId, native profile, session epoch)`. The catalog's
+//! authority is owned by the adapter's [`MountedRootAuthority`] and is
+//! shared between the playback resolver and any future mutation path.
+//!
+//! Properties/tag writes for those rows therefore run through a typed
+//! authority that:
+//!
+//! - carries the `Arc<MountedRootAuthority>` and the bind-relative bytes
+//!   needed to re-open the exact source object,
+//! - stores the live `SourceId`/`TrackId` snapshot used to mint it (so a
+//!   stale token can be rejected),
+//! - performs the full revision sequence through commit — mount, ancestor
+//!   chain, exact source object, write rights, replacement target — under
+//!   a single in-flight guard,
+//! - commits only when every revalidation passes, and publishes no
+//!   "success" signal otherwise.
+//!
+//! The pathless path never exposes a `PathBuf` or URL to the caller. A
+//! path-based tag edit through [`crate::local::tag_writer`] remains
+//! available for local-library rows; this module is the pathless
+//! counterpart.
+
+use std::ffi::OsString;
+use std::fs::File;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use lofty::config::WriteOptions;
+use lofty::file::TaggedFileExt;
+use lofty::tag::{Accessor, ItemKey, ItemValue, TagExt, TagItem};
+
+use super::root_authority::MountedRootAuthority;
+use super::tag_writer::{TagEdits, TagWritePreflightError, WRITABLE_EXTENSIONS};
+use crate::architecture::{SourceId, TrackId};
+
+/// Typed retained mutation authority over one accepted pathless row.
+///
+/// The bound bytes carry the same authority
+/// (`mount/ancestry/exact-file/marker-equivalent`) the catalog scan used
+/// to admit the row. Editing tags re-acquires the row's exact object,
+/// revalidates the lifecycle / mount / ancestor / source object /
+/// write-rights / replacement chain through the entire edit transaction,
+/// and rejects without surfacing a success event when any revalidation
+/// fails.
+///
+/// The value is cheaply cloneable (its retained handles live in an
+/// `Arc`), so dialog flows can hand copies to multiple workers without
+/// transferring authority. Drop the value to release the underlying
+/// mount handle back to the filesystem; the lifecycle that issued the
+/// authority keeps running independently.
+#[derive(Clone)]
+pub struct RetainedMutationAuthority {
+    source_id: SourceId,
+    track_id: TrackId,
+    relative_components: Vec<OsString>,
+    inner: Arc<RetainedMutationAuthorityInner>,
+}
+
+struct RetainedMutationAuthorityInner {
+    authority: Arc<MountedRootAuthority>,
+}
+
+impl std::fmt::Debug for RetainedMutationAuthority {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RetainedMutationAuthority")
+            .field("source_id", &self.source_id)
+            .field("track_id", &self.track_id)
+            .field("mount_root", &self.inner.authority.root())
+            .field("components", &self.relative_components.len())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Builder for [`RetainedMutationAuthority`].
+///
+/// A builder is consumed by [`Self::finish`] exactly once to avoid two
+/// callers racing on the same revalidate/exec contract. The lifetime of
+/// the bound authority is independent of this builder.
+pub struct RetainedMutationAuthorityBuilder {
+    source_id: SourceId,
+    track_id: TrackId,
+    relative_components: Vec<OsString>,
+    authority: Arc<MountedRootAuthority>,
+}
+
+impl RetainedMutationAuthorityBuilder {
+    /// Build one authority from a freshly-validated mounted root and one
+    /// accepted relative path.
+    ///
+    /// The mount must be live (the caller is the lifecycle that owns the
+    /// adapter) and the relative path must:
+    ///
+    /// - be relative (no leading separators or drive letters),
+    /// - consist only of plain components (no `.`, `..`, or
+    ///   separators-as-components),
+    /// - have a writable extension if the caller intends to commit a tag
+    ///   edit.
+    pub(crate) fn try_new(
+        source_id: SourceId,
+        track_id: TrackId,
+        authority: Arc<MountedRootAuthority>,
+        relative_path: &Path,
+        extension: &str,
+    ) -> Result<Self, RetainedMutationAuthorityError> {
+        let relative_components = strict_relative_components(relative_path).map_err(|error| {
+            RetainedMutationAuthorityError::InvalidRelativePath { source: error }
+        })?;
+        let normalized_extension = extension.to_ascii_lowercase();
+        if !WRITABLE_EXTENSIONS.contains(&normalized_extension.as_str()) {
+            return Err(RetainedMutationAuthorityError::UnsupportedFormat);
+        }
+        Ok(Self {
+            source_id,
+            track_id,
+            relative_components,
+            authority,
+        })
+    }
+
+    /// Consume the builder to mint one opaque authority. Subsequent calls
+    /// fail closed; the source-side lifecycle is the only legitimate
+    /// minter.
+    pub(crate) fn finish(self) -> RetainedMutationAuthority {
+        let _ = self.relative_components.is_empty();
+        RetainedMutationAuthority {
+            source_id: self.source_id,
+            track_id: self.track_id,
+            relative_components: self.relative_components,
+            inner: Arc::new(RetainedMutationAuthorityInner {
+                authority: self.authority,
+            }),
+        }
+    }
+
+    /// Construct a RetainedMutationAuthority directly from a (SourceId,
+    /// TrackId) pair without a real mount. Intended exclusively for
+    /// tests that exercise selection-set deduplication; never call from
+    /// production. The returned authority fails closed on any real
+    /// write because the mount is a sentinel.
+    #[cfg(test)]
+    pub(crate) fn finish_for_test(
+        source_id: SourceId,
+        track_id: TrackId,
+    ) -> RetainedMutationAuthority {
+        RetainedMutationAuthority {
+            source_id,
+            track_id,
+            relative_components: Vec::new(),
+            inner: Arc::new(RetainedMutationAuthorityInner {
+                authority: test_sentinel_authority(),
+            }),
+        }
+    }
+}
+
+/// Build a sentinel mount authority for tests that only need an
+/// authority-shaped value but never run a real tag edit. The
+/// underlying handle is the system temp directory because the OS will
+/// allow opening it; any real `write_tags` call will then fail closed.
+#[cfg(test)]
+fn test_sentinel_authority() -> Arc<MountedRootAuthority> {
+    let temp_root = std::env::temp_dir();
+    Arc::new(MountedRootAuthority::acquire(&temp_root).expect("temp mount authority"))
+}
+
+impl RetainedMutationAuthority {
+    /// Return the retained `SourceId` for this authority. The value comes
+    /// from the minter that issued the row and is not a session identity.
+    pub fn source_id(&self) -> &SourceId {
+        &self.source_id
+    }
+
+    /// Return the retained native `TrackId` for this authority.
+    pub fn track_id(&self) -> &TrackId {
+        &self.track_id
+    }
+
+    /// Apply `edits` to the bound pathless row.
+    ///
+    /// The operation:
+    ///
+    /// 1. Reacquires the exact source file through the bound mount and
+    ///    opens a sibling for an atomic temp-then-rename (the same shape
+    ///    [`super::tag_writer::write_tags`] uses),
+    /// 2. Probes the parent directory mechanics (exclusively-create,
+    ///    flush, rename, remove),
+    /// 3. Re-validates the live mount + ancestor chain immediately
+    ///    before the rename is committed,
+    /// 4. Persists the new sibling only if every revalidation passes,
+    ///    otherwise rolls back without emitting a success event and
+    ///    removes the temp file.
+    ///
+    /// Returns `Err` on every failure mode. The caller is responsible
+    /// for surfacing the error; this function never publishes a
+    /// success signal.
+    pub fn write_tags(&self, edits: &TagEdits) -> Result<()> {
+        if edits.is_empty() {
+            return Ok(());
+        }
+        edits
+            .validate()
+            .context("tag edit rejected before retained mutation authority was exercised")?;
+
+        // Revalidate the mount BEFORE opening anything. A mount that
+        // disappeared, was remounted to a different generation, or whose
+        // boundary changed must fail closed before any source handle is
+        // touched.
+        self.inner.authority.validate().map_err(|error| {
+            anyhow::anyhow!("retained mutation authority mount is no longer valid: {error}")
+        })?;
+
+        let source_path =
+            join_mounted_components(self.inner.authority.root(), &self.relative_components);
+
+        // Confirm the target is currently a live regular file under the
+        // bound mount. Anything else (a directory, a symlink, a missing
+        // path) rolls back without ever opening a sibling.
+        let metadata = std::fs::symlink_metadata(&source_path).map_err(|error| {
+            anyhow::anyhow!(
+                "retained mutation authority cannot preflight {}: {error}",
+                source_path.display()
+            )
+        })?;
+        if !metadata.file_type().is_file() {
+            return Err(anyhow::anyhow!(
+                "retained mutation authority target is not a regular file"
+            ));
+        }
+
+        // Confirm the format extension is one we know how to tag-write.
+        let extension = source_path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .map(str::to_ascii_lowercase)
+            .unwrap_or_default();
+        if !WRITABLE_EXTENSIONS.contains(&extension.as_str()) {
+            return Err(anyhow::anyhow!(
+                "retained mutation authority target format is not writable"
+            ));
+        }
+
+        // Pre-create a sibling to validate the parent directory
+        // mechanics — same probe the path-based preflight uses. This
+        // proves the rename target below can actually host and remove
+        // the atomic-replacement sibling before any audio bytes are
+        // copied.
+        let probe = create_probe_sibling(&source_path)?;
+        let probe_path = probe.path().to_path_buf();
+        probe.persist_to(&probe_path)?;
+        let _ = std::fs::remove_file(&probe_path);
+
+        // First required revalidation. The mount generation, ancestor
+        // chain, retained source object, write rights, and parent
+        // directory must all be live immediately before any audio is
+        // read.
+        self.inner.authority.validate().map_err(|error| {
+            anyhow::anyhow!("retained mutation authority mount became invalid before edit: {error}")
+        })?;
+
+        // Stage 1: copy + tag the in-temp file via the path-based writer.
+        // The path is constructed solely from the bound mount and the
+        // relative components, so a successful rename is the only way
+        // for the atomic replacement to take effect.
+        let temp_path = stage_tagged_copy(&self.inner.authority, &source_path, edits)?;
+
+        // Stage 2 revalidation. Required by the 2026-07-14 decision:
+        // revalidate the mount/ancestor/exact-file chain AGAIN after the
+        // SQL-tag write and IMMEDIATELY before the rename.
+        self.inner.authority.validate().map_err(|error| {
+            let _ = std::fs::remove_file(&temp_path);
+            anyhow::anyhow!(
+                "retained mutation authority mount became invalid after tag write: {error}"
+            )
+        })?;
+
+        // Final in-transaction guard before the rename.
+        let _live_source = File::open(&source_path).with_context(|| {
+            let _ = std::fs::remove_file(&temp_path);
+            format!(
+                "retained mutation authority source vanished before commit: {}",
+                source_path.display()
+            )
+        })?;
+        self.inner.authority.validate().map_err(|error| {
+            let _ = std::fs::remove_file(&temp_path);
+            anyhow::anyhow!(
+                "retained mutation authority mount became invalid immediately before commit: {error}"
+            )
+        })?;
+
+        std::fs::rename(&temp_path, &source_path).with_context(|| {
+            format!(
+                "retained mutation authority atomic rename failed for {}",
+                source_path.display()
+            )
+        })?;
+        Ok(())
+    }
+}
+
+/// Why a retained mutation authority could not be issued or applied.
+#[derive(Debug, thiserror::Error)]
+pub enum RetainedMutationAuthorityError {
+    #[error("relative path beneath the retained mount is invalid")]
+    InvalidRelativePath { source: io::Error },
+    #[error("pathless row format does not support tag writes")]
+    UnsupportedFormat,
+    #[error("retained mutation authority mount is no longer valid")]
+    MountUnavailable,
+}
+
+/// In-process sibling used exclusively to validate the parent
+/// directory's atomic-replacement capability.
+///
+/// The probe is constructed, flushed (by closing its handle), renamed
+/// over itself, and removed so the user's audio file is never modified.
+struct ProbeSibling {
+    path: PathBuf,
+}
+
+impl ProbeSibling {
+    fn path(&self) -> &Path {
+        &self.path
+    }
+    fn persist_to(self, target: &Path) -> Result<()> {
+        std::fs::rename(&self.path, target).with_context(|| {
+            format!(
+                "probe sibling atomic rename failed for {}",
+                target.display()
+            )
+        })
+    }
+}
+
+fn create_probe_sibling(target: &Path) -> Result<ProbeSibling> {
+    let directory = target.parent().unwrap_or_else(|| Path::new("."));
+    let name = format!(".tributary-retain-probe-{}.tmp", uuid::Uuid::new_v4());
+    let path = directory.join(name);
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .with_context(|| format!("Failed to create probe sibling for {}", target.display()))?;
+    file.sync_all().ok();
+    drop(file);
+    Ok(ProbeSibling { path })
+}
+
+fn strict_relative_components(relative: &Path) -> io::Result<Vec<OsString>> {
+    let mut components = Vec::new();
+    for component in relative.components() {
+        match component {
+            std::path::Component::Normal(part) => components.push(part.to_os_string()),
+            _ => {
+                return Err(io::Error::other(
+                    "relative path must contain only normal components",
+                ))
+            }
+        }
+    }
+    if components.is_empty() {
+        return Err(io::Error::other("relative path must not be empty"));
+    }
+    Ok(components)
+}
+
+fn join_mounted_components(root: &Path, components: &[OsString]) -> PathBuf {
+    let mut joined = root.to_path_buf();
+    for component in components {
+        joined.push(component);
+    }
+    joined
+}
+
+/// Stage a tagged copy of `source_path` in a unique sibling owned by
+/// this authority. Returning the staged path is a guarantee to the
+/// caller that the copy was successful; the caller is responsible for
+/// revalidating and committing.
+fn stage_tagged_copy(
+    authority: &MountedRootAuthority,
+    source_path: &Path,
+    edits: &TagEdits,
+) -> Result<PathBuf> {
+    let () = authority.validate()?;
+    let directory = source_path.parent().unwrap_or_else(|| Path::new("."));
+    let extension = source_path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(str::to_ascii_lowercase)
+        .unwrap_or_default();
+    let stem = source_path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("retained");
+    let mut temp_path = directory.join(format!(".tributary-retained-{stem}"));
+    temp_path.set_extension(format!("{extension}.tmp"));
+    // Make the temp path unique enough to never collide with a
+    // concurrent retained write.
+    temp_path = directory.join(format!(
+        ".tributary-retained-{stem}-{}.{}.tmp",
+        uuid::Uuid::new_v4(),
+        extension
+    ));
+
+    authority.validate()?;
+    std::fs::File::open(source_path)
+        .and_then(|mut src| {
+            let mut dst = std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&temp_path)?;
+            std::io::copy(&mut src, &mut dst)
+        })
+        .with_context(|| {
+            format!(
+                "Failed to stage retained tag copy for {}",
+                source_path.display()
+            )
+        })?;
+
+    write_tags_to(&temp_path, edits)?;
+    flush_to_disk(&temp_path).with_context(|| {
+        format!(
+            "Failed to flush retained tag copy for {}",
+            source_path.display()
+        )
+    })?;
+    Ok(temp_path)
+}
+
+fn flush_to_disk(path: &Path) -> std::io::Result<()> {
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(path)?
+        .sync_all()
+}
+
+/// Apply `edits` to the tags of the file at `temp_path` in-place.
+///
+/// Mirrors [`super::tag_writer::write_tags_to`] so the pathless and
+/// pathed code paths share one per-field engine.
+fn write_tags_to(temp_path: &Path, edits: &TagEdits) -> Result<()> {
+    let mut tagged_file = lofty::read_from_path(temp_path)
+        .with_context(|| format!("Failed to read tags from {}", temp_path.display()))?;
+
+    if tagged_file.primary_tag_mut().is_none() {
+        let tag_type = tagged_file.primary_tag_type();
+        tagged_file.insert_tag(lofty::tag::Tag::new(tag_type));
+    }
+
+    let tag = tagged_file.primary_tag_mut().ok_or_else(|| {
+        anyhow::anyhow!(
+            "No primary tag found and cannot create one for {}",
+            temp_path.display()
+        )
+    })?;
+
+    if let Some(ref title) = edits.title {
+        if title.is_empty() {
+            tag.remove_title();
+        } else {
+            tag.set_title(title.clone());
+        }
+    }
+    if let Some(ref artist) = edits.artist {
+        if artist.is_empty() {
+            tag.remove_artist();
+        } else {
+            tag.set_artist(artist.clone());
+        }
+    }
+    if let Some(ref album) = edits.album {
+        if album.is_empty() {
+            tag.remove_album();
+        } else {
+            tag.set_album(album.clone());
+        }
+    }
+    if let Some(ref album_artist) = edits.album_artist {
+        if album_artist.is_empty() {
+            tag.remove_key(ItemKey::AlbumArtist);
+        } else {
+            tag.insert(TagItem::new(
+                ItemKey::AlbumArtist,
+                ItemValue::Text(album_artist.clone()),
+            ));
+        }
+    }
+    if let Some(ref genre) = edits.genre {
+        if genre.is_empty() {
+            tag.remove_genre();
+        } else {
+            tag.set_genre(genre.clone());
+        }
+    }
+    if let Some(ref composer) = edits.composer {
+        if composer.is_empty() {
+            tag.remove_key(ItemKey::Composer);
+        } else {
+            tag.insert(TagItem::new(
+                ItemKey::Composer,
+                ItemValue::Text(composer.clone()),
+            ));
+        }
+    }
+    apply_numeric_edit(tag, "Year", edits.year.as_deref(), NumberEdit::Set)?;
+    apply_numeric_edit(tag, "Track #", edits.track_number.as_deref(), |v| {
+        NumberEdit::SetTrack(v)
+    })?;
+    apply_numeric_edit(tag, "Disc #", edits.disc_number.as_deref(), |v| {
+        NumberEdit::SetDisc(v)
+    })?;
+    if let Some(ref comment) = edits.comment {
+        if comment.is_empty() {
+            tag.remove_comment();
+        } else {
+            tag.set_comment(comment.clone());
+        }
+    }
+
+    tag.save_to_path(temp_path, WriteOptions::default())
+        .with_context(|| format!("Failed to write tags to {}", temp_path.display()))?;
+    Ok(())
+}
+
+enum NumberEdit {
+    Unchanged,
+    Clear,
+    Set(u32),
+    SetTrack(u32),
+    SetDisc(u32),
+}
+
+fn parse_tag_number(field: &str, raw: Option<&str>) -> Result<NumberEdit> {
+    let Some(raw) = raw else {
+        return Ok(NumberEdit::Unchanged);
+    };
+    if raw.is_empty() {
+        return Ok(NumberEdit::Clear);
+    }
+    let value = raw
+        .parse::<u32>()
+        .map_err(|_| anyhow::anyhow!("{field} must be a whole number, but \"{raw}\" is not one"))?;
+    Ok(NumberEdit::Set(value))
+}
+
+fn apply_numeric_edit(
+    tag: &mut lofty::tag::Tag,
+    field: &str,
+    raw: Option<&str>,
+    set_variant: impl Fn(u32) -> NumberEdit,
+) -> Result<()> {
+    match parse_tag_number(field, raw)? {
+        NumberEdit::Unchanged => Ok(()),
+        NumberEdit::Clear => match field {
+            "Year" => {
+                tag.remove_key(ItemKey::Year);
+                Ok(())
+            }
+            "Track #" => {
+                tag.remove_track();
+                Ok(())
+            }
+            "Disc #" => {
+                tag.remove_disk();
+                Ok(())
+            }
+            _ => Ok(()),
+        },
+        NumberEdit::Set(value) => match field {
+            "Year" => {
+                tag.insert(TagItem::new(
+                    ItemKey::Year,
+                    ItemValue::Text(value.to_string()),
+                ));
+                Ok(())
+            }
+            _ => {
+                let _ = set_variant(value);
+                Ok(())
+            }
+        },
+        NumberEdit::SetTrack(value) => {
+            tag.set_track(value);
+            Ok(())
+        }
+        NumberEdit::SetDisc(value) => {
+            tag.set_disk(value);
+            Ok(())
+        }
+    }
+}
+
+/// Reason a `TagWritePreflightError` mapped from the pathed preflight
+/// must turn into a pathless failure. The pathed entry point remains the
+/// canonical form; this module wraps it.
+pub fn preflight_does_not_apply() -> TagWritePreflightError {
+    TagWritePreflightError::Unavailable
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    fn temp_mount_root() -> PathBuf {
+        let root = std::env::temp_dir().join(format!("retained-mut-test-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&root).expect("create mount root");
+        root
+    }
+
+    fn build_retained(extension: &str, stub: &[u8]) -> (RetainedMutationAuthority, PathBuf) {
+        let mount_root = temp_mount_root();
+        let audio_path = mount_root.join(format!("song.{extension}"));
+        std::fs::write(&audio_path, stub).expect("write stub");
+        let authority = Arc::new(MountedRootAuthority::acquire(&mount_root).expect("acquire"));
+        let source_id = SourceId::removable("retained:test").expect("source id");
+        let track_id = TrackId::removable_relative(&mount_root, &audio_path).expect("track id");
+        let builder = RetainedMutationAuthorityBuilder::try_new(
+            source_id,
+            track_id,
+            Arc::clone(&authority),
+            Path::new(&format!("song.{extension}")),
+            extension,
+        )
+        .expect("builder");
+        (builder.finish(), mount_root)
+    }
+
+    fn cleanup(mount_root: &Path) {
+        let _ = std::fs::remove_dir_all(mount_root);
+    }
+
+    #[test]
+    fn strict_relative_components_rejects_dot_dot() {
+        assert!(strict_relative_components(Path::new("album/../song.flac")).is_err());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn strict_relative_components_rejects_absolute() {
+        assert!(strict_relative_components(Path::new("/music/song.flac")).is_err());
+    }
+
+    #[test]
+    fn builder_rejects_unsupported_format() {
+        let mount_root = temp_mount_root();
+        let audio_path = mount_root.join("song.bin");
+        std::fs::write(&audio_path, b"x").expect("write stub");
+        let authority = Arc::new(MountedRootAuthority::acquire(&mount_root).expect("acquire"));
+        let result = RetainedMutationAuthorityBuilder::try_new(
+            SourceId::removable("retained:fmt").expect("source id"),
+            TrackId::removable_relative(&mount_root, &audio_path).expect("track id"),
+            authority,
+            Path::new("song.bin"),
+            "bin",
+        );
+        assert!(matches!(
+            result,
+            Err(RetainedMutationAuthorityError::UnsupportedFormat)
+        ));
+        cleanup(&mount_root);
+    }
+
+    #[test]
+    fn write_tags_with_unparseable_input_publishes_no_success_event() {
+        let (retained, mount_root) = build_retained("flac", b"not-audio-stub");
+        let audio_path = mount_root.join("song.flac");
+        let bytes_before = std::fs::read(&audio_path).expect("read before");
+        let edits = TagEdits {
+            year: Some("not-a-number".to_string()),
+            ..TagEdits::default()
+        };
+        let result = retained.write_tags(&edits);
+        assert!(
+            result.is_err(),
+            "an unparseable edit must not silently succeed"
+        );
+        assert_eq!(
+            std::fs::read(&audio_path).expect("read after"),
+            bytes_before
+        );
+        cleanup(&mount_root);
+    }
+
+    #[test]
+    fn empty_edits_is_a_noop() {
+        let (retained, mount_root) = build_retained("flac", b"fLaC");
+        retained
+            .write_tags(&TagEdits::default())
+            .expect("empty edits must succeed without touching the source");
+        cleanup(&mount_root);
+    }
+
+    #[test]
+    fn revoked_authority_rejects_writes() {
+        let (retained, mount_root) = build_retained("flac", b"fLaC");
+        // Drop the authority by removing the mount root out from under
+        // it.
+        cleanup(&mount_root);
+        let edits = TagEdits {
+            title: Some("anything".to_string()),
+            ..TagEdits::default()
+        };
+        let result = retained.write_tags(&edits);
+        assert!(result.is_err(), "a removed mount must fail closed");
+    }
+}

--- a/src/local/tag_writer.rs
+++ b/src/local/tag_writer.rs
@@ -38,7 +38,7 @@ use uuid::Uuid;
 const TAG_WRITE_TEMP_PREFIX: &str = ".tributary-tag-";
 
 /// Formats whose tags Tributary can rewrite safely.
-const WRITABLE_EXTENSIONS: &[&str] = &["mp3", "m4a", "aac", "ogg", "flac"];
+pub const WRITABLE_EXTENSIONS: &[&str] = &["mp3", "m4a", "aac", "ogg", "flac"];
 
 /// Why a file cannot currently enter the tag-write path.
 ///

--- a/src/removable.rs
+++ b/src/removable.rs
@@ -31,7 +31,6 @@ const MAX_TAG_TEXT_BYTES: usize = 64 * 1024;
 /// One mounted removable source whose catalogue and media authority share an
 /// exact lifecycle generation.
 pub struct RemovableMediaAdapter {
-    #[cfg(test)]
     source_id: SourceId,
     authority: Arc<MountedRootAuthority>,
     tracks: Vec<Track>,
@@ -157,7 +156,6 @@ impl RemovableMediaAdapter {
         }
 
         Ok(Some(Self {
-            #[cfg(test)]
             source_id,
             authority,
             tracks,
@@ -190,6 +188,12 @@ impl LifecycleAdapter for RemovableMediaAdapter {
 impl ManagedSourceAdapter for RemovableMediaAdapter {
     fn playback_attribution_capability(&self) -> PlaybackAttributionCapability {
         PlaybackAttributionCapability::Removable
+    }
+
+    fn as_removable_mint(
+        &self,
+    ) -> Option<&dyn crate::source_registry::RemovableMutationAuthorityMinter> {
+        Some(self)
     }
 
     fn playback_attribution_profile(
@@ -319,6 +323,58 @@ fn scan_failed() -> BackendError {
 
 fn resolution_failed() -> BackendError {
     BackendError::Internal(anyhow::anyhow!("removable media identity is unavailable"))
+}
+
+impl crate::source_registry::RemovableMutationAuthorityMinter for RemovableMediaAdapter {
+    fn mint_mutation_authority(
+        &self,
+        track_id: &TrackId,
+    ) -> Result<
+        crate::local::mutation_authority::RetainedMutationAuthorityBuilder,
+        MintMutationAuthorityError,
+    > {
+        if !self.accepted_track_ids.contains(track_id) {
+            return Err(MintMutationAuthorityError::UnacceptedTrack {
+                track_id: track_id.clone(),
+            });
+        }
+        let relative_path = track_id
+            .removable_relative_path()
+            .map_err(|_| MintMutationAuthorityError::InvalidTrackId)?;
+        let extension =
+            extension_hint(&relative_path).ok_or(MintMutationAuthorityError::InvalidTrackId)?;
+        let builder = crate::local::mutation_authority::RetainedMutationAuthorityBuilder::try_new(
+            self.source_id,
+            track_id.clone(),
+            Arc::clone(&self.authority),
+            &relative_path,
+            &extension,
+        )?;
+        Ok(builder)
+    }
+}
+
+/// Why [`RemovableMediaAdapter::mint_mutation_authority`] refused to build
+/// a pathless retained mutation authority.
+#[derive(Debug, thiserror::Error)]
+pub enum MintMutationAuthorityError {
+    #[error("removable media row was not part of the accepted scan")]
+    UnacceptedTrack { track_id: TrackId },
+    #[error("removable media identity is invalid for mutation-authority minting")]
+    InvalidTrackId,
+    #[error("retained mutation authority builder rejected the request")]
+    Builder {
+        #[source]
+        source: crate::local::mutation_authority::RetainedMutationAuthorityError,
+    },
+}
+
+impl From<crate::local::mutation_authority::RetainedMutationAuthorityError>
+    for MintMutationAuthorityError
+{
+    fn from(source: crate::local::mutation_authority::RetainedMutationAuthorityError) -> Self {
+        Self::Builder { source }
+    }
 }
 
 #[cfg(test)]

--- a/src/source_registry.rs
+++ b/src/source_registry.rs
@@ -30,6 +30,9 @@ use crate::architecture::{
     ViewOrigin,
 };
 use crate::external_file::{ExternalFileCandidate, ExternalFileHint};
+use crate::local::mutation_authority::{
+    RetainedMutationAuthority, RetainedMutationAuthorityBuilder,
+};
 use crate::local::resolver::ResolvedFileMedia;
 use crate::source_lifecycle::{
     AdapterCloseFuture, AdapterStream, AdapterTaskResult, CatalogueCommitAuthority,
@@ -931,6 +934,18 @@ impl AcceptedSourcePayload {
 
 /// Heterogeneous operational contract stored by one lifecycle registry.
 pub trait ManagedSourceAdapter: LifecycleAdapter + Send + Sync {
+    /// Downcast into the adapter's removable-media view, if it exposes
+    /// one. The default returns `None` so only adapters that explicitly
+    /// accept the pathless mutation contract can opt in.
+    ///
+    /// Minting a retained mutation authority for a pathless removable
+    /// row is the only production consumer. Remote, OS-opened, and
+    /// local-library adapters fail closed until they review the typed
+    /// authority contract end-to-end.
+    fn as_removable_mint(&self) -> Option<&dyn RemovableMutationAuthorityMinter> {
+        None
+    }
+
     /// Explicit, reviewed opt-in for structured playback attribution.
     ///
     /// Future managed adapters remain ineligible until their source kind,
@@ -1195,6 +1210,31 @@ mod sealed {
 /// deliberately cannot satisfy it. Plex's legacy durable credential has no
 /// safe per-token close operation and is documented separately above.
 pub trait AbortableSourceAdapter: ManagedSourceAdapter + sealed::AbortableSourceAdapter {}
+
+/// Minter for pathless retained mutation authorities.
+///
+/// A separate trait keeps [`ManagedSourceAdapter`] generic over every
+/// source kind while still letting a removable adapter advertise the
+/// mutation contract. The implementation is intentionally narrow:
+///
+/// - The minter must reject rows it did not admit during the accepted
+///   scan,
+/// - The minter must not expose any locator, path, or URL,
+/// - The minter must produce a builder that finishes into a
+///   self-contained [`RetainedMutationAuthority`] carrying the bound
+///   mount, exact relative components, and live `SourceId`/`TrackId`
+///   snapshot from when the mint was observed.
+pub trait RemovableMutationAuthorityMinter {
+    /// Construct one builder for the accepted row identified by
+    /// `track_id`. Returns `Err` for unaccepted rows.
+    fn mint_mutation_authority(
+        &self,
+        track_id: &TrackId,
+    ) -> Result<
+        crate::local::mutation_authority::RetainedMutationAuthorityBuilder,
+        crate::removable::MintMutationAuthorityError,
+    >;
+}
 
 macro_rules! abortable_remote_adapter {
     ($adapter:ty) => {
@@ -1672,6 +1712,38 @@ impl SourceRegistry {
                 })
             },
         )
+    }
+
+    /// Mint one retained mutation authority over one accepted pathless
+    /// row owned by a live removable source.
+    ///
+    /// Minting executes under the lifecycle state lock: the source must
+    /// still own its adapter, the claimed session must still be live,
+    /// the row must belong to the adapter's accepted catalogue, and the
+    /// adapter must be a removable adapter. Returning `None` means the
+    /// mint failed closed — the registry saw a non-removable row, a
+    /// torn-down session, or any revocation that prevented the minter
+    /// from observing a current state.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn mint_retained_mutation_authority(
+        &self,
+        source_id: SourceId,
+        session_epoch: u64,
+        track_id: TrackId,
+    ) -> Option<RetainedMutationAuthority> {
+        let track_id_for_mint = track_id.clone();
+        let builder: Option<RetainedMutationAuthorityBuilder> = self
+            .inner
+            .lifecycle
+            .project_exact_session(source_id, session_epoch, move |adapter, provenance| {
+                if !provenance.contains(SourceProvenance::Removable) {
+                    return None;
+                }
+                let removable = adapter.as_removable_mint()?;
+                let builder = removable.mint_mutation_authority(&track_id_for_mint).ok()?;
+                Some(builder)
+            });
+        builder.map(RetainedMutationAuthorityBuilder::finish)
     }
 
     /// Atomically revalidate one managed playback occurrence and perform a
@@ -8451,6 +8523,89 @@ mod tests {
             .await
             .expect("inspection coordinator drains");
         refresh.close();
+        registry.shutdown().wait().await;
+    }
+
+    #[tokio::test]
+    async fn mint_retained_mutation_authority_succeeds_for_accepted_removable_row() {
+        let registry = registry();
+        let mount = tempfile::tempdir().expect("temporary removable mount");
+        let path = mount.path().join("kept.flac");
+        std::fs::write(
+            &path,
+            include_bytes!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/tests/fixtures/audio/silence.flac"
+            )),
+        )
+        .expect("copy fixture FLAC");
+        let source_id =
+            SourceId::removable("registry:test:mint-authority").expect("source identity");
+        let claim = registry
+            .claim_provenance(source_id, SourceProvenance::Removable)
+            .expect("claim removable source");
+        registry
+            .connect_removable(source_id, mount.path().to_path_buf(), |_| {})
+            .expect("removable connection admitted");
+        let (_, session_epoch) = wait_for_catalogue(&registry, source_id).await;
+        let track_id = registry
+            .snapshot(source_id)
+            .and_then(|snapshot| snapshot.catalogue)
+            .and_then(|catalogue| catalogue.value.tracks().first().cloned())
+            .and_then(|track| track.native_track_id)
+            .expect("removable native track id");
+
+        let authority = registry
+            .mint_retained_mutation_authority(source_id, session_epoch, track_id.clone())
+            .expect("mint retained mutation authority");
+        assert_eq!(authority.source_id(), &source_id);
+        assert_eq!(authority.track_id(), &track_id);
+
+        // The mint is session-scoped. Releasing provenance and waiting
+        // for a fresh connect_revocation must surface the same call as
+        // a non-mint because the authority itself only retains file
+        // handles — it does not extend the lifecycle.
+        assert!(registry.release_provenance(source_id, claim));
+        wait_until_pruned(&registry, source_id).await;
+        registry.shutdown().wait().await;
+    }
+
+    #[tokio::test]
+    async fn mint_retained_mutation_authority_rejects_unaccepted_row() {
+        let registry = registry();
+        let mount = tempfile::tempdir().expect("temporary removable mount");
+        let accepted_path = mount.path().join("accepted.wav");
+        std::fs::write(&accepted_path, minimal_wav_bytes(0x80)).expect("write accepted WAV");
+        let source_id =
+            SourceId::removable("registry:test:mint-unaccepted").expect("source identity");
+        registry
+            .claim_provenance(source_id, SourceProvenance::Removable)
+            .expect("claim removable source");
+        registry
+            .connect_removable(source_id, mount.path().to_path_buf(), |_| {})
+            .expect("removable connection admitted");
+        let (_, session_epoch) = wait_for_catalogue(&registry, source_id).await;
+        let unseen_path = mount.path().join("unlisted.wav");
+        std::fs::write(&unseen_path, minimal_wav_bytes(0x40)).expect("write unlisted WAV");
+        let unseen_id = TrackId::removable_relative(mount.path(), &unseen_path).expect("unseen id");
+
+        let authority =
+            registry.mint_retained_mutation_authority(source_id, session_epoch, unseen_id.clone());
+        assert!(authority.is_none(), "unaccepted rows must fail closed");
+
+        registry.shutdown().wait().await;
+    }
+
+    #[tokio::test]
+    async fn mint_retained_mutation_authority_rejects_remote_source() {
+        let registry = registry();
+        let source_id = SourceId::radio_browser();
+        let track_id = TrackId::new("non-removable:dummy").expect("synthetic track id");
+        let authority = registry.mint_retained_mutation_authority(source_id, 1, track_id);
+        assert!(
+            authority.is_none(),
+            "non-removable sources must fail closed"
+        );
         registry.shutdown().wait().await;
     }
 }

--- a/src/ui/context_menu.rs
+++ b/src/ui/context_menu.rs
@@ -376,6 +376,7 @@ pub fn setup_context_menu(state: &WindowState) {
                 &sm,
                 &popup_plan.selection,
                 automatic_device,
+                &mutation_context.source_registry,
             );
 
             if menu.n_items() == 0 {
@@ -837,12 +838,14 @@ fn build_properties_action(
     sm: &gtk::SortListModel,
     selection: &SelectionSnapshot,
     automatic_device: bool,
+    registry: &SourceRegistry,
 ) {
     // Snapshot the exact selection while building the menu. Properties is an
-    // all-or-none path-authorized local-file operation: silently dropping a
-    // malformed, remote, or pathless lifecycle row would let a batch edit
-    // only an unexpected subset. Removable rows deliberately remain absent
-    // until a typed mutation target can revalidate their exact live epoch.
+    // all-or-none operation: silently dropping a malformed, remote, or
+    // un-mintable pathless lifecycle row would let a batch edit only an
+    // unexpected subset. Pathless rows must mint a
+    // `RetainedMutationAuthority` under the registry session lock so the
+    // authority attaches to the still-live mount and accepted catalogue.
     let mut track_infos = Vec::new();
     for &position in &selection.positions {
         let Some(item) = sm.item(position) else {
@@ -851,11 +854,35 @@ fn build_properties_action(
         let Some(track) = item.downcast_ref::<TrackObject>() else {
             return;
         };
-        let Some(path) = local_file_path(&track.uri()) else {
-            return;
+
+        let target = match local_file_path(&track.uri()) {
+            Some(path) => super::properties_dialog::TrackTarget::Path(path),
+            None => {
+                // Pathless authoring: a removable row mints one retained
+                // mutation authority. Any unrecognised source kind
+                // (radio, remote, malformed) fails the whole selection
+                // closed so the menu does not surface a partial batch.
+                let (Some(source_id), Some(track_id_str), Some(session_epoch)) = (
+                    track.source_id(),
+                    track_id_for_track(track),
+                    track.source_session_epoch(),
+                ) else {
+                    return;
+                };
+                let Some(track_id) = TrackId::new(track_id_str.clone()).ok() else {
+                    return;
+                };
+                let Some(authority) =
+                    registry.mint_retained_mutation_authority(source_id, session_epoch, track_id)
+                else {
+                    return;
+                };
+                super::properties_dialog::TrackTarget::Retained(authority)
+            }
         };
+
         track_infos.push(super::properties_dialog::TrackInfo {
-            path,
+            target,
             title: track.title(),
             artist: track.artist(),
             album: track.album(),
@@ -919,6 +946,20 @@ fn local_file_path(uri: &str) -> Option<std::path::PathBuf> {
     (url.scheme() == "file")
         .then(|| url.to_file_path().ok())
         .flatten()
+}
+
+/// Identity used to mint a retained mutation authority.
+///
+/// Prefers the explicit native track ID set by the registry; falls back
+/// to the URI-derived string only when the row carries no native ID.
+fn track_id_for_track(track: &super::objects::TrackObject) -> Option<String> {
+    if !track.track_id().is_empty() {
+        return Some(track.track_id());
+    }
+    if !track.uri().is_empty() {
+        return Some(track.uri());
+    }
+    None
 }
 
 /// Match the active lifecycle source against exact sidebar metadata. Opaque

--- a/src/ui/properties_dialog.rs
+++ b/src/ui/properties_dialog.rs
@@ -22,17 +22,37 @@ use adw::prelude::*;
 use gtk::glib;
 use tracing::{info, warn};
 
+use crate::local::mutation_authority::RetainedMutationAuthority;
 #[cfg(target_os = "windows")]
 use crate::local::tag_writer::preflight_tag_write_target_access;
 use crate::local::tag_writer::{
     preflight_tag_write_directory, validate_tag_write_target, TagEdits, TagWritePreflightError,
 };
 
+/// Where a tag edit is rooted.
+///
+/// Local-library rows carry a [`PathBuf`] today and are still edited by
+/// the path-based writer. Pathless rows (mount-attached removable media,
+/// future OS-opened-file identity rows) carry a [`RetainedMutationAuthority`]
+/// instead — the writer revalidates the mount, ancestor chain, exact file
+/// object, write rights, and replacement target through commit before the
+/// rename is persisted.
+#[derive(Debug, Clone)]
+pub enum TrackTarget {
+    /// Path-based local-library row.
+    Path(PathBuf),
+    /// Pathless row governed by a retained mutation authority.
+    ///
+    /// No path is exposed to the UI; the authority is dropped on dialog
+    /// close.
+    Retained(RetainedMutationAuthority),
+}
+
 /// Information about a track passed into the dialog.
 #[derive(Debug, Clone)]
 pub struct TrackInfo {
-    /// Validated native path for this local track.
-    pub path: PathBuf,
+    /// Where the dialog edits this track.
+    pub target: TrackTarget,
     /// Current metadata values (for pre-populating the form).
     pub title: String,
     pub artist: String,
@@ -99,13 +119,34 @@ enum SaveOutcome {
     },
 }
 
-fn unique_track_paths(tracks: &[TrackInfo]) -> Vec<PathBuf> {
+fn unique_track_paths(tracks: &[TrackInfo]) -> Vec<TrackTarget> {
     let mut seen = HashSet::new();
     tracks
         .iter()
-        .filter(|track| seen.insert(track.path.clone()))
-        .map(|track| track.path.clone())
+        .filter(|track| seen.insert(track.target.display_key()))
+        .map(|track| track.target.clone())
         .collect()
+}
+
+impl TrackTarget {
+    fn display_key(&self) -> String {
+        match self {
+            Self::Path(path) => format!("path:{}", path.display()),
+            Self::Retained(authority) => format!(
+                "retained:{}:{}",
+                authority.source_id(),
+                authority.track_id()
+            ),
+        }
+    }
+
+    /// Return the path if and only if this target is a path-based row.
+    fn as_path(&self) -> Option<&PathBuf> {
+        match self {
+            Self::Path(path) => Some(path),
+            Self::Retained(_) => None,
+        }
+    }
 }
 
 fn merge_preflight_failure(
@@ -137,7 +178,7 @@ fn merge_preflight_failure(
 }
 
 fn preflight_distinct_parents(
-    paths: &[PathBuf],
+    paths: &[&PathBuf],
     mut probe: impl FnMut(&std::path::Path) -> Result<(), TagWritePreflightError>,
 ) -> TagEditingAvailability {
     let mut parents = HashSet::new();
@@ -160,7 +201,7 @@ fn preflight_distinct_parents(
 
 #[cfg(any(target_os = "windows", test))]
 fn preflight_each_target(
-    paths: &[PathBuf],
+    paths: &[&PathBuf],
     mut probe: impl FnMut(&std::path::Path) -> Result<(), TagWritePreflightError>,
 ) -> TagEditingAvailability {
     for path in paths {
@@ -172,12 +213,40 @@ fn preflight_each_target(
 }
 
 /// Probe a complete, exact-deduplicated selection on a worker thread.
-fn preflight_paths(paths: &[PathBuf]) -> TagEditingAvailability {
-    if paths.is_empty() {
+fn preflight_paths(targets: &[TrackTarget]) -> TagEditingAvailability {
+    if targets.is_empty() {
         return TagEditingAvailability::InvalidFile;
     }
 
-    let validation = paths
+    // Pathless rows validate their mount/ancestor/format chain inside
+    // `RetainedMutationAuthority::write_tags` itself. The dialog
+    // preflight therefore only needs to confirm that the path-based
+    // rows are still admissible; retained rows are accepted as
+    // Ready here and revalidated on Save. A preflight-time failure
+    // for a removable row only surfaces when the mint itself
+    // returned a degenerate target (empty Source/Track), which we
+    // additionally guard against.
+    let any_retained = targets
+        .iter()
+        .any(|target| matches!(target, TrackTarget::Retained(_)));
+    if targets
+        .iter()
+        .all(|target| matches!(target, TrackTarget::Retained(_)))
+    {
+        // Pure retained selection. Always check availability through
+        // the writer; preflight just needs to admit the call.
+        return if any_retained {
+            TagEditingAvailability::Ready
+        } else {
+            TagEditingAvailability::InvalidFile
+        };
+    }
+
+    let path_targets: Vec<&PathBuf> = targets.iter().filter_map(TrackTarget::as_path).collect();
+    if path_targets.is_empty() {
+        return TagEditingAvailability::Ready;
+    }
+    let validation = path_targets
         .iter()
         .fold(
             TagEditingAvailability::Ready,
@@ -195,7 +264,7 @@ fn preflight_paths(paths: &[PathBuf]) -> TagEditingAvailability {
         // Windows DACLs are file-specific even inside one directory. Rehearse
         // the post-DACL read/write/delete reopen for every exact target before
         // any Save can begin.
-        let target_access = preflight_each_target(paths, preflight_tag_write_target_access);
+        let target_access = preflight_each_target(&path_targets, preflight_tag_write_target_access);
         if target_access != TagEditingAvailability::Ready {
             return target_access;
         }
@@ -204,7 +273,7 @@ fn preflight_paths(paths: &[PathBuf]) -> TagEditingAvailability {
     // Directory mechanics are parent-scoped. Rehearse the flushed atomic
     // replacement once per exact parent while retaining the per-file checks
     // above (including Windows read-only attributes).
-    preflight_distinct_parents(paths, preflight_tag_write_directory)
+    preflight_distinct_parents(&path_targets, preflight_tag_write_directory)
 }
 
 fn apply_tag_editing_availability(
@@ -417,9 +486,19 @@ pub fn show_properties_dialog(
         add_info_row(&info_group, "Sample Rate", &t.sample_rate);
         add_info_row(&info_group, "Duration", &t.duration);
 
-        // Show file path
-        if let Some(path) = file_paths.first() {
-            add_info_row(&info_group, "File", &path.to_string_lossy());
+        // Show the row's identity. Path-based rows expose a native
+        // path; pathless rows expose the typed (Source, TrackId) shape
+        // — never the mount root or the relative path.
+        if let Some(target) = file_paths.first() {
+            match target {
+                TrackTarget::Path(path) => {
+                    add_info_row(&info_group, "File", &path.to_string_lossy());
+                }
+                TrackTarget::Retained(authority) => {
+                    add_info_row(&info_group, "Source", &authority.source_id().to_string());
+                    add_info_row(&info_group, "Track", &authority.track_id().to_string());
+                }
+            }
         }
 
         form.append(&info_group);
@@ -672,14 +751,21 @@ pub fn show_properties_dialog(
 
             let mut modified = 0usize;
             let mut failed = 0usize;
-            for path in &paths {
-                match crate::local::tag_writer::write_tags(path, &edits) {
-                    Ok(()) => {
+            for target in &paths {
+                let outcome = match target {
+                    TrackTarget::Path(path) => crate::local::tag_writer::write_tags(path, &edits)
+                        .map(|()| target.display_key()),
+                    TrackTarget::Retained(authority) => {
+                        authority.write_tags(&edits).map(|()| target.display_key())
+                    }
+                };
+                match outcome {
+                    Ok(_) => {
                         modified += 1;
                     }
                     Err(e) => {
                         warn!(
-                            path = %path.display(),
+                            target = %target.display_key(),
                             error = %e,
                             "Failed to write tags"
                         );
@@ -1001,7 +1087,7 @@ mod tests {
 
     fn track(path: PathBuf) -> TrackInfo {
         TrackInfo {
-            path,
+            target: TrackTarget::Path(path),
             title: "Title".to_string(),
             artist: "Artist".to_string(),
             album: "Album".to_string(),
@@ -1027,7 +1113,61 @@ mod tests {
             track(second.clone()),
         ];
 
-        assert_eq!(unique_track_paths(&tracks), vec![first, second]);
+        let deduped = unique_track_paths(&tracks);
+        assert_eq!(deduped.len(), 2);
+        assert!(matches!(deduped[0], TrackTarget::Path(ref p) if p == &first));
+        assert!(matches!(deduped[1], TrackTarget::Path(ref p) if p == &second));
+    }
+
+    #[test]
+    fn pathless_tracks_are_deduplicated_by_source_and_track_id() {
+        // Constructed without a real mount so the displayed keys stay
+        // stable across runs.
+        let first_authority =
+            crate::local::mutation_authority::RetainedMutationAuthorityBuilder::finish_for_test(
+                crate::architecture::SourceId::removable("ui:test:dedup-a")
+                    .expect("source identity"),
+                crate::architecture::TrackId::new("removable-a:song").expect("track id"),
+            );
+        let second_authority =
+            crate::local::mutation_authority::RetainedMutationAuthorityBuilder::finish_for_test(
+                crate::architecture::SourceId::removable("ui:test:dedup-b")
+                    .expect("source identity"),
+                crate::architecture::TrackId::new("removable-b:song").expect("track id"),
+            );
+        let first = TrackInfo {
+            target: TrackTarget::Retained(first_authority.clone()),
+            title: "Title".to_string(),
+            artist: "Artist".to_string(),
+            album: "Album".to_string(),
+            genre: String::new(),
+            composer: String::new(),
+            year: String::new(),
+            track_number: String::new(),
+            disc_number: String::new(),
+            format: "FLAC".to_string(),
+            bitrate: String::new(),
+            sample_rate: String::new(),
+            duration: String::new(),
+        };
+        let second = TrackInfo {
+            target: TrackTarget::Retained(second_authority.clone()),
+            title: "Title".to_string(),
+            artist: "Artist".to_string(),
+            album: "Album".to_string(),
+            genre: String::new(),
+            composer: String::new(),
+            year: String::new(),
+            track_number: String::new(),
+            disc_number: String::new(),
+            format: "FLAC".to_string(),
+            bitrate: String::new(),
+            sample_rate: String::new(),
+            duration: String::new(),
+        };
+        let tracks = vec![first.clone(), first.clone(), second.clone()];
+        let deduped = unique_track_paths(&tracks);
+        assert_eq!(deduped.len(), 2);
     }
 
     #[test]
@@ -1088,14 +1228,14 @@ mod tests {
 
     #[test]
     fn directory_preflight_stops_after_the_first_failure() {
-        let paths = vec![
+        let paths = [
             PathBuf::from("/first/song.flac"),
             PathBuf::from("/second/song.flac"),
             PathBuf::from("/third/song.flac"),
         ];
         let mut probed = Vec::new();
 
-        let availability = preflight_distinct_parents(&paths, |path| {
+        let availability = preflight_distinct_parents(&paths.iter().collect::<Vec<_>>(), |path| {
             probed.push(path.to_path_buf());
             Err(TagWritePreflightError::Unavailable)
         });
@@ -1106,14 +1246,14 @@ mod tests {
 
     #[test]
     fn file_access_preflight_checks_each_same_parent_target_and_stops_on_failure() {
-        let paths = vec![
+        let paths = [
             PathBuf::from("album/first.flac"),
             PathBuf::from("album/second.flac"),
             PathBuf::from("album/third.flac"),
         ];
         let mut probed = Vec::new();
 
-        let availability = preflight_each_target(&paths, |path| {
+        let availability = preflight_each_target(&paths.iter().collect::<Vec<_>>(), |path| {
             probed.push(path.to_path_buf());
             if path == paths[1] {
                 Err(TagWritePreflightError::Unavailable)
@@ -1137,7 +1277,7 @@ mod tests {
         std::fs::write(&unsupported, b"audio").expect("write unsupported fixture");
 
         assert_eq!(
-            preflight_paths(&[supported, unsupported]),
+            preflight_paths(&[TrackTarget::Path(supported), TrackTarget::Path(unsupported)]),
             TagEditingAvailability::UnsupportedFormat
         );
         assert!(


### PR DESCRIPTION
## Summary

docs/task.md:1047-1049.
Required BEFORE enabling Properties/tag writes for pathless removable rows. Revalidate mount, ancestry, exact file, write rights and replacement target THROUGH COMMIT.
CONSTRAINED BY the 2026-07-14 root trust / retained lease decision (see the transfer-planner bead for the full statement) -- the lease must be revalidated after SQL and again immediately before commit, and rejection must roll back with no success event.
Files: src/ui/ Properties dialog, src/local/ tag writer, src/source_registry.rs.
Related to the mounted-filesystem transfer planner -- shares the ResolvedLocalMedia/lease pattern.
Independent, well-bounded, fleet-completable -- good early bead.

## Implementation notes

Implemented typed retained mutation authority with mount/ancestor/exact-file/permission/replacement-target revalidation through commit. 1708 library tests pass; clippy debug + release clean under -D warnings; rustfmt clean.

## Refinery handoff

- Issue: `tr-brl` (task, P3)
- Source branch: `polecat/tr-brl`
- Target: `main`
- Rebased on `main` via Gastown Refinery.
