### PR TITLE
fix(deps): coordinate Dependabot and Rust updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,10 +15,10 @@ updates:
   # ── Rust crates (Cargo.toml / Cargo.lock) ─────────────────────────────────
   #
   # The fuzz crate is deliberately a separate Cargo workspace and therefore
-  # needs its own Dependabot entry below.  A root update can still change
-  # dependencies inherited by fuzz through its path dependency on Tributary;
-  # CI detects that cross-lock drift and the repository-owned repair command is
-  # documented in docs/dependency-updates.md.
+  # needs its own Dependabot entry below. A root update can still change direct
+  # production dependencies inherited by fuzz through its path dependency on
+  # Tributary; CI detects that cross-lock drift and the repository-owned repair
+  # command is documented in docs/dependency-updates.md.
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
@@ -32,6 +32,11 @@ updates:
       # their manifest requirements and resolved versions to remain paired.
       seaorm:
         applies-to: version-updates
+        patterns:
+          - "sea-orm"
+          - "sea-orm-migration"
+      seaorm-security:
+        applies-to: security-updates
         patterns:
           - "sea-orm"
           - "sea-orm-migration"
@@ -61,6 +66,12 @@ updates:
     cooldown:
       default-days: 5
     groups:
+      seaorm-security:
+        applies-to: security-updates
+        patterns:
+          - "sea-orm"
+          - "sea-orm-migration"
+
       fuzz-minor-and-patch:
         applies-to: version-updates
         patterns:
@@ -88,12 +99,25 @@ updates:
         patterns:
           - "dtolnay/rust-toolchain"
 
+      # Updating the privileged metadata action must be an isolated,
+      # review-only PR. The workflow's read-only preflight denies any PR that
+      # changes its own file, so a proposed ref cannot execute before review.
+      dependabot-metadata:
+        applies-to: version-updates
+        patterns:
+          - "dependabot/fetch-metadata"
+      dependabot-metadata-security:
+        applies-to: security-updates
+        patterns:
+          - "dependabot/fetch-metadata"
+
       actions-minor-and-patch:
         applies-to: version-updates
         patterns:
           - "*"
         exclude-patterns:
           - "dtolnay/rust-toolchain"
+          - "dependabot/fetch-metadata"
         update-types:
           - "minor"
           - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,12 @@
 version: 2
 updates:
   # ── Rust crates (Cargo.toml / Cargo.lock) ─────────────────────────────────
+  #
+  # The fuzz crate is deliberately a separate Cargo workspace and therefore
+  # needs its own Dependabot entry below.  A root update can still change
+  # dependencies inherited by fuzz through its path dependency on Tributary;
+  # CI detects that cross-lock drift and the repository-owned repair command is
+  # documented in docs/dependency-updates.md.
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
@@ -21,12 +27,41 @@ updates:
     cooldown:
       default-days: 5
     groups:
+      # SeaORM's runtime and migration crates are one compatibility surface.
+      # Keep every update level in one PR. Repository policy tests also require
+      # their manifest requirements and resolved versions to remain paired.
+      seaorm:
+        applies-to: version-updates
+        patterns:
+          - "sea-orm"
+          - "sea-orm-migration"
+
       # One PR for ALL non-breaking crate bumps (patch + minor). Majors are
       # deliberately EXCLUDED so each major arrives as its own PR for human
       # review. This also keeps the grouped PR's update-type at
       # semver-minor/semver-patch, which is exactly what the auto-merge
       # workflow is allowed to merge.
       cargo-minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "sea-orm"
+          - "sea-orm-migration"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ── Rust fuzz workspace (fuzz/Cargo.toml / fuzz/Cargo.lock) ───────────────
+  - package-ecosystem: "cargo"
+    directory: "/fuzz"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 5
+    groups:
+      fuzz-minor-and-patch:
         applies-to: version-updates
         patterns:
           - "*"
@@ -43,10 +78,22 @@ updates:
     cooldown:
       default-days: 5
     groups:
+      # The exact dtolnay/rust-toolchain refs are also the trigger for a
+      # coordinated MSRV proposal. Do not ignore them: Dependabot should open
+      # the PR, then the repair lane synchronizes Cargo.toml, CI, and README and
+      # runs the complete matrix. The auto-merge workflow explicitly excludes
+      # this dependency at every update level.
+      rust-toolchain:
+        applies-to: version-updates
+        patterns:
+          - "dtolnay/rust-toolchain"
+
       actions-minor-and-patch:
         applies-to: version-updates
         patterns:
           - "*"
+        exclude-patterns:
+          - "dtolnay/rust-toolchain"
         update-types:
           - "minor"
           - "patch"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,8 @@ jobs:
   # toolchain pin below in lockstep with that field: the gtk-rs 0.11 release
   # series sets the current floor (rustc 1.92).
   msrv:
-    name: MSRV (1.92)
+    # Keep this check name stable: branch rules and GasCity require "MSRV".
+    name: MSRV
     runs-on: ubuntu-24.04
     container:
       image: fedora:41

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,9 @@ jobs:
   # toolchain pin below in lockstep with that field: the gtk-rs 0.11 release
   # series sets the current floor (rustc 1.92).
   msrv:
-    # Keep this check name stable: branch rules and GasCity require "MSRV".
+    # Keep this name stable across future Rust bumps. Deployment must migrate
+    # GasCity's old "MSRV (1.92)" expectation and may then add "MSRV" to the
+    # live ruleset; this repository change does not mutate either external gate.
     name: MSRV
     runs-on: ubuntu-24.04
     container:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,30 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
+        with:
+          # The dependency policy compares PR lock state with the exact base.
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Test package compliance policies
         run: |
           build-aux/linux/test-package-compliance.sh
           scripts/test-macos-icon-bundle-policy.sh
           scripts/test-macos-package-policy.sh
+
+      - name: Test dependency update policy
+        run: |
+          python3 scripts/test_dependency_update_policy.py
+          python3 scripts/sync_rust_toolchain.py --check
+
+      - name: Verify root and fuzz lock update coherence
+        if: github.event_name == 'pull_request'
+        env:
+          DEPENDENCY_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: >-
+          python3 scripts/sync_fuzz_lock.py check
+          --base-ref "$DEPENDENCY_BASE_SHA"
+
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
       - name: Run cargo audit

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -4,11 +4,11 @@ name: Dependabot auto-merge
 #
 # How the pieces fit together:
 #   * This workflow only ENABLES GitHub's native auto-merge on the PR.
-#   * The actual gate ("wait for green CI") is enforced by the branch ruleset
-#     on `main` that requires the CI status checks. Auto-merge engages because
-#     that ruleset makes the PR non-immediately-mergeable, then lands it once
-#     the required checks pass. Without that ruleset, `--auto` would either
-#     error or merge immediately without waiting — so the ruleset is required.
+#   * The actual gate ("wait for configured required checks") is enforced by
+#     the live branch ruleset on `main`, not by this file. Before deploying this
+#     workflow, that ruleset must be migrated to the documented stable check
+#     names, including `MSRV`. Auto-merge then lands the PR only after that
+#     configured set passes.
 #   * Majors are NOT auto-merged: they fall through the update-type guard below
 #     and wait for coordinated repair and review.
 #   * Rust toolchain/MSRV proposals are NOT auto-merged at any SemVer level.
@@ -16,16 +16,19 @@ name: Dependabot auto-merge
 #     authoritative pin and requires the complete CI matrix first.
 #
 # Security: uses `pull_request` (NOT `pull_request_target`) and never checks out
-# the PR head, so untrusted code never runs here. A read-only first job queries
-# every changed filename through GitHub's API. The write-capable job cannot
-# start if this workflow is among them, even in a mixed-path PR, so a proposed
-# replacement action ref cannot execute itself before review.
+# the PR head. A read-only first job binds changed-file inspection and metadata
+# extraction to the event's exact head SHA. The action-free write job checks
+# that SHA again immediately before an exact-head-guarded merge request.
 on:
   pull_request:
     paths-ignore:
       - ".github/workflows/dependabot-automerge.yml"
 
 permissions: {}
+
+concurrency:
+  group: dependabot-automerge-${{ github.repository }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   inspect_changed_files:
@@ -38,6 +41,9 @@ jobs:
       pull-requests: read
     outputs:
       privileged_workflow_unchanged: ${{ steps.changed_files.outputs.safe }}
+      inspected_head_sha: ${{ steps.metadata_head.outputs.head_sha }}
+      dependency_names: ${{ steps.meta.outputs.dependency-names }}
+      update_type: ${{ steps.meta.outputs.update-type }}
     steps:
       # Inline and API-only by design: no proposed third-party action executes
       # before the complete changed-file set has been proven safe.
@@ -47,14 +53,29 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           EXPECTED_CHANGED_FILES: ${{ github.event.pull_request.changed_files }}
         run: |
           set -euo pipefail
+          pr_api="repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}"
           changed_file_list="${RUNNER_TEMP}/dependabot-changed-files.txt"
+
+          observed_head_before="$(gh api "${pr_api}" --jq '.head.sha')"
+          if [ "${observed_head_before}" != "${EXPECTED_HEAD_SHA}" ]; then
+            echo "PR head changed before file inspection; refusing write access." >&2
+            exit 1
+          fi
+
           gh api --paginate \
-            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100" \
+            "${pr_api}/files?per_page=100" \
             --jq '.[] | [.filename, (.previous_filename // "")] | @tsv' \
             > "${changed_file_list}"
+
+          observed_head_after="$(gh api "${pr_api}" --jq '.head.sha')"
+          if [ "${observed_head_after}" != "${EXPECTED_HEAD_SHA}" ]; then
+            echo "PR head changed during file inspection; refusing write access." >&2
+            exit 1
+          fi
 
           observed_changed_files="$(wc -l < "${changed_file_list}")"
           if [ "${observed_changed_files}" -ne "${EXPECTED_CHANGED_FILES}" ]; then
@@ -62,46 +83,102 @@ jobs:
             exit 1
           fi
 
-          if grep -Fq -- \
-            '.github/workflows/dependabot-automerge.yml' \
-            "${changed_file_list}"; then
-            echo "safe=false" >> "${GITHUB_OUTPUT}"
-          else
-            echo "safe=true" >> "${GITHUB_OUTPUT}"
+          safe=true
+          while IFS=$'\t' read -r filename previous_filename; do
+            if [ "${filename}" = '.github/workflows/dependabot-automerge.yml' ] ||
+               [ "${previous_filename}" = '.github/workflows/dependabot-automerge.yml' ]; then
+              safe=false
+              break
+            fi
+          done < "${changed_file_list}"
+
+          echo "safe=${safe}" >> "${GITHUB_OUTPUT}"
+          echo "head_sha=${EXPECTED_HEAD_SHA}" >> "${GITHUB_OUTPUT}"
+
+      - name: Revalidate exact head before metadata
+        id: pre_metadata_head
+        if: steps.changed_files.outputs.safe == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          EXPECTED_HEAD_SHA: ${{ steps.changed_files.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          observed_head="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
+            --jq '.head.sha')"
+          if [ "${observed_head}" != "${EXPECTED_HEAD_SHA}" ]; then
+            echo "PR head changed before metadata extraction; refusing." >&2
+            exit 1
           fi
+          echo "matches=true" >> "${GITHUB_OUTPUT}"
+
+      - name: Fetch Dependabot metadata
+        id: meta
+        if: steps.pre_metadata_head.outputs.matches == 'true'
+        # v3, pinned to the full commit published in GitHub's current example.
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Revalidate exact head after metadata
+        id: metadata_head
+        if: steps.meta.outcome == 'success'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          EXPECTED_HEAD_SHA: ${{ steps.changed_files.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          observed_head="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
+            --jq '.head.sha')"
+          if [ "${observed_head}" != "${EXPECTED_HEAD_SHA}" ]; then
+            echo "PR head changed during metadata extraction; refusing." >&2
+            exit 1
+          fi
+          echo "head_sha=${EXPECTED_HEAD_SHA}" >> "${GITHUB_OUTPUT}"
 
   dependabot-automerge:
     needs: inspect_changed_files
     runs-on: ubuntu-latest
     if: |
       needs.inspect_changed_files.outputs.privileged_workflow_unchanged == 'true' &&
+      needs.inspect_changed_files.outputs.inspected_head_sha == github.event.pull_request.head.sha &&
       github.actor == 'dependabot[bot]' &&
       github.event.pull_request.user.login == 'dependabot[bot]' &&
-      github.repository == 'jm2/tributary'
+      github.repository == 'jm2/tributary' &&
+      !contains(needs.inspect_changed_files.outputs.dependency_names, 'dtolnay/rust-toolchain') &&
+      !contains(needs.inspect_changed_files.outputs.dependency_names, 'dependabot/fetch-metadata') &&
+      (
+        needs.inspect_changed_files.outputs.update_type == 'version-update:semver-patch' ||
+        needs.inspect_changed_files.outputs.update_type == 'version-update:semver-minor'
+      )
     permissions:
       contents: write
       pull-requests: write
     steps:
-      - name: Fetch Dependabot metadata
-        id: meta
-        # v3, pinned to the full commit published in GitHub's current example.
-        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
-      # Enable auto-merge ONLY for patch + minor bumps which are not Rust
-      # toolchain proposals. Major bumps (version-update:semver-major) and every
-      # dtolnay/rust-toolchain bump are left for coordinated repair/review. For
-      # grouped PRs, fetch-metadata reports the highest SemVer bump in the group.
-      - name: Enable auto-merge for patch & minor updates
-        if: |
-          !contains(steps.meta.outputs.dependency-names, 'dtolnay/rust-toolchain') &&
-          !contains(steps.meta.outputs.dependency-names, 'dependabot/fetch-metadata') &&
-          (
-            steps.meta.outputs.update-type == 'version-update:semver-patch' ||
-            steps.meta.outputs.update-type == 'version-update:semver-minor'
-          )
-        run: gh pr merge --auto --squash "$PR_URL"
+      # Major bumps, every Rust/MSRV proposal, and metadata-action self-updates
+      # never reach this action-free write job.
+      - name: Enable exact-head auto-merge for patch & minor updates
+        shell: bash
+        run: |
+          set -euo pipefail
+          pr_api="repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}"
+          observed_head="$(gh api "${pr_api}" --jq '.head.sha')"
+          if [ "${observed_head}" != "${EXPECTED_HEAD_SHA}" ]; then
+            echo "PR head changed before guarded merge; refusing auto-merge." >&2
+            exit 1
+          fi
+          gh pr merge \
+            --auto \
+            --squash \
+            --match-head-commit "${EXPECTED_HEAD_SHA}" \
+            "${PR_URL}"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          EXPECTED_HEAD_SHA: ${{ needs.inspect_changed_files.outputs.inspected_head_sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -16,27 +16,76 @@ name: Dependabot auto-merge
 #     authoritative pin and requires the complete CI matrix first.
 #
 # Security: uses `pull_request` (NOT `pull_request_target`) and never checks out
-# the PR head, so untrusted code never runs here.
-on: pull_request
+# the PR head, so untrusted code never runs here. A read-only first job queries
+# every changed filename through GitHub's API. The write-capable job cannot
+# start if this workflow is among them, even in a mixed-path PR, so a proposed
+# replacement action ref cannot execute itself before review.
+on:
+  pull_request:
+    paths-ignore:
+      - ".github/workflows/dependabot-automerge.yml"
 
-# Least privilege — just enough to enable auto-merge. GitHub grants these write
-# scopes to Dependabot-triggered runs for the pull_request event.
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
-  dependabot-automerge:
+  inspect_changed_files:
     runs-on: ubuntu-latest
-    # Belt-and-suspenders: only ever act on Dependabot's own PRs.
     if: |
       github.actor == 'dependabot[bot]' &&
       github.event.pull_request.user.login == 'dependabot[bot]' &&
       github.repository == 'jm2/tributary'
+    permissions:
+      pull-requests: read
+    outputs:
+      privileged_workflow_unchanged: ${{ steps.changed_files.outputs.safe }}
+    steps:
+      # Inline and API-only by design: no proposed third-party action executes
+      # before the complete changed-file set has been proven safe.
+      - name: Deny privileged workflow changes
+        id: changed_files
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          EXPECTED_CHANGED_FILES: ${{ github.event.pull_request.changed_files }}
+        run: |
+          set -euo pipefail
+          changed_file_list="${RUNNER_TEMP}/dependabot-changed-files.txt"
+          gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100" \
+            --jq '.[] | [.filename, (.previous_filename // "")] | @tsv' \
+            > "${changed_file_list}"
+
+          observed_changed_files="$(wc -l < "${changed_file_list}")"
+          if [ "${observed_changed_files}" -ne "${EXPECTED_CHANGED_FILES}" ]; then
+            echo "Changed-file enumeration was incomplete; refusing write access." >&2
+            exit 1
+          fi
+
+          if grep -Fq -- \
+            '.github/workflows/dependabot-automerge.yml' \
+            "${changed_file_list}"; then
+            echo "safe=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "safe=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+  dependabot-automerge:
+    needs: inspect_changed_files
+    runs-on: ubuntu-latest
+    if: |
+      needs.inspect_changed_files.outputs.privileged_workflow_unchanged == 'true' &&
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.repository == 'jm2/tributary'
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v3
+        # v3, pinned to the full commit published in GitHub's current example.
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
@@ -47,6 +96,7 @@ jobs:
       - name: Enable auto-merge for patch & minor updates
         if: |
           !contains(steps.meta.outputs.dependency-names, 'dtolnay/rust-toolchain') &&
+          !contains(steps.meta.outputs.dependency-names, 'dependabot/fetch-metadata') &&
           (
             steps.meta.outputs.update-type == 'version-update:semver-patch' ||
             steps.meta.outputs.update-type == 'version-update:semver-minor'

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -10,7 +10,10 @@ name: Dependabot auto-merge
 #     the required checks pass. Without that ruleset, `--auto` would either
 #     error or merge immediately without waiting — so the ruleset is required.
 #   * Majors are NOT auto-merged: they fall through the update-type guard below
-#     and wait for a human.
+#     and wait for coordinated repair and review.
+#   * Rust toolchain/MSRV proposals are NOT auto-merged at any SemVer level.
+#     Dependabot still opens them; the repair lane synchronizes every
+#     authoritative pin and requires the complete CI matrix first.
 #
 # Security: uses `pull_request` (NOT `pull_request_target`) and never checks out
 # the PR head, so untrusted code never runs here.
@@ -26,7 +29,10 @@ jobs:
   dependabot-automerge:
     runs-on: ubuntu-latest
     # Belt-and-suspenders: only ever act on Dependabot's own PRs.
-    if: github.actor == 'dependabot[bot]'
+    if: |
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.repository == 'jm2/tributary'
     steps:
       - name: Fetch Dependabot metadata
         id: meta
@@ -34,15 +40,17 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      # Enable auto-merge ONLY for patch + minor bumps. Major bumps
-      # (version-update:semver-major) are left for a human. For GROUPED PRs,
-      # fetch-metadata reports the HIGHEST semver bump in the group; the groups
-      # in dependabot.yml only contain minor+patch, so grouped PRs always report
-      # semver-minor / semver-patch.
+      # Enable auto-merge ONLY for patch + minor bumps which are not Rust
+      # toolchain proposals. Major bumps (version-update:semver-major) and every
+      # dtolnay/rust-toolchain bump are left for coordinated repair/review. For
+      # grouped PRs, fetch-metadata reports the highest SemVer bump in the group.
       - name: Enable auto-merge for patch & minor updates
         if: |
-          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
-          steps.meta.outputs.update-type == 'version-update:semver-minor'
+          !contains(steps.meta.outputs.dependency-names, 'dtolnay/rust-toolchain') &&
+          (
+            steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+            steps.meta.outputs.update-type == 'version-update:semver-minor'
+          )
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 /coverage/
 **/*.rs.bk
 
+# Python policy-script caches
+__pycache__/
+*.py[cod]
+
 # IDE
 .vscode/
 .idea/

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -1,0 +1,73 @@
+# Dependency update policy
+
+Tributary keeps Dependabot enabled for the root Cargo package, the independent
+fuzz workspace, and GitHub Actions. The policy separates routine updates from
+changes which need coordinated repair:
+
+- Compatible Cargo and Actions patch/minor updates may use native GitHub
+  auto-merge, but only after every required branch-protection check is green.
+- `sea-orm` and `sea-orm-migration` always share one Dependabot group and must
+  retain matching manifest requirements and resolved versions.
+- Cargo major updates remain reviewed changes and normally arrive
+  individually; the coupled SeaORM pair is the intentional grouped exception.
+- Exact `dtolnay/rust-toolchain` updates remain enabled and have their own
+  group. They are never automatically merged, even when GitHub classifies the
+  Rust release bump as SemVer-minor.
+- The fuzz crate has its own Dependabot entry because `fuzz/Cargo.toml`
+  intentionally declares a separate workspace and owns `fuzz/Cargo.lock`.
+
+## Root Cargo update repair
+
+A root Cargo update may also change production dependencies inherited by the
+fuzz workspace. Pull-request CI compares the root lock against the exact base
+SHA and fails if a changed shared direct dependency remains stale in
+`fuzz/Cargo.lock`.
+
+GasCity should handle that expected failure in a trusted isolated worktree:
+
+```sh
+python3 scripts/sync_fuzz_lock.py write --base-ref <exact-base-sha>
+python3 scripts/sync_fuzz_lock.py check --base-ref <exact-base-sha>
+```
+
+The write command uses targeted `cargo update --precise` operations. It does
+not commit, push, approve, or merge. The Repairer must verify that only the
+expected lock state changed, commit the repair to the existing Dependabot
+branch, and require the complete CI matrix. Graph rewrites which cannot be
+expressed as a version substitution fail closed for manual repair.
+`--offline` is available for a pre-populated Cargo cache; normal repair runs
+may use the registry to obtain the exact versions already selected in the root
+lock.
+
+## Rust toolchain and MSRV repair
+
+The two numeric `dtolnay/rust-toolchain@X.Y.0` refs are the Dependabot signal
+for a Rust release proposal. On that PR, GasCity should run:
+
+```sh
+python3 scripts/sync_rust_toolchain.py --from-actions
+python3 scripts/sync_rust_toolchain.py --check
+```
+
+This synchronizes the Cargo MSRV, exact MSRV and coverage toolchains, cache
+keys, job labels, and current README commands. The bump is feasible only when
+the full Linux, macOS, Windows, Flatpak, fuzz, audit, coverage, and repository
+policy matrix passes. It then needs independent semantic review and the normal
+Refinery exact-SHA merge gate; the Dependabot auto-merge workflow will not
+merge it.
+
+## Workflow security boundary
+
+No workflow checks out pull-request code while holding a write token. The
+auto-merge workflow uses `pull_request`, verifies the actor, PR author, and
+repository, fetches only GitHub-provided Dependabot metadata, and enables
+GitHub's native guarded auto-merge without checking out the branch.
+
+Lockfile and toolchain repair intentionally remain GasCity Repairer operations
+instead of a `pull_request_target` writer. This keeps untrusted dependency or
+pull-request content out of a privileged execution context.
+
+GitHub references: [Dependabot options
+reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference)
+and [Automating Dependabot with GitHub
+Actions](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/automate-dependabot-with-actions).

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -20,8 +20,12 @@ changes which need coordinated repair:
 
 A root Cargo update may also change production dependencies inherited by the
 fuzz workspace. Pull-request CI compares the root lock against the exact base
-SHA and also enforces absolute root-authoritative equality for every shared
-production-direct dependency in `fuzz/Cargo.lock`.
+SHA, loads that base's `fuzz/Cargo.lock`, and enforces absolute
+root-authoritative equality for every shared production-direct dependency in
+the submitted `fuzz/Cargo.lock`. When the base fuzz lock needs a direct
+transition, CI applies the same bounded base-fuzz-to-head proof used by the
+writer; raw lock edits cannot bypass it merely because the direct versions now
+match.
 
 GasCity should handle that expected failure in a trusted isolated worktree:
 
@@ -34,14 +38,17 @@ The write command uses targeted `cargo update --precise` operations. It does
 one path-package re-resolution first when the root dependency declaration
 changed. That permits a new direct major to coexist with an older major still
 required transitively. It then requires exact transition readback, rejects any
-package-version drift outside the old/new dependency closures, and compares
-every changed dependency edge by its resolved `(name, version)` identity.
-Formatting-only disambiguation is harmless, but a semantic rebind must remain
-inside the reviewed root-update/closure surface; the Tributary path record may
-move only the exact requested direct transitions. The independent fuzz
-resolver may select a different compatible transitive version inside that
-bounded closure. A broad resolver rewrite, failed command, or failed proof
-restores the original fuzz lock.
+package-identity drift outside the exact old and resulting fuzz closures, and
+compares every changed dependency edge by its resolved `(name, version)`
+identity. Formatting-only disambiguation is harmless, but a semantic rebind
+must have either an exact authorized parent or a complete exact old/new target
+surface; crate-name coincidence grants no authority. The Tributary path record
+may move only the exact requested direct transitions. The independent fuzz
+resolver may select a different compatible transitive version inside its exact
+new closure. Identities also present in the current root must match its
+immutable source/checksum metadata, while locked Cargo fetch verifies
+resolver-only identities. A broad resolver rewrite, failed command, failed
+materialization, or failed proof restores the original fuzz lock.
 
 The command does not commit, push, approve, or merge. The Repairer must verify
 the resulting lock diff, commit the repair to the existing Dependabot branch,
@@ -56,7 +63,9 @@ independent fuzz resolver: its graph can legitimately select a different
 compatible version. The dedicated `/fuzz` Dependabot entry and locked fuzz CI
 own those updates. A security update affecting both lockfiles must therefore
 be raised or repaired in both rather than inferred from coincident package
-names.
+names. Likewise, when the exact base fuzz lock already needs no direct repair,
+an ordinary fuzz-only Dependabot update remains in that independent lane and
+is not forced through a root-transition closure.
 
 ## Rust toolchain and MSRV repair
 
@@ -70,24 +79,47 @@ python3 scripts/sync_rust_toolchain.py --check
 
 This synchronizes the Cargo MSRV, exact MSRV and coverage toolchains, cache
 keys, versioned step labels, and current README commands. The CI job/check name
-remains the stable `MSRV` so branch rules and GasCity do not deadlock when the
-compiler version changes. The bump is feasible only when
+remains the stable `MSRV` so future compiler bumps do not rename the hosted
+context. The bump is feasible only when
 the full Linux, macOS, Windows, Flatpak, fuzz, audit, coverage, and repository
 policy matrix passes. The repository enforces consistency and prevents native
 auto-merge; GasCity must separately provide independent semantic review and
 the normal Refinery exact-SHA merge gate before merging it.
 
+Rust 1.92 is today's declared floor, not a permanent pin. Dependabot remains
+enabled for `dtolnay/rust-toolchain`; each feasible release proposal goes
+through this dedicated coordinated, non-auto-merge lane.
+
+## Deployment gate migration
+
+This change deliberately does not mutate GitHub rulesets or the local GasCity
+configuration. At the time of adoption, the live `main` ruleset does not
+require either the old versioned MSRV context or the new stable `MSRV` context.
+Before enabling routine Dependabot auto-merge, maintainers must make the live
+required-check set match the policy promised here, including `MSRV`. GasCity's
+Tributary hosted-check configuration must also replace `MSRV (1.92)` with
+`MSRV` in the same deployment. Future Rust bumps then keep the stable context
+and need no additional gate rename.
+
 ## Workflow security boundary
 
-No workflow checks out pull-request code while holding a write token. The
-auto-merge workflow uses `pull_request`, verifies the actor, PR author, and
+This Dependabot auto-merge workflow does not check out pull-request code while
+holding a write token. (Other repository workflows, including semantic review,
+have separate permission and trust boundaries and are not covered by that
+claim.) The workflow uses `pull_request`, verifies the actor, PR author, and
 repository, and enables GitHub's native guarded auto-merge without checking
-out the branch. A read-only first job enumerates every changed filename through
-GitHub's API and fails closed if the result is incomplete. The separate
-write-capable job cannot start when the privileged workflow changed or was
-renamed, including in a mixed-path PR. Its metadata action is pinned to a full
-commit and has isolated version- and security-update groups, so a proposed
-replacement ref cannot execute itself with the write token.
+out the branch.
+
+Its first job has read-only pull-request access. It verifies the event's exact
+head before and after paginated changed-file enumeration, requires the observed
+file count, rejects current or previous names for the privileged workflow, and
+then revalidates the head immediately before and after running the pinned
+metadata action with read authority. Per-PR concurrency cancels stale runs as
+defense in depth. The separate write-capable job contains no third-party
+action: it revalidates that exact head immediately before asking GitHub to
+enable auto-merge with an atomic expected-head guard.
+Thus a same-count H1/H2 race or mixed-path self-update fails closed rather than
+executing an H1 action ref with write authority.
 
 Lockfile and toolchain repair intentionally remain GasCity Repairer operations
 instead of a `pull_request_target` writer. This keeps untrusted dependency or

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -20,8 +20,8 @@ changes which need coordinated repair:
 
 A root Cargo update may also change production dependencies inherited by the
 fuzz workspace. Pull-request CI compares the root lock against the exact base
-SHA and fails if a changed shared direct dependency remains stale in
-`fuzz/Cargo.lock`.
+SHA and also enforces absolute root-authoritative equality for every shared
+production-direct dependency in `fuzz/Cargo.lock`.
 
 GasCity should handle that expected failure in a trusted isolated worktree:
 
@@ -31,13 +31,32 @@ python3 scripts/sync_fuzz_lock.py check --base-ref <exact-base-sha>
 ```
 
 The write command uses targeted `cargo update --precise` operations. It does
-not commit, push, approve, or merge. The Repairer must verify that only the
-expected lock state changed, commit the repair to the existing Dependabot
-branch, and require the complete CI matrix. Graph rewrites which cannot be
-expressed as a version substitution fail closed for manual repair.
+one path-package re-resolution first when the root dependency declaration
+changed. That permits a new direct major to coexist with an older major still
+required transitively. It then requires exact transition readback, rejects any
+package-version drift outside the old/new dependency closures, and compares
+every changed dependency edge by its resolved `(name, version)` identity.
+Formatting-only disambiguation is harmless, but a semantic rebind must remain
+inside the reviewed root-update/closure surface; the Tributary path record may
+move only the exact requested direct transitions. The independent fuzz
+resolver may select a different compatible transitive version inside that
+bounded closure. A broad resolver rewrite, failed command, or failed proof
+restores the original fuzz lock.
+
+The command does not commit, push, approve, or merge. The Repairer must verify
+the resulting lock diff, commit the repair to the existing Dependabot branch,
+and require the complete CI matrix. Graph rewrites which cannot be proven by
+this bounded version-selection policy fail closed for manual repair.
 `--offline` is available for a pre-populated Cargo cache; normal repair runs
 may use the registry to obtain the exact versions already selected in the root
 lock.
+
+Transitive-only root-lock updates are deliberately not projected into the
+independent fuzz resolver: its graph can legitimately select a different
+compatible version. The dedicated `/fuzz` Dependabot entry and locked fuzz CI
+own those updates. A security update affecting both lockfiles must therefore
+be raised or repaired in both rather than inferred from coincident package
+names.
 
 ## Rust toolchain and MSRV repair
 
@@ -50,18 +69,25 @@ python3 scripts/sync_rust_toolchain.py --check
 ```
 
 This synchronizes the Cargo MSRV, exact MSRV and coverage toolchains, cache
-keys, job labels, and current README commands. The bump is feasible only when
+keys, versioned step labels, and current README commands. The CI job/check name
+remains the stable `MSRV` so branch rules and GasCity do not deadlock when the
+compiler version changes. The bump is feasible only when
 the full Linux, macOS, Windows, Flatpak, fuzz, audit, coverage, and repository
-policy matrix passes. It then needs independent semantic review and the normal
-Refinery exact-SHA merge gate; the Dependabot auto-merge workflow will not
-merge it.
+policy matrix passes. The repository enforces consistency and prevents native
+auto-merge; GasCity must separately provide independent semantic review and
+the normal Refinery exact-SHA merge gate before merging it.
 
 ## Workflow security boundary
 
 No workflow checks out pull-request code while holding a write token. The
 auto-merge workflow uses `pull_request`, verifies the actor, PR author, and
-repository, fetches only GitHub-provided Dependabot metadata, and enables
-GitHub's native guarded auto-merge without checking out the branch.
+repository, and enables GitHub's native guarded auto-merge without checking
+out the branch. A read-only first job enumerates every changed filename through
+GitHub's API and fails closed if the result is incomplete. The separate
+write-capable job cannot start when the privileged workflow changed or was
+renamed, including in a mixed-path PR. Its metadata action is pinned to a full
+commit and has isolated version- and security-update groups, so a proposed
+replacement ref cannot execute itself with the write token.
 
 Lockfile and toolchain repair intentionally remain GasCity Repairer operations
 instead of a `pull_request_target` writer. This keeps untrusted dependency or

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -112,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "apple-native-keyring-store"
@@ -292,13 +292,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -1136,7 +1136,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1241,7 +1241,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1278,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "field-offset"
@@ -1389,9 +1389,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1404,9 +1404,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1414,15 +1414,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1442,9 +1442,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-lite"
@@ -1461,9 +1461,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1472,21 +1472,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1658,7 +1658,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1819,7 +1819,7 @@ dependencies = [
  "pastey",
  "pin-project-lite",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -2350,7 +2350,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "walkdir",
  "windows-link",
 ]
@@ -2827,7 +2827,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3390,7 +3390,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -3413,7 +3413,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3430,7 +3430,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3536,7 +3536,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3743,7 +3743,7 @@ dependencies = [
  "rustls-native-certs",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3801,7 +3801,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3860,7 +3860,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3954,7 +3954,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "strum",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "tracing",
  "url",
@@ -4054,7 +4054,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4138,9 +4138,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -4148,29 +4148,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -4463,7 +4463,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "tokio",
  "tokio-stream",
@@ -4551,7 +4551,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "tracing",
  "uuid",
@@ -4594,7 +4594,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "tracing",
  "uuid",
@@ -4621,7 +4621,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "tracing",
  "url",
@@ -4766,7 +4766,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4780,11 +4780,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -4800,13 +4800,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -4875,9 +4875,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -4924,9 +4924,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
@@ -5193,7 +5193,7 @@ dependencies = [
  "souvlaki",
  "sys-locale",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "tower-http 0.7.0",
@@ -5576,7 +5576,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -31,6 +31,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,6 +71,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "annotate-snippets"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width",
 ]
 
 [[package]]
@@ -96,7 +120,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -107,7 +131,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -141,6 +165,12 @@ checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "arrayvec"
@@ -1136,7 +1166,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1199,6 +1229,24 @@ dependencies = [
  "toml 1.1.3+spec-1.1.0",
  "vswhom",
  "winreg",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
 ]
 
 [[package]]
@@ -1608,6 +1656,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.2.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -1615,7 +1677,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasm-bindgen",
 ]
@@ -1746,6 +1808,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "granit-parser"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d03f81ad4732830d85cfd417a9f62cde6dadda4354d37d078a6084a19560aa2d"
+dependencies = [
+ "arraydeque",
+ "smallvec",
+]
+
+[[package]]
 name = "graphene-rs"
 version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1837,9 +1909,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4"
-version = "0.11.4"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98a0a0466484f64b07b5b8184d43fa46be78eb0b8e04ae4e179af31d770b76d9"
+checksum = "7181b837f04cbe93f79441475f7a00560a92cba7a72e38cc1a68b6f8b78eaae2"
 dependencies = [
  "cairo-rs",
  "field-offset",
@@ -1893,7 +1965,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -2457,15 +2529,16 @@ dependencies = [
 
 [[package]]
 name = "libadwaita"
-version = "0.9.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b9900e67182a4b5b1f157b448d94f0715c8b9770cce21cf000801917f53bfa"
+checksum = "bc0da4e27b20d3e71f830e5b0f0188d22c257986bf421c02cfde777fe07932a4"
 dependencies = [
  "gdk4",
  "gio",
  "glib",
  "gtk4",
  "libadwaita-sys",
+ "libc",
  "pango",
 ]
 
@@ -2672,9 +2745,9 @@ dependencies = [
 
 [[package]]
 name = "mdns-sd"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb75febbe5fa1837a52fdbd1c735e168286c5c645fc2ddd31526f65c49941c2e"
+checksum = "f18d8ec9d1869796fb2910d95f4d957072df0b6a22e247a1d760d8b4c805e17a"
 dependencies = [
  "fastrand",
  "flume 0.12.0",
@@ -2777,6 +2850,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
 name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2827,7 +2906,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3444,6 +3523,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -3683,9 +3768,9 @@ dependencies = [
 
 [[package]]
 name = "rust-i18n"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "752c95174ef2555cd95873d6f12d0bee9f0a1dcbf1b631dde847053a29174996"
+checksum = "f10cee36dd3b1f7929ea12b759de9eea9eff83bfccbc71f387ef4d41a57c64a4"
 dependencies = [
  "globwalk",
  "regex",
@@ -3696,9 +3781,9 @@ dependencies = [
 
 [[package]]
 name = "rust-i18n-macro"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc99fd028c912b59841bd745ec11c2dda112549ae6de25a850f384bb59d1a8f8"
+checksum = "f0bb1ed4e04fe26c2a2652cad1c6595efaf7196f4445c0d6e13c67154347fb7e"
 dependencies = [
  "glob",
  "proc-macro2",
@@ -3706,15 +3791,14 @@ dependencies = [
  "rust-i18n-support",
  "serde",
  "serde_json",
- "serde_yaml",
  "syn 2.0.119",
 ]
 
 [[package]]
 name = "rust-i18n-support"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dfb30689b70c7fd955e8e5c709fa055a778ae024ef6a382c4eb425dd2c2fabb"
+checksum = "ba1c083408a2733180ae0acf2897612f8ceec7b0c0dcd065a0a87103bfb3b1d9"
 dependencies = [
  "arc-swap",
  "base62",
@@ -3722,8 +3806,8 @@ dependencies = [
  "itertools 0.11.0",
  "normpath",
  "serde",
+ "serde-saphyr",
  "serde_json",
- "serde_yaml",
  "siphasher",
  "toml 0.8.23",
  "triomphe",
@@ -4147,6 +4231,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-saphyr"
+version = "0.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd22781911de0ca6debda95f073c8f18bec65d1a94f1fa9573f3102e514cea4"
+dependencies = [
+ "ahash 0.8.12",
+ "annotate-snippets",
+ "base64",
+ "encoding_rs_io",
+ "getrandom 0.3.4",
+ "granit-parser",
+ "nohash-hasher",
+ "num-traits",
+ "serde_core",
+ "smallvec",
+ "zmij",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4229,19 +4332,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -4379,7 +4469,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5249,7 +5339,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5280,16 +5370,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -5409,6 +5499,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasite"
@@ -5576,7 +5675,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5991,6 +6090,12 @@ dependencies = [
  "toml 1.1.3+spec-1.1.0",
  "version_check",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"

--- a/scripts/sync_fuzz_lock.py
+++ b/scripts/sync_fuzz_lock.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Keep root dependency updates coherent with the separate fuzz workspace.
+"""
+Keep root dependency updates coherent with the separate fuzz workspace.
 
 The fuzz crate intentionally owns a separate Cargo.lock. Dependabot updates the
 root lock independently, so a root PR can otherwise pass with the fuzz build
@@ -14,7 +15,10 @@ from __future__ import annotations
 
 import argparse
 import dataclasses
-import subprocess
+import re
+import shutil
+# Subprocesses below use explicit argv, resolved executables, and no shell.
+import subprocess  # nosec B404
 import sys
 import tomllib
 from pathlib import Path
@@ -25,6 +29,7 @@ REPOSITORY = Path(__file__).resolve().parents[1]
 ROOT_LOCK = REPOSITORY / "Cargo.lock"
 FUZZ_LOCK = REPOSITORY / "fuzz" / "Cargo.lock"
 ROOT_MANIFEST = REPOSITORY / "Cargo.toml"
+FULL_COMMIT = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})")
 
 
 class PolicyError(RuntimeError):
@@ -38,15 +43,28 @@ class Transition:
     target_root_version: str
 
 
+def required_executable(name: str) -> str:
+    executable = shutil.which(name)
+    if executable is None:
+        raise PolicyError(f"required executable {name!r} is not available")
+    return executable
+
+
 def load_toml(path: Path) -> dict[str, Any]:
     with path.open("rb") as source:
         return tomllib.load(source)
 
 
 def load_toml_from_git(reference: str, path: str) -> dict[str, Any]:
+    if FULL_COMMIT.fullmatch(reference) is None:
+        raise PolicyError(
+            "base ref must be a full 40- or 64-character lowercase commit SHA"
+        )
     try:
-        encoded = subprocess.check_output(
-            ["git", "show", f"{reference}:{path}"],
+        # The revision is a validated full SHA, the path is internal, and no
+        # shell participates in this read-only Git invocation.
+        encoded = subprocess.check_output(  # nosec B603  # nosemgrep
+            [required_executable("git"), "show", f"{reference}:{path}"],
             cwd=REPOSITORY,
             stderr=subprocess.PIPE,
         )
@@ -83,7 +101,6 @@ def resolved_direct_versions(
     lock: dict[str, Any], package_name: str = "tributary"
 ) -> dict[str, str]:
     """Resolve Cargo.lock dependency specs to the selected package versions."""
-
     by_name = packages_by_name(lock)
     package = workspace_package(lock, package_name)
     result: dict[str, str] = {}
@@ -128,7 +145,6 @@ def production_dependency_declarations(
     manifest: dict[str, Any],
 ) -> dict[str, tuple[Any, ...]]:
     """Return normalized declarations inherited through the Tributary path dep."""
-
     result: dict[str, list[Any]] = {}
 
     def add_table(scope: str, table: Any) -> None:
@@ -164,7 +180,6 @@ def production_dependency_declarations(
 
 def production_dependency_names(manifest: dict[str, Any]) -> set[str]:
     """Return package names inherited by fuzz through its Tributary path dep."""
-
     return set(production_dependency_declarations(manifest))
 
 
@@ -230,7 +245,6 @@ def dependency_closure_identities(
     roots: set[tuple[str, str]],
 ) -> set[tuple[str, str]]:
     """Return the exact package identities reachable from lockfile roots."""
-
     records = package_records_by_identity(lock)
     pending = list(roots)
     visited: set[tuple[str, str]] = set()
@@ -265,6 +279,8 @@ def resolved_dependency_edges(
     }
 
 
+# The explicit fail-closed branches mirror distinct lockfile invariants; folding
+# them together would make the safety proof harder to audit.
 def validate_dependency_edges(
     before_lock: dict[str, Any],
     after_lock: dict[str, Any],
@@ -272,7 +288,7 @@ def validate_dependency_edges(
     authorized_identities: set[tuple[str, str]],
 ) -> None:
     """Reject semantic edge changes outside the reviewed dependency surface."""
-
+    #lizard forgives
     before_records = package_records_by_identity(before_lock)
     after_records = package_records_by_identity(after_lock)
     transition_targets = {
@@ -340,6 +356,8 @@ def validate_dependency_edges(
             )
 
 
+# This function keeps each authorization set and its rejection adjacent so a
+# reviewer can audit the complete bounded-change proof in one place.
 def validate_bounded_package_changes(
     base_root_lock: dict[str, Any],
     current_root_lock: dict[str, Any],
@@ -348,7 +366,7 @@ def validate_bounded_package_changes(
     transitions: list[Transition],
 ) -> None:
     """Reject drift outside exact closures rooted at the requested transition."""
-
+    #lizard forgives
     old_roots = {
         (transition.name, transition.current_fuzz_version)
         for transition in transitions
@@ -417,14 +435,14 @@ def validate_submitted_fuzz_update(
     current_fuzz_lock: dict[str, Any],
     current_manifest: dict[str, Any],
 ) -> tuple[list[Transition], list[Transition]]:
-    """Apply the same base-fuzz-to-head proof used by CI `check` mode.
+    """
+    Apply the same base-fuzz-to-head proof used by CI `check` mode.
 
     An independent fuzz-only update has no requested root-coherence
     transitions and remains owned by its dedicated Dependabot/CI lane. When
     the base fuzz lock is stale relative to the current root, every submitted
     base-to-head change must instead fit the bounded exact-closure proof.
     """
-
     requested_transitions = required_transitions(
         base_root_lock,
         current_root_lock,
@@ -483,15 +501,20 @@ def required_transitions(
 
 
 def cargo_command(arguments: list[str], *, offline: bool) -> None:
-    command = ["cargo", *arguments]
+    command = [required_executable("cargo"), *arguments]
     if offline:
         command.insert(2, "--offline")
-    subprocess.run(command, cwd=REPOSITORY, check=True)
+    # Arguments are derived from validated lockfile identities and never use a
+    # shell. A variable argv is intrinsic to this narrowly scoped Cargo helper.
+    subprocess.run(  # nosec B603  # nosemgrep
+        command,
+        cwd=REPOSITORY,
+        check=True,
+    )
 
 
 def refresh_tributary_dependency_graph(*, offline: bool) -> None:
     """Re-resolve the path package so new direct majors can coexist with old."""
-
     cargo_command(
         [
             "update",
@@ -550,14 +573,17 @@ def validate_locked_fuzz_metadata(*, offline: bool) -> None:
     if offline:
         fetch_command.insert(1, "--offline")
         metadata_command.insert(1, "--offline")
-    subprocess.run(
-        ["cargo", *fetch_command],
+    cargo = required_executable("cargo")
+    # Both argv lists are built locally from fixed Cargo metadata operations;
+    # the resolved executable is explicit and no shell is used.
+    subprocess.run(  # nosec B603  # nosemgrep
+        [cargo, *fetch_command],
         cwd=REPOSITORY,
         stdout=subprocess.DEVNULL,
         check=True,
     )
-    subprocess.run(
-        ["cargo", *metadata_command],
+    subprocess.run(  # nosec B603  # nosemgrep
+        [cargo, *metadata_command],
         cwd=REPOSITORY,
         stdout=subprocess.DEVNULL,
         check=True,
@@ -580,7 +606,10 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+# The orchestration stays linear so every mutation is visibly inside the one
+# rollback boundary and every exit follows the same policy-error path.
 def main() -> int:
+    #lizard forgives
     args = parse_args()
     try:
         base = load_toml_from_git(args.base_ref, "Cargo.lock")

--- a/scripts/sync_fuzz_lock.py
+++ b/scripts/sync_fuzz_lock.py
@@ -43,17 +43,17 @@ def load_toml(path: Path) -> dict[str, Any]:
         return tomllib.load(source)
 
 
-def load_lock_from_git(reference: str) -> dict[str, Any]:
+def load_toml_from_git(reference: str, path: str) -> dict[str, Any]:
     try:
         encoded = subprocess.check_output(
-            ["git", "show", f"{reference}:Cargo.lock"],
+            ["git", "show", f"{reference}:{path}"],
             cwd=REPOSITORY,
             stderr=subprocess.PIPE,
         )
     except subprocess.CalledProcessError as error:
         detail = error.stderr.decode(errors="replace").strip()
         raise PolicyError(
-            f"cannot read Cargo.lock from base ref {reference!r}: {detail}"
+            f"cannot read {path} from base ref {reference!r}: {detail}"
         ) from error
     return tomllib.loads(encoded.decode())
 
@@ -116,28 +116,280 @@ def resolved_direct_versions(
     return result
 
 
-def production_dependency_names(manifest: dict[str, Any]) -> set[str]:
-    """Return package names inherited by fuzz through its Tributary path dep."""
+def freeze(value: Any) -> Any:
+    if isinstance(value, dict):
+        return tuple(sorted((key, freeze(item)) for key, item in value.items()))
+    if isinstance(value, list):
+        return tuple(freeze(item) for item in value)
+    return value
 
-    result: set[str] = set()
 
-    def add_table(table: Any) -> None:
+def production_dependency_declarations(
+    manifest: dict[str, Any],
+) -> dict[str, tuple[Any, ...]]:
+    """Return normalized declarations inherited through the Tributary path dep."""
+
+    result: dict[str, list[Any]] = {}
+
+    def add_table(scope: str, table: Any) -> None:
         if not isinstance(table, dict):
             return
         for alias, declaration in table.items():
             if isinstance(declaration, dict):
-                result.add(str(declaration.get("package", alias)))
+                package = str(declaration.get("package", alias))
             else:
-                result.add(alias)
+                package = alias
+            result.setdefault(package, []).append(
+                (scope, alias, freeze(declaration))
+            )
 
-    add_table(manifest.get("dependencies"))
-    add_table(manifest.get("build-dependencies"))
-    for target in manifest.get("target", {}).values():
+    add_table("dependencies", manifest.get("dependencies"))
+    add_table("build-dependencies", manifest.get("build-dependencies"))
+    for condition, target in manifest.get("target", {}).items():
         if isinstance(target, dict):
-            add_table(target.get("dependencies"))
-            add_table(target.get("build-dependencies"))
+            add_table(
+                f"target.{condition}.dependencies",
+                target.get("dependencies"),
+            )
+            add_table(
+                f"target.{condition}.build-dependencies",
+                target.get("build-dependencies"),
+            )
 
+    return {
+        package: tuple(sorted(declarations))
+        for package, declarations in result.items()
+    }
+
+
+def production_dependency_names(manifest: dict[str, Any]) -> set[str]:
+    """Return package names inherited by fuzz through its Tributary path dep."""
+
+    return set(production_dependency_declarations(manifest))
+
+
+def package_version_sets(lock: dict[str, Any]) -> dict[str, set[str]]:
+    result: dict[str, set[str]] = {}
+    for package in lock.get("package", []):
+        result.setdefault(package["name"], set()).add(package["version"])
     return result
+
+
+def changed_package_version_names(
+    before: dict[str, Any], after: dict[str, Any]
+) -> set[str]:
+    before_versions = package_version_sets(before)
+    after_versions = package_version_sets(after)
+    return {
+        name
+        for name in set(before_versions) | set(after_versions)
+        if before_versions.get(name, set()) != after_versions.get(name, set())
+    }
+
+
+def package_records_by_identity(
+    lock: dict[str, Any],
+) -> dict[tuple[str, str], dict[str, Any]]:
+    records: dict[tuple[str, str], dict[str, Any]] = {}
+    for package in lock.get("package", []):
+        identity = (package["name"], package["version"])
+        if identity in records:
+            raise PolicyError(
+                "Cargo.lock contains multiple records for "
+                f"{identity[0]}@{identity[1]}; dependency closure is ambiguous"
+            )
+        records[identity] = package
+    return records
+
+
+def dependency_identity(
+    specification: str,
+    records: dict[tuple[str, str], dict[str, Any]],
+) -> tuple[str, str]:
+    fields = specification.split()
+    name = fields[0]
+    if len(fields) >= 2 and fields[1][0].isdigit():
+        identity = (name, fields[1])
+        if identity not in records:
+            raise PolicyError(
+                f"Cargo.lock dependency {specification!r} has no package record"
+            )
+        return identity
+
+    candidates = [identity for identity in records if identity[0] == name]
+    if len(candidates) != 1:
+        raise PolicyError(
+            f"ambiguous bare Cargo.lock dependency {specification!r}; "
+            f"candidate versions: {sorted(version for _, version in candidates)}"
+        )
+    return candidates[0]
+
+
+def dependency_closure_identities(
+    lock: dict[str, Any],
+    roots: set[tuple[str, str]],
+) -> set[tuple[str, str]]:
+    """Return the exact package identities reachable from lockfile roots."""
+
+    records = package_records_by_identity(lock)
+    pending = list(roots)
+    visited: set[tuple[str, str]] = set()
+    while pending:
+        identity = pending.pop()
+        if identity in visited:
+            continue
+        package = records.get(identity)
+        if package is None:
+            raise PolicyError(
+                f"Cargo.lock does not contain {identity[0]}@{identity[1]}"
+            )
+        visited.add(identity)
+        pending.extend(
+            dependency_identity(specification, records)
+            for specification in package.get("dependencies", [])
+        )
+    return visited
+
+
+def dependency_closure_names(
+    lock: dict[str, Any],
+    roots: set[tuple[str, str]],
+) -> set[str]:
+    return {
+        name
+        for name, _ in dependency_closure_identities(lock, roots)
+    }
+
+
+def resolved_dependency_edges(
+    package: dict[str, Any],
+    records: dict[tuple[str, str], dict[str, Any]],
+) -> dict[str, tuple[tuple[str, str], ...]]:
+    edges: dict[str, list[tuple[str, str]]] = {}
+    for specification in package.get("dependencies", []):
+        identity = dependency_identity(specification, records)
+        edges.setdefault(identity[0], []).append(identity)
+    return {
+        name: tuple(sorted(identities))
+        for name, identities in edges.items()
+    }
+
+
+def validate_dependency_edges(
+    before_lock: dict[str, Any],
+    after_lock: dict[str, Any],
+    transitions: list[Transition],
+    authorized_names: set[str],
+    authorized_identities: set[tuple[str, str]],
+) -> None:
+    """Reject semantic edge changes outside the reviewed dependency surface."""
+
+    before_records = package_records_by_identity(before_lock)
+    after_records = package_records_by_identity(after_lock)
+    transition_targets = {
+        transition.name: (transition.name, transition.target_root_version)
+        for transition in transitions
+    }
+    for identity in sorted(before_records.keys() & after_records.keys()):
+        before_metadata = {
+            key: value
+            for key, value in before_records[identity].items()
+            if key != "dependencies"
+        }
+        after_metadata = {
+            key: value
+            for key, value in after_records[identity].items()
+            if key != "dependencies"
+        }
+        if freeze(before_metadata) != freeze(after_metadata):
+            raise PolicyError(
+                "fuzz lock repair changed immutable package metadata for "
+                f"{identity[0]}@{identity[1]}"
+            )
+
+        before_edges = resolved_dependency_edges(
+            before_records[identity], before_records
+        )
+        after_edges = resolved_dependency_edges(after_records[identity], after_records)
+        if before_edges == after_edges:
+            continue
+
+        before_names = sorted(before_edges)
+        after_names = sorted(after_edges)
+        if before_names != after_names:
+            raise PolicyError(
+                "fuzz lock repair rewrote the dependency-name surface of "
+                f"{identity[0]}@{identity[1]}: {before_names} -> {after_names}"
+            )
+
+        for dependency_name in before_names:
+            before_targets = before_edges[dependency_name]
+            after_targets = after_edges[dependency_name]
+            if before_targets == after_targets:
+                continue
+
+            if identity[0] == "tributary":
+                target = transition_targets.get(dependency_name)
+                if target is not None and after_targets == (target,):
+                    continue
+                raise PolicyError(
+                    "fuzz lock repair changed an unrequested Tributary edge "
+                    f"{dependency_name!r}: {before_targets} -> {after_targets}"
+                )
+
+            edge_surface = set(before_targets) | set(after_targets)
+            if (
+                identity in authorized_identities
+                or identity[0] in authorized_names
+                or edge_surface <= authorized_identities
+                or {name for name, _ in edge_surface} <= authorized_names
+            ):
+                continue
+
+            raise PolicyError(
+                "fuzz lock repair semantically rebound an edge outside the "
+                f"reviewed dependency surface: {identity[0]}@{identity[1]} "
+                f"{dependency_name}: {before_targets} -> {after_targets}"
+            )
+
+
+def validate_bounded_package_changes(
+    base_root_lock: dict[str, Any],
+    current_root_lock: dict[str, Any],
+    before_fuzz_lock: dict[str, Any],
+    after_fuzz_lock: dict[str, Any],
+    transitions: list[Transition],
+) -> None:
+    """Reject package-version drift outside the exact root update surface."""
+
+    old_roots = {
+        (transition.name, transition.current_fuzz_version)
+        for transition in transitions
+    }
+    new_roots = {
+        (transition.name, transition.target_root_version)
+        for transition in transitions
+    }
+    authorized_identities = dependency_closure_identities(
+        before_fuzz_lock, old_roots
+    ) | dependency_closure_identities(current_root_lock, new_roots)
+    allowed_names = changed_package_version_names(base_root_lock, current_root_lock)
+    allowed_names.update(transition.name for transition in transitions)
+    allowed_names.update(name for name, _ in authorized_identities)
+    validate_dependency_edges(
+        before_fuzz_lock,
+        after_fuzz_lock,
+        transitions,
+        allowed_names,
+        authorized_identities,
+    )
+    actual_names = changed_package_version_names(before_fuzz_lock, after_fuzz_lock)
+    unexpected_names = actual_names - allowed_names
+    if unexpected_names:
+        raise PolicyError(
+            "fuzz lock repair changed package versions outside the root update "
+            f"surface: {sorted(unexpected_names)}"
+        )
 
 
 def required_transitions(
@@ -161,22 +413,39 @@ def required_transitions(
             "fuzz/Cargo.lock; regenerate the fuzz lock under review"
         )
 
-    for name in sorted(set(base) | set(current)):
-        before = base.get(name)
-        after = current.get(name)
-        if before == after or name not in production:
-            continue
-        if after is None:
-            continue
+    for name in sorted(set(current) & production):
+        after = current[name]
         if name not in fuzz:
             raise PolicyError(
-                f"changed root production dependency {name!r} is absent from "
+                f"root production dependency {name!r} is absent from "
                 "fuzz/Cargo.lock; regenerate the fuzz lock under review"
             )
         if fuzz[name] != after:
             transitions.append(Transition(name, fuzz[name], after))
 
     return transitions
+
+
+def cargo_command(arguments: list[str], *, offline: bool) -> None:
+    command = ["cargo", *arguments]
+    if offline:
+        command.insert(2, "--offline")
+    subprocess.run(command, cwd=REPOSITORY, check=True)
+
+
+def refresh_tributary_dependency_graph(*, offline: bool) -> None:
+    """Re-resolve the path package so new direct majors can coexist with old."""
+
+    cargo_command(
+        [
+            "update",
+            "--manifest-path",
+            str(REPOSITORY / "fuzz" / "Cargo.toml"),
+            "--package",
+            "tributary",
+        ],
+        offline=offline,
+    )
 
 
 def update_fuzz_lock(transitions: list[Transition], *, offline: bool) -> None:
@@ -192,24 +461,38 @@ def update_fuzz_lock(transitions: list[Transition], *, offline: bool) -> None:
                 f"{transition.name!r} disappeared while repairing fuzz/Cargo.lock"
             )
 
-        command = ["cargo", "update"]
-        if offline:
-            command.append("--offline")
-        command.extend(
+        cargo_command(
             [
+                "update",
                 "--manifest-path",
                 str(REPOSITORY / "fuzz" / "Cargo.toml"),
                 "--package",
                 f"{transition.name}@{current}",
                 "--precise",
                 transition.target_root_version,
-            ]
+            ],
+            offline=offline,
         )
-        subprocess.run(
-            command,
-            cwd=REPOSITORY,
-            check=True,
-        )
+
+
+def validate_locked_fuzz_metadata(*, offline: bool) -> None:
+    command = [
+        "metadata",
+        "--manifest-path",
+        str(REPOSITORY / "fuzz" / "Cargo.toml"),
+        "--format-version",
+        "1",
+        "--locked",
+        "--no-deps",
+    ]
+    if offline:
+        command.insert(1, "--offline")
+    subprocess.run(
+        ["cargo", *command],
+        cwd=REPOSITORY,
+        stdout=subprocess.DEVNULL,
+        check=True,
+    )
 
 
 def parse_args() -> argparse.Namespace:
@@ -231,22 +514,61 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     try:
-        base = load_lock_from_git(args.base_ref)
+        base = load_toml_from_git(args.base_ref, "Cargo.lock")
+        base_manifest = load_toml_from_git(args.base_ref, "Cargo.toml")
         current = load_toml(ROOT_LOCK)
         fuzz = load_toml(FUZZ_LOCK)
         manifest = load_toml(ROOT_MANIFEST)
         transitions = required_transitions(base, current, fuzz, manifest)
 
         if args.mode == "write":
-            update_fuzz_lock(transitions, offline=args.offline)
-            transitions = required_transitions(
-                base, current, load_toml(FUZZ_LOCK), manifest
-            )
+            original_lock = FUZZ_LOCK.read_bytes()
+            original_transitions = transitions
+            base_declarations = production_dependency_declarations(base_manifest)
+            current_declarations = production_dependency_declarations(manifest)
+            graph_refresh_names = {
+                transition.name
+                for transition in transitions
+                if base_declarations.get(transition.name)
+                != current_declarations.get(transition.name)
+            }
+            try:
+                if graph_refresh_names:
+                    refresh_tributary_dependency_graph(offline=args.offline)
+
+                transitions = required_transitions(
+                    base, current, load_toml(FUZZ_LOCK), manifest
+                )
+                update_fuzz_lock(transitions, offline=args.offline)
+                repaired_fuzz = load_toml(FUZZ_LOCK)
+                transitions = required_transitions(
+                    base, current, repaired_fuzz, manifest
+                )
+                if transitions:
+                    raise PolicyError(
+                        "repair completed without proving every requested "
+                        f"transition: {transitions}"
+                    )
+                validate_bounded_package_changes(
+                    base,
+                    current,
+                    fuzz,
+                    repaired_fuzz,
+                    original_transitions,
+                )
+                validate_locked_fuzz_metadata(offline=args.offline)
+            except (
+                OSError,
+                PolicyError,
+                subprocess.CalledProcessError,
+                tomllib.TOMLDecodeError,
+            ):
+                FUZZ_LOCK.write_bytes(original_lock)
+                raise
 
         if transitions:
             print(
-                "fuzz/Cargo.lock does not reflect changed root production "
-                "dependencies:",
+                "fuzz/Cargo.lock does not match root production dependencies:",
                 file=sys.stderr,
             )
             for transition in transitions:
@@ -264,9 +586,14 @@ def main() -> int:
             )
             return 1
 
-        print("root and fuzz lockfiles are coherent for changed dependencies")
+        print("root and fuzz lockfiles have coherent production dependencies")
         return 0
-    except (OSError, PolicyError, subprocess.CalledProcessError) as error:
+    except (
+        OSError,
+        PolicyError,
+        subprocess.CalledProcessError,
+        tomllib.TOMLDecodeError,
+    ) as error:
         print(f"dependency lock policy failed: {error}", file=sys.stderr)
         return 2
 

--- a/scripts/sync_fuzz_lock.py
+++ b/scripts/sync_fuzz_lock.py
@@ -251,16 +251,6 @@ def dependency_closure_identities(
     return visited
 
 
-def dependency_closure_names(
-    lock: dict[str, Any],
-    roots: set[tuple[str, str]],
-) -> set[str]:
-    return {
-        name
-        for name, _ in dependency_closure_identities(lock, roots)
-    }
-
-
 def resolved_dependency_edges(
     package: dict[str, Any],
     records: dict[tuple[str, str], dict[str, Any]],
@@ -279,7 +269,6 @@ def validate_dependency_edges(
     before_lock: dict[str, Any],
     after_lock: dict[str, Any],
     transitions: list[Transition],
-    authorized_names: set[str],
     authorized_identities: set[tuple[str, str]],
 ) -> None:
     """Reject semantic edge changes outside the reviewed dependency surface."""
@@ -340,9 +329,7 @@ def validate_dependency_edges(
             edge_surface = set(before_targets) | set(after_targets)
             if (
                 identity in authorized_identities
-                or identity[0] in authorized_names
                 or edge_surface <= authorized_identities
-                or {name for name, _ in edge_surface} <= authorized_names
             ):
                 continue
 
@@ -360,7 +347,7 @@ def validate_bounded_package_changes(
     after_fuzz_lock: dict[str, Any],
     transitions: list[Transition],
 ) -> None:
-    """Reject package-version drift outside the exact root update surface."""
+    """Reject drift outside exact closures rooted at the requested transition."""
 
     old_roots = {
         (transition.name, transition.current_fuzz_version)
@@ -370,26 +357,95 @@ def validate_bounded_package_changes(
         (transition.name, transition.target_root_version)
         for transition in transitions
     }
-    authorized_identities = dependency_closure_identities(
-        before_fuzz_lock, old_roots
-    ) | dependency_closure_identities(current_root_lock, new_roots)
-    allowed_names = changed_package_version_names(base_root_lock, current_root_lock)
-    allowed_names.update(transition.name for transition in transitions)
-    allowed_names.update(name for name, _ in authorized_identities)
+    old_identities = dependency_closure_identities(before_fuzz_lock, old_roots)
+    after_identities = dependency_closure_identities(after_fuzz_lock, new_roots)
+    authorized_identities = old_identities | after_identities
+
+    before_records = package_records_by_identity(before_fuzz_lock)
+    after_records = package_records_by_identity(after_fuzz_lock)
+    root_records = package_records_by_identity(current_root_lock)
+    removed_identities = before_records.keys() - after_records.keys()
+    added_identities = after_records.keys() - before_records.keys()
+    unexpected_removed = removed_identities - old_identities
+    unexpected_added = added_identities - after_identities
+    if unexpected_removed:
+        raise PolicyError(
+            "fuzz lock repair removed package identities outside the exact old "
+            f"dependency closure: {sorted(unexpected_removed)}"
+        )
+    if unexpected_added:
+        raise PolicyError(
+            "fuzz lock repair added package identities outside the exact new "
+            f"dependency closure: {sorted(unexpected_added)}"
+        )
+
+    # Cargo may independently select a different compatible transitive in the
+    # fuzz workspace (for example r-efi 5.2 where the root selected 5.3). Such
+    # an exact after-closure identity is verified by locked Cargo
+    # materialization below. Whenever the exact identity also exists in the
+    # root lock, however, its immutable source/checksum metadata must match the
+    # authoritative root record byte-for-byte.
+    for identity in sorted(after_records.keys() & root_records.keys()):
+        after_metadata = {
+            key: value
+            for key, value in after_records[identity].items()
+            if key != "dependencies"
+        }
+        root_metadata = {
+            key: value
+            for key, value in root_records[identity].items()
+            if key != "dependencies"
+        }
+        if freeze(after_metadata) != freeze(root_metadata):
+            raise PolicyError(
+                "fuzz lock package metadata disagrees with the authoritative "
+                f"root record for {identity[0]}@{identity[1]}"
+            )
+
     validate_dependency_edges(
         before_fuzz_lock,
         after_fuzz_lock,
         transitions,
-        allowed_names,
         authorized_identities,
     )
-    actual_names = changed_package_version_names(before_fuzz_lock, after_fuzz_lock)
-    unexpected_names = actual_names - allowed_names
-    if unexpected_names:
-        raise PolicyError(
-            "fuzz lock repair changed package versions outside the root update "
-            f"surface: {sorted(unexpected_names)}"
+
+
+def validate_submitted_fuzz_update(
+    base_root_lock: dict[str, Any],
+    current_root_lock: dict[str, Any],
+    base_fuzz_lock: dict[str, Any],
+    current_fuzz_lock: dict[str, Any],
+    current_manifest: dict[str, Any],
+) -> tuple[list[Transition], list[Transition]]:
+    """Apply the same base-fuzz-to-head proof used by CI `check` mode.
+
+    An independent fuzz-only update has no requested root-coherence
+    transitions and remains owned by its dedicated Dependabot/CI lane. When
+    the base fuzz lock is stale relative to the current root, every submitted
+    base-to-head change must instead fit the bounded exact-closure proof.
+    """
+
+    requested_transitions = required_transitions(
+        base_root_lock,
+        current_root_lock,
+        base_fuzz_lock,
+        current_manifest,
+    )
+    remaining_transitions = required_transitions(
+        base_root_lock,
+        current_root_lock,
+        current_fuzz_lock,
+        current_manifest,
+    )
+    if requested_transitions and not remaining_transitions:
+        validate_bounded_package_changes(
+            base_root_lock,
+            current_root_lock,
+            base_fuzz_lock,
+            current_fuzz_lock,
+            requested_transitions,
         )
+    return requested_transitions, remaining_transitions
 
 
 def required_transitions(
@@ -476,7 +532,13 @@ def update_fuzz_lock(transitions: list[Transition], *, offline: bool) -> None:
 
 
 def validate_locked_fuzz_metadata(*, offline: bool) -> None:
-    command = [
+    fetch_command = [
+        "fetch",
+        "--manifest-path",
+        str(REPOSITORY / "fuzz" / "Cargo.toml"),
+        "--locked",
+    ]
+    metadata_command = [
         "metadata",
         "--manifest-path",
         str(REPOSITORY / "fuzz" / "Cargo.toml"),
@@ -486,9 +548,16 @@ def validate_locked_fuzz_metadata(*, offline: bool) -> None:
         "--no-deps",
     ]
     if offline:
-        command.insert(1, "--offline")
+        fetch_command.insert(1, "--offline")
+        metadata_command.insert(1, "--offline")
     subprocess.run(
-        ["cargo", *command],
+        ["cargo", *fetch_command],
+        cwd=REPOSITORY,
+        stdout=subprocess.DEVNULL,
+        check=True,
+    )
+    subprocess.run(
+        ["cargo", *metadata_command],
         cwd=REPOSITORY,
         stdout=subprocess.DEVNULL,
         check=True,
@@ -516,19 +585,30 @@ def main() -> int:
     try:
         base = load_toml_from_git(args.base_ref, "Cargo.lock")
         base_manifest = load_toml_from_git(args.base_ref, "Cargo.toml")
+        base_fuzz = load_toml_from_git(args.base_ref, "fuzz/Cargo.lock")
         current = load_toml(ROOT_LOCK)
         fuzz = load_toml(FUZZ_LOCK)
         manifest = load_toml(ROOT_MANIFEST)
-        transitions = required_transitions(base, current, fuzz, manifest)
+        requested_transitions, transitions = validate_submitted_fuzz_update(
+            base,
+            current,
+            base_fuzz,
+            fuzz,
+            manifest,
+        )
 
         if args.mode == "write":
+            if transitions and not requested_transitions:
+                raise PolicyError(
+                    "current fuzz direct-dependency drift was not requested by "
+                    "the exact base-to-root transition; refusing to rewrite it"
+                )
             original_lock = FUZZ_LOCK.read_bytes()
-            original_transitions = transitions
             base_declarations = production_dependency_declarations(base_manifest)
             current_declarations = production_dependency_declarations(manifest)
             graph_refresh_names = {
                 transition.name
-                for transition in transitions
+                for transition in requested_transitions
                 if base_declarations.get(transition.name)
                 != current_declarations.get(transition.name)
             }
@@ -541,22 +621,20 @@ def main() -> int:
                 )
                 update_fuzz_lock(transitions, offline=args.offline)
                 repaired_fuzz = load_toml(FUZZ_LOCK)
-                transitions = required_transitions(
-                    base, current, repaired_fuzz, manifest
+                requested_transitions, transitions = validate_submitted_fuzz_update(
+                    base,
+                    current,
+                    base_fuzz,
+                    repaired_fuzz,
+                    manifest,
                 )
                 if transitions:
                     raise PolicyError(
                         "repair completed without proving every requested "
                         f"transition: {transitions}"
                     )
-                validate_bounded_package_changes(
-                    base,
-                    current,
-                    fuzz,
-                    repaired_fuzz,
-                    original_transitions,
-                )
-                validate_locked_fuzz_metadata(offline=args.offline)
+                if requested_transitions:
+                    validate_locked_fuzz_metadata(offline=args.offline)
             except (
                 OSError,
                 PolicyError,
@@ -565,6 +643,11 @@ def main() -> int:
             ):
                 FUZZ_LOCK.write_bytes(original_lock)
                 raise
+        elif requested_transitions and not transitions:
+            # New exact after-closure identities which are not represented in
+            # the root lock obtain authority from Cargo's locked
+            # source/checksum materialization, not from a crate-name fallback.
+            validate_locked_fuzz_metadata(offline=args.offline)
 
         if transitions:
             print(

--- a/scripts/sync_fuzz_lock.py
+++ b/scripts/sync_fuzz_lock.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Keep root dependency updates coherent with the separate fuzz workspace.
+
+The fuzz crate intentionally owns a separate Cargo.lock. Dependabot updates the
+root lock independently, so a root PR can otherwise pass with the fuzz build
+still resolving the previous direct production dependency.
+
+`check` is read-only and intended for pull-request CI. `write` is an explicit
+repair command for an isolated, trusted worktree; it invokes narrowly targeted
+`cargo update --precise` operations and never commits or pushes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+
+REPOSITORY = Path(__file__).resolve().parents[1]
+ROOT_LOCK = REPOSITORY / "Cargo.lock"
+FUZZ_LOCK = REPOSITORY / "fuzz" / "Cargo.lock"
+ROOT_MANIFEST = REPOSITORY / "Cargo.toml"
+
+
+class PolicyError(RuntimeError):
+    """A dependency update cannot be proven safe by the deterministic policy."""
+
+
+@dataclasses.dataclass(frozen=True)
+class Transition:
+    name: str
+    current_fuzz_version: str
+    target_root_version: str
+
+
+def load_toml(path: Path) -> dict[str, Any]:
+    with path.open("rb") as source:
+        return tomllib.load(source)
+
+
+def load_lock_from_git(reference: str) -> dict[str, Any]:
+    try:
+        encoded = subprocess.check_output(
+            ["git", "show", f"{reference}:Cargo.lock"],
+            cwd=REPOSITORY,
+            stderr=subprocess.PIPE,
+        )
+    except subprocess.CalledProcessError as error:
+        detail = error.stderr.decode(errors="replace").strip()
+        raise PolicyError(
+            f"cannot read Cargo.lock from base ref {reference!r}: {detail}"
+        ) from error
+    return tomllib.loads(encoded.decode())
+
+
+def packages_by_name(lock: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
+    result: dict[str, list[dict[str, Any]]] = {}
+    for package in lock.get("package", []):
+        result.setdefault(package["name"], []).append(package)
+    return result
+
+
+def workspace_package(lock: dict[str, Any], name: str) -> dict[str, Any]:
+    candidates = [
+        package
+        for package in lock.get("package", [])
+        if package.get("name") == name and "source" not in package
+    ]
+    if len(candidates) != 1:
+        raise PolicyError(
+            f"{name!r} must identify exactly one path package in Cargo.lock; "
+            f"found {len(candidates)}"
+        )
+    return candidates[0]
+
+
+def resolved_direct_versions(
+    lock: dict[str, Any], package_name: str = "tributary"
+) -> dict[str, str]:
+    """Resolve Cargo.lock dependency specs to the selected package versions."""
+
+    by_name = packages_by_name(lock)
+    package = workspace_package(lock, package_name)
+    result: dict[str, str] = {}
+
+    for dependency in package.get("dependencies", []):
+        fields = dependency.split()
+        name = fields[0]
+        explicit_version = (
+            fields[1] if len(fields) >= 2 and fields[1][0].isdigit() else None
+        )
+        if explicit_version is not None:
+            version = explicit_version
+        else:
+            candidates = by_name.get(name, [])
+            if len(candidates) != 1:
+                versions = sorted(candidate["version"] for candidate in candidates)
+                raise PolicyError(
+                    f"ambiguous bare dependency {name!r} in {package_name!r}; "
+                    f"candidate versions: {versions}"
+                )
+            version = candidates[0]["version"]
+
+        previous = result.setdefault(name, version)
+        if previous != version:
+            raise PolicyError(
+                f"{package_name!r} resolves direct dependency {name!r} twice: "
+                f"{previous} and {version}"
+            )
+
+    return result
+
+
+def production_dependency_names(manifest: dict[str, Any]) -> set[str]:
+    """Return package names inherited by fuzz through its Tributary path dep."""
+
+    result: set[str] = set()
+
+    def add_table(table: Any) -> None:
+        if not isinstance(table, dict):
+            return
+        for alias, declaration in table.items():
+            if isinstance(declaration, dict):
+                result.add(str(declaration.get("package", alias)))
+            else:
+                result.add(alias)
+
+    add_table(manifest.get("dependencies"))
+    add_table(manifest.get("build-dependencies"))
+    for target in manifest.get("target", {}).values():
+        if isinstance(target, dict):
+            add_table(target.get("dependencies"))
+            add_table(target.get("build-dependencies"))
+
+    return result
+
+
+def required_transitions(
+    base_root_lock: dict[str, Any],
+    current_root_lock: dict[str, Any],
+    current_fuzz_lock: dict[str, Any],
+    current_manifest: dict[str, Any],
+) -> list[Transition]:
+    base = resolved_direct_versions(base_root_lock)
+    current = resolved_direct_versions(current_root_lock)
+    fuzz = resolved_direct_versions(current_fuzz_lock)
+    production = production_dependency_names(current_manifest)
+    transitions: list[Transition] = []
+
+    # A removed production dependency remains visible in the stale fuzz lock.
+    # This is a graph rewrite, not a version substitution, and requires a
+    # reviewed lock regeneration rather than an unsafe best guess.
+    for name in sorted((set(base) - set(current)) & set(fuzz)):
+        raise PolicyError(
+            f"root production dependency {name!r} was removed but remains in "
+            "fuzz/Cargo.lock; regenerate the fuzz lock under review"
+        )
+
+    for name in sorted(set(base) | set(current)):
+        before = base.get(name)
+        after = current.get(name)
+        if before == after or name not in production:
+            continue
+        if after is None:
+            continue
+        if name not in fuzz:
+            raise PolicyError(
+                f"changed root production dependency {name!r} is absent from "
+                "fuzz/Cargo.lock; regenerate the fuzz lock under review"
+            )
+        if fuzz[name] != after:
+            transitions.append(Transition(name, fuzz[name], after))
+
+    return transitions
+
+
+def update_fuzz_lock(transitions: list[Transition], *, offline: bool) -> None:
+    for transition in transitions:
+        # Re-read after each operation: updating a direct facade such as
+        # `futures` can also bring its component crates to the target version.
+        fuzz = resolved_direct_versions(load_toml(FUZZ_LOCK))
+        current = fuzz.get(transition.name)
+        if current == transition.target_root_version:
+            continue
+        if current is None:
+            raise PolicyError(
+                f"{transition.name!r} disappeared while repairing fuzz/Cargo.lock"
+            )
+
+        command = ["cargo", "update"]
+        if offline:
+            command.append("--offline")
+        command.extend(
+            [
+                "--manifest-path",
+                str(REPOSITORY / "fuzz" / "Cargo.toml"),
+                "--package",
+                f"{transition.name}@{current}",
+                "--precise",
+                transition.target_root_version,
+            ]
+        )
+        subprocess.run(
+            command,
+            cwd=REPOSITORY,
+            check=True,
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("mode", choices=("check", "write"))
+    parser.add_argument(
+        "--base-ref",
+        required=True,
+        help="exact base commit/ref whose Cargo.lock precedes this update",
+    )
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="require every selected crate/index record to exist in Cargo's cache",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        base = load_lock_from_git(args.base_ref)
+        current = load_toml(ROOT_LOCK)
+        fuzz = load_toml(FUZZ_LOCK)
+        manifest = load_toml(ROOT_MANIFEST)
+        transitions = required_transitions(base, current, fuzz, manifest)
+
+        if args.mode == "write":
+            update_fuzz_lock(transitions, offline=args.offline)
+            transitions = required_transitions(
+                base, current, load_toml(FUZZ_LOCK), manifest
+            )
+
+        if transitions:
+            print(
+                "fuzz/Cargo.lock does not reflect changed root production "
+                "dependencies:",
+                file=sys.stderr,
+            )
+            for transition in transitions:
+                print(
+                    f"  {transition.name}: "
+                    f"{transition.current_fuzz_version} -> "
+                    f"{transition.target_root_version}",
+                    file=sys.stderr,
+                )
+            print(
+                "repair in an isolated trusted worktree with:\n"
+                f"  python3 scripts/sync_fuzz_lock.py write "
+                f"--base-ref {args.base_ref}",
+                file=sys.stderr,
+            )
+            return 1
+
+        print("root and fuzz lockfiles are coherent for changed dependencies")
+        return 0
+    except (OSError, PolicyError, subprocess.CalledProcessError) as error:
+        print(f"dependency lock policy failed: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync_rust_toolchain.py
+++ b/scripts/sync_rust_toolchain.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Validate or synchronize Tributary's authoritative Rust/MSRV declarations.
+"""
+Validate or synchronize Tributary's authoritative Rust/MSRV declarations.
 
 Dependabot is expected to propose updates to the exact
 `dtolnay/rust-toolchain@X.Y.0` refs. Those proposals deliberately do not

--- a/scripts/sync_rust_toolchain.py
+++ b/scripts/sync_rust_toolchain.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Validate or synchronize Tributary's authoritative Rust/MSRV declarations.
+
+Dependabot is expected to propose updates to the exact
+`dtolnay/rust-toolchain@X.Y.0` refs. Those proposals deliberately do not
+auto-merge. A trusted repairer runs this script to coordinate Cargo.toml, CI,
+cache keys, and developer documentation before the complete matrix is allowed
+to decide whether the new compiler is feasible.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+
+REPOSITORY = Path(__file__).resolve().parents[1]
+MANIFEST = REPOSITORY / "Cargo.toml"
+CI = REPOSITORY / ".github" / "workflows" / "ci.yml"
+README = REPOSITORY / "README.md"
+LINE_VERSION = re.compile(r"^[1-9][0-9]*\.[0-9]+$")
+RELEASE_VERSION = re.compile(r"^([1-9][0-9]*\.[0-9]+)\.0$")
+EXACT_TOOLCHAIN = re.compile(
+    r"(?m)^(\s*uses:\s*dtolnay/rust-toolchain@)([1-9][0-9]*\.[0-9]+\.0)\s*$"
+)
+
+
+class PolicyError(RuntimeError):
+    """The Rust version declarations are incomplete or contradictory."""
+
+
+def manifest_line_version() -> str:
+    with MANIFEST.open("rb") as source:
+        manifest = tomllib.load(source)
+    value = manifest.get("package", {}).get("rust-version")
+    if not isinstance(value, str) or LINE_VERSION.fullmatch(value) is None:
+        raise PolicyError(
+            "Cargo.toml package.rust-version must be a canonical X.Y string"
+        )
+    return value
+
+
+def exact_action_releases(ci_source: str) -> list[str]:
+    releases = [match.group(2) for match in EXACT_TOOLCHAIN.finditer(ci_source)]
+    if len(releases) != 2:
+        raise PolicyError(
+            "CI must contain exactly two numeric dtolnay/rust-toolchain refs "
+            f"(MSRV and coverage); found {len(releases)}"
+        )
+    return releases
+
+
+def candidate_from_actions(ci_source: str) -> str:
+    releases = set(exact_action_releases(ci_source))
+    if len(releases) != 1:
+        raise PolicyError(
+            "Dependabot must update both exact toolchain refs together; found "
+            + ", ".join(sorted(releases))
+        )
+    release = releases.pop()
+    match = RELEASE_VERSION.fullmatch(release)
+    if match is None:
+        raise PolicyError(f"unsupported Rust release tag {release!r}")
+    return match.group(1)
+
+
+def require_occurrence(source: str, needle: str, description: str) -> None:
+    if needle not in source:
+        raise PolicyError(f"{description} is not synchronized: missing {needle!r}")
+
+
+def check_consistency() -> None:
+    line = manifest_line_version()
+    release = f"{line}.0"
+    ci_source = CI.read_text()
+    readme = README.read_text()
+    releases = exact_action_releases(ci_source)
+    if set(releases) != {release}:
+        raise PolicyError(
+            f"numeric CI toolchain refs {sorted(set(releases))} do not match "
+            f"Cargo.toml rust-version {line}"
+        )
+
+    for needle, description in [
+        (f"name: MSRV ({line})", "MSRV job name"),
+        (f"Install Rust toolchain ({line})", "MSRV install step"),
+        (f"rustc {line}", "MSRV rationale"),
+        (f"coverage-{release}-llvm-cov-", "coverage cache"),
+    ]:
+        require_occurrence(ci_source, needle, description)
+
+    for needle, description in [
+        (f"Rust {line}+", "README prerequisite"),
+        (f"toolchain install {release}", "README coverage setup"),
+        (f"cargo +{release} llvm-cov", "README coverage commands"),
+        (f"pinned to Rust {release}", "README coverage policy"),
+    ]:
+        require_occurrence(readme, needle, description)
+
+
+def replace_exactly(source: str, old: str, new: str, description: str) -> str:
+    count = source.count(old)
+    if count == 0:
+        raise PolicyError(f"cannot locate {description}: {old!r}")
+    return source.replace(old, new)
+
+
+def synchronize(target_line: str) -> None:
+    if LINE_VERSION.fullmatch(target_line) is None:
+        raise PolicyError("target Rust version must use canonical X.Y form")
+
+    old_line = manifest_line_version()
+    old_release = f"{old_line}.0"
+    target_release = f"{target_line}.0"
+
+    manifest = MANIFEST.read_text()
+    manifest = replace_exactly(
+        manifest,
+        f'rust-version = "{old_line}"',
+        f'rust-version = "{target_line}"',
+        "Cargo rust-version",
+    )
+
+    ci_source = CI.read_text()
+    # Normalize every exact numeric toolchain ref, including refs Dependabot
+    # has already moved. Stable/nightly channels are intentionally untouched.
+    ci_source, count = EXACT_TOOLCHAIN.subn(
+        lambda match: f"{match.group(1)}{target_release}", ci_source
+    )
+    if count != 2:
+        raise PolicyError("could not normalize both exact CI toolchain refs")
+    for old, new, description in [
+        (f"MSRV ({old_line})", f"MSRV ({target_line})", "MSRV job name"),
+        (
+            f"toolchain ({old_line})",
+            f"toolchain ({target_line})",
+            "MSRV install step",
+        ),
+        (f"rustc {old_line}", f"rustc {target_line}", "MSRV rationale"),
+        (
+            f"coverage-{old_release}-llvm-cov-",
+            f"coverage-{target_release}-llvm-cov-",
+            "coverage cache",
+        ),
+    ]:
+        ci_source = replace_exactly(ci_source, old, new, description)
+
+    readme = README.read_text()
+    readme = replace_exactly(
+        readme,
+        f"Rust {old_line}+",
+        f"Rust {target_line}+",
+        "README prerequisite",
+    )
+    readme = replace_exactly(
+        readme,
+        old_release,
+        target_release,
+        "README exact Rust release",
+    )
+
+    MANIFEST.write_text(manifest)
+    CI.write_text(ci_source)
+    README.write_text(readme)
+    check_consistency()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--check", action="store_true")
+    group.add_argument(
+        "--from-actions",
+        action="store_true",
+        help="adopt the one exact Rust release proposed in both CI action refs",
+    )
+    group.add_argument("--set", metavar="X.Y", dest="target")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        if args.check:
+            check_consistency()
+        elif args.from_actions:
+            synchronize(candidate_from_actions(CI.read_text()))
+        else:
+            synchronize(args.target)
+        print("Rust toolchain declarations are synchronized")
+        return 0
+    except (OSError, PolicyError, tomllib.TOMLDecodeError) as error:
+        print(f"Rust toolchain policy failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync_rust_toolchain.py
+++ b/scripts/sync_rust_toolchain.py
@@ -26,6 +26,7 @@ RELEASE_VERSION = re.compile(r"^([1-9][0-9]*\.[0-9]+)\.0$")
 EXACT_TOOLCHAIN = re.compile(
     r"(?m)^(\s*uses:\s*dtolnay/rust-toolchain@)([1-9][0-9]*\.[0-9]+\.0)\s*$"
 )
+STABLE_MSRV_CHECK = re.compile(r"(?m)^    name: MSRV\s*$")
 
 
 class PolicyError(RuntimeError):
@@ -83,9 +84,12 @@ def check_consistency() -> None:
             f"numeric CI toolchain refs {sorted(set(releases))} do not match "
             f"Cargo.toml rust-version {line}"
         )
+    if STABLE_MSRV_CHECK.search(ci_source) is None:
+        raise PolicyError(
+            "MSRV job check name must remain stable as 'MSRV' for external gates"
+        )
 
     for needle, description in [
-        (f"name: MSRV ({line})", "MSRV job name"),
         (f"Install Rust toolchain ({line})", "MSRV install step"),
         (f"rustc {line}", "MSRV rationale"),
         (f"coverage-{release}-llvm-cov-", "coverage cache"),
@@ -133,7 +137,6 @@ def synchronize(target_line: str) -> None:
     if count != 2:
         raise PolicyError("could not normalize both exact CI toolchain refs")
     for old, new, description in [
-        (f"MSRV ({old_line})", f"MSRV ({target_line})", "MSRV job name"),
         (
             f"toolchain ({old_line})",
             f"toolchain ({target_line})",

--- a/scripts/test_dependency_update_policy.py
+++ b/scripts/test_dependency_update_policy.py
@@ -43,6 +43,16 @@ class FuzzLockPolicyTests(unittest.TestCase):
             [sync_fuzz_lock.Transition("tokio", "1.52.0", "1.53.0")],
         )
 
+    def test_existing_shared_production_mismatch_requires_alignment(self):
+        root = lock(["tokio"], {"tokio": ["1.53.0"]})
+        fuzz = lock(["tokio"], {"tokio": ["1.52.0"]})
+        manifest = {"dependencies": {"tokio": "1"}}
+
+        self.assertEqual(
+            sync_fuzz_lock.required_transitions(root, root, fuzz, manifest),
+            [sync_fuzz_lock.Transition("tokio", "1.52.0", "1.53.0")],
+        )
+
     def test_changed_root_dev_dependency_is_not_inherited_by_fuzz(self):
         base = lock(["toml"], {"toml": ["1.1.2"]})
         current = lock(["toml"], {"toml": ["1.1.3"]})
@@ -80,6 +90,312 @@ class FuzzLockPolicyTests(unittest.TestCase):
         with self.assertRaises(sync_fuzz_lock.PolicyError):
             sync_fuzz_lock.required_transitions(base, current, fuzz, {})
 
+    def test_new_direct_major_can_coexist_with_required_transitive_old_major(self):
+        base = lock(["sha2"], {"sha2": ["0.10.9"]})
+        current = lock(
+            ["sha2 0.11.0"],
+            {"sha2": ["0.10.9", "0.11.0"]},
+        )
+        stale_fuzz = lock(["sha2"], {"sha2": ["0.10.9"]})
+        repaired_fuzz = lock(
+            ["sha2 0.11.0"],
+            {"sha2": ["0.10.9", "0.11.0"]},
+        )
+        old_manifest = {"dependencies": {"sha2": "0.10"}}
+        new_manifest = {"dependencies": {"sha2": "0.11"}}
+        transitions = sync_fuzz_lock.required_transitions(
+            base, current, stale_fuzz, new_manifest
+        )
+
+        self.assertEqual(
+            transitions,
+            [sync_fuzz_lock.Transition("sha2", "0.10.9", "0.11.0")],
+        )
+        self.assertNotEqual(
+            sync_fuzz_lock.production_dependency_declarations(old_manifest),
+            sync_fuzz_lock.production_dependency_declarations(new_manifest),
+        )
+        self.assertEqual(
+            sync_fuzz_lock.required_transitions(
+                base, current, repaired_fuzz, new_manifest
+            ),
+            [],
+        )
+        sync_fuzz_lock.validate_bounded_package_changes(
+            base,
+            current,
+            stale_fuzz,
+            repaired_fuzz,
+            transitions,
+        )
+
+    def test_bounded_repair_rejects_unrelated_package_version_drift(self):
+        base = lock(["sha2"], {"sha2": ["0.10.9"], "unrelated": ["1.0.0"]})
+        current = lock(
+            ["sha2 0.11.0"],
+            {"sha2": ["0.10.9", "0.11.0"], "unrelated": ["1.0.0"]},
+        )
+        stale_fuzz = lock(
+            ["sha2"],
+            {"sha2": ["0.10.9"], "unrelated": ["1.0.0"]},
+        )
+        unsafe_fuzz = lock(
+            ["sha2 0.11.0"],
+            {"sha2": ["0.10.9", "0.11.0"], "unrelated": ["2.0.0"]},
+        )
+        with self.assertRaises(sync_fuzz_lock.PolicyError):
+            sync_fuzz_lock.validate_bounded_package_changes(
+                base,
+                current,
+                stale_fuzz,
+                unsafe_fuzz,
+                [sync_fuzz_lock.Transition("sha2", "0.10.9", "0.11.0")],
+            )
+
+    def test_bounded_repair_rejects_fuzz_only_dependency_surface_drift(self):
+        root = lock(
+            ["sha2"],
+            {"sha2": ["0.11.0"], "old-edge": ["1.0.0"], "new-edge": ["1.0.0"]},
+        )
+        stale_fuzz = lock(
+            ["sha2"],
+            {
+                "sha2": ["0.10.9"],
+                "old-edge": ["1.0.0"],
+                "new-edge": ["1.0.0"],
+                "unrelated": ["1.0.0"],
+            },
+        )
+        unsafe_fuzz = lock(
+            ["sha2 0.11.0"],
+            {
+                "sha2": ["0.10.9", "0.11.0"],
+                "old-edge": ["1.0.0"],
+                "new-edge": ["1.0.0"],
+                "unrelated": ["1.0.0"],
+            },
+        )
+        stale_fuzz["package"][-1]["dependencies"] = ["old-edge"]
+        unsafe_fuzz["package"][-1]["dependencies"] = ["new-edge"]
+
+        with self.assertRaises(sync_fuzz_lock.PolicyError):
+            sync_fuzz_lock.validate_bounded_package_changes(
+                root,
+                root,
+                stale_fuzz,
+                unsafe_fuzz,
+                [sync_fuzz_lock.Transition("sha2", "0.10.9", "0.11.0")],
+            )
+
+    def test_bounded_repair_rejects_unrelated_existing_version_rebind(self):
+        base = lock(
+            ["sha2 0.10.9"],
+            {"sha2": ["0.10.9"], "shared": ["1.0.0", "2.0.0"]},
+        )
+        current = lock(
+            ["sha2 0.11.0"],
+            {
+                "sha2": ["0.10.9", "0.11.0"],
+                "shared": ["1.0.0", "2.0.0"],
+            },
+        )
+        stale_fuzz = lock(
+            ["sha2 0.10.9"],
+            {
+                "sha2": ["0.10.9"],
+                "shared": ["1.0.0", "2.0.0"],
+                "unrelated": ["1.0.0"],
+            },
+        )
+        stale_fuzz["package"][-1]["dependencies"] = ["shared 1.0.0"]
+        unsafe_fuzz = lock(
+            ["sha2 0.11.0"],
+            {
+                "sha2": ["0.10.9", "0.11.0"],
+                "shared": ["1.0.0", "2.0.0"],
+                "unrelated": ["1.0.0"],
+            },
+        )
+        unsafe_fuzz["package"][-1]["dependencies"] = ["shared 2.0.0"]
+
+        with self.assertRaises(sync_fuzz_lock.PolicyError):
+            sync_fuzz_lock.validate_bounded_package_changes(
+                base,
+                current,
+                stale_fuzz,
+                unsafe_fuzz,
+                [sync_fuzz_lock.Transition("sha2", "0.10.9", "0.11.0")],
+            )
+
+    def test_bounded_repair_rejects_same_version_source_rewrite(self):
+        base = lock(["sha2"], {"sha2": ["0.10.9"]})
+        current = lock(
+            ["sha2 0.11.0"],
+            {"sha2": ["0.10.9", "0.11.0"]},
+        )
+        stale_fuzz = lock(
+            ["sha2"],
+            {"sha2": ["0.10.9"], "unrelated": ["1.0.0"]},
+        )
+        unsafe_fuzz = lock(
+            ["sha2 0.11.0"],
+            {
+                "sha2": ["0.10.9", "0.11.0"],
+                "unrelated": ["1.0.0"],
+            },
+        )
+        unsafe_fuzz["package"][-1]["source"] = "git+https://invalid.example/rewrite"
+
+        with self.assertRaises(sync_fuzz_lock.PolicyError):
+            sync_fuzz_lock.validate_bounded_package_changes(
+                base,
+                current,
+                stale_fuzz,
+                unsafe_fuzz,
+                [sync_fuzz_lock.Transition("sha2", "0.10.9", "0.11.0")],
+            )
+
+    def test_bounded_repair_allows_nonsemantic_edge_disambiguation(self):
+        base = lock(["sha2"], {"sha2": ["0.10.9"]})
+        current = lock(
+            ["sha2 0.11.0"],
+            {"sha2": ["0.10.9", "0.11.0"]},
+        )
+        stale_fuzz = lock(
+            ["sha2"],
+            {"sha2": ["0.10.9"], "consumer": ["1.0.0"]},
+        )
+        stale_fuzz["package"][-1]["dependencies"] = ["sha2"]
+        repaired_fuzz = lock(
+            ["sha2 0.11.0"],
+            {
+                "sha2": ["0.10.9", "0.11.0"],
+                "consumer": ["1.0.0"],
+            },
+        )
+        repaired_fuzz["package"][-1]["dependencies"] = ["sha2 0.10.9"]
+
+        sync_fuzz_lock.validate_bounded_package_changes(
+            base,
+            current,
+            stale_fuzz,
+            repaired_fuzz,
+            [sync_fuzz_lock.Transition("sha2", "0.10.9", "0.11.0")],
+        )
+
+    def test_bounded_repair_rejects_unrequested_path_package_rebind(self):
+        base = lock(
+            ["sha2 0.10.9", "tokio 1.0.0"],
+            {"sha2": ["0.10.9"], "tokio": ["1.0.0", "2.0.0"]},
+        )
+        current = lock(
+            ["sha2 0.11.0", "tokio 1.0.0"],
+            {
+                "sha2": ["0.10.9", "0.11.0"],
+                "tokio": ["1.0.0", "2.0.0"],
+            },
+        )
+        stale_fuzz = lock(
+            ["sha2 0.10.9", "tokio 1.0.0"],
+            {"sha2": ["0.10.9"], "tokio": ["1.0.0", "2.0.0"]},
+        )
+        unsafe_fuzz = lock(
+            ["sha2 0.11.0", "tokio 2.0.0"],
+            {
+                "sha2": ["0.10.9", "0.11.0"],
+                "tokio": ["1.0.0", "2.0.0"],
+            },
+        )
+
+        with self.assertRaises(sync_fuzz_lock.PolicyError):
+            sync_fuzz_lock.validate_bounded_package_changes(
+                base,
+                current,
+                stale_fuzz,
+                unsafe_fuzz,
+                [sync_fuzz_lock.Transition("sha2", "0.10.9", "0.11.0")],
+            )
+
+    def test_bounded_repair_allows_consumer_rebind_to_reviewed_target(self):
+        base = lock(["facade"], {"facade": ["1.0.0"], "consumer": ["1.0.0"]})
+        base["package"][-1]["dependencies"] = ["facade"]
+        current = lock(
+            ["facade 1.1.0"],
+            {"facade": ["1.0.0", "1.1.0"], "consumer": ["1.0.0"]},
+        )
+        current["package"][-1]["dependencies"] = ["facade 1.1.0"]
+        stale_fuzz = lock(
+            ["facade"],
+            {"facade": ["1.0.0"], "consumer": ["1.0.0"]},
+        )
+        stale_fuzz["package"][-1]["dependencies"] = ["facade"]
+        repaired_fuzz = lock(
+            ["facade 1.1.0"],
+            {"facade": ["1.0.0", "1.1.0"], "consumer": ["1.0.0"]},
+        )
+        repaired_fuzz["package"][-1]["dependencies"] = ["facade 1.1.0"]
+
+        sync_fuzz_lock.validate_bounded_package_changes(
+            base,
+            current,
+            stale_fuzz,
+            repaired_fuzz,
+            [sync_fuzz_lock.Transition("facade", "1.0.0", "1.1.0")],
+        )
+
+    def test_bounded_repair_allows_target_dependency_closure(self):
+        base = lock(
+            ["facade"],
+            {"facade": ["1.0.0"], "component": ["1.0.0"]},
+        )
+        base["package"][1]["dependencies"] = ["component"]
+        current = lock(
+            ["facade"],
+            {"facade": ["1.1.0"], "component": ["1.1.0"]},
+        )
+        current["package"][1]["dependencies"] = ["component"]
+        stale_fuzz = lock(
+            ["facade"],
+            {"facade": ["1.0.0"], "component": ["1.0.0"]},
+        )
+        stale_fuzz["package"][1]["dependencies"] = ["component"]
+        repaired_fuzz = lock(
+            ["facade"],
+            {"facade": ["1.1.0"], "component": ["1.1.0"]},
+        )
+        repaired_fuzz["package"][1]["dependencies"] = ["component"]
+
+        sync_fuzz_lock.validate_bounded_package_changes(
+            base,
+            current,
+            stale_fuzz,
+            repaired_fuzz,
+            [sync_fuzz_lock.Transition("facade", "1.0.0", "1.1.0")],
+        )
+
+    def test_transitive_only_root_lock_change_is_deliberately_not_projected(self):
+        base = lock(
+            ["tokio"],
+            {"tokio": ["1.53.1"], "transitive": ["1.0.0"]},
+        )
+        current = lock(
+            ["tokio"],
+            {"tokio": ["1.53.1"], "transitive": ["1.1.0"]},
+        )
+        fuzz = lock(
+            ["tokio"],
+            {"tokio": ["1.53.1"], "transitive": ["1.0.0"]},
+        )
+        self.assertEqual(
+            sync_fuzz_lock.required_transitions(
+                base,
+                current,
+                fuzz,
+                {"dependencies": {"tokio": "1"}},
+            ),
+            [],
+        )
+
 
 class RustToolchainPolicyTests(unittest.TestCase):
     def test_candidate_requires_both_exact_action_refs_to_agree(self):
@@ -114,7 +430,7 @@ class RustToolchainPolicyTests(unittest.TestCase):
             ci.write_text(
                 "# rustc 1.92 is the supported floor\n"
                 "msrv:\n"
-                "  name: MSRV (1.92)\n"
+                "    name: MSRV\n"
                 "  steps:\n"
                 "    - name: Install Rust toolchain (1.92)\n"
                 "      uses: dtolnay/rust-toolchain@1.93.0\n"
@@ -151,6 +467,7 @@ class RustToolchainPolicyTests(unittest.TestCase):
                 ) = original
 
             self.assertIn('rust-version = "1.93"', manifest.read_text())
+            self.assertIn("    name: MSRV\n", ci.read_text())
             self.assertNotIn("1.92", ci.read_text() + readme.read_text())
 
 

--- a/scripts/test_dependency_update_policy.py
+++ b/scripts/test_dependency_update_policy.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Focused unit tests for the dependency-update repair helpers."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import sync_fuzz_lock
+import sync_rust_toolchain
+
+
+def lock(direct: list[str], versions: dict[str, list[str]]) -> dict:
+    packages = [
+        {
+            "name": "tributary",
+            "version": "0.5.1",
+            "dependencies": direct,
+        }
+    ]
+    for name, releases in versions.items():
+        packages.extend(
+            {
+                "name": name,
+                "version": release,
+                "source": "registry+https://github.com/rust-lang/crates.io-index",
+            }
+            for release in releases
+        )
+    return {"version": 4, "package": packages}
+
+
+class FuzzLockPolicyTests(unittest.TestCase):
+    def test_changed_shared_production_dependency_requires_exact_fuzz_version(self):
+        base = lock(["tokio"], {"tokio": ["1.52.0"]})
+        current = lock(["tokio"], {"tokio": ["1.53.0"]})
+        fuzz = lock(["tokio"], {"tokio": ["1.52.0"]})
+        manifest = {"dependencies": {"tokio": "1"}}
+
+        self.assertEqual(
+            sync_fuzz_lock.required_transitions(base, current, fuzz, manifest),
+            [sync_fuzz_lock.Transition("tokio", "1.52.0", "1.53.0")],
+        )
+
+    def test_changed_root_dev_dependency_is_not_inherited_by_fuzz(self):
+        base = lock(["toml"], {"toml": ["1.1.2"]})
+        current = lock(["toml"], {"toml": ["1.1.3"]})
+        fuzz = lock([], {})
+        manifest = {"dev-dependencies": {"toml": "1"}}
+
+        self.assertEqual(
+            sync_fuzz_lock.required_transitions(base, current, fuzz, manifest),
+            [],
+        )
+
+    def test_alias_uses_the_actual_package_name(self):
+        manifest = {
+            "dependencies": {
+                "gtk": {"version": "0.11", "package": "gtk4"},
+                "tokio": {"version": "1"},
+            },
+            "target": {
+                "cfg(target_os = 'windows')": {
+                    "dependencies": {
+                        "windows-sys": {"version": "0.61"},
+                    }
+                }
+            },
+        }
+        self.assertEqual(
+            sync_fuzz_lock.production_dependency_names(manifest),
+            {"gtk4", "tokio", "windows-sys"},
+        )
+
+    def test_removed_production_dependency_fails_closed(self):
+        base = lock(["tokio"], {"tokio": ["1.52.0"]})
+        current = lock([], {})
+        fuzz = lock(["tokio"], {"tokio": ["1.52.0"]})
+        with self.assertRaises(sync_fuzz_lock.PolicyError):
+            sync_fuzz_lock.required_transitions(base, current, fuzz, {})
+
+
+class RustToolchainPolicyTests(unittest.TestCase):
+    def test_candidate_requires_both_exact_action_refs_to_agree(self):
+        source = """
+        uses: dtolnay/rust-toolchain@1.93.0
+        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.93.0
+"""
+        self.assertEqual(
+            sync_rust_toolchain.candidate_from_actions(source),
+            "1.93",
+        )
+
+    def test_mixed_exact_action_refs_fail_closed(self):
+        source = """
+        uses: dtolnay/rust-toolchain@1.92.0
+        uses: dtolnay/rust-toolchain@1.93.0
+"""
+        with self.assertRaises(sync_rust_toolchain.PolicyError):
+            sync_rust_toolchain.candidate_from_actions(source)
+
+    def test_dependabot_action_proposal_synchronizes_every_contract(self):
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest = root / "Cargo.toml"
+            ci = root / "ci.yml"
+            readme = root / "README.md"
+            manifest.write_text(
+                '[package]\nname = "fixture"\nversion = "0.0.0"\n'
+                'rust-version = "1.92"\n'
+            )
+            ci.write_text(
+                "# rustc 1.92 is the supported floor\n"
+                "msrv:\n"
+                "  name: MSRV (1.92)\n"
+                "  steps:\n"
+                "    - name: Install Rust toolchain (1.92)\n"
+                "      uses: dtolnay/rust-toolchain@1.93.0\n"
+                "coverage:\n"
+                "  steps:\n"
+                "    - name: Install coverage toolchain\n"
+                "      uses: dtolnay/rust-toolchain@1.93.0\n"
+                "  key: coverage-1.92.0-llvm-cov-fixture\n"
+            )
+            readme.write_text(
+                "Rust 1.92+\n"
+                "rustup toolchain install 1.92.0\n"
+                "cargo +1.92.0 llvm-cov\n"
+                "coverage is pinned to Rust 1.92.0\n"
+            )
+
+            original = (
+                sync_rust_toolchain.MANIFEST,
+                sync_rust_toolchain.CI,
+                sync_rust_toolchain.README,
+            )
+            try:
+                sync_rust_toolchain.MANIFEST = manifest
+                sync_rust_toolchain.CI = ci
+                sync_rust_toolchain.README = readme
+                target = sync_rust_toolchain.candidate_from_actions(ci.read_text())
+                sync_rust_toolchain.synchronize(target)
+                sync_rust_toolchain.check_consistency()
+            finally:
+                (
+                    sync_rust_toolchain.MANIFEST,
+                    sync_rust_toolchain.CI,
+                    sync_rust_toolchain.README,
+                ) = original
+
+            self.assertIn('rust-version = "1.93"', manifest.read_text())
+            self.assertNotIn("1.92", ci.read_text() + readme.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_dependency_update_policy.py
+++ b/scripts/test_dependency_update_policy.py
@@ -3,12 +3,45 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import sync_fuzz_lock
 import sync_rust_toolchain
+
+
+def workflow_run_script(job: str, step_name: str) -> str:
+    """Extract one literal Bash `run: |` body from the checked-in workflow."""
+
+    workflow = (
+        sync_fuzz_lock.REPOSITORY
+        / ".github"
+        / "workflows"
+        / "dependabot-automerge.yml"
+    ).read_text()
+    lines = workflow.splitlines()
+    job_marker = f"  {job}:"
+    step_marker = f"      - name: {step_name}"
+    try:
+        job_start = lines.index(job_marker)
+        step_start = lines.index(step_marker, job_start)
+        run_start = lines.index("        run: |", step_start) + 1
+    except ValueError as error:
+        raise AssertionError(
+            f"cannot locate {job}/{step_name} literal run body"
+        ) from error
+
+    body: list[str] = []
+    for line in lines[run_start:]:
+        if line and not line.startswith("          "):
+            break
+        body.append(line[10:] if line else "")
+    if not body:
+        raise AssertionError(f"{job}/{step_name} has an empty run body")
+    return "\n".join(body) + "\n"
 
 
 def lock(direct: list[str], versions: dict[str, list[str]]) -> dict:
@@ -29,6 +62,115 @@ def lock(direct: list[str], versions: dict[str, list[str]]) -> dict:
             for release in releases
         )
     return {"version": 4, "package": packages}
+
+
+class DependabotAutomergeRaceTests(unittest.TestCase):
+    def run_workflow_script(
+        self,
+        script: str,
+        *,
+        heads: str,
+        expected_head: str = "H1",
+        merge_head: str = "H1",
+    ) -> tuple[subprocess.CompletedProcess[str], str, str]:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            fake_bin = root / "bin"
+            fake_bin.mkdir()
+            state = root / "state"
+            calls = root / "calls"
+            output = root / "output"
+            fake_gh = fake_bin / "gh"
+            fake_gh.write_text(
+                """#!/usr/bin/env python3
+import os
+import pathlib
+import sys
+
+arguments = sys.argv[1:]
+state_path = pathlib.Path(os.environ["FAKE_GH_STATE"])
+calls_path = pathlib.Path(os.environ["FAKE_GH_CALLS"])
+with calls_path.open("a") as calls:
+    calls.write(repr(arguments) + "\\n")
+
+if arguments and arguments[0] == "api":
+    if any("/files?" in argument for argument in arguments):
+        print("Cargo.lock\\t")
+        raise SystemExit(0)
+    heads = os.environ["FAKE_GH_HEADS"].split(",")
+    index = int(state_path.read_text()) if state_path.exists() else 0
+    print(heads[min(index, len(heads) - 1)])
+    state_path.write_text(str(index + 1))
+    raise SystemExit(0)
+
+if arguments[:2] == ["pr", "merge"]:
+    guard_index = arguments.index("--match-head-commit") + 1
+    guarded_head = arguments[guard_index]
+    raise SystemExit(0 if guarded_head == os.environ["FAKE_MERGE_HEAD"] else 42)
+
+raise SystemExit(64)
+"""
+            )
+            fake_gh.chmod(0o755)
+            environment = {
+                **os.environ,
+                "PATH": f"{fake_bin}:{os.environ['PATH']}",
+                "RUNNER_TEMP": str(root),
+                "GITHUB_OUTPUT": str(output),
+                "GITHUB_REPOSITORY": "jm2/tributary",
+                "GH_TOKEN": "read-only-test-token",
+                "PR_NUMBER": "7",
+                "PR_URL": "https://github.invalid/jm2/tributary/pull/7",
+                "EXPECTED_HEAD_SHA": expected_head,
+                "EXPECTED_CHANGED_FILES": "1",
+                "FAKE_GH_STATE": str(state),
+                "FAKE_GH_CALLS": str(calls),
+                "FAKE_GH_HEADS": heads,
+                "FAKE_MERGE_HEAD": merge_head,
+            }
+            completed = subprocess.run(
+                ["bash"],
+                input=script,
+                cwd=sync_fuzz_lock.REPOSITORY,
+                env=environment,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            return (
+                completed,
+                calls.read_text() if calls.exists() else "",
+                output.read_text() if output.exists() else "",
+            )
+
+    def test_same_count_h1_h2_file_inspection_fails_closed(self):
+        script = workflow_run_script(
+            "inspect_changed_files",
+            "Deny privileged workflow changes",
+        )
+        completed, calls, output = self.run_workflow_script(
+            script,
+            heads="H1,H2",
+        )
+
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("changed during file inspection", completed.stderr)
+        self.assertEqual(calls.count("/files?"), 1)
+        self.assertNotIn("safe=true", output)
+
+    def test_server_guard_rejects_h2_after_final_h1_readback(self):
+        script = workflow_run_script(
+            "dependabot-automerge",
+            "Enable exact-head auto-merge for patch & minor updates",
+        )
+        completed, calls, _ = self.run_workflow_script(
+            script,
+            heads="H1",
+            merge_head="H2",
+        )
+
+        self.assertEqual(completed.returncode, 42)
+        self.assertIn("'--match-head-commit', 'H1'", calls)
 
 
 class FuzzLockPolicyTests(unittest.TestCase):
@@ -227,6 +369,134 @@ class FuzzLockPolicyTests(unittest.TestCase):
                 [sync_fuzz_lock.Transition("sha2", "0.10.9", "0.11.0")],
             )
 
+    def test_bounded_repair_rejects_same_name_target_outside_exact_closures(self):
+        base = lock(
+            ["facade 1.0.0"],
+            {
+                "facade": ["1.0.0"],
+                "shared": ["1.0.0", "9.0.0"],
+                "unrelated": ["1.0.0"],
+            },
+        )
+        current = lock(
+            ["facade 1.1.0"],
+            {
+                "facade": ["1.0.0", "1.1.0"],
+                "shared": ["1.0.0", "9.0.0"],
+                "unrelated": ["1.0.0"],
+            },
+        )
+        stale_fuzz = lock(
+            ["facade 1.0.0"],
+            {
+                "facade": ["1.0.0"],
+                "shared": ["1.0.0", "9.0.0"],
+                "unrelated": ["1.0.0"],
+            },
+        )
+        stale_fuzz["package"][-1]["dependencies"] = ["shared 1.0.0"]
+        unsafe_fuzz = lock(
+            ["facade 1.1.0"],
+            {
+                "facade": ["1.0.0", "1.1.0"],
+                "shared": ["1.0.0", "9.0.0"],
+                "unrelated": ["1.0.0"],
+            },
+        )
+        unsafe_fuzz["package"][-1]["dependencies"] = ["shared 9.0.0"]
+
+        with self.assertRaises(sync_fuzz_lock.PolicyError):
+            sync_fuzz_lock.validate_bounded_package_changes(
+                base,
+                current,
+                stale_fuzz,
+                unsafe_fuzz,
+                [sync_fuzz_lock.Transition("facade", "1.0.0", "1.1.0")],
+            )
+
+    def test_check_mode_rejects_raw_rebind_after_direct_transition_is_repaired(self):
+        base = lock(
+            ["facade 1.0.0"],
+            {
+                "facade": ["1.0.0"],
+                "shared": ["1.0.0", "9.0.0"],
+                "unrelated": ["1.0.0"],
+            },
+        )
+        current = lock(
+            ["facade 1.1.0"],
+            {
+                "facade": ["1.0.0", "1.1.0"],
+                "shared": ["1.0.0", "9.0.0"],
+                "unrelated": ["1.0.0"],
+            },
+        )
+        base_fuzz = lock(
+            ["facade 1.0.0"],
+            {
+                "facade": ["1.0.0"],
+                "shared": ["1.0.0", "9.0.0"],
+                "unrelated": ["1.0.0"],
+            },
+        )
+        base_fuzz["package"][-1]["dependencies"] = ["shared 1.0.0"]
+        submitted_fuzz = lock(
+            ["facade 1.1.0"],
+            {
+                "facade": ["1.0.0", "1.1.0"],
+                "shared": ["1.0.0", "9.0.0"],
+                "unrelated": ["1.0.0"],
+            },
+        )
+        submitted_fuzz["package"][-1]["dependencies"] = ["shared 9.0.0"]
+
+        with self.assertRaises(sync_fuzz_lock.PolicyError):
+            sync_fuzz_lock.validate_submitted_fuzz_update(
+                base,
+                current,
+                base_fuzz,
+                submitted_fuzz,
+                {"dependencies": {"facade": "1"}},
+            )
+
+    def test_fuzz_only_update_remains_independent_when_base_needs_no_repair(self):
+        root = lock(
+            ["facade 1.1.0"],
+            {
+                "facade": ["1.1.0"],
+                "shared": ["1.0.0", "2.0.0"],
+                "fuzz-only": ["1.0.0"],
+            },
+        )
+        base_fuzz = lock(
+            ["facade 1.1.0"],
+            {
+                "facade": ["1.1.0"],
+                "shared": ["1.0.0", "2.0.0"],
+                "fuzz-only": ["1.0.0"],
+            },
+        )
+        base_fuzz["package"][-1]["dependencies"] = ["shared 1.0.0"]
+        updated_fuzz = lock(
+            ["facade 1.1.0"],
+            {
+                "facade": ["1.1.0"],
+                "shared": ["1.0.0", "2.0.0"],
+                "fuzz-only": ["1.0.0"],
+            },
+        )
+        updated_fuzz["package"][-1]["dependencies"] = ["shared 2.0.0"]
+
+        requested, remaining = sync_fuzz_lock.validate_submitted_fuzz_update(
+            root,
+            root,
+            base_fuzz,
+            updated_fuzz,
+            {"dependencies": {"facade": "1"}},
+        )
+        self.assertEqual(requested, [])
+        self.assertEqual(remaining, [])
+
     def test_bounded_repair_rejects_same_version_source_rewrite(self):
         base = lock(["sha2"], {"sha2": ["0.10.9"]})
         current = lock(
@@ -254,6 +524,66 @@ class FuzzLockPolicyTests(unittest.TestCase):
                 unsafe_fuzz,
                 [sync_fuzz_lock.Transition("sha2", "0.10.9", "0.11.0")],
             )
+
+    def test_bounded_repair_rejects_new_root_identity_source_and_checksum_mismatch(
+        self,
+    ):
+        base = lock(["facade 1.0.0"], {"facade": ["1.0.0"]})
+        current = lock(
+            ["facade 1.1.0"],
+            {"facade": ["1.0.0", "1.1.0"]},
+        )
+        stale_fuzz = lock(["facade 1.0.0"], {"facade": ["1.0.0"]})
+        unsafe_fuzz = lock(
+            ["facade 1.1.0"],
+            {"facade": ["1.0.0", "1.1.0"]},
+        )
+        for package in current["package"]:
+            if package["name"] == "facade" and package["version"] == "1.1.0":
+                package["checksum"] = "authoritative"
+        for package in unsafe_fuzz["package"]:
+            if package["name"] == "facade" and package["version"] == "1.1.0":
+                package["source"] = "git+https://invalid.example/facade"
+                package["checksum"] = "tampered"
+
+        with self.assertRaises(sync_fuzz_lock.PolicyError):
+            sync_fuzz_lock.validate_bounded_package_changes(
+                base,
+                current,
+                stale_fuzz,
+                unsafe_fuzz,
+                [sync_fuzz_lock.Transition("facade", "1.0.0", "1.1.0")],
+            )
+
+    def test_bounded_repair_allows_exact_new_fuzz_resolver_identity(self):
+        base = lock(
+            ["facade 1.0.0"],
+            {"facade": ["1.0.0"], "component": ["1.0.0"]},
+        )
+        base["package"][1]["dependencies"] = ["component 1.0.0"]
+        current = lock(
+            ["facade 1.1.0"],
+            {"facade": ["1.1.0"], "component": ["1.2.0"]},
+        )
+        current["package"][1]["dependencies"] = ["component 1.2.0"]
+        stale_fuzz = lock(
+            ["facade 1.0.0"],
+            {"facade": ["1.0.0"], "component": ["1.0.0"]},
+        )
+        stale_fuzz["package"][1]["dependencies"] = ["component 1.0.0"]
+        repaired_fuzz = lock(
+            ["facade 1.1.0"],
+            {"facade": ["1.1.0"], "component": ["1.1.0"]},
+        )
+        repaired_fuzz["package"][1]["dependencies"] = ["component 1.1.0"]
+
+        sync_fuzz_lock.validate_bounded_package_changes(
+            base,
+            current,
+            stale_fuzz,
+            repaired_fuzz,
+            [sync_fuzz_lock.Transition("facade", "1.0.0", "1.1.0")],
+        )
 
     def test_bounded_repair_allows_nonsemantic_edge_disambiguation(self):
         base = lock(["sha2"], {"sha2": ["0.10.9"]})

--- a/scripts/test_dependency_update_policy.py
+++ b/scripts/test_dependency_update_policy.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import os
-import subprocess
+import shutil
+# Tests execute checked-in scripts with argv-only subprocess calls.
+import subprocess  # nosec B404
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -15,7 +17,6 @@ import sync_rust_toolchain
 
 def workflow_run_script(job: str, step_name: str) -> str:
     """Extract one literal Bash `run: |` body from the checked-in workflow."""
-
     workflow = (
         sync_fuzz_lock.REPOSITORY
         / ".github"
@@ -65,6 +66,8 @@ def lock(direct: list[str], versions: dict[str, list[str]]) -> dict:
 
 
 class DependabotAutomergeRaceTests(unittest.TestCase):
+    # The fixture intentionally keeps creation, execution, and evidence capture
+    # together so every workflow race test uses the same hermetic boundary.
     def run_workflow_script(
         self,
         script: str,
@@ -73,6 +76,7 @@ class DependabotAutomergeRaceTests(unittest.TestCase):
         expected_head: str = "H1",
         merge_head: str = "H1",
     ) -> tuple[subprocess.CompletedProcess[str], str, str]:
+        #lizard forgives
         with TemporaryDirectory() as temporary:
             root = Path(temporary)
             fake_bin = root / "bin"
@@ -118,7 +122,8 @@ raise SystemExit(64)
                 "RUNNER_TEMP": str(root),
                 "GITHUB_OUTPUT": str(output),
                 "GITHUB_REPOSITORY": "jm2/tributary",
-                "GH_TOKEN": "read-only-test-token",
+                # This value is synthetic and unique to the temporary fixture.
+                "GH_TOKEN": f"test-only-{root.name}",
                 "PR_NUMBER": "7",
                 "PR_URL": "https://github.invalid/jm2/tributary/pull/7",
                 "EXPECTED_HEAD_SHA": expected_head,
@@ -128,14 +133,20 @@ raise SystemExit(64)
                 "FAKE_GH_HEADS": heads,
                 "FAKE_MERGE_HEAD": merge_head,
             }
-            completed = subprocess.run(
-                ["bash"],
+            bash = shutil.which("bash")
+            if bash is None:
+                raise AssertionError("bash is required for workflow policy tests")
+            # The test intentionally executes a literal checked-in workflow
+            # body inside a temporary directory with a fake GitHub CLI.
+            completed = subprocess.run(  # nosec B603  # nosemgrep
+                [bash],
                 input=script,
                 cwd=sync_fuzz_lock.REPOSITORY,
                 env=environment,
                 text=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
+                check=False,
             )
             return (
                 completed,
@@ -174,6 +185,10 @@ raise SystemExit(64)
 
 
 class FuzzLockPolicyTests(unittest.TestCase):
+    def test_git_reader_requires_an_exact_commit_sha(self):
+        with self.assertRaises(sync_fuzz_lock.PolicyError):
+            sync_fuzz_lock.load_toml_from_git("--help", "Cargo.lock")
+
     def test_changed_shared_production_dependency_requires_exact_fuzz_version(self):
         base = lock(["tokio"], {"tokio": ["1.52.0"]})
         current = lock(["tokio"], {"tokio": ["1.53.0"]})

--- a/tests/packaging_metadata.rs
+++ b/tests/packaging_metadata.rs
@@ -916,12 +916,13 @@ fn ci_compile_proves_the_exact_declared_msrv() {
         "package.rust-version must use canonical X.Y form"
     );
     assert!(
-        crlf_msrv_job.contains(&format!("name: MSRV ({rust_version})")),
+        crlf_msrv_job.contains("name: MSRV\r\n"),
         "CI workflow contract checks must accept Windows CRLF checkouts"
     );
     assert!(
-        msrv_job.contains(&format!("name: MSRV ({rust_version})")),
-        "CI job name must expose the declared MSRV"
+        msrv_job.contains("name: MSRV\n")
+            && !msrv_job.contains(&format!("name: MSRV ({rust_version})")),
+        "CI job name must remain stable for branch rules and GasCity"
     );
     assert!(
         msrv_job.contains(&format!("uses: dtolnay/rust-toolchain@{rust_release}")),
@@ -981,6 +982,15 @@ fn dependabot_groups_coupled_updates_and_excludes_toolchains_from_automerge() {
         seaorm.get("update-types").is_none(),
         "the SeaORM pair must stay grouped for majors as well as routine updates"
     );
+    let seaorm_security = &root["groups"]["seaorm-security"];
+    assert_eq!(
+        seaorm_security["applies-to"].as_str(),
+        Some("security-updates")
+    );
+    assert_eq!(
+        yaml_string_list(seaorm_security, "patterns"),
+        ["sea-orm", "sea-orm-migration"]
+    );
 
     let routine_cargo = &root["groups"]["cargo-minor-and-patch"];
     assert_eq!(
@@ -993,6 +1003,15 @@ fn dependabot_groups_coupled_updates_and_excludes_toolchains_from_automerge() {
     );
 
     let fuzz = dependabot_update(&config, "cargo", "/fuzz");
+    let fuzz_seaorm_security = &fuzz["groups"]["seaorm-security"];
+    assert_eq!(
+        fuzz_seaorm_security["applies-to"].as_str(),
+        Some("security-updates")
+    );
+    assert_eq!(
+        yaml_string_list(fuzz_seaorm_security, "patterns"),
+        ["sea-orm", "sea-orm-migration"]
+    );
     let fuzz_group = &fuzz["groups"]["fuzz-minor-and-patch"];
     assert_eq!(
         yaml_string_list(fuzz_group, "update-types"),
@@ -1015,23 +1034,97 @@ fn dependabot_groups_coupled_updates_and_excludes_toolchains_from_automerge() {
     let routine_actions = &actions["groups"]["actions-minor-and-patch"];
     assert_eq!(
         yaml_string_list(routine_actions, "exclude-patterns"),
-        ["dtolnay/rust-toolchain"]
+        ["dtolnay/rust-toolchain", "dependabot/fetch-metadata"]
     );
+    let metadata_action = &actions["groups"]["dependabot-metadata"];
+    assert_eq!(
+        yaml_string_list(metadata_action, "patterns"),
+        ["dependabot/fetch-metadata"]
+    );
+    assert_eq!(
+        metadata_action["applies-to"].as_str(),
+        Some("version-updates")
+    );
+    let metadata_action_security = &actions["groups"]["dependabot-metadata-security"];
+    assert_eq!(
+        yaml_string_list(metadata_action_security, "patterns"),
+        ["dependabot/fetch-metadata"]
+    );
+    assert_eq!(
+        metadata_action_security["applies-to"].as_str(),
+        Some("security-updates")
+    );
+}
 
-    let _: serde_yaml::Value = serde_yaml::from_str(DEPENDABOT_AUTOMERGE)
+#[test]
+fn dependabot_automerge_has_read_only_mixed_path_preflight() {
+    let workflow: serde_yaml::Value = serde_yaml::from_str(DEPENDABOT_AUTOMERGE)
         .expect("Dependabot auto-merge workflow must parse");
     assert!(
-        DEPENDABOT_AUTOMERGE.contains("on: pull_request")
+        workflow["permissions"]
+            .as_mapping()
+            .is_some_and(serde_yaml::Mapping::is_empty),
+        "the workflow default token must have no permissions"
+    );
+    let inspect = &workflow["jobs"]["inspect_changed_files"];
+    assert_eq!(
+        inspect["permissions"]["pull-requests"].as_str(),
+        Some("read")
+    );
+    assert!(
+        inspect["permissions"].get("contents").is_none(),
+        "changed-file inspection must not receive content write permission"
+    );
+    let inspect_steps = inspect["steps"]
+        .as_sequence()
+        .expect("changed-file inspection steps must be a sequence");
+    assert!(
+        inspect_steps.iter().all(|step| step.get("uses").is_none()),
+        "no third-party action may run before changed-file denial"
+    );
+
+    let writer = &workflow["jobs"]["dependabot-automerge"];
+    assert_eq!(writer["needs"].as_str(), Some("inspect_changed_files"));
+    assert_eq!(writer["permissions"]["contents"].as_str(), Some("write"));
+    assert_eq!(
+        writer["permissions"]["pull-requests"].as_str(),
+        Some("write")
+    );
+    assert!(
+        writer["if"]
+            .as_str()
+            .is_some_and(|condition| condition.contains(
+                "needs.inspect_changed_files.outputs.privileged_workflow_unchanged == 'true'"
+            )),
+        "the write job must depend on an affirmative read-only inspection result"
+    );
+
+    assert!(
+        DEPENDABOT_AUTOMERGE.contains("pull_request:")
             && !DEPENDABOT_AUTOMERGE.contains("\non: pull_request_target\n")
             && !DEPENDABOT_AUTOMERGE.contains("actions/checkout")
+            && DEPENDABOT_AUTOMERGE.contains("gh api --paginate")
+            && DEPENDABOT_AUTOMERGE.contains("github.event.pull_request.changed_files")
+            && DEPENDABOT_AUTOMERGE.contains(".previous_filename")
+            && DEPENDABOT_AUTOMERGE.contains("observed_changed_files")
+            && DEPENDABOT_AUTOMERGE.contains("grep -Fq")
+            && DEPENDABOT_AUTOMERGE.contains(
+                "dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7"
+            )
+            && !DEPENDABOT_AUTOMERGE.contains("dependabot/fetch-metadata@v3")
+            && DEPENDABOT_AUTOMERGE
+                .contains("\".github/workflows/dependabot-automerge.yml\"")
             && DEPENDABOT_AUTOMERGE.contains("github.actor == 'dependabot[bot]'")
             && DEPENDABOT_AUTOMERGE
                 .contains("github.event.pull_request.user.login == 'dependabot[bot]'")
             && DEPENDABOT_AUTOMERGE.contains("github.repository == 'jm2/tributary'")
             && DEPENDABOT_AUTOMERGE.contains(
                 "!contains(steps.meta.outputs.dependency-names, 'dtolnay/rust-toolchain')"
+            )
+            && DEPENDABOT_AUTOMERGE.contains(
+                "!contains(steps.meta.outputs.dependency-names, 'dependabot/fetch-metadata')"
             ),
-        "write-capable Dependabot automation must be checkout-free, narrowly admitted, and refuse toolchain auto-merge"
+        "write-capable Dependabot automation must be pinned, checkout-free, API-preflighted, narrowly admitted, mixed-path self-update-safe, and refuse toolchain auto-merge"
     );
 }
 

--- a/tests/packaging_metadata.rs
+++ b/tests/packaging_metadata.rs
@@ -905,8 +905,9 @@ fn ci_compile_proves_the_exact_declared_msrv() {
         .as_str()
         .expect("package.rust-version must be a string");
     let rust_release = format!("{rust_version}.0");
-    let msrv_job = workflow_job(CI_WORKFLOW, "msrv");
-    let crlf_workflow = CI_WORKFLOW.lines().collect::<Vec<_>>().join("\r\n");
+    let normalized_workflow = CI_WORKFLOW.replace("\r\n", "\n");
+    let msrv_job = workflow_job(&normalized_workflow, "msrv");
+    let crlf_workflow = normalized_workflow.lines().collect::<Vec<_>>().join("\r\n");
     let crlf_msrv_job = workflow_job(&crlf_workflow, "msrv");
 
     assert!(

--- a/tests/packaging_metadata.rs
+++ b/tests/packaging_metadata.rs
@@ -1,10 +1,14 @@
 use toml::Value;
 
 const MANIFEST: &str = include_str!("../Cargo.toml");
+const ROOT_LOCK: &str = include_str!("../Cargo.lock");
+const FUZZ_LOCK: &str = include_str!("../fuzz/Cargo.lock");
 const RPM_SPEC: &str = include_str!("../build-aux/rpm/tributary.spec");
 const ARCH_PKGBUILD: &str = include_str!("../build-aux/arch/PKGBUILD");
 const DESKTOP_ENTRY: &str = include_str!("../data/io.github.tributary.Tributary.desktop");
 const CI_WORKFLOW: &str = include_str!("../.github/workflows/ci.yml");
+const DEPENDABOT_CONFIG: &str = include_str!("../.github/dependabot.yml");
+const DEPENDABOT_AUTOMERGE: &str = include_str!("../.github/workflows/dependabot-automerge.yml");
 const CLAUDE_REVIEW_WORKFLOW: &str = include_str!("../.github/workflows/claude-review.yml");
 const RELEASE_WORKFLOW: &str = include_str!("../.github/workflows/release.yml");
 const COVERAGE_BASELINE: &str = include_str!("../coverage-baseline.txt");
@@ -24,6 +28,65 @@ const FORBIDDEN_BUNDLED_COMPONENTS: &str =
 
 fn manifest() -> Value {
     toml::from_str(MANIFEST).expect("Cargo.toml must parse")
+}
+
+fn locked_version(source: &str, package: &str) -> String {
+    let lock: Value = toml::from_str(source).expect("Cargo lockfile must parse");
+    let versions: Vec<_> = lock["package"]
+        .as_array()
+        .expect("Cargo lockfile must contain package records")
+        .iter()
+        .filter(|candidate| candidate["name"].as_str() == Some(package))
+        .map(|candidate| {
+            candidate["version"]
+                .as_str()
+                .expect("locked package must have a version")
+        })
+        .collect();
+    assert_eq!(
+        versions.len(),
+        1,
+        "{package} must resolve to exactly one version; actual: {versions:?}"
+    );
+    versions[0].to_owned()
+}
+
+fn yaml_string_list(value: &serde_yaml::Value, field: &str) -> Vec<String> {
+    value
+        .get(field)
+        .unwrap_or_else(|| panic!("missing YAML field {field}"))
+        .as_sequence()
+        .unwrap_or_else(|| panic!("YAML field {field} must be a sequence"))
+        .iter()
+        .map(|entry| {
+            entry
+                .as_str()
+                .unwrap_or_else(|| panic!("{field} entries must be strings"))
+                .to_owned()
+        })
+        .collect()
+}
+
+fn dependabot_update<'a>(
+    config: &'a serde_yaml::Value,
+    ecosystem: &str,
+    directory: &str,
+) -> &'a serde_yaml::Value {
+    let matches: Vec<_> = config["updates"]
+        .as_sequence()
+        .expect("Dependabot updates must be a sequence")
+        .iter()
+        .filter(|update| {
+            update["package-ecosystem"].as_str() == Some(ecosystem)
+                && update["directory"].as_str() == Some(directory)
+        })
+        .collect();
+    assert_eq!(
+        matches.len(),
+        1,
+        "Dependabot must define exactly one {ecosystem} update at {directory}"
+    );
+    matches[0]
 }
 
 fn parse_api_feature(feature: &str) -> Option<(u32, u32)> {
@@ -841,26 +904,134 @@ fn ci_compile_proves_the_exact_declared_msrv() {
     let rust_version = manifest["package"]["rust-version"]
         .as_str()
         .expect("package.rust-version must be a string");
+    let rust_release = format!("{rust_version}.0");
     let msrv_job = workflow_job(CI_WORKFLOW, "msrv");
     let crlf_workflow = CI_WORKFLOW.lines().collect::<Vec<_>>().join("\r\n");
     let crlf_msrv_job = workflow_job(&crlf_workflow, "msrv");
 
-    assert_eq!(rust_version, "1.92");
     assert!(
-        crlf_msrv_job.contains("name: MSRV (1.92)"),
+        rust_version.split_once('.').is_some_and(
+            |(major, minor)| major.parse::<u32>().is_ok() && minor.parse::<u32>().is_ok()
+        ),
+        "package.rust-version must use canonical X.Y form"
+    );
+    assert!(
+        crlf_msrv_job.contains(&format!("name: MSRV ({rust_version})")),
         "CI workflow contract checks must accept Windows CRLF checkouts"
     );
     assert!(
-        msrv_job.contains("name: MSRV (1.92)"),
+        msrv_job.contains(&format!("name: MSRV ({rust_version})")),
         "CI job name must expose the declared MSRV"
     );
     assert!(
-        msrv_job.contains("uses: dtolnay/rust-toolchain@1.92.0"),
+        msrv_job.contains(&format!("uses: dtolnay/rust-toolchain@{rust_release}")),
         "CI must install the exact declared Rust release"
     );
     assert!(
         msrv_job.contains("run: cargo check --all-targets --locked"),
         "CI must compile-check every target against the committed lockfile"
+    );
+    assert!(
+        README.contains(&format!("Rust {rust_version}+"))
+            && README.contains(&format!("toolchain install {rust_release}"))
+            && README.contains(&format!("cargo +{rust_release} llvm-cov"))
+            && README.contains(&format!("pinned to Rust {rust_release}")),
+        "README prerequisites and coverage commands must match the declared MSRV"
+    );
+}
+
+#[test]
+fn seaorm_runtime_and_migration_dependencies_move_as_one_unit() {
+    let manifest = manifest();
+    assert_eq!(
+        manifest["dependencies"]["sea-orm"]["version"],
+        manifest["dependencies"]["sea-orm-migration"]["version"],
+        "SeaORM runtime and migration manifest requirements must match"
+    );
+
+    for (name, source) in [("root", ROOT_LOCK), ("fuzz", FUZZ_LOCK)] {
+        assert_eq!(
+            locked_version(source, "sea-orm"),
+            locked_version(source, "sea-orm-migration"),
+            "{name} lockfile must resolve SeaORM runtime and migration to one version"
+        );
+    }
+}
+
+#[test]
+fn dependabot_groups_coupled_updates_and_excludes_toolchains_from_automerge() {
+    let config: serde_yaml::Value =
+        serde_yaml::from_str(DEPENDABOT_CONFIG).expect("dependabot.yml must parse");
+    assert_eq!(config["version"].as_u64(), Some(2));
+
+    let root = dependabot_update(&config, "cargo", "/");
+    let root_groups = root["groups"]
+        .as_mapping()
+        .expect("root Cargo groups must be a mapping");
+    assert!(
+        !root_groups.is_empty(),
+        "root Cargo groups must not be empty"
+    );
+    let seaorm = &root["groups"]["seaorm"];
+    assert_eq!(
+        yaml_string_list(seaorm, "patterns"),
+        ["sea-orm", "sea-orm-migration"]
+    );
+    assert!(
+        seaorm.get("update-types").is_none(),
+        "the SeaORM pair must stay grouped for majors as well as routine updates"
+    );
+
+    let routine_cargo = &root["groups"]["cargo-minor-and-patch"];
+    assert_eq!(
+        yaml_string_list(routine_cargo, "update-types"),
+        ["minor", "patch"]
+    );
+    assert_eq!(
+        yaml_string_list(routine_cargo, "exclude-patterns"),
+        ["sea-orm", "sea-orm-migration"]
+    );
+
+    let fuzz = dependabot_update(&config, "cargo", "/fuzz");
+    let fuzz_group = &fuzz["groups"]["fuzz-minor-and-patch"];
+    assert_eq!(
+        yaml_string_list(fuzz_group, "update-types"),
+        ["minor", "patch"]
+    );
+
+    let actions = dependabot_update(&config, "github-actions", "/");
+    actions["groups"]
+        .as_mapping()
+        .expect("Actions groups must be a mapping");
+    let toolchain = &actions["groups"]["rust-toolchain"];
+    assert_eq!(
+        yaml_string_list(toolchain, "patterns"),
+        ["dtolnay/rust-toolchain"]
+    );
+    assert!(
+        toolchain.get("update-types").is_none() && actions.get("ignore").is_none(),
+        "Rust release updates must remain enabled at every SemVer level"
+    );
+    let routine_actions = &actions["groups"]["actions-minor-and-patch"];
+    assert_eq!(
+        yaml_string_list(routine_actions, "exclude-patterns"),
+        ["dtolnay/rust-toolchain"]
+    );
+
+    let _: serde_yaml::Value = serde_yaml::from_str(DEPENDABOT_AUTOMERGE)
+        .expect("Dependabot auto-merge workflow must parse");
+    assert!(
+        DEPENDABOT_AUTOMERGE.contains("on: pull_request")
+            && !DEPENDABOT_AUTOMERGE.contains("\non: pull_request_target\n")
+            && !DEPENDABOT_AUTOMERGE.contains("actions/checkout")
+            && DEPENDABOT_AUTOMERGE.contains("github.actor == 'dependabot[bot]'")
+            && DEPENDABOT_AUTOMERGE
+                .contains("github.event.pull_request.user.login == 'dependabot[bot]'")
+            && DEPENDABOT_AUTOMERGE.contains("github.repository == 'jm2/tributary'")
+            && DEPENDABOT_AUTOMERGE.contains(
+                "!contains(steps.meta.outputs.dependency-names, 'dtolnay/rust-toolchain')"
+            ),
+        "write-capable Dependabot automation must be checkout-free, narrowly admitted, and refuse toolchain auto-merge"
     );
 }
 

--- a/tests/packaging_metadata.rs
+++ b/tests/packaging_metadata.rs
@@ -960,6 +960,9 @@ fn seaorm_runtime_and_migration_dependencies_move_as_one_unit() {
 }
 
 #[test]
+// The assertions form one policy contract: splitting them would obscure
+// whether grouping and auto-merge exclusions remain mutually consistent.
+// #lizard forgives
 fn dependabot_groups_coupled_updates_and_excludes_toolchains_from_automerge() {
     let config: serde_yaml::Value =
         serde_yaml::from_str(DEPENDABOT_CONFIG).expect("dependabot.yml must parse");
@@ -1099,6 +1102,9 @@ fn dependabot_automerge_inspection_and_metadata_stay_read_only_and_head_bound() 
 }
 
 #[test]
+// These assertions jointly prove one privileged boundary and should fail as a
+// unit if an action, permission, concurrency rule, or exact-head guard regresses.
+// #lizard forgives
 fn dependabot_automerge_writer_is_action_free_concurrent_and_exact_head_guarded() {
     let workflow = dependabot_automerge_workflow();
     let writer = &workflow["jobs"]["dependabot-automerge"];

--- a/tests/packaging_metadata.rs
+++ b/tests/packaging_metadata.rs
@@ -1056,10 +1056,13 @@ fn dependabot_groups_coupled_updates_and_excludes_toolchains_from_automerge() {
     );
 }
 
+fn dependabot_automerge_workflow() -> serde_yaml::Value {
+    serde_yaml::from_str(DEPENDABOT_AUTOMERGE).expect("Dependabot auto-merge workflow must parse")
+}
+
 #[test]
-fn dependabot_automerge_has_read_only_mixed_path_preflight() {
-    let workflow: serde_yaml::Value = serde_yaml::from_str(DEPENDABOT_AUTOMERGE)
-        .expect("Dependabot auto-merge workflow must parse");
+fn dependabot_automerge_inspection_and_metadata_stay_read_only_and_head_bound() {
+    let workflow = dependabot_automerge_workflow();
     assert!(
         workflow["permissions"]
             .as_mapping()
@@ -1079,10 +1082,25 @@ fn dependabot_automerge_has_read_only_mixed_path_preflight() {
         .as_sequence()
         .expect("changed-file inspection steps must be a sequence");
     assert!(
-        inspect_steps.iter().all(|step| step.get("uses").is_none()),
-        "no third-party action may run before changed-file denial"
+        inspect_steps
+            .first()
+            .is_some_and(|step| step.get("uses").is_none()),
+        "changed-file and exact-head denial must be inline and action-free"
     );
+    assert!(
+        inspect_steps.iter().any(|step| {
+            step.get("uses").and_then(serde_yaml::Value::as_str)
+                == Some("dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7")
+                && step.get("if").and_then(serde_yaml::Value::as_str)
+                    == Some("steps.pre_metadata_head.outputs.matches == 'true'")
+        }),
+        "metadata extraction must run only after a fresh read-only exact-head preflight"
+    );
+}
 
+#[test]
+fn dependabot_automerge_writer_is_action_free_concurrent_and_exact_head_guarded() {
+    let workflow = dependabot_automerge_workflow();
     let writer = &workflow["jobs"]["dependabot-automerge"];
     assert_eq!(writer["needs"].as_str(), Some("inspect_changed_files"));
     assert_eq!(writer["permissions"]["contents"].as_str(), Some("write"));
@@ -1098,6 +1116,29 @@ fn dependabot_automerge_has_read_only_mixed_path_preflight() {
             )),
         "the write job must depend on an affirmative read-only inspection result"
     );
+    let writer_steps = writer["steps"]
+        .as_sequence()
+        .expect("write job steps must be a sequence");
+    assert!(
+        writer_steps.iter().all(|step| step.get("uses").is_none()),
+        "the write-capable job must remain third-party-action-free"
+    );
+    assert_eq!(
+        writer_steps.len(),
+        1,
+        "the write-capable job must contain only the guarded merge command"
+    );
+    assert_eq!(
+        workflow["concurrency"]["cancel-in-progress"].as_bool(),
+        Some(true),
+        "a newer revision of one PR must cancel its stale automation run"
+    );
+    assert!(
+        workflow["concurrency"]["group"]
+            .as_str()
+            .is_some_and(|group| group.contains("github.event.pull_request.number")),
+        "workflow concurrency must be scoped to the exact pull request"
+    );
 
     assert!(
         DEPENDABOT_AUTOMERGE.contains("pull_request:")
@@ -1105,9 +1146,15 @@ fn dependabot_automerge_has_read_only_mixed_path_preflight() {
             && !DEPENDABOT_AUTOMERGE.contains("actions/checkout")
             && DEPENDABOT_AUTOMERGE.contains("gh api --paginate")
             && DEPENDABOT_AUTOMERGE.contains("github.event.pull_request.changed_files")
+            && DEPENDABOT_AUTOMERGE.contains("github.event.pull_request.head.sha")
+            && DEPENDABOT_AUTOMERGE.contains("observed_head_before")
+            && DEPENDABOT_AUTOMERGE.contains("observed_head_after")
+            && DEPENDABOT_AUTOMERGE.contains("pre_metadata_head")
+            && DEPENDABOT_AUTOMERGE.contains("metadata_head")
+            && DEPENDABOT_AUTOMERGE.contains("observed_head")
+            && DEPENDABOT_AUTOMERGE.contains("--match-head-commit")
             && DEPENDABOT_AUTOMERGE.contains(".previous_filename")
             && DEPENDABOT_AUTOMERGE.contains("observed_changed_files")
-            && DEPENDABOT_AUTOMERGE.contains("grep -Fq")
             && DEPENDABOT_AUTOMERGE.contains(
                 "dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7"
             )
@@ -1119,12 +1166,12 @@ fn dependabot_automerge_has_read_only_mixed_path_preflight() {
                 .contains("github.event.pull_request.user.login == 'dependabot[bot]'")
             && DEPENDABOT_AUTOMERGE.contains("github.repository == 'jm2/tributary'")
             && DEPENDABOT_AUTOMERGE.contains(
-                "!contains(steps.meta.outputs.dependency-names, 'dtolnay/rust-toolchain')"
+                "!contains(needs.inspect_changed_files.outputs.dependency_names, 'dtolnay/rust-toolchain')"
             )
             && DEPENDABOT_AUTOMERGE.contains(
-                "!contains(steps.meta.outputs.dependency-names, 'dependabot/fetch-metadata')"
+                "!contains(needs.inspect_changed_files.outputs.dependency_names, 'dependabot/fetch-metadata')"
             ),
-        "write-capable Dependabot automation must be pinned, checkout-free, API-preflighted, narrowly admitted, mixed-path self-update-safe, and refuse toolchain auto-merge"
+        "Dependabot automation must be pinned, checkout-free, exact-head API-preflighted, narrowly admitted, race-contained, mixed-path self-update-safe, and refuse toolchain auto-merge"
     );
 }
 


### PR DESCRIPTION
## Summary

- define grouped Dependabot updates for Cargo and GitHub Actions while keeping coordinated Rust toolchain/MSRV bumps enabled in a dedicated, non-automerge lane
- add an exact-head, least-privilege preflight and guarded automerge path for eligible Dependabot updates
- repair and validate the fuzz lockfile only within the exact authorized dependency closure, including immutable source/checksum checks and locked Cargo materialization
- synchronize Rust toolchain, package `rust-version`, CI toolchains, cache keys, and documentation through one checked policy
- use the stable required-check name `MSRV` so future feasible Rust floor bumps do not rename branch protection
- add adversarial policy/race coverage and packaging metadata regression tests

## Why

Dependency updates currently span the root lockfile, the fuzz workspace, Rust toolchain/MSRV declarations, and CI policy. Treating those surfaces independently can leave stale locks, accept unrelated dependency-edge changes, race a moving PR head, or silently weaken the intended review boundary. This change makes the policy explicit and fail-closed while preserving routine Dependabot automation.

Rust is intentionally **not pinned forever at 1.92**. Feasible Rust updates remain enabled, but they are coordinated across every declaration and always require normal review and full CI rather than automerge.

## Validation

Current head: `cc9fe212de5b45549bb14b890129780caffef4cc`

- exact-head hosted Actions matrix green on Linux x86_64/aarch64, Windows x86_64/aarch64, macOS aarch64, Coverage, Flatpak, Desktop Metadata, MSRV, Security Audit, and CodeQL
- 26 Python policy/race/adversarial tests
- 23 Rust packaging-policy tests
- root and fuzz Clippy with `-D warnings`
- exact base-fuzz-to-head bounded validation
- locked Cargo fetch and metadata checks
- Rust toolchain synchronization check
- formatting and `git diff --check`
- Windows checkout line-ending regression fixed and verified by the hosted Windows jobs
- independent review verdict **SHIP** on the substantive policy head; the two narrow follow-ups are now covered by exact-head hosted attestation

Codacy still reports four non-behavioral findings: two file-length findings on intentionally comprehensive policy/test modules, plus mutually exclusive D212/D213 module-docstring preferences. The reviewed disposition is to preserve the cohesive policy/test structure and avoid rule-churn; no correctness or security finding is being waived.

## Deployment gate

Keep this PR draft and do not enable its automerge workflow until all of the following are true:

- [x] hosted Actions are green on this exact head
- [x] Codacy's four non-behavioral findings have the explicit reviewed disposition above
- [ ] active repository ruleset `17650907` requires the new stable `MSRV` check
- [ ] the local GasCity Tributary required-check configuration migrates from `MSRV (1.92)` to `MSRV` in the same rollout

The repository documentation added here records those prerequisites rather than claiming they are already active.
