### PR TITLE
style(ui): re-evaluate separator, count-opacity and alignment against GNOME HIG (tr-ewq)

### DIFF
--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -537,10 +537,7 @@ fn build_pane(title: &str, store: &gio::ListStore) -> gtk::Box {
             .item()
             .and_downcast::<BrowserItem>()
             .expect("BrowserItem");
-        let row = list_item
-            .child()
-            .and_downcast::<gtk::Box>()
-            .expect("Box");
+        let row = list_item.child().and_downcast::<gtk::Box>().expect("Box");
         let first = row
             .first_child()
             .and_downcast::<gtk::Label>()

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -489,6 +489,17 @@ impl TrackSnapshot {
     }
 }
 
+/// Widgets owned by a single browser-pane [`gtk::ListItem`]. Held by the
+/// ListItem via `set_data` so bind / unbind can address them by name
+/// instead of relying on insertion order (`first_child` / `last_child`).
+struct RowWidgets {
+    label: gtk::Label,
+    count: gtk::Label,
+    row: gtk::Box,
+}
+
+const ROW_WIDGETS_KEY: &str = "tributary-browser-row-widgets";
+
 fn build_pane(title: &str, store: &gio::ListStore) -> gtk::Box {
     let header = gtk::Label::builder()
         .label(title)
@@ -516,7 +527,7 @@ fn build_pane(title: &str, store: &gio::ListStore) -> gtk::Box {
         let count = gtk::Label::builder()
             .halign(gtk::Align::End)
             .valign(gtk::Align::Center)
-            .css_classes(["dim-label", "caption", "numeric"])
+            .css_classes(["dim-label", "caption", "numeric", "browser-count"])
             .build();
         let row = gtk::Box::builder()
             .orientation(gtk::Orientation::Horizontal)
@@ -528,6 +539,23 @@ fn build_pane(title: &str, store: &gio::ListStore) -> gtk::Box {
             .build();
         row.append(&label);
         row.append(&count);
+        // Mark the child labels as presentational so the screen reader
+        // does not announce them as separate items; the combined text
+        // is announced from the row's accessible label set in bind.
+        label.set_accessible_role(gtk::AccessibleRole::Presentation);
+        count.set_accessible_role(gtk::AccessibleRole::Presentation);
+        // Stable ownership: hold the labels and the row as a wrapper
+        // attached to the ListItem so bind / unbind can address them by
+        // name instead of by first_child / last_child (which depends on
+        // insertion order).
+        let widgets = RowWidgets {
+            label: label.clone(),
+            count: count.clone(),
+            row: row.clone(),
+        };
+        unsafe {
+            list_item.set_data(ROW_WIDGETS_KEY, widgets);
+        }
         list_item.set_child(Some(&row));
     });
 
@@ -537,17 +565,32 @@ fn build_pane(title: &str, store: &gio::ListStore) -> gtk::Box {
             .item()
             .and_downcast::<BrowserItem>()
             .expect("BrowserItem");
-        let row = list_item.child().and_downcast::<gtk::Box>().expect("Box");
-        let first = row
-            .first_child()
-            .and_downcast::<gtk::Label>()
-            .expect("Label");
-        let second = row
-            .last_child()
-            .and_downcast::<gtk::Label>()
-            .expect("Label");
-        first.set_text(&item.label());
-        second.set_text(&format!("({})", item.count()));
+        let widgets = unsafe { list_item.data::<RowWidgets>(ROW_WIDGETS_KEY) }
+            .expect("RowWidgets attached in setup");
+        let widgets = unsafe { widgets.as_ref() };
+        widgets.label.set_text(&item.label());
+        let count_text = format!("({})", item.count());
+        widgets.count.set_text(&count_text);
+        // Combine the label and parenthesized count into a single
+        // accessible label so a screen reader announces the row as one
+        // utterance ("Artist Name, 123") rather than two adjacent
+        // separate labels. The child labels are marked Presentation in
+        // setup so they are not announced individually.
+        let accessible = format!("{}, {}", item.label(), count_text);
+        widgets
+            .row
+            .update_property(&[gtk::accessible::Property::Label(&accessible)]);
+    });
+
+    factory.connect_unbind(|_, list_item| {
+        let list_item = list_item.downcast_ref::<gtk::ListItem>().expect("ListItem");
+        let Some(widgets) = (unsafe { list_item.data::<RowWidgets>(ROW_WIDGETS_KEY) }) else {
+            return;
+        };
+        let widgets = unsafe { widgets.as_ref() };
+        widgets.label.set_text("");
+        widgets.count.set_text("");
+        widgets.row.reset_property(gtk::AccessibleProperty::Label);
     });
 
     let list_view = gtk::ListView::builder()

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -508,13 +508,27 @@ fn build_pane(title: &str, store: &gio::ListStore) -> gtk::Box {
         let list_item = list_item.downcast_ref::<gtk::ListItem>().expect("ListItem");
         let label = gtk::Label::builder()
             .halign(gtk::Align::Start)
+            .valign(gtk::Align::Center)
+            .ellipsize(gtk::pango::EllipsizeMode::End)
+            .hexpand(true)
+            .single_line_mode(true)
+            .build();
+        let count = gtk::Label::builder()
+            .halign(gtk::Align::End)
+            .valign(gtk::Align::Center)
+            .css_classes(["dim-label", "caption", "numeric"])
+            .build();
+        let row = gtk::Box::builder()
+            .orientation(gtk::Orientation::Horizontal)
+            .spacing(6)
             .margin_start(8)
             .margin_end(8)
             .margin_top(2)
             .margin_bottom(2)
-            .ellipsize(gtk::pango::EllipsizeMode::End)
             .build();
-        list_item.set_child(Some(&label));
+        row.append(&label);
+        row.append(&count);
+        list_item.set_child(Some(&row));
     });
 
     factory.connect_bind(|_, list_item| {
@@ -523,11 +537,20 @@ fn build_pane(title: &str, store: &gio::ListStore) -> gtk::Box {
             .item()
             .and_downcast::<BrowserItem>()
             .expect("BrowserItem");
-        let label = list_item
+        let row = list_item
             .child()
+            .and_downcast::<gtk::Box>()
+            .expect("Box");
+        let first = row
+            .first_child()
             .and_downcast::<gtk::Label>()
             .expect("Label");
-        label.set_text(&item.display());
+        let second = row
+            .last_child()
+            .and_downcast::<gtk::Label>()
+            .expect("Label");
+        first.set_text(&item.label());
+        second.set_text(&format!("({})", item.count()));
     });
 
     let list_view = gtk::ListView::builder()

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -12,6 +12,7 @@ use std::rc::Rc;
 use gtk::gio;
 use gtk::glib;
 use gtk::prelude::*;
+use gtk::subclass::prelude::ObjectSubclassIsExt;
 
 use super::objects::{BrowserItem, TrackObject};
 use crate::ui::folder_browser::{FolderBrowser, RootBrowseError};
@@ -489,16 +490,88 @@ impl TrackSnapshot {
     }
 }
 
-/// Widgets owned by a single browser-pane [`gtk::ListItem`]. Held by the
-/// ListItem via `set_data` so bind / unbind can address them by name
-/// instead of relying on insertion order (`first_child` / `last_child`).
-struct RowWidgets {
-    label: gtk::Label,
-    count: gtk::Label,
-    row: gtk::Box,
+/// One browser-pane row: the primary label plus the dimmed trailing
+/// count, owned by a dedicated [`gtk::Box`] subclass so bind / unbind
+/// can address the labels by name — without GObject data pointers
+/// (`set_data` / `data`, which require `unsafe`) and without
+/// insertion-order traversal (`first_child` / `last_child`).
+mod imp {
+    use super::*;
+    use gtk::subclass::prelude::*;
+
+    #[derive(Debug)]
+    pub struct BrowserRow {
+        pub label: gtk::Label,
+        pub count: gtk::Label,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for BrowserRow {
+        const NAME: &'static str = "TributaryBrowserRow";
+        type Type = super::BrowserRow;
+        type ParentType = gtk::Box;
+
+        fn new() -> Self {
+            let label = gtk::Label::builder()
+                .halign(gtk::Align::Start)
+                .valign(gtk::Align::Center)
+                .ellipsize(gtk::pango::EllipsizeMode::End)
+                .hexpand(true)
+                .single_line_mode(true)
+                .build();
+            // Presentational: the row's combined accessible label is
+            // set in bind, so the screen reader announces the row as
+            // one utterance rather than two separate labels.
+            label.set_accessible_role(gtk::AccessibleRole::Presentation);
+            let count = gtk::Label::builder()
+                .halign(gtk::Align::End)
+                .valign(gtk::Align::Center)
+                .css_classes(["dim-label", "caption", "numeric", "browser-count"])
+                .build();
+            count.set_accessible_role(gtk::AccessibleRole::Presentation);
+            Self { label, count }
+        }
+    }
+
+    impl ObjectImpl for BrowserRow {
+        fn constructed(&self) {
+            self.parent_constructed();
+            let row = self.obj();
+            row.set_orientation(gtk::Orientation::Horizontal);
+            row.set_spacing(6);
+            row.set_margin_start(8);
+            row.set_margin_end(8);
+            row.set_margin_top(2);
+            row.set_margin_bottom(2);
+            row.append(&self.label);
+            row.append(&self.count);
+        }
+    }
+
+    impl BoxImpl for BrowserRow {}
+    impl WidgetImpl for BrowserRow {}
 }
 
-const ROW_WIDGETS_KEY: &str = "tributary-browser-row-widgets";
+glib::wrapper! {
+    pub struct BrowserRow(ObjectSubclass<imp::BrowserRow>)
+        @extends gtk::Box, gtk::Widget,
+        @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget,
+                    gtk::Orientable;
+}
+
+impl BrowserRow {
+    fn new() -> Self {
+        glib::Object::builder().build()
+    }
+
+    fn label(&self) -> &gtk::Label {
+        &self.imp().label
+    }
+
+    fn count(&self) -> &gtk::Label {
+        &self.imp().count
+    }
+}
 
 fn build_pane(title: &str, store: &gio::ListStore) -> gtk::Box {
     let header = gtk::Label::builder()
@@ -517,46 +590,10 @@ fn build_pane(title: &str, store: &gio::ListStore) -> gtk::Box {
 
     factory.connect_setup(|_, list_item| {
         let list_item = list_item.downcast_ref::<gtk::ListItem>().expect("ListItem");
-        let label = gtk::Label::builder()
-            .halign(gtk::Align::Start)
-            .valign(gtk::Align::Center)
-            .ellipsize(gtk::pango::EllipsizeMode::End)
-            .hexpand(true)
-            .single_line_mode(true)
-            .build();
-        let count = gtk::Label::builder()
-            .halign(gtk::Align::End)
-            .valign(gtk::Align::Center)
-            .css_classes(["dim-label", "caption", "numeric", "browser-count"])
-            .build();
-        let row = gtk::Box::builder()
-            .orientation(gtk::Orientation::Horizontal)
-            .spacing(6)
-            .margin_start(8)
-            .margin_end(8)
-            .margin_top(2)
-            .margin_bottom(2)
-            .build();
-        row.append(&label);
-        row.append(&count);
-        // Mark the child labels as presentational so the screen reader
-        // does not announce them as separate items; the combined text
-        // is announced from the row's accessible label set in bind.
-        label.set_accessible_role(gtk::AccessibleRole::Presentation);
-        count.set_accessible_role(gtk::AccessibleRole::Presentation);
-        // Stable ownership: hold the labels and the row as a wrapper
-        // attached to the ListItem so bind / unbind can address them by
-        // name instead of by first_child / last_child (which depends on
-        // insertion order).
-        let widgets = RowWidgets {
-            label: label.clone(),
-            count: count.clone(),
-            row: row.clone(),
-        };
-        unsafe {
-            list_item.set_data(ROW_WIDGETS_KEY, widgets);
-        }
-        list_item.set_child(Some(&row));
+        // The BrowserRow subclass owns the label / count widgets as
+        // named children, so bind / unbind can reach them by downcasting
+        // the ListItem's child — no GObject data storage needed.
+        list_item.set_child(Some(&BrowserRow::new()));
     });
 
     factory.connect_bind(|_, list_item| {
@@ -565,32 +602,30 @@ fn build_pane(title: &str, store: &gio::ListStore) -> gtk::Box {
             .item()
             .and_downcast::<BrowserItem>()
             .expect("BrowserItem");
-        let widgets = unsafe { list_item.data::<RowWidgets>(ROW_WIDGETS_KEY) }
-            .expect("RowWidgets attached in setup");
-        let widgets = unsafe { widgets.as_ref() };
-        widgets.label.set_text(&item.label());
+        let row = list_item
+            .child()
+            .and_downcast::<BrowserRow>()
+            .expect("BrowserRow attached in setup");
         let count_text = format!("({})", item.count());
-        widgets.count.set_text(&count_text);
+        row.label().set_text(&item.label());
+        row.count().set_text(&count_text);
         // Combine the label and parenthesized count into a single
         // accessible label so a screen reader announces the row as one
         // utterance ("Artist Name, 123") rather than two adjacent
         // separate labels. The child labels are marked Presentation in
         // setup so they are not announced individually.
         let accessible = format!("{}, {}", item.label(), count_text);
-        widgets
-            .row
-            .update_property(&[gtk::accessible::Property::Label(&accessible)]);
+        row.update_property(&[gtk::accessible::Property::Label(&accessible)]);
     });
 
     factory.connect_unbind(|_, list_item| {
         let list_item = list_item.downcast_ref::<gtk::ListItem>().expect("ListItem");
-        let Some(widgets) = (unsafe { list_item.data::<RowWidgets>(ROW_WIDGETS_KEY) }) else {
+        let Some(row) = list_item.child().and_downcast::<BrowserRow>() else {
             return;
         };
-        let widgets = unsafe { widgets.as_ref() };
-        widgets.label.set_text("");
-        widgets.count.set_text("");
-        widgets.row.reset_property(gtk::AccessibleProperty::Label);
+        row.label().set_text("");
+        row.count().set_text("");
+        row.reset_property(gtk::AccessibleProperty::Label);
     });
 
     let list_view = gtk::ListView::builder()

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -420,14 +420,29 @@ pub fn build_browser(
     // ── Layout ───────────────────────────────────────────────────────
     let panes_box = gtk::Box::builder()
         .orientation(gtk::Orientation::Horizontal)
-        .homogeneous(true)
         .spacing(1)
         .vexpand(true)
         .build();
-    panes_box.append(&genre_pane);
-    panes_box.append(&artist_pane);
-    panes_box.append(&album_pane);
-    panes_box.append(&folder_pane);
+    // A real 1px `.browser-separator` gutter between the panes (HIG: a
+    // gutter, not a hard divider). Homogeneous is off because a
+    // homogeneous Box counts the separators in its equal split and would
+    // shrink every pane; each pane expands instead, and a Box distributes
+    // the extra width equally across expanding children, which preserves
+    // the equal-pane layout.
+    for (index, pane) in [&genre_pane, &artist_pane, &album_pane, &folder_pane]
+        .into_iter()
+        .enumerate()
+    {
+        if index > 0 {
+            let separator = gtk::Separator::builder()
+                .orientation(gtk::Orientation::Vertical)
+                .css_classes(["browser-separator"])
+                .build();
+            panes_box.append(&separator);
+        }
+        pane.set_hexpand(true);
+        panes_box.append(pane);
+    }
 
     let browser_box = gtk::Box::builder()
         .orientation(gtk::Orientation::Vertical)
@@ -593,10 +608,21 @@ fn bind_browser_row(list_item: &gtk::ListItem, item: &BrowserItem) {
         .child()
         .and_downcast::<BrowserRow>()
         .expect("BrowserRow attached in setup");
-    let count_text = format!("({})", item.count());
+    // Folder navigation and status rows carry no count; render only the
+    // label rather than a meaningless "(0)" — numeric secondary text is
+    // only announced when it carries information (HIG).
+    let count_text = if item.count() > 0 {
+        format!("({})", item.count())
+    } else {
+        String::new()
+    };
     row.label().set_text(&item.label());
     row.count().set_text(&count_text);
-    let accessible = format!("{}, {}", item.label(), count_text);
+    let accessible = if count_text.is_empty() {
+        item.label()
+    } else {
+        format!("{}, {}", item.label(), count_text)
+    };
     list_item.set_accessible_label(&accessible);
 }
 
@@ -1026,7 +1052,11 @@ fn get_store_from_pane(pane: &gtk::Box) -> Option<gio::ListStore> {
         .and_then(|m| m.downcast::<gio::ListStore>().ok())
 }
 
-#[cfg(test)]
+// macOS is excluded at the module level: GTK's Quartz backend panics when
+// initialized from the test harness worker thread. Gating only the test
+// function instead would leave `use super::*` unused on macOS and fail the
+// `-D warnings` clippy pass there (observed in run 33921896331).
+#[cfg(all(test, not(target_os = "macos")))]
 mod tests {
     use super::*;
 
@@ -1034,7 +1064,8 @@ mod tests {
     /// `GtkListItem` — the list-row boundary assistive technology
     /// actually navigates — not on an inner widget, and the child labels
     /// must be presentational so the row is announced as a single
-    /// utterance ("Artist Name, (123)").
+    /// utterance ("Artist Name, (123)"). Zero-count rows (folder
+    /// navigation and status) must render and announce only the label.
     ///
     /// This drives the real factory setup signal, then the exact
     /// production bind / unbind helpers on a standalone `GtkListItem`,
@@ -1046,16 +1077,25 @@ mod tests {
     /// list; `bind_browser_row` / `unbind_browser_row` are the exact
     /// functions the closure calls.)
     ///
-    /// Headless CI (cargo test in a container with no X/Wayland socket)
-    /// cannot initialize GTK, so the test gates on `gtk::init()`'s
-    /// non-panicking result and skips with a printed reason. macOS is
-    /// excluded because GTK's Quartz backend panics when initialized
-    /// from the test harness worker thread. The contract still holds on
-    /// any machine with a display (or a Broadway headless server) — run
-    /// there to exercise it.
-    #[cfg(not(target_os = "macos"))]
+    /// Skips on headless machines BEFORE initializing GTK: headless GTK
+    /// can still come up via its Broadway fallback, and a test process
+    /// that initialized GTK without a real display session segfaults in
+    /// GTK teardown at exit (observed as SIGSEGV after all tests passed
+    /// on headless Linux CI, run 33921896331). A display session
+    /// (`$WAYLAND_DISPLAY` or `$DISPLAY`) is required both to exercise
+    /// the contract meaningfully and to exit cleanly.
     #[test]
     fn browser_row_accessible_label_exposed_on_list_item_boundary() {
+        if std::env::var_os("WAYLAND_DISPLAY").is_none() && std::env::var_os("DISPLAY").is_none() {
+            eprintln!(
+                "browser_row_accessible_label_exposed_on_list_item_boundary: \
+                 no display session ($WAYLAND_DISPLAY/$DISPLAY unset); \
+                 skipping. Re-run inside a desktop session to exercise the \
+                 contract."
+            );
+            return;
+        }
+
         if let Err(e) = gtk::init() {
             eprintln!(
                 "browser_row_accessible_label_exposed_on_list_item_boundary: \
@@ -1107,6 +1147,32 @@ mod tests {
             "",
             "unbind must reset the accessible label"
         );
+        assert_eq!(row.label().text(), "");
+        assert_eq!(row.count().text(), "");
+
+        // Zero-count rows (folder navigation and status) carry no count:
+        // render and announce only the label, never a meaningless "(0)".
+        let nav_item = BrowserItem::new("Folder browsing follows the local library sources", 0);
+        bind_browser_row(&list_item, &nav_item);
+        assert_eq!(
+            row.count().text(),
+            "",
+            "zero-count rows must not render a count"
+        );
+        assert_eq!(
+            list_item.accessible_label(),
+            "Folder browsing follows the local library sources",
+            "zero-count accessible label must be the bare label"
+        );
+        assert_eq!(
+            row.label().text(),
+            "Folder browsing follows the local library sources"
+        );
+
+        // The recycled item must still reset cleanly after a zero-count
+        // bind.
+        unbind_browser_row(&list_item);
+        assert_eq!(list_item.accessible_label(), "");
         assert_eq!(row.label().text(), "");
         assert_eq!(row.count().text(), "");
     }

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -573,19 +573,51 @@ impl BrowserRow {
     }
 }
 
-fn build_pane(title: &str, store: &gio::ListStore) -> gtk::Box {
-    let header = gtk::Label::builder()
-        .label(title)
-        .css_classes(["heading"])
-        .halign(gtk::Align::Start)
-        .margin_start(8)
-        .margin_top(4)
-        .margin_bottom(2)
-        .build();
+/// Bind one browser row to its item: populate the visible texts and
+/// publish the combined accessible label on the [`gtk::ListItem`].
+///
+/// The label and parenthesized count are combined into a single
+/// utterance ("Artist Name, (123)") and exposed on the GtkListItem
+/// itself — the list-row boundary assistive technology actually
+/// navigates — via the dedicated GtkListItem:accessible-label property
+/// (GTK 4.12), which GTK uses as the row's accessible name. The child
+/// labels are marked Presentation in setup so they are not announced
+/// individually.
+///
+/// Split out from the factory closure so tests can drive the exact
+/// production bind on a standalone `GtkListItem` (`ListItem:item` is
+/// read-only and set by the ListView, so a factory-driven bind cannot
+/// be exercised outside a realized list).
+fn bind_browser_row(list_item: &gtk::ListItem, item: &BrowserItem) {
+    let row = list_item
+        .child()
+        .and_downcast::<BrowserRow>()
+        .expect("BrowserRow attached in setup");
+    let count_text = format!("({})", item.count());
+    row.label().set_text(&item.label());
+    row.count().set_text(&count_text);
+    let accessible = format!("{}, {}", item.label(), count_text);
+    list_item.set_accessible_label(&accessible);
+}
 
-    let selection = gtk::SingleSelection::new(Some(store.clone()));
-    selection.set_autoselect(true);
+/// Unbind one browser row: reset the row's accessible name so a
+/// recycled list item never announces a stale label while waiting for
+/// its next bind, and clear the visible texts.
+fn unbind_browser_row(list_item: &gtk::ListItem) {
+    list_item.set_accessible_label("");
+    let Some(row) = list_item.child().and_downcast::<BrowserRow>() else {
+        return;
+    };
+    row.label().set_text("");
+    row.count().set_text("");
+}
 
+/// Row factory shared by every browser pane: each [`gtk::ListItem`]
+/// hosts a [`BrowserRow`], and bind / unbind keep the visible texts and
+/// the combined accessible label in sync with the item. Exposed as a
+/// function so tests can drive the setup / bind / unbind contract
+/// directly on a standalone [`gtk::ListItem`].
+fn browser_row_factory() -> gtk::SignalListItemFactory {
     let factory = gtk::SignalListItemFactory::new();
 
     factory.connect_setup(|_, list_item| {
@@ -602,31 +634,31 @@ fn build_pane(title: &str, store: &gio::ListStore) -> gtk::Box {
             .item()
             .and_downcast::<BrowserItem>()
             .expect("BrowserItem");
-        let row = list_item
-            .child()
-            .and_downcast::<BrowserRow>()
-            .expect("BrowserRow attached in setup");
-        let count_text = format!("({})", item.count());
-        row.label().set_text(&item.label());
-        row.count().set_text(&count_text);
-        // Combine the label and parenthesized count into a single
-        // accessible label so a screen reader announces the row as one
-        // utterance ("Artist Name, 123") rather than two adjacent
-        // separate labels. The child labels are marked Presentation in
-        // setup so they are not announced individually.
-        let accessible = format!("{}, {}", item.label(), count_text);
-        row.update_property(&[gtk::accessible::Property::Label(&accessible)]);
+        bind_browser_row(list_item, &item);
     });
 
     factory.connect_unbind(|_, list_item| {
         let list_item = list_item.downcast_ref::<gtk::ListItem>().expect("ListItem");
-        let Some(row) = list_item.child().and_downcast::<BrowserRow>() else {
-            return;
-        };
-        row.label().set_text("");
-        row.count().set_text("");
-        row.reset_property(gtk::AccessibleProperty::Label);
+        unbind_browser_row(list_item);
     });
+
+    factory
+}
+
+fn build_pane(title: &str, store: &gio::ListStore) -> gtk::Box {
+    let header = gtk::Label::builder()
+        .label(title)
+        .css_classes(["heading"])
+        .halign(gtk::Align::Start)
+        .margin_start(8)
+        .margin_top(4)
+        .margin_bottom(2)
+        .build();
+
+    let selection = gtk::SingleSelection::new(Some(store.clone()));
+    selection.set_autoselect(true);
+
+    let factory = browser_row_factory();
 
     let list_view = gtk::ListView::builder()
         .model(&selection)
@@ -992,4 +1024,90 @@ fn get_store_from_pane(pane: &gtk::Box) -> Option<gio::ListStore> {
     selection
         .model()
         .and_then(|m| m.downcast::<gio::ListStore>().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The combined row label ("Label, (Count)") must be exposed on the
+    /// `GtkListItem` — the list-row boundary assistive technology
+    /// actually navigates — not on an inner widget, and the child labels
+    /// must be presentational so the row is announced as a single
+    /// utterance ("Artist Name, (123)").
+    ///
+    /// This drives the real factory setup signal, then the exact
+    /// production bind / unbind helpers on a standalone `GtkListItem`,
+    /// and asserts on the `GtkListItem:accessible-label` property
+    /// (GTK 4.12), which GTK uses as the row's accessible name — the
+    /// widget-level equivalent of an Orca row-announcement smoke test.
+    /// (`ListItem:item` is read-only and set by the ListView, so the
+    /// bind closure itself cannot be exercised outside a realized
+    /// list; `bind_browser_row` / `unbind_browser_row` are the exact
+    /// functions the closure calls.)
+    ///
+    /// Headless CI (cargo test in a container with no X/Wayland socket)
+    /// cannot initialize GTK, so the test gates on `gtk::init()`'s
+    /// non-panicking result and skips with a printed reason. macOS is
+    /// excluded because GTK's Quartz backend panics when initialized
+    /// from the test harness worker thread. The contract still holds on
+    /// any machine with a display (or a Broadway headless server) — run
+    /// there to exercise it.
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn browser_row_accessible_label_exposed_on_list_item_boundary() {
+        if let Err(e) = gtk::init() {
+            eprintln!(
+                "browser_row_accessible_label_exposed_on_list_item_boundary: \
+                 GTK unavailable ({e}); skipping. Re-run on a box with a display \
+                 session (or under a Broadway headless server) to exercise the \
+                 contract."
+            );
+            return;
+        }
+
+        let factory = browser_row_factory();
+        let list_item: gtk::ListItem = glib::Object::new();
+
+        // Setup attaches the BrowserRow; its child labels must be
+        // presentational so they are not announced individually.
+        factory.emit_by_name::<()>("setup", &[&list_item]);
+        let row = list_item
+            .child()
+            .and_downcast::<BrowserRow>()
+            .expect("setup must attach a BrowserRow child");
+        assert_eq!(
+            row.label().accessible_role(),
+            gtk::AccessibleRole::Presentation,
+            "primary label must be presentational"
+        );
+        assert_eq!(
+            row.count().accessible_role(),
+            gtk::AccessibleRole::Presentation,
+            "count label must be presentational"
+        );
+
+        // Bind must publish the combined utterance on the GtkListItem
+        // itself — the row boundary — and populate the visible texts.
+        let item = BrowserItem::new("Miles Davis", 12);
+        bind_browser_row(&list_item, &item);
+        assert_eq!(
+            list_item.accessible_label(),
+            "Miles Davis, (12)",
+            "combined accessible label must be set on the GtkListItem boundary"
+        );
+        assert_eq!(row.label().text(), "Miles Davis");
+        assert_eq!(row.count().text(), "(12)");
+
+        // Unbind must clear the accessible name and visible texts so a
+        // recycled list item never announces a stale label.
+        unbind_browser_row(&list_item);
+        assert_eq!(
+            list_item.accessible_label(),
+            "",
+            "unbind must reset the accessible label"
+        );
+        assert_eq!(row.label().text(), "");
+        assert_eq!(row.count().text(), "");
+    }
 }

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -1056,66 +1056,64 @@ fn get_store_from_pane(pane: &gtk::Box) -> Option<gio::ListStore> {
 // initialized from the test harness worker thread. Gating only the test
 // function instead would leave `use super::*` unused on macOS and fail the
 // `-D warnings` clippy pass there (observed in run 33921896331).
+//
+// The contract under test stays in ONE `#[test]` function (GTK must be
+// exercised from a single thread, and `gtk::init` must not race itself);
+// its sections live in small helpers below, which also keeps each function
+// under Codacy's 50-lines-of-code method limit.
 #[cfg(all(test, not(target_os = "macos")))]
 mod tests {
     use super::*;
 
-    /// The combined row label ("Label, (Count)") must be exposed on the
-    /// `GtkListItem` — the list-row boundary assistive technology
-    /// actually navigates — not on an inner widget, and the child labels
-    /// must be presentational so the row is announced as a single
-    /// utterance ("Artist Name, (123)"). Zero-count rows (folder
-    /// navigation and status) must render and announce only the label.
-    ///
-    /// This drives the real factory setup signal, then the exact
-    /// production bind / unbind helpers on a standalone `GtkListItem`,
-    /// and asserts on the `GtkListItem:accessible-label` property
-    /// (GTK 4.12), which GTK uses as the row's accessible name — the
-    /// widget-level equivalent of an Orca row-announcement smoke test.
-    /// (`ListItem:item` is read-only and set by the ListView, so the
-    /// bind closure itself cannot be exercised outside a realized
-    /// list; `bind_browser_row` / `unbind_browser_row` are the exact
-    /// functions the closure calls.)
-    ///
     /// Skips on headless machines BEFORE initializing GTK: headless GTK
     /// can still come up via its Broadway fallback, and a test process
     /// that initialized GTK without a real display session segfaults in
     /// GTK teardown at exit (observed as SIGSEGV after all tests passed
     /// on headless Linux CI, run 33921896331). A display session
     /// (`$WAYLAND_DISPLAY` or `$DISPLAY`) is required both to exercise
-    /// the contract meaningfully and to exit cleanly.
-    #[test]
-    fn browser_row_accessible_label_exposed_on_list_item_boundary() {
+    /// the contract meaningfully and to exit cleanly. Returns `false`
+    /// (after printing why) when the caller must skip.
+    fn display_session_available() -> bool {
         if std::env::var_os("WAYLAND_DISPLAY").is_none() && std::env::var_os("DISPLAY").is_none() {
             eprintln!(
-                "browser_row_accessible_label_exposed_on_list_item_boundary: \
-                 no display session ($WAYLAND_DISPLAY/$DISPLAY unset); \
-                 skipping. Re-run inside a desktop session to exercise the \
-                 contract."
+                "browser_row widget test: no display session \
+                 ($WAYLAND_DISPLAY/$DISPLAY unset); skipping. Re-run inside \
+                 a desktop session to exercise the contract."
             );
-            return;
+            return false;
         }
 
         if let Err(e) = gtk::init() {
             eprintln!(
-                "browser_row_accessible_label_exposed_on_list_item_boundary: \
-                 GTK unavailable ({e}); skipping. Re-run on a box with a display \
-                 session (or under a Broadway headless server) to exercise the \
-                 contract."
+                "browser_row widget test: GTK unavailable ({e}); skipping. \
+                 Re-run on a box with a display session (or under a Broadway \
+                 headless server) to exercise the contract."
             );
-            return;
+            return false;
         }
 
+        true
+    }
+
+    /// Drives the real factory setup signal on a standalone `GtkListItem`.
+    /// (`ListItem:item` is read-only and set by the ListView, so the bind
+    /// closure itself cannot be exercised outside a realized list;
+    /// `browser_row_factory` / `bind_browser_row` / `unbind_browser_row`
+    /// are the exact functions the closure calls.)
+    fn make_setup_list_item() -> (gtk::ListItem, BrowserRow) {
         let factory = browser_row_factory();
         let list_item: gtk::ListItem = glib::Object::new();
-
-        // Setup attaches the BrowserRow; its child labels must be
-        // presentational so they are not announced individually.
         factory.emit_by_name::<()>("setup", &[&list_item]);
         let row = list_item
             .child()
             .and_downcast::<BrowserRow>()
             .expect("setup must attach a BrowserRow child");
+        (list_item, row)
+    }
+
+    /// Setup attaches the BrowserRow; its child labels must be
+    /// presentational so they are not announced individually.
+    fn assert_row_roles_presentational(row: &BrowserRow) {
         assert_eq!(
             row.label().accessible_role(),
             gtk::AccessibleRole::Presentation,
@@ -1126,11 +1124,14 @@ mod tests {
             gtk::AccessibleRole::Presentation,
             "count label must be presentational"
         );
+    }
 
-        // Bind must publish the combined utterance on the GtkListItem
-        // itself — the row boundary — and populate the visible texts.
+    /// Bind must publish the combined utterance on the GtkListItem itself
+    /// — the row boundary assistive technology actually navigates — and
+    /// populate the visible texts.
+    fn assert_combined_bind_contract(list_item: &gtk::ListItem, row: &BrowserRow) {
         let item = BrowserItem::new("Miles Davis", 12);
-        bind_browser_row(&list_item, &item);
+        bind_browser_row(list_item, &item);
         assert_eq!(
             list_item.accessible_label(),
             "Miles Davis, (12)",
@@ -1138,22 +1139,13 @@ mod tests {
         );
         assert_eq!(row.label().text(), "Miles Davis");
         assert_eq!(row.count().text(), "(12)");
+    }
 
-        // Unbind must clear the accessible name and visible texts so a
-        // recycled list item never announces a stale label.
-        unbind_browser_row(&list_item);
-        assert_eq!(
-            list_item.accessible_label(),
-            "",
-            "unbind must reset the accessible label"
-        );
-        assert_eq!(row.label().text(), "");
-        assert_eq!(row.count().text(), "");
-
-        // Zero-count rows (folder navigation and status) carry no count:
-        // render and announce only the label, never a meaningless "(0)".
+    /// Zero-count rows (folder navigation and status) carry no count:
+    /// render and announce only the label, never a meaningless "(0)".
+    fn assert_zero_count_contract(list_item: &gtk::ListItem, row: &BrowserRow) {
         let nav_item = BrowserItem::new("Folder browsing follows the local library sources", 0);
-        bind_browser_row(&list_item, &nav_item);
+        bind_browser_row(list_item, &nav_item);
         assert_eq!(
             row.count().text(),
             "",
@@ -1168,12 +1160,41 @@ mod tests {
             row.label().text(),
             "Folder browsing follows the local library sources"
         );
+    }
 
-        // The recycled item must still reset cleanly after a zero-count
-        // bind.
-        unbind_browser_row(&list_item);
-        assert_eq!(list_item.accessible_label(), "");
+    /// Unbind must clear the accessible name and visible texts so a
+    /// recycled list item never announces a stale label.
+    fn assert_unbind_reset(list_item: &gtk::ListItem, row: &BrowserRow) {
+        unbind_browser_row(list_item);
+        assert_eq!(
+            list_item.accessible_label(),
+            "",
+            "unbind must reset the accessible label"
+        );
         assert_eq!(row.label().text(), "");
         assert_eq!(row.count().text(), "");
+    }
+
+    /// The combined row label ("Label, (Count)") must be exposed on the
+    /// `GtkListItem` — the list-row boundary — not on an inner widget, the
+    /// child labels must be presentational so the row is announced as a
+    /// single utterance ("Artist Name, (123)"), zero-count rows must
+    /// announce only the label, and unbind must reset everything.
+    ///
+    /// Asserts on the `GtkListItem:accessible-label` property (GTK 4.12),
+    /// which GTK uses as the row's accessible name — the widget-level
+    /// equivalent of an Orca row-announcement smoke test.
+    #[test]
+    fn browser_row_accessible_label_exposed_on_list_item_boundary() {
+        if !display_session_available() {
+            return;
+        }
+
+        let (list_item, row) = make_setup_list_item();
+        assert_row_roles_presentational(&row);
+        assert_combined_bind_contract(&list_item, &row);
+        assert_unbind_reset(&list_item, &row);
+        assert_zero_count_contract(&list_item, &row);
+        assert_unbind_reset(&list_item, &row);
     }
 }

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -1063,40 +1063,13 @@ fn get_store_from_pane(pane: &gtk::Box) -> Option<gio::ListStore> {
 // The contract under test stays in ONE `#[test]` function (GTK must be
 // exercised from a single thread, and `gtk::init` must not race itself);
 // its sections live in small helpers below, which also keeps each function
-// under Codacy's 50-lines-of-code method limit.
+// under Codacy's 50-lines-of-code method limit. The test funnels its
+// display gate, `gtk::init`, and the whole widget-exercising body through
+// the crate-wide `ui::widget_test_session` lock so it cannot race the
+// context_menu widget test on libtest's worker threads.
 #[cfg(all(test, not(target_os = "macos")))]
 mod tests {
     use super::*;
-
-    /// Skips on headless machines BEFORE initializing GTK: headless GTK
-    /// can still come up via its Broadway fallback, and a test process
-    /// that initialized GTK without a real display session segfaults in
-    /// GTK teardown at exit (observed as SIGSEGV after all tests passed
-    /// on headless Linux CI, run 33921896331). A display session
-    /// (`$WAYLAND_DISPLAY` or `$DISPLAY`) is required both to exercise
-    /// the contract meaningfully and to exit cleanly. Returns `false`
-    /// (after printing why) when the caller must skip.
-    fn display_session_available() -> bool {
-        if std::env::var_os("WAYLAND_DISPLAY").is_none() && std::env::var_os("DISPLAY").is_none() {
-            eprintln!(
-                "browser_row widget test: no display session \
-                 ($WAYLAND_DISPLAY/$DISPLAY unset); skipping. Re-run inside \
-                 a desktop session to exercise the contract."
-            );
-            return false;
-        }
-
-        if let Err(e) = gtk::init() {
-            eprintln!(
-                "browser_row widget test: GTK unavailable ({e}); skipping. \
-                 Re-run on a box with a display session (or under a Broadway \
-                 headless server) to exercise the contract."
-            );
-            return false;
-        }
-
-        true
-    }
 
     /// Drives the real factory setup signal on a standalone `GtkListItem`.
     /// (`ListItem:item` is read-only and set by the ListView, so the bind
@@ -1189,9 +1162,15 @@ mod tests {
     /// equivalent of an Orca row-announcement smoke test.
     #[test]
     fn browser_row_accessible_label_exposed_on_list_item_boundary() {
-        if !display_session_available() {
+        // Hold the process-wide GTK test session (display gate + single
+        // `gtk::init` + serialization lock) across every widget
+        // construction and assertion below; libtest runs each `#[test]`
+        // on its own worker thread, and GTK requires single-threaded use
+        // after initialization. See `ui::widget_test_session`.
+        let Some(_gtk_session) = crate::ui::widget_test_session::acquire("browser_row widget test")
+        else {
             return;
-        }
+        };
 
         let (list_item, row) = make_setup_list_item();
         assert_row_roles_presentational(&row);

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -418,9 +418,12 @@ pub fn build_browser(
     }
 
     // ── Layout ───────────────────────────────────────────────────────
+    // Spacing must stay 0: the separators appended below are the gutter,
+    // and Box spacing adds pixels on both sides of each separator,
+    // widening every 1px gutter to 3px (2026-09-07 review rejection).
     let panes_box = gtk::Box::builder()
         .orientation(gtk::Orientation::Horizontal)
-        .spacing(1)
+        .spacing(0)
         .vexpand(true)
         .build();
     // A real 1px `.browser-separator` gutter between the panes (HIG: a

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -1060,13 +1060,19 @@ fn get_store_from_pane(pane: &gtk::Box) -> Option<gio::ListStore> {
 // function instead would leave `use super::*` unused on macOS and fail the
 // `-D warnings` clippy pass there (observed in run 33921896331).
 //
-// The contract under test stays in ONE `#[test]` function (GTK must be
-// exercised from a single thread, and `gtk::init` must not race itself);
-// its sections live in small helpers below, which also keeps each function
-// under Codacy's 50-lines-of-code method limit. The test funnels its
-// display gate, `gtk::init`, and the whole widget-exercising body through
-// the crate-wide `ui::widget_test_session` lock so it cannot race the
-// context_menu widget test on libtest's worker threads.
+// This module holds the crate's SINGLE GTK-initializing `#[test]` (GTK
+// must be exercised from a single thread, and `gtk::init` must not race
+// itself). The `ui::widget_test_session` mutex serializes GTK-initializing
+// tests but does not give them thread affinity, so a second GTK-touching
+// `#[test]` would still run on a different libtest worker thread than the
+// one that ran `gtk::init` and construct widgets off the initializing
+// thread (2026-09-09 review rejection, PR #179). Every GTK-touching
+// contract in the crate — including the context-menu ones — therefore runs
+// inside that one test's body, via small helpers here and in
+// `context_menu::tests`, which also keeps each function under Codacy's
+// 50-lines-of-code method limit. The test funnels its display gate, the
+// single `gtk::init`, and the whole widget-exercising body through the
+// crate-wide `ui::widget_test_session` lock.
 #[cfg(all(test, not(target_os = "macos")))]
 mod tests {
     use super::*;
@@ -1151,23 +1157,38 @@ mod tests {
         assert_eq!(row.count().text(), "");
     }
 
-    /// The combined row label ("Label, (Count)") must be exposed on the
-    /// `GtkListItem` — the list-row boundary — not on an inner widget, the
-    /// child labels must be presentational so the row is announced as a
-    /// single utterance ("Artist Name, (123)"), zero-count rows must
-    /// announce only the label, and unbind must reset everything.
+    /// The crate's single consolidated GTK widget test, all run on the ONE
+    /// thread that owns the GTK session:
+    ///
+    /// - the combined browser-row label ("Label, (Count)") must be exposed
+    ///   on the `GtkListItem` — the list-row boundary — not on an inner
+    ///   widget; the child labels must be presentational so the row is
+    ///   announced as a single utterance ("Artist Name, (123)"); zero-count
+    ///   rows must announce only the label; unbind must reset everything;
+    /// - the context-menu popover must attach a visible scrolling child
+    ///   with one button per enabled action
+    ///   ([`crate::ui::context_menu::tests::popover_from_menu_model_attaches_a_visible_child_widget`]);
+    /// - tracklist drags must start only from the data row area (folded
+    ///   into the popover contract).
+    ///
+    /// This is deliberately the only GTK-initializing `#[test]` in the
+    /// crate: the `ui::widget_test_session` mutex serializes but does not
+    /// give thread affinity, so a second GTK-touching `#[test]` would
+    /// construct widgets off the initializing thread and trip gtk-rs
+    /// main-thread checks (2026-09-09 review rejection, PR #179).
     ///
     /// Asserts on the `GtkListItem:accessible-label` property (GTK 4.12),
     /// which GTK uses as the row's accessible name — the widget-level
     /// equivalent of an Orca row-announcement smoke test.
     #[test]
-    fn browser_row_accessible_label_exposed_on_list_item_boundary() {
+    fn gtk_widget_contracts_hold_on_one_session() {
         // Hold the process-wide GTK test session (display gate + single
         // `gtk::init` + serialization lock) across every widget
-        // construction and assertion below; libtest runs each `#[test]`
-        // on its own worker thread, and GTK requires single-threaded use
-        // after initialization. See `ui::widget_test_session`.
-        let Some(_gtk_session) = crate::ui::widget_test_session::acquire("browser_row widget test")
+        // construction and assertion below, including the context-menu
+        // helpers: GTK requires single-threaded use after initialization.
+        // See `ui::widget_test_session`.
+        let Some(_gtk_session) =
+            crate::ui::widget_test_session::acquire("gtk widget contracts test")
         else {
             return;
         };
@@ -1178,5 +1199,7 @@ mod tests {
         assert_unbind_reset(&list_item, &row);
         assert_zero_count_contract(&list_item, &row);
         assert_unbind_reset(&list_item, &row);
+
+        crate::ui::context_menu::tests::popover_from_menu_model_attaches_a_visible_child_widget();
     }
 }

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -1168,6 +1168,10 @@ mod tests {
     /// - the context-menu popover must attach a visible scrolling child
     ///   with one button per enabled action
     ///   ([`crate::ui::context_menu::tests::popover_from_menu_model_attaches_a_visible_child_widget`]);
+    /// - browser gutter separators must join visible panes around hidden
+    ///   ones — exactly one surviving gutter between panes that straddle
+    ///   a disabled pane, no dangling edge gutters
+    ///   ([`crate::ui::preferences::widget_tests::separator_gutters_join_visible_panes_around_hidden_ones`]);
     /// - tracklist drags must start only from the data row area (folded
     ///   into the popover contract).
     ///
@@ -1201,5 +1205,6 @@ mod tests {
         assert_unbind_reset(&list_item, &row);
 
         crate::ui::context_menu::tests::popover_from_menu_model_attaches_a_visible_child_widget();
+        crate::ui::preferences::widget_tests::separator_gutters_join_visible_panes_around_hidden_ones();
     }
 }

--- a/src/ui/context_menu.rs
+++ b/src/ui/context_menu.rs
@@ -1886,6 +1886,28 @@ pub mod tests {
     pub fn popover_from_menu_model_attaches_a_visible_child_widget() {
         assert_track_drags_start_only_from_the_data_row_area();
 
+        let harness = popover_menu_harness();
+        let parent = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        let popover = popover_from_menu_model(&parent, &harness.menu, &harness.actions);
+
+        let viewport = assert_popover_wraps_scrolling_viewport(&popover);
+        let vbox = menu_box_inside(&viewport);
+        clicking_first_button_fires_only_its_action(&vbox, &harness.prop_rx, &harness.add_rx);
+    }
+
+    /// Menu model + action group backing the popover contract, with one
+    /// receiver per action so assertions can observe exactly which
+    /// action a click activated.
+    #[cfg(not(target_os = "macos"))]
+    struct PopoverMenuHarness {
+        menu: gtk::gio::Menu,
+        actions: gtk::gio::SimpleActionGroup,
+        prop_rx: async_channel::Receiver<()>,
+        add_rx: async_channel::Receiver<()>,
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    fn popover_menu_harness() -> PopoverMenuHarness {
         let menu = gtk::gio::Menu::new();
         menu.append(Some("Open Properties"), Some("ctx.properties"));
         menu.append(Some("Add to Playlist"), Some("ctx.add"));
@@ -1905,9 +1927,19 @@ pub mod tests {
         });
         actions.add_action(&add_action);
 
-        let parent = gtk::Box::new(gtk::Orientation::Vertical, 0);
-        let popover = popover_from_menu_model(&parent, &menu, &actions);
+        PopoverMenuHarness {
+            menu,
+            actions,
+            prop_rx,
+            add_rx,
+        }
+    }
 
+    /// The popover must wrap its menu in a scrolling viewport with the
+    /// documented policy/size contract; returns the viewport so callers
+    /// can descend to the menu box.
+    #[cfg(not(target_os = "macos"))]
+    fn assert_popover_wraps_scrolling_viewport(popover: &gtk::Popover) -> gtk::ScrolledWindow {
         let child = popover
             .child()
             .expect("popover must have a non-null child after construction");
@@ -1922,9 +1954,14 @@ pub mod tests {
             viewport.max_content_height(),
             CONTEXT_MENU_MAX_CONTENT_HEIGHT
         );
-        // The menu box is not `GtkScrollable`, so `ScrolledWindow::set_child`
-        // wraps it in an auto-added `GtkViewport`, and `child()` returns that
-        // viewport rather than the box. Look through the wrapper when present.
+        viewport
+    }
+
+    /// The menu box is not `GtkScrollable`, so `ScrolledWindow::set_child`
+    /// wraps it in an auto-added `GtkViewport`, and `child()` returns that
+    /// viewport rather than the box. Look through the wrapper when present.
+    #[cfg(not(target_os = "macos"))]
+    fn menu_box_inside(viewport: &gtk::ScrolledWindow) -> gtk::Box {
         let vbox = viewport
             .child()
             .and_then(|child| match child.downcast::<gtk::Box>() {
@@ -1942,9 +1979,17 @@ pub mod tests {
             2,
             "one button per enabled action"
         );
+        vbox
+    }
 
-        // Clicking the first button must activate the corresponding
-        // action and close the popover — that's the user-visible fix.
+    /// Clicking the first button must activate the corresponding
+    /// action and close the popover — that's the user-visible fix.
+    #[cfg(not(target_os = "macos"))]
+    fn clicking_first_button_fires_only_its_action(
+        vbox: &gtk::Box,
+        prop_rx: &async_channel::Receiver<()>,
+        add_rx: &async_channel::Receiver<()>,
+    ) {
         let first_button = vbox
             .observe_children()
             .item(0)

--- a/src/ui/context_menu.rs
+++ b/src/ui/context_menu.rs
@@ -1336,7 +1336,7 @@ pub fn popover_from_menu_model(
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use std::path::PathBuf;
 
     use super::*;
@@ -1857,35 +1857,33 @@ mod tests {
     /// menu display through `popover_from_menu_model`, which always sets a
     /// non-null child widget built from the menu's actions.
     ///
-    /// This test exercises that contract end-to-end: with a populated
+    /// This contract is exercised end-to-end: with a populated
     /// menu and matching action group, the resulting popover MUST have a
     /// bounded scrolling child containing one button per enabled action. If a
     /// future change drops the child assignment or scrolling constraint (e.g.
     /// by re-introducing `gtk::PopoverMenu::from_model` or attaching the menu
-    /// box directly), this test will fail.
+    /// box directly), the consolidated GTK test will fail.
     ///
     /// Headless CI (cargo test in the Fedora container with no X/Wayland socket)
-    /// cannot initialize GTK, so the test skips with a printed reason when
+    /// cannot initialize GTK, so the contract skips with a printed reason when
     /// no display session is available or GTK cannot acquire a display.
     /// macOS is excluded because GTK's Quartz backend panics when
     /// initialized from the test harness worker thread. The contract still
-    /// holds on any machine with a display — the test is therefore
+    /// holds on any machine with a display — it is therefore
     /// meaningful on a developer box and harmless in CI.
     ///
-    /// The display gate, `gtk::init`, and every widget construction and
-    /// assertion below run while holding the crate-wide
-    /// `ui::widget_test_session` lock: libtest runs each `#[test]` on its
-    /// own worker thread, and GTK requires single-threaded use after
-    /// initialization, so the browser.rs widget test must not be able to
-    /// touch GTK state while this one is mid-flight (or vice versa).
+    /// This contract is NOT its own `#[test]`: the
+    /// `ui::widget_test_session` mutex serializes GTK-initializing tests
+    /// but does not give them thread affinity, so a second GTK-touching
+    /// `#[test]` would run on a different libtest worker thread than the
+    /// one that ran `gtk::init` and construct widgets off the
+    /// initializing thread, tripping gtk-rs main-thread checks
+    /// (2026-09-09 review rejection, PR #179). It is instead invoked from
+    /// the crate's single consolidated GTK test in `browser.rs`, whose
+    /// `acquire` call owns the display gate, the single `gtk::init`, and
+    /// the serialization lock across this body.
     #[cfg(not(target_os = "macos"))]
-    #[test]
-    fn popover_from_menu_model_attaches_a_visible_child_widget() {
-        let Some(_gtk_session) = crate::ui::widget_test_session::acquire(
-            "popover_from_menu_model_attaches_a_visible_child_widget",
-        ) else {
-            return;
-        };
+    pub fn popover_from_menu_model_attaches_a_visible_child_widget() {
         assert_track_drags_start_only_from_the_data_row_area();
 
         let menu = gtk::gio::Menu::new();

--- a/src/ui/context_menu.rs
+++ b/src/ui/context_menu.rs
@@ -1865,23 +1865,27 @@ mod tests {
     /// box directly), this test will fail.
     ///
     /// Headless CI (cargo test in the Fedora container with no X/Wayland socket)
-    /// cannot initialize GTK, so the test gates on `gtk::init()`'s
-    /// non-panicking result and skips with a printed reason when GTK
-    /// cannot acquire a display. macOS is excluded because GTK's Quartz
-    /// backend panics when initialized from the test harness worker thread.
-    /// The contract still holds on any machine with a display — the test is
-    /// therefore meaningful on a developer box and harmless in CI.
+    /// cannot initialize GTK, so the test skips with a printed reason when
+    /// no display session is available or GTK cannot acquire a display.
+    /// macOS is excluded because GTK's Quartz backend panics when
+    /// initialized from the test harness worker thread. The contract still
+    /// holds on any machine with a display — the test is therefore
+    /// meaningful on a developer box and harmless in CI.
+    ///
+    /// The display gate, `gtk::init`, and every widget construction and
+    /// assertion below run while holding the crate-wide
+    /// `ui::widget_test_session` lock: libtest runs each `#[test]` on its
+    /// own worker thread, and GTK requires single-threaded use after
+    /// initialization, so the browser.rs widget test must not be able to
+    /// touch GTK state while this one is mid-flight (or vice versa).
     #[cfg(not(target_os = "macos"))]
     #[test]
     fn popover_from_menu_model_attaches_a_visible_child_widget() {
-        if let Err(e) = gtk::init() {
-            eprintln!(
-                "popover_from_menu_model_attaches_a_visible_child_widget: \
-                 GTK unavailable ({e}); skipping. Re-run on a box with a display \
-                 session to exercise the contract."
-            );
+        let Some(_gtk_session) = crate::ui::widget_test_session::acquire(
+            "popover_from_menu_model_attaches_a_visible_child_widget",
+        ) else {
             return;
-        }
+        };
         assert_track_drags_start_only_from_the_data_row_area();
 
         let menu = gtk::gio::Menu::new();
@@ -2014,10 +2018,11 @@ mod tests {
 
     /// Widget-constructing contract for the tracklist drag origin. Called from
     /// [`popover_from_menu_model_attaches_a_visible_child_widget`] rather than
-    /// being its own `#[test]`: gtk-rs allows GTK to be initialized on exactly
-    /// one thread per process, and the test harness runs tests on a pool of
-    /// threads, so a second GTK-initializing test panics whenever it lands on
-    /// a different thread from the first.
+    /// being its own `#[test]`: the harness runs tests on a pool of threads,
+    /// so a second GTK-initializing test would have to coordinate through the
+    /// `ui::widget_test_session` lock with a test in another module; folding
+    /// it into the one GTK session this module already holds keeps the
+    /// contract exercised without a cross-module handshake.
     #[cfg(not(target_os = "macos"))]
     fn assert_track_drags_start_only_from_the_data_row_area() {
         let (window, column_view, label) = realized_tracklist_for_drag_test();

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -46,6 +46,15 @@ pub mod window_state;
 // serializes them behind one process-wide mutex held across `gtk::init()`
 // AND all widget construction/assertions, while keeping the display-gated
 // skip messages on machines without a display session.
+//
+// Note that the mutex SERIALIZES but does not give THREAD AFFINITY: a
+// second GTK-initializing `#[test]` still runs on its own worker thread
+// and, seeing `gtk::is_initialized()` already true, would skip init and
+// construct widgets off the initializing thread — tripping gtk-rs
+// main-thread checks (2026-09-09 review rejection, PR #179). The crate
+// therefore keeps exactly ONE GTK-initializing `#[test]` (the consolidated
+// widget-contracts test in `browser.rs`); a new GTK-touching contract must
+// join that test's body as a helper, never become a second `#[test]`.
 #[cfg(all(test, not(target_os = "macos")))]
 pub mod widget_test_session {
     use std::sync::{Mutex, MutexGuard, OnceLock};

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -34,3 +34,78 @@ pub mod tracklist;
 pub mod win32_snap;
 pub mod window;
 pub mod window_state;
+
+// GTK must be initialized exactly once per process and used from a single
+// thread afterwards, but libtest runs each `#[test]` function on its own
+// worker thread. Two widget tests that both pass their display gate can
+// therefore reach `gtk::init()` concurrently — or on successive worker
+// threads — which panics or races GTK's single-threaded state on any
+// machine with a real display session. Headless CI never sees this because
+// `gtk::init` fails there and every test skips. Every widget test in this
+// crate funnels through [`widget_test_session::acquire`], which
+// serializes them behind one process-wide mutex held across `gtk::init()`
+// AND all widget construction/assertions, while keeping the display-gated
+// skip messages on machines without a display session.
+#[cfg(all(test, not(target_os = "macos")))]
+pub mod widget_test_session {
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    /// The process-wide GTK test lock.
+    fn lock() -> &'static Mutex<()> {
+        static GTK_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        GTK_TEST_LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    /// Acquires the process-wide GTK test lock, then — still holding it —
+    /// applies the display-session gate and initializes GTK at most once
+    /// per process.
+    ///
+    /// Returns the guard that the caller MUST hold across every widget
+    /// construction and assertion in the test body (that is the whole
+    /// point of the lock: a second GTK-initializing test must not touch
+    /// GTK state while the first is mid-flight, on this or any other
+    /// worker thread). Returns `None` — releasing the lock — when the
+    /// caller must skip:
+    ///
+    /// - no display session (`$WAYLAND_DISPLAY`/`$DISPLAY` both unset):
+    ///   headless GTK can still come up via its Broadway fallback, and a
+    ///   test process that initialized GTK without a real display session
+    ///   segfaults in GTK teardown at exit (observed as SIGSEGV after all
+    ///   tests passed on headless Linux CI, run 33921896331), so the gate
+    ///   fires BEFORE any GTK call;
+    /// - GTK cannot initialize (no display server reachable): same skip
+    ///   path, with the reason printed.
+    ///
+    /// `label` names the calling test so the printed skip reason stays
+    /// attributable to the test that produced it.
+    pub fn acquire(label: &str) -> Option<MutexGuard<'static, ()>> {
+        // A panicked earlier test must not cascade into every later widget
+        // test: the data the guard protects is stateless (just ordering),
+        // so a poisoned lock is safe to carry on from.
+        let guard = lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        if std::env::var_os("WAYLAND_DISPLAY").is_none() && std::env::var_os("DISPLAY").is_none() {
+            eprintln!(
+                "{label}: no display session ($WAYLAND_DISPLAY/$DISPLAY \
+                 unset); skipping. Re-run inside a desktop session to \
+                 exercise the contract."
+            );
+            return None;
+        }
+
+        if !gtk::is_initialized() {
+            if let Err(e) = gtk::init() {
+                eprintln!(
+                    "{label}: GTK unavailable ({e}); skipping. Re-run on a \
+                     box with a display session (or under a Broadway \
+                     headless server) to exercise the contract."
+                );
+                return None;
+            }
+        }
+
+        Some(guard)
+    }
+}

--- a/src/ui/objects/browser_item.rs
+++ b/src/ui/objects/browser_item.rs
@@ -41,13 +41,4 @@ impl BrowserItem {
     pub fn count(&self) -> u32 {
         self.imp().count.get()
     }
-
-    /// Render label + parenthesized count in the legacy single-string form.
-    ///
-    /// Prefer [`Self::label`] + [`Self::count`] from the UI layer so the
-    /// count can be styled independently (dimmed secondary text per
-    /// GNOME HIG). Kept for any callers that still want a single string.
-    pub fn display(&self) -> String {
-        format!("{} ({})", self.label(), self.count())
-    }
 }

--- a/src/ui/objects/browser_item.rs
+++ b/src/ui/objects/browser_item.rs
@@ -42,6 +42,11 @@ impl BrowserItem {
         self.imp().count.get()
     }
 
+    /// Render label + parenthesized count in the legacy single-string form.
+    ///
+    /// Prefer [`Self::label`] + [`Self::count`] from the UI layer so the
+    /// count can be styled independently (dimmed secondary text per
+    /// GNOME HIG). Kept for any callers that still want a single string.
     pub fn display(&self) -> String {
         format!("{} ({})", self.label(), self.count())
     }

--- a/src/ui/preferences.rs
+++ b/src/ui/preferences.rs
@@ -1081,58 +1081,85 @@ pub fn read_column_order(column_view: &gtk::ColumnView) -> Vec<String> {
 /// cannot drift out of sync with the layout if gutters are added or
 /// removed (indexing raw child positions broke here once the separators
 /// became real widgets: disabling Artist hid a separator, disabling
-/// Album hid Artist, and Album/Folder could never be hidden).  A
-/// separator stays visible only when it joins two visible panes, which
-/// prevents doubled or dangling gutters around hidden panes.  If all
-/// four panes are hidden, the entire browser box is hidden.
+/// Album hid Artist, and Album/Folder could never be hidden).
+///
+/// A gutter is visible only while a pane survives on each side of it.
+/// Panes hidden between two surviving panes hand their separators to the
+/// next visible pane, which keeps exactly one (the one adjacent to it)
+/// as the gutter and collapses the rest — so with Artist disabled, Genre
+/// and Album still get their one 1px gutter instead of touching (spacing
+/// is 0; the separator widget is the sole gutter). Separators with no
+/// visible pane before or after them — leading the box or trailing the
+/// last visible pane — stay hidden so no gutter dangles at an edge. If
+/// all four panes are hidden, the entire browser box is hidden.
 pub fn update_browser_visibility(browser_box: &gtk::Box, views: &BrowserViewsConfig) {
     // The browser_box layout is: SearchEntry, panes_box (horizontal Box).
     // Find the panes_box (last child, which is a horizontal Box).
-    let panes_box = browser_box
+    if let Some(panes_box) = browser_box
         .last_child()
-        .and_then(|w| w.downcast::<gtk::Box>().ok());
+        .and_then(|w| w.downcast::<gtk::Box>().ok())
+    {
+        update_panes_box_visibility(&panes_box, views);
+    }
+    browser_box.set_visible(views.genre || views.artist || views.album || views.folder);
+}
 
-    if let Some(ref panes_box) = panes_box {
-        let mut pane_idx = 0;
-        // A separator leading the box would dangle at its edge, so the
-        // "previous pane" starts out treated as hidden.
-        let mut previous_pane_visible = false;
-        let mut pending_separators: Vec<gtk::Widget> = Vec::new();
-        let mut child = panes_box.first_child();
-        while let Some(widget) = child {
-            child = widget.next_sibling();
-            if widget.downcast_ref::<gtk::Separator>().is_some() {
-                // A gutter belongs to the pair of panes around it; decide
-                // its visibility once the next pane is reached.
-                pending_separators.push(widget);
-            } else {
-                // Panes map positionally to the config flags; anything
-                // beyond the four known panes stays visible (the old
-                // `_ => true` match arm). The bounds-checked lookup
-                // keeps this function under Codacy's cyclomatic
-                // complexity threshold (PR #179 re-analysis flagged the
-                // match-driven version as its one new medium issue).
-                let visible = [views.genre, views.artist, views.album, views.folder]
-                    .get(pane_idx)
-                    .copied()
-                    .unwrap_or(true);
-                pane_idx += 1;
-                let gutter_visible = visible && previous_pane_visible;
-                for separator in std::mem::take(&mut pending_separators) {
-                    separator.set_visible(gutter_visible);
-                }
-                widget.set_visible(visible);
-                previous_pane_visible = visible;
-            }
+/// Walk the panes_box toggling pane visibility from the config flags, and
+/// settle each gutter once a pane survives on both sides of it.
+///
+/// Split from [`update_browser_visibility`] so each function stays well
+/// under Codacy's cyclomatic complexity threshold: the separator-aware
+/// traversal was Codacy's one new medium Complexity issue on PR #179, and
+/// collapsing the pane match to an array lookup alone did not clear it
+/// (Codacy counts closures and boolean operators as decision points).
+fn update_panes_box_visibility(panes_box: &gtk::Box, views: &BrowserViewsConfig) {
+    let mut pane_idx = 0;
+    // A gutter needs a visible pane on its left; the box edge is not one,
+    // so the traversal starts with no visible pane behind it.
+    let mut seen_visible_pane = false;
+    // Separators whose right-hand pane has not been reached yet. A hidden
+    // pane leaves the queue untouched, so the next visible pane inherits
+    // the pending gutters instead of dropping them.
+    let mut pending_separators: Vec<gtk::Widget> = Vec::new();
+    let mut child = panes_box.first_child();
+    while let Some(widget) = child {
+        child = widget.next_sibling();
+        if widget.downcast_ref::<gtk::Separator>().is_some() {
+            // A gutter belongs to the pair of panes around it; decide
+            // its visibility once the next visible pane is reached.
+            pending_separators.push(widget);
+            continue;
         }
-        // Separators after the last pane would dangle at the box edge.
-        for separator in std::mem::take(&mut pending_separators) {
-            separator.set_visible(false);
+        // Panes map positionally to the config flags; anything
+        // beyond the four known panes stays visible (the old
+        // `_ => true` match arm).
+        let visible = [views.genre, views.artist, views.album, views.folder]
+            .get(pane_idx)
+            .copied()
+            .unwrap_or(true);
+        pane_idx += 1;
+        widget.set_visible(visible);
+        if visible {
+            settle_pending_separators(&mut pending_separators, seen_visible_pane);
+            seen_visible_pane = true;
         }
     }
+    // Separators after the last visible pane would dangle at the box edge.
+    settle_pending_separators(&mut pending_separators, false);
+}
 
-    let any_visible = views.genre || views.artist || views.album || views.folder;
-    browser_box.set_visible(any_visible);
+/// Show exactly one pending separator — the last queued, the one adjacent
+/// to the pane just reached — as the gutter back to the previous visible
+/// pane, or hide them all when no visible pane precedes them. Separators
+/// carried across hidden panes collapse onto that single gutter, so two
+/// surviving panes keep one 1px gap and never a doubled 2px one.
+fn settle_pending_separators(pending_separators: &mut Vec<gtk::Widget>, gutter_visible: bool) {
+    if let Some(gutter) = pending_separators.pop() {
+        gutter.set_visible(gutter_visible);
+    }
+    for separator in pending_separators.drain(..) {
+        separator.set_visible(false);
+    }
 }
 
 /// Build a library-folder row: the path (left, ellipsized) and its own "−"
@@ -1770,5 +1797,143 @@ mod tests {
         migrate_column_schema(&mut config);
         assert_eq!(config.visible_columns, ["Title"]);
         assert_eq!(config.column_order, ["Rating", "Title"]);
+    }
+}
+
+/// GTK-touching tests for the browser pane/gutter traversal. These are
+/// helpers folded into the crate's single consolidated GTK-initializing
+/// test (browser.rs `gtk_widget_contracts_hold_on_one_session`) — never
+/// standalone `#[test]`s — so only one test ever owns the GTK session.
+/// See `ui::widget_test_session`.
+#[cfg(test)]
+pub mod widget_tests {
+    use super::update_browser_visibility;
+    use super::BrowserViewsConfig;
+    use gtk::prelude::{BoxExt, WidgetExt};
+
+    /// Mirror of `build_browser`'s pane row: SearchEntry stand-in, then
+    /// the horizontal panes_box alternating genre, gutter, artist,
+    /// gutter, album, gutter, folder. Returns the widgets so assertions
+    /// can read each pane's and each gutter's visibility directly.
+    struct PaneRow {
+        browser_box: gtk::Box,
+        panes: [gtk::Box; 4],
+        gutters: [gtk::Separator; 3],
+    }
+
+    impl PaneRow {
+        fn build() -> Self {
+            let browser_box = gtk::Box::new(gtk::Orientation::Vertical, 0);
+            browser_box.append(&gtk::Label::new(Some("search")));
+            let panes_box = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+            let panes: [gtk::Box; 4] = [
+                gtk::Box::new(gtk::Orientation::Horizontal, 0),
+                gtk::Box::new(gtk::Orientation::Horizontal, 0),
+                gtk::Box::new(gtk::Orientation::Horizontal, 0),
+                gtk::Box::new(gtk::Orientation::Horizontal, 0),
+            ];
+            let gutters: [gtk::Separator; 3] = [
+                gtk::Separator::new(gtk::Orientation::Vertical),
+                gtk::Separator::new(gtk::Orientation::Vertical),
+                gtk::Separator::new(gtk::Orientation::Vertical),
+            ];
+            panes_box.append(&panes[0]);
+            for (i, pane) in panes.iter().enumerate().skip(1) {
+                panes_box.append(&gutters[i - 1]);
+                panes_box.append(pane);
+            }
+            browser_box.append(&panes_box);
+            Self {
+                browser_box,
+                panes,
+                gutters,
+            }
+        }
+    }
+
+    /// The gutter contract around hidden panes, including the PR #179
+    /// review defect: a pane disabled between two enabled panes must
+    /// leave exactly one visible 1px gutter between the survivors (panes
+    /// spacing is 0 — the separator widget is the sole gutter), never
+    /// zero (survivors touching) and never two (a doubled gap). Leading
+    /// and trailing gutters must never dangle at a box edge.
+    pub fn separator_gutters_join_visible_panes_around_hidden_ones() {
+        let views_of = |genre: bool, artist: bool, album: bool, folder: bool| BrowserViewsConfig {
+            genre,
+            artist,
+            album,
+            folder,
+        };
+
+        // THE reported defect: Genre + Album on, Artist + Folder off.
+        // Exactly one gutter (the one adjacent to Album) survives between
+        // the two survivors; the carried separator from the hidden Artist
+        // collapses instead of hiding both.
+        let row = PaneRow::build();
+        update_browser_visibility(&row.browser_box, &views_of(true, false, true, false));
+        assert!(row.panes[0].is_visible(), "genre pane must stay visible");
+        assert!(!row.panes[1].is_visible(), "artist pane must hide");
+        assert!(row.panes[2].is_visible(), "album pane must stay visible");
+        assert!(!row.panes[3].is_visible(), "folder pane must hide");
+        assert!(
+            !row.gutters[0].is_visible(),
+            "gutter carried across the hidden artist must collapse"
+        );
+        assert!(
+            row.gutters[1].is_visible(),
+            "genre and album must keep exactly one gutter between them"
+        );
+        assert!(
+            !row.gutters[2].is_visible(),
+            "no gutter may dangle after the last visible pane"
+        );
+
+        // All four panes visible: every interior gutter joins two visible
+        // panes and shows.
+        let row = PaneRow::build();
+        update_browser_visibility(&row.browser_box, &views_of(true, true, true, true));
+        for (i, gutter) in row.gutters.iter().enumerate() {
+            assert!(
+                gutter.is_visible(),
+                "gutter {i} joins two visible panes and must show"
+            );
+        }
+
+        // Genre + Folder on, Artist + Album off: the two carried gutters
+        // collapse onto the single gutter adjacent to Folder.
+        let row = PaneRow::build();
+        update_browser_visibility(&row.browser_box, &views_of(true, false, false, true));
+        assert!(!row.gutters[0].is_visible());
+        assert!(!row.gutters[1].is_visible());
+        assert!(row.gutters[2].is_visible(), "exactly one gutter survives");
+
+        // Only the first pane visible: every gutter lacks a visible pane
+        // on one side, so none may dangle at an edge.
+        let row = PaneRow::build();
+        update_browser_visibility(&row.browser_box, &views_of(true, false, false, false));
+        for (i, gutter) in row.gutters.iter().enumerate() {
+            assert!(!gutter.is_visible(), "leading gutter {i} must not dangle");
+        }
+
+        // Only the last pane visible: same, from the other edge.
+        let row = PaneRow::build();
+        update_browser_visibility(&row.browser_box, &views_of(false, false, false, true));
+        for (i, gutter) in row.gutters.iter().enumerate() {
+            assert!(
+                !gutter.is_visible(),
+                "leading gutter {i} before the only visible pane must hide"
+            );
+        }
+
+        // All panes hidden: no gutters, and the whole browser box hides.
+        let row = PaneRow::build();
+        update_browser_visibility(&row.browser_box, &views_of(false, false, false, false));
+        for (i, gutter) in row.gutters.iter().enumerate() {
+            assert!(!gutter.is_visible(), "gutter {i} must hide");
+        }
+        assert!(
+            !row.browser_box.is_visible(),
+            "with every pane hidden the browser box must hide"
+        );
     }
 }

--- a/src/ui/preferences.rs
+++ b/src/ui/preferences.rs
@@ -1106,13 +1106,16 @@ pub fn update_browser_visibility(browser_box: &gtk::Box, views: &BrowserViewsCon
                 // its visibility once the next pane is reached.
                 pending_separators.push(widget);
             } else {
-                let visible = match pane_idx {
-                    0 => views.genre,
-                    1 => views.artist,
-                    2 => views.album,
-                    3 => views.folder,
-                    _ => true,
-                };
+                // Panes map positionally to the config flags; anything
+                // beyond the four known panes stays visible (the old
+                // `_ => true` match arm). The bounds-checked lookup
+                // keeps this function under Codacy's cyclomatic
+                // complexity threshold (PR #179 re-analysis flagged the
+                // match-driven version as its one new medium issue).
+                let visible = [views.genre, views.artist, views.album, views.folder]
+                    .get(pane_idx)
+                    .copied()
+                    .unwrap_or(true);
                 pane_idx += 1;
                 let gutter_visible = visible && previous_pane_visible;
                 for separator in std::mem::take(&mut pending_separators) {

--- a/src/ui/preferences.rs
+++ b/src/ui/preferences.rs
@@ -1073,10 +1073,18 @@ pub fn read_column_order(column_view: &gtk::ColumnView) -> Vec<String> {
 
 /// Update browser pane visibility based on config.
 ///
-/// The browser `Box` now has a vertical layout: SearchEntry at the top,
-/// then a horizontal panes_box containing three children (genre, artist,
-/// album pane `Box` widgets).  If all three panes are hidden, hide the
-/// entire browser box.  The search entry visibility follows the browser.
+/// The browser `Box` has a vertical layout: SearchEntry at the top, then
+/// a horizontal panes_box whose children alternate pane and gutter:
+/// genre, `.browser-separator`, artist, separator, album, separator,
+/// folder.  Panes are recognized structurally — any non-`Separator`
+/// child, mapped in that order to the config flags — so this traversal
+/// cannot drift out of sync with the layout if gutters are added or
+/// removed (indexing raw child positions broke here once the separators
+/// became real widgets: disabling Artist hid a separator, disabling
+/// Album hid Artist, and Album/Folder could never be hidden).  A
+/// separator stays visible only when it joins two visible panes, which
+/// prevents doubled or dangling gutters around hidden panes.  If all
+/// four panes are hidden, the entire browser box is hidden.
 pub fn update_browser_visibility(browser_box: &gtk::Box, views: &BrowserViewsConfig) {
     // The browser_box layout is: SearchEntry, panes_box (horizontal Box).
     // Find the panes_box (last child, which is a horizontal Box).
@@ -1085,19 +1093,38 @@ pub fn update_browser_visibility(browser_box: &gtk::Box, views: &BrowserViewsCon
         .and_then(|w| w.downcast::<gtk::Box>().ok());
 
     if let Some(ref panes_box) = panes_box {
-        let mut child_idx = 0;
+        let mut pane_idx = 0;
+        // A separator leading the box would dangle at its edge, so the
+        // "previous pane" starts out treated as hidden.
+        let mut previous_pane_visible = false;
+        let mut pending_separators: Vec<gtk::Widget> = Vec::new();
         let mut child = panes_box.first_child();
         while let Some(widget) = child {
-            let visible = match child_idx {
-                0 => views.genre,
-                1 => views.artist,
-                2 => views.album,
-                3 => views.folder,
-                _ => true,
-            };
-            widget.set_visible(visible);
             child = widget.next_sibling();
-            child_idx += 1;
+            if widget.downcast_ref::<gtk::Separator>().is_some() {
+                // A gutter belongs to the pair of panes around it; decide
+                // its visibility once the next pane is reached.
+                pending_separators.push(widget);
+            } else {
+                let visible = match pane_idx {
+                    0 => views.genre,
+                    1 => views.artist,
+                    2 => views.album,
+                    3 => views.folder,
+                    _ => true,
+                };
+                pane_idx += 1;
+                let gutter_visible = visible && previous_pane_visible;
+                for separator in std::mem::take(&mut pending_separators) {
+                    separator.set_visible(gutter_visible);
+                }
+                widget.set_visible(visible);
+                previous_pane_visible = visible;
+            }
+        }
+        // Separators after the last pane would dangle at the box edge.
+        for separator in std::mem::take(&mut pending_separators) {
+            separator.set_visible(false);
         }
     }
 

--- a/src/ui/preferences.rs
+++ b/src/ui/preferences.rs
@@ -1805,7 +1805,11 @@ mod tests {
 /// test (browser.rs `gtk_widget_contracts_hold_on_one_session`) — never
 /// standalone `#[test]`s — so only one test ever owns the GTK session.
 /// See `ui::widget_test_session`.
-#[cfg(test)]
+// macOS gates out the sole caller (browser.rs's consolidated GTK test
+// shares the crate's one GTK session only off-macOS); an ungated copy of
+// these symbols is dead code there and fails clippy -D warnings. Mirror
+// the caller's gate exactly, as context_menu's helper already does.
+#[cfg(all(test, not(target_os = "macos")))]
 pub mod widget_tests {
     use super::update_browser_visibility;
     use super::BrowserViewsConfig;
@@ -1851,26 +1855,21 @@ pub mod widget_tests {
         }
     }
 
-    /// The gutter contract around hidden panes, including the PR #179
-    /// review defect: a pane disabled between two enabled panes must
-    /// leave exactly one visible 1px gutter between the survivors (panes
-    /// spacing is 0 — the separator widget is the sole gutter), never
-    /// zero (survivors touching) and never two (a doubled gap). Leading
-    /// and trailing gutters must never dangle at a box edge.
-    pub fn separator_gutters_join_visible_panes_around_hidden_ones() {
-        let views_of = |genre: bool, artist: bool, album: bool, folder: bool| BrowserViewsConfig {
-            genre,
-            artist,
-            album,
-            folder,
-        };
-
-        // THE reported defect: Genre + Album on, Artist + Folder off.
-        // Exactly one gutter (the one adjacent to Album) survives between
-        // the two survivors; the carried separator from the hidden Artist
-        // collapses instead of hiding both.
+    /// THE reported defect: Genre + Album on, Artist + Folder off.
+    /// Exactly one gutter (the one adjacent to Album) survives between
+    /// the two survivors; the carried separator from the hidden Artist
+    /// collapses instead of hiding both.
+    fn interior_hidden_pane_leaves_exactly_one_gutter() {
         let row = PaneRow::build();
-        update_browser_visibility(&row.browser_box, &views_of(true, false, true, false));
+        update_browser_visibility(
+            &row.browser_box,
+            &BrowserViewsConfig {
+                genre: true,
+                artist: false,
+                album: true,
+                folder: false,
+            },
+        );
         assert!(row.panes[0].is_visible(), "genre pane must stay visible");
         assert!(!row.panes[1].is_visible(), "artist pane must hide");
         assert!(row.panes[2].is_visible(), "album pane must stay visible");
@@ -1887,47 +1886,97 @@ pub mod widget_tests {
             !row.gutters[2].is_visible(),
             "no gutter may dangle after the last visible pane"
         );
+    }
 
-        // All four panes visible: every interior gutter joins two visible
-        // panes and shows.
+    /// All four panes visible: every interior gutter joins two visible
+    /// panes and shows.
+    fn all_panes_visible_show_every_interior_gutter() {
         let row = PaneRow::build();
-        update_browser_visibility(&row.browser_box, &views_of(true, true, true, true));
+        update_browser_visibility(
+            &row.browser_box,
+            &BrowserViewsConfig {
+                genre: true,
+                artist: true,
+                album: true,
+                folder: true,
+            },
+        );
         for (i, gutter) in row.gutters.iter().enumerate() {
             assert!(
                 gutter.is_visible(),
                 "gutter {i} joins two visible panes and must show"
             );
         }
+    }
 
-        // Genre + Folder on, Artist + Album off: the two carried gutters
-        // collapse onto the single gutter adjacent to Folder.
+    /// Genre + Folder on, Artist + Album off: the two carried gutters
+    /// collapse onto the single gutter adjacent to Folder.
+    fn disjoint_survivors_collapse_onto_one_gutter() {
         let row = PaneRow::build();
-        update_browser_visibility(&row.browser_box, &views_of(true, false, false, true));
+        update_browser_visibility(
+            &row.browser_box,
+            &BrowserViewsConfig {
+                genre: true,
+                artist: false,
+                album: false,
+                folder: true,
+            },
+        );
         assert!(!row.gutters[0].is_visible());
         assert!(!row.gutters[1].is_visible());
         assert!(row.gutters[2].is_visible(), "exactly one gutter survives");
+    }
 
-        // Only the first pane visible: every gutter lacks a visible pane
-        // on one side, so none may dangle at an edge.
+    /// Only the first pane visible: every gutter lacks a visible pane
+    /// on one side, so none may dangle at an edge.
+    fn lone_leading_pane_leaves_no_dangling_gutters() {
         let row = PaneRow::build();
-        update_browser_visibility(&row.browser_box, &views_of(true, false, false, false));
+        update_browser_visibility(
+            &row.browser_box,
+            &BrowserViewsConfig {
+                genre: true,
+                artist: false,
+                album: false,
+                folder: false,
+            },
+        );
         for (i, gutter) in row.gutters.iter().enumerate() {
             assert!(!gutter.is_visible(), "leading gutter {i} must not dangle");
         }
+    }
 
-        // Only the last pane visible: same, from the other edge.
+    /// Only the last pane visible: same, from the other edge.
+    fn lone_trailing_pane_leaves_no_dangling_gutters() {
         let row = PaneRow::build();
-        update_browser_visibility(&row.browser_box, &views_of(false, false, false, true));
+        update_browser_visibility(
+            &row.browser_box,
+            &BrowserViewsConfig {
+                genre: false,
+                artist: false,
+                album: false,
+                folder: true,
+            },
+        );
         for (i, gutter) in row.gutters.iter().enumerate() {
             assert!(
                 !gutter.is_visible(),
                 "leading gutter {i} before the only visible pane must hide"
             );
         }
+    }
 
-        // All panes hidden: no gutters, and the whole browser box hides.
+    /// All panes hidden: no gutters, and the whole browser box hides.
+    fn all_panes_hidden_hide_the_browser_box() {
         let row = PaneRow::build();
-        update_browser_visibility(&row.browser_box, &views_of(false, false, false, false));
+        update_browser_visibility(
+            &row.browser_box,
+            &BrowserViewsConfig {
+                genre: false,
+                artist: false,
+                album: false,
+                folder: false,
+            },
+        );
         for (i, gutter) in row.gutters.iter().enumerate() {
             assert!(!gutter.is_visible(), "gutter {i} must hide");
         }
@@ -1935,5 +1984,20 @@ pub mod widget_tests {
             !row.browser_box.is_visible(),
             "with every pane hidden the browser box must hide"
         );
+    }
+
+    /// The gutter contract around hidden panes, including the PR #179
+    /// review defect: a pane disabled between two enabled panes must
+    /// leave exactly one visible 1px gutter between the survivors (panes
+    /// spacing is 0 — the separator widget is the sole gutter), never
+    /// zero (survivors touching) and never two (a doubled gap). Leading
+    /// and trailing gutters must never dangle at a box edge.
+    pub fn separator_gutters_join_visible_panes_around_hidden_ones() {
+        interior_hidden_pane_leaves_exactly_one_gutter();
+        all_panes_visible_show_every_interior_gutter();
+        disjoint_survivors_collapse_onto_one_gutter();
+        lone_leading_pane_leaves_no_dangling_gutters();
+        lone_trailing_pane_leaves_no_dangling_gutters();
+        all_panes_hidden_hide_the_browser_box();
     }
 }

--- a/src/ui/style.css
+++ b/src/ui/style.css
@@ -46,9 +46,12 @@
 
 /* Subtle separator between browser panes (HIG: rely on background
  * contrast rather than a hard rule; tone the line down so it reads
- * as a gutter, not a divider). */
+ * as a gutter, not a divider). Standard CSS only: the opaque theme
+ * border color scaled down by element opacity — the web-CSS-safe
+ * equivalent of GTK's alpha(@borders, 0.15). */
 .browser-separator {
-    background-color: alpha(@borders, 0.15);
+    background-color: @borders;
+    opacity: 0.15;
     min-width: 1px;
 }
 

--- a/src/ui/style.css
+++ b/src/ui/style.css
@@ -63,10 +63,12 @@ searchentry {
     border-radius: 6px;
 }
 
-/* Numeric (right-aligned) secondary text in browser rows — keep the
- * dim-label opacity but lift the minimum contrast a touch so the
- * count remains legible at small caption size. */
-.caption.dim-label.numeric {
+/* Numeric secondary text in browser rows — keep the dim-label opacity
+ * but lift the minimum contrast a touch so the count remains legible
+ * at small caption size. Scoped to the dedicated `.browser-count` class
+ * so the rule does not also re-style the header-bar scrubber time
+ * labels (which share the same `dim-label caption numeric` triplet). */
+.browser-count {
     opacity: 0.75;
 }
 

--- a/src/ui/style.css
+++ b/src/ui/style.css
@@ -1,15 +1,18 @@
 /* Tributary — Custom CSS overrides for the GTK4/libadwaita theme */
 
-/* Dense row spacing for the tracklist column view */
+/* Tracklist column view — let Adwaita drive row padding so the list
+ * keeps the standard dense-list rhythm rather than collapsing onto
+ * the row separators. (HIG: dense data lists should not look like a
+ * grid; Adwaita already encodes the right vertical rhythm.) */
 .data-table .cell {
-    padding-top: 1px;
-    padding-bottom: 1px;
+    min-height: 24px;
 }
 
 /* Status bar at bottom of tracklist */
 .statusbar-box {
     background-color: alpha(@window_bg_color, 0.95);
     border-top: 1px solid alpha(@borders, 0.3);
+    padding: 4px 12px;
 }
 
 /* Sidebar header labels */
@@ -41,9 +44,11 @@
     min-height: 4px;
 }
 
-/* Subtle separator between browser panes */
+/* Subtle separator between browser panes (HIG: rely on background
+ * contrast rather than a hard rule; tone the line down so it reads
+ * as a gutter, not a divider). */
 .browser-separator {
-    background-color: alpha(@borders, 0.3);
+    background-color: alpha(@borders, 0.15);
     min-width: 1px;
 }
 
@@ -56,6 +61,13 @@
 /* Search entry in the browser filter bar */
 searchentry {
     border-radius: 6px;
+}
+
+/* Numeric (right-aligned) secondary text in browser rows — keep the
+ * dim-label opacity but lift the minimum contrast a touch so the
+ * count remains legible at small caption size. */
+.caption.dim-label.numeric {
+    opacity: 0.75;
 }
 
 

--- a/src/ui/tracklist.rs
+++ b/src/ui/tracklist.rs
@@ -435,7 +435,7 @@ pub(super) fn build_tracklist(
         .model(&selection)
         .reorderable(true)
         .show_column_separators(true)
-        .show_row_separators(true)
+        .show_row_separators(false)
         .css_classes(["data-table"])
         .hexpand(true)
         .vexpand(true)
@@ -633,19 +633,16 @@ pub(super) fn build_tracklist(
     let server_playlist_status_shell = ServerPlaylistStatusShell::new(&column_view);
     let status_label = gtk::Label::builder()
         .halign(gtk::Align::End)
+        .valign(gtk::Align::Center)
         .hexpand(true)
-        .margin_start(8)
-        .margin_end(12)
-        .css_classes(["dim-label", "caption"])
+        .css_classes(["dim-label", "caption", "numeric"])
         .build();
     update_status(&status_label, initial_tracks);
 
     let status_bar = gtk::Box::builder()
         .orientation(gtk::Orientation::Horizontal)
         .spacing(8)
-        .margin_start(8)
-        .margin_top(4)
-        .margin_bottom(4)
+        .valign(gtk::Align::Center)
         .css_classes(["statusbar-box"])
         .build();
     status_bar.append(server_playlist_status_shell.widget());


### PR DESCRIPTION
## Summary

docs/task.md:997-999. Issue #29.
Visual and accessibility review of separator treatment, count opacity and alignment against current GNOME HIG.
Small, independent, fleet-completable.

## Implementation notes

Implemented: HIG refinements — count-opacity split (browser row label + dimmed caption count), tracklist row separators dropped and cell padding surrendered to Adwaita, status-bar margins unified into .statusbar-box, .browser-separator toned down. fmt/clippy clean; cargo test (1712) all pass. Reformatted with cargo fmt after refinery fmt gate failure.

## Refinery handoff

- Issue: `tr-ewq` (task, P3)
- Source branch: `polecat/tr-ewq`
- Target: `main`
- Rebased on `main` via Gastown Refinery.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser panes now expand to use available space and are separated by vertical dividers.
  * Browser entries display labels and counts separately, with improved truncation and accessibility support.
  * Entries with zero results omit count text for a cleaner presentation.

* **Style**
  * Refined browser spacing, separators, and count emphasis.
  * Improved tracklist row styling and status bar alignment, spacing, and visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->