### PR TITLE
Prevent duplicate release checksum entries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,11 +521,13 @@ jobs:
       - name: Generate cargo-sources.json
         run: bash build-aux/flatpak/generate-cargo-sources.sh
 
-      - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+      - name: Build Flatpak bundle
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
           bundle: tributary.flatpak
           manifest-path: build-aux/flatpak/io.github.tributary.Tributary.yml
           cache-key: flatpak-${{ hashFiles('**/Cargo.lock') }}
+          upload-artifact: false
 
       - name: Validate completed Flatpak bundle payload
         run: build-aux/flatpak/validate-bundle-compliance.sh tributary.flatpak

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,12 +138,14 @@ jobs:
           python3 build-aux/flatpak/flatpak-cargo-generator.py \
             Cargo.lock -o build-aux/flatpak/cargo-sources.json
 
-      - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+      - name: Build Flatpak bundle
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
           bundle: tributary-linux-${{ matrix.arch }}.flatpak
           manifest-path: build-aux/flatpak/io.github.tributary.Tributary.yml
           cache-key: flatpak-${{ matrix.arch }}-${{ hashFiles('**/Cargo.lock') }}
           arch: ${{ matrix.arch }}
+          upload-artifact: false
 
       - name: Validate completed Flatpak bundle payload
         run: >-
@@ -155,6 +157,7 @@ jobs:
         with:
           name: tributary-linux-${{ matrix.arch }}-flatpak
           path: tributary-linux-${{ matrix.arch }}.flatpak
+          if-no-files-found: error
 
   # ── macOS (.dmg) ──────────────────────────────────────────────────────────
   macos:
@@ -549,10 +552,61 @@ jobs:
       - name: Generate SHA256SUMS
         run: |
           cd artifacts
+          expected_assets=(
+            'tributary-aarch64.rpm'
+            'tributary-amd64.deb'
+            'tributary-arm64.deb'
+            'tributary-linux-aarch64.flatpak'
+            'tributary-linux-x86_64.flatpak'
+            'tributary-macos-aarch64.dmg'
+            'tributary-windows-aarch64-setup.exe'
+            'tributary-windows-aarch64.zip'
+            'tributary-windows-x86_64-setup.exe'
+            'tributary-windows-x86_64.zip'
+            'tributary-x86_64.pkg.tar.zst'
+            'tributary-x86_64.rpm'
+          )
+          release_file_list="$(mktemp)"
+          trap 'rm -f "$release_file_list"' EXIT
           find . -type f \( -name '*.zip' -o -name '*.dmg' -o -name '*.flatpak' \
             -o -name '*.deb' -o -name '*.rpm' -o -name '*.pkg.tar.zst' \
-            -o -name '*-setup.exe' \) \
-            -exec sha256sum {} + | sed 's|  .*/|  |' | sort -k2 > ../SHA256SUMS.txt
+            -o -name '*-setup.exe' \) -print0 > "$release_file_list"
+          mapfile -d '' release_files < "$release_file_list"
+          if (( ${#release_files[@]} == 0 )); then
+            echo 'No release artifacts were downloaded' >&2
+            exit 1
+          fi
+
+          declare -A release_paths=()
+          for path in "${release_files[@]}"; do
+            name="${path##*/}"
+            if [[ -n "${release_paths[$name]+present}" ]]; then
+              echo "Duplicate release artifact filename: ${name}" >&2
+              printf '  %s\n' "${release_paths[$name]}" "${path}" >&2
+              exit 1
+            fi
+            release_paths["$name"]="$path"
+          done
+
+          if (( ${#release_paths[@]} != ${#expected_assets[@]} )); then
+            echo "Expected ${#expected_assets[@]} unique release assets; found ${#release_paths[@]}" >&2
+            printf '  %s\n' "${!release_paths[@]}" | LC_ALL=C sort >&2
+            exit 1
+          fi
+
+          for name in "${expected_assets[@]}"; do
+            if [[ -z "${release_paths[$name]+present}" ]]; then
+              echo "Missing release artifact: ${name}" >&2
+              exit 1
+            fi
+          done
+
+          {
+            for name in "${expected_assets[@]}"; do
+              digest="$(sha256sum "${release_paths[$name]}")"
+              printf '%s  %s\n' "${digest%% *}" "$name"
+            done
+          } | LC_ALL=C sort -k2 > ../SHA256SUMS.txt
           cat ../SHA256SUMS.txt
 
       - name: Upload SHA256SUMS as artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to Tributary are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Release checksum manifests** — Upload each validated Flatpak exactly once and reject missing,
+  unexpected, or duplicate package filenames before publishing release checksums.
+
+---
+
 ## [0.6.0] — 2026-07-31
 
 ### Added
@@ -460,6 +469,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.desktop` file and AppStream metainfo for Linux desktop integration.
 - Windows resource file with icon embedding.
 
+[Unreleased]: https://github.com/jm2/tributary/compare/v0.6.0...HEAD
 [0.6.0]: https://github.com/jm2/tributary/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/jm2/tributary/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/jm2/tributary/compare/v0.4.1...v0.5.0

--- a/docs/task.md
+++ b/docs/task.md
@@ -28,10 +28,19 @@ checklist completion, not equal engineering effort: several P3 records are delib
 epics. The archived remediation remains **220/223 (98.7%)** complete; its three open records are
 real-environment validation, not missing implementation.
 
-Release checkpoint: v0.6.0 (2026-07-31) packages the completed migration, playlist, ratings,
-history, shuffle, audio-device, native-icon, Linux, and artifact-policy work summarized in the
-[`CHANGELOG.md`](../CHANGELOG.md). Cutting this release does not change the **14/38 (36.8%)**
-feature numerator; P2.1 Last.fm remains the next implementation focus after release publication.
+Release checkpoint: [v0.6.0](https://github.com/jm2/tributary/releases/tag/v0.6.0) (2026-07-31),
+prepared in [#199](https://github.com/jm2/tributary/pull/199), packages the completed migration,
+playlist, ratings, history, shuffle, audio-device, native-icon, Linux, and artifact-policy work
+summarized in the [`CHANGELOG.md`](../CHANGELOG.md). Cutting this release does not change the
+**14/38 (36.8%)** feature numerator; P2.1 Last.fm remains the next implementation focus after
+release publication.
+
+Post-publication verification downloaded and validated all 12 v0.6.0 package payloads, then
+replaced a checksum manifest that repeated the two Flatpak records with a canonical 12-entry
+manifest. The follow-up workflow correction disables Flatpak's pre-validation automatic upload,
+retains the explicit post-validation upload, and rejects missing, unexpected, or duplicate release
+asset filenames before generating future manifests. This distribution correction does not change
+the **14/38 (36.8%)** feature numerator.
 
 ## Current focus
 

--- a/tests/packaging_metadata.rs
+++ b/tests/packaging_metadata.rs
@@ -181,6 +181,141 @@ fn workflow_job<'a>(source: &'a str, name: &str) -> &'a str {
     &source[start..]
 }
 
+fn assert_flatpak_artifact_boundary(
+    source: &str,
+    job_name: &str,
+    label: &str,
+    artifact_name: &str,
+    artifact_path: &str,
+) {
+    let job = workflow_job(source, job_name);
+    let build = job
+        .find("name: Build Flatpak bundle")
+        .unwrap_or_else(|| panic!("{label} must name its Flatpak build boundary"));
+    let validation = job
+        .find("name: Validate completed Flatpak bundle payload")
+        .unwrap_or_else(|| panic!("{label} must validate the completed Flatpak"));
+    let upload = job
+        .find("name: Upload Flatpak")
+        .unwrap_or_else(|| panic!("{label} must retain one explicit Flatpak upload"));
+
+    assert!(
+        build < validation && validation < upload,
+        "{label} must validate the completed Flatpak before making it a workflow artifact"
+    );
+    assert!(
+        job[build..validation].contains("upload-artifact: false"),
+        "{label} must disable flatpak-builder's implicit pre-validation artifact upload"
+    );
+    assert_eq!(
+        job.matches("uses: flatpak/flatpak-github-actions/flatpak-builder@v6")
+            .count(),
+        1,
+        "{label} must contain exactly one Flatpak builder action"
+    );
+    assert_eq!(
+        job.matches("uses: actions/upload-artifact@v7").count(),
+        1,
+        "{label} must upload the Flatpak exactly once"
+    );
+    let upload_step = &job[upload..];
+    assert!(
+        upload_step.contains(&format!("name: {artifact_name}"))
+            && upload_step.contains(&format!("path: {artifact_path}"))
+            && upload_step.contains("if-no-files-found: error"),
+        "{label} must upload the exact validated Flatpak and fail when it is missing"
+    );
+}
+
+#[test]
+fn flatpak_artifacts_publish_once_after_compliance_validation() {
+    assert_flatpak_artifact_boundary(
+        CI_WORKFLOW,
+        "build-flatpak",
+        "CI",
+        "tributary-flatpak",
+        "tributary.flatpak",
+    );
+    assert_flatpak_artifact_boundary(
+        RELEASE_WORKFLOW,
+        "flatpak",
+        "release",
+        "tributary-linux-${{ matrix.arch }}-flatpak",
+        "tributary-linux-${{ matrix.arch }}.flatpak",
+    );
+}
+
+#[test]
+fn release_checksums_require_one_exact_asset_set() {
+    let checksums = workflow_job(RELEASE_WORKFLOW, "checksums");
+    let expected_assets = shell_array(checksums, "expected_assets");
+    assert_eq!(
+        expected_assets,
+        [
+            "tributary-aarch64.rpm",
+            "tributary-amd64.deb",
+            "tributary-arm64.deb",
+            "tributary-linux-aarch64.flatpak",
+            "tributary-linux-x86_64.flatpak",
+            "tributary-macos-aarch64.dmg",
+            "tributary-windows-aarch64-setup.exe",
+            "tributary-windows-aarch64.zip",
+            "tributary-windows-x86_64-setup.exe",
+            "tributary-windows-x86_64.zip",
+            "tributary-x86_64.pkg.tar.zst",
+            "tributary-x86_64.rpm",
+        ],
+        "release checksums must cover exactly the published package set"
+    );
+
+    for fragment in [
+        "release_file_list=\"$(mktemp)\"",
+        "trap 'rm -f \"$release_file_list\"' EXIT",
+        ") -print0 > \"$release_file_list\"",
+        "mapfile -d '' release_files < \"$release_file_list\"",
+        "declare -A release_paths=()",
+        "release_paths[\"$name\"]=\"$path\"",
+        "${#release_paths[@]} != ${#expected_assets[@]}",
+        "${release_paths[$name]+present}",
+    ] {
+        assert!(
+            checksums.contains(fragment),
+            "release checksum validation is missing its fail-closed contract: {fragment}"
+        );
+    }
+
+    let discovery = checksums
+        .find("release_file_list=\"$(mktemp)\"")
+        .expect("release artifact discovery must use a checked temporary list");
+    let list_read = checksums
+        .find("mapfile -d '' release_files < \"$release_file_list\"")
+        .expect("the checked artifact list must be read without process substitution");
+    let duplicate_guard = checksums
+        .find("Duplicate release artifact filename")
+        .expect("duplicate package basenames must be rejected");
+    let exact_count_guard = checksums
+        .find("unique release assets; found")
+        .expect("the unique package count must be exact");
+    let missing_guard = checksums
+        .find("Missing release artifact")
+        .expect("every expected package basename must be present");
+    let hashing = checksums
+        .find("digest=\"$(sha256sum")
+        .expect("validated release packages must be hashed");
+    assert!(
+        discovery < list_read
+            && list_read < duplicate_guard
+            && duplicate_guard < exact_count_guard
+            && exact_count_guard < missing_guard
+            && missing_guard < hashing,
+        "checked discovery plus duplicate, extra, and missing guards must run before hashing"
+    );
+    assert!(
+        !checksums.contains("sort -u") && !checksums.contains("< <("),
+        "release checksums must neither hide duplicate names nor lose discovery failures"
+    );
+}
+
 fn forbidden_bundle_tokens() -> Vec<&'static str> {
     FORBIDDEN_BUNDLED_COMPONENTS
         .lines()


### PR DESCRIPTION
## Summary

- disable the Flatpak builder action implicit artifact upload in CI and releases
- retain one explicit upload only after compliance validation
- require the exact 12 unique release package names before generating checksums
- document the v0.6.0 post-publication audit and correction

## Incident

The v0.6.0 workflow produced valid package hashes, but SHA256SUMS.txt repeated each Flatpak because both the builder action and Tributary uploaded the same bundle. The published v0.6.0 manifest has already been replaced with a verified 12-entry copy; package assets and their hashes did not change.

## Validation

- cargo fmt --all -- --check
- cargo test --locked --test packaging_metadata (25 passed)
- cargo clippy --locked --test packaging_metadata -- -D warnings
- YAML parse for both changed workflows
- real v0.6.0 payload set produces the exact 12-line manifest
- duplicate-basename and incomplete-set fixtures fail before hashing
- simulated find producer that emits all names then exits 42 propagates exit 42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release asset validation to detect missing, duplicate, or unexpected package files.
  - Checksum manifests are now generated consistently and only after all release assets pass validation.
  - Strengthened Flatpak bundle publishing to prevent incomplete or missing uploads.

- **Documentation**
  - Updated the changelog and release documentation with checksum verification and Flatpak publishing safeguards.
  - Added details on validating published package payloads and release assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->