### PR TITLE
Prepare Tributary 0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Tributary are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.0] — 2026-07-31
 
 ### Added
 
@@ -460,7 +460,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.desktop` file and AppStream metainfo for Linux desktop integration.
 - Windows resource file with icon embedding.
 
-[Unreleased]: https://github.com/jm2/tributary/compare/v0.5.1...HEAD
+[0.6.0]: https://github.com/jm2/tributary/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/jm2/tributary/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/jm2/tributary/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/jm2/tributary/compare/v0.4.0...v0.4.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5317,7 +5317,7 @@ dependencies = [
 
 [[package]]
 name = "tributary"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tributary"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.92"
 description = "A high-performance, Rhythmbox-style media manager with unified local and remote backends"

--- a/data/io.github.tributary.Tributary.metainfo.xml
+++ b/data/io.github.tributary.Tributary.metainfo.xml
@@ -44,6 +44,19 @@
   </screenshots>
 
   <releases>
+    <release version="0.6.0" date="2026-07-31">
+      <description>
+        <p>Feature and reliability release:</p>
+        <ul>
+          <li>Import Rhythmbox ratings, play history, and playlists through a preview-first migration</li>
+          <li>Browse, import, and sync Subsonic playlists and build mixed-source playlists</li>
+          <li>Add local ratings and committed playback history for smart playlists, Recently Played, and Top 25</li>
+          <li>Preserve volume and default-device routing across Windows and macOS audio changes</li>
+          <li>Fix Linux dialogs and rescan loops, unsupported playlist writes, and shuffle navigation</li>
+          <li>Harden native application metadata and release-artifact component validation</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.5.1" date="2026-07-18">
       <description>
         <p>Security and reliability release:</p>

--- a/docs/task.md
+++ b/docs/task.md
@@ -1,6 +1,6 @@
 # Tributary active implementation backlog
 
-Last audited: 2026-07-28
+Last audited: 2026-07-31
 
 This is the executable backlog for feature fixes and additions. It replaces the completed
 holistic-review tracker, which is preserved as
@@ -27,6 +27,11 @@ Current status: **14/38 (36.8%)** active implementation records complete. This p
 checklist completion, not equal engineering effort: several P3 records are deliberately large
 epics. The archived remediation remains **220/223 (98.7%)** complete; its three open records are
 real-environment validation, not missing implementation.
+
+Release checkpoint: v0.6.0 (2026-07-31) packages the completed migration, playlist, ratings,
+history, shuffle, audio-device, native-icon, Linux, and artifact-policy work summarized in the
+[`CHANGELOG.md`](../CHANGELOG.md). Cutting this release does not change the **14/38 (36.8%)**
+feature numerator; P2.1 Last.fm remains the next implementation focus after release publication.
 
 ## Current focus
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -5242,7 +5242,7 @@ dependencies = [
 
 [[package]]
 name = "tributary"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",


### PR DESCRIPTION
## Summary

- bump the crate and lockfile metadata to 0.6.0
- promote the compact Unreleased notes to 0.6.0 dated 2026-07-31
- add matching AppStream release metadata
- record the release checkpoint in docs/task.md without changing backlog completion

## Validation

- cargo fmt --all -- --check
- locked Cargo metadata for the root and fuzz workspaces
- xmllint and offline AppStream validation
- cargo test --locked --test packaging_metadata (23 passed)
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Released version 0.6.0 on July 31, 2026.
  * Updated the changelog and application release metadata with the new version details.

* **Documentation**
  * Added release information covering feature updates, reliability improvements, metadata validation, and platform-specific fixes.
  * Updated the project audit checkpoint and recorded the next planned implementation focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->