### PR TITLE
ci: finish retiring hosted AI reviewer

### DIFF
--- a/docs/refinery-config.md
+++ b/docs/refinery-config.md
@@ -37,96 +37,21 @@ left intact. A bead (tr-3h7) opened the issue and another polecat can land
 the city-config edit through the usual refinery handoff if the change
 hasn't already been applied out-of-band.
 
-## Reviewer wait-for-comments gate (LOCAL-ONLY)
+## Reviewer policy
 
-A second piece of upstream refinery behavior was miscalibrated for this rig,
-recorded by bead `tr-xqu`.
+Repository-owned AI review workflows are deliberately absent from both forks.
+Refinery does not wait on an AI-review workflow, vendor bot status, or reviewer
+credential stored by the repository. The only repo-owned admission gate is the
+normal hosted CI gate above. Third-party status integrations configured outside
+the repository are not accepted as refinery-review evidence.
 
-The withdrawn upstream PR `#235` ("gate refinery closes on review, hosted CI,
-and bot comments", commits `4ad09b3` / `720bd22`) hardcoded a reviewer wait
-gate that listed `gemini-code-assist[bot]` and `chatgpt-codex-connector[bot]`.
-On `jm2/tributary`, the Gemini Code Assist GitHub App announced its sunset
-on 2026-07-23 and now posts an identical tombstone comment on every PR; the
-withdrawn gate treated that comment as unaddressable, so every branch was
-rejected forever and merge throughput froze. PR `#235` was withdrawn and
-replaced by upstream PR `#239`, which deliberately excludes any reviewer gate
-on automated reviewer comments. The live pack at the city's pinned sha
-(`9bb06e00`) does not contain the gate — verified: no `review_bots` reference
-in the shipped refinery prompt, formula, or assets.
+Operational review is performed out of band by Gas City's locally configured
+GLM 5.3 reviewer. Its admission and evidence belong to the rollout manifests,
+not GitHub Actions or this repository. A reviewer outage must never become an
+unsatisfiable branch-close gate.
 
-The operator wants a wait-for-review-comments rule restored, but:
-
-1. **LOCAL-ONLY**, not upstream-bound. The reviewer policy is a deployment
-   preference (one operator's choice of which comments are blocking), not a
-   Gastown defect. It lives in the local pack stack
-   (`file:///home/jmulesa/gascity-packs//gastown`), is listed in
-   `LOCAL-ONLY.md` at the packs repo root, and must never ride into an
-   upstream PR.
-
-2. **Keyed on the live Claude reviewer.** The `claude-review.yml` workflow
-   became live on `jm2/tributary` (commit `68ed2b0`, "ci: add automatic
-   Claude PR review", 2026-07-25 18:42 EDT). The first run on a real PR
-   (PR `#178`, head `polecat/tr-t3i` at `ce09d0c`, run `30178620793`)
-   completed at 2026-07-25 23:05:09Z and posted under the login
-   **`claude[bot]`** — the GitHub App is installed, so the workflow posts
-   as the App rather than as `github-actions[bot]` (which would be the
-   `claude-code-action` fallback when the App is absent). `review_bots` is
-   pinned to that exact value.
-
-3. **Bounded**, not "wait forever". The original Gate 3 in PR `#235` had no
-   bound, which is exactly the deadlock the decommissioned Gemini bot
-   produced. The restored gate has four terminal conditions, none of which
-   can stall indefinitely:
-
-   - **Reviewer comments present** → evaluate them via the gate's normal
-     path (resolved thread, in-thread substantive non-bot reply, or an
-     APPROVED review).
-   - **`Claude PR Review` check-run concluded, no comments** → proceed.
-     This is the operator's stated case ("especially if CI has completed
-     and after that there's still no comments") and keys on the
-     *strongest available signal* (the workflow's check-run conclusion,
-     not a clock). Stamp `review_gate_result=no-comments` and proceed; do
-     not burn the full timeout here, that is pure latency on every clean
-     PR.
-   - **Absolute timeout** → proceed loudly, stamping what was waited on
-     and for how long. Backstop for the case where the review workflow
-     never registers a check-run at all (never triggered, workflow
-     disabled, or the event was missed). Must be tuned to real CI
-     duration, not the `900` default — Tributary's CI regularly runs
-     `20-53` minutes (Coverage + cross-compiled `aarch64` tail); the
-     `ci_timeout_seconds = "3600"` override above provides that margin
-     and the same bound should bound the reviewer wait on this rig.
-   - **Review workflow failed or errored** → do NOT block. Report loudly
-     and proceed. A broken reviewer must not freeze the queue. Same
-     lesson as the CI gate: an absolute gate that cannot distinguish
-     "reviewer says no" from "reviewer is broken" converts every reviewer
-     outage into a fleet-wide deadlock.
-
-### What this rig overrides
-
-The actual gate code lives in the local pack stack at:
-
-- `gastown/agents/refinery/prompt.template.md` — the Gate block, plus the
-  `review_bots` reference.
-- `gastown/formulas/mol-refinery-patrol.toml` — the bound vars
-  (`review_bots`, `review_timeout_seconds`, `review_workflow`).
-
-The rig-side clone does not own those files. They are edited in the local
-pack fork (`~/gascity-packs`, pinned via
-`source = "file:///home/jmulesa/gascity-packs//gastown"` in `city.toml`),
-and the city picks them up on next controller start. Per `LOCAL-ONLY.md`,
-those edits ride only into local rigs and never into an upstream PR.
-
-The pin values for this rig:
-
-| var | value | meaning |
-|---|---|---|
-| `review_bots` | `claude[bot]` | Read off PR `#178` run `30178620793` on 2026-07-25. App is installed, so this is the Claude GitHub App login, not the `github-actions[bot]` `claude-code-action` fallback. |
-| `review_timeout_seconds` | `3600` | Same one-hour budget as `ci_timeout_seconds` above. Anything tighter risks a false positive on a long CI run that is still queued for review. |
-| `review_workflow` | `Claude PR Review` | The check-run whose conclusion is the strongest "reviewer ran" signal. Bound to the `.github/workflows/claude-review.yml` workflow on `jm2/tributary main` and `jm2/kisakcod master`. |
-
-If the App is ever uninstalled and the workflow falls back to
-`github-actions[bot]`, the rig-side owner of these vars must rerun the
-discovery step (push to any PR, read the first real review's author) and
-update `review_bots`. Guessing that value is how the original unsatisfiable
-gate got built.
+The former local-only `review_bots`, `review_timeout_seconds`, and
+`review_workflow` overrides are retired and must remain absent from the
+pack and city configuration. Any future hosted reviewer is a new change that
+requires explicit authorization, a finite timeout, a credential and threat
+model, and regression coverage.

--- a/tests/packaging_metadata.rs
+++ b/tests/packaging_metadata.rs
@@ -10,8 +10,8 @@ const CI_WORKFLOW: &str = include_str!("../.github/workflows/ci.yml");
 const RUST_TOOLCHAIN_MANIFEST: &str = include_str!("../.github/rust-toolchain.toml");
 const DEPENDABOT_CONFIG: &str = include_str!("../.github/dependabot.yml");
 const DEPENDABOT_AUTOMERGE: &str = include_str!("../.github/workflows/dependabot-automerge.yml");
-const CLAUDE_REVIEW_WORKFLOW: &str = include_str!("../.github/workflows/claude-review.yml");
 const RELEASE_WORKFLOW: &str = include_str!("../.github/workflows/release.yml");
+const REFINERY_CONFIG: &str = include_str!("../docs/refinery-config.md");
 const COVERAGE_BASELINE: &str = include_str!("../coverage-baseline.txt");
 const README: &str = include_str!("../README.md");
 const BUILD_SCRIPT: &str = include_str!("../build.rs");
@@ -1372,412 +1372,74 @@ fn dependabot_automerge_writer_is_action_free_concurrent_and_exact_head_guarded(
     );
 }
 
-fn claude_review_workflow() -> serde_yaml::Value {
-    serde_yaml::from_str(CLAUDE_REVIEW_WORKFLOW).expect("Claude review workflow must parse")
-}
-
-fn claude_review_job<'a>(workflow: &'a serde_yaml::Value, name: &str) -> &'a serde_yaml::Value {
-    workflow
-        .get("jobs")
-        .and_then(serde_yaml::Value::as_mapping)
-        .and_then(|jobs| jobs.get(serde_yaml::Value::String(name.into())))
-        .unwrap_or_else(|| panic!("Claude review job {name} must exist"))
-}
-
-fn claude_review_steps(job: &serde_yaml::Value) -> &[serde_yaml::Value] {
-    job.get("steps")
-        .and_then(serde_yaml::Value::as_sequence)
-        .expect("Claude review job steps must be a sequence")
-}
-
-fn claude_review_step_named<'a>(job: &'a serde_yaml::Value, name: &str) -> &'a serde_yaml::Value {
-    claude_review_steps(job)
-        .iter()
-        .find(|step| step.get("name").and_then(serde_yaml::Value::as_str) == Some(name))
-        .unwrap_or_else(|| panic!("Claude review step {name} must exist"))
-}
-
-fn claude_review_step_using<'a>(job: &'a serde_yaml::Value, action: &str) -> &'a serde_yaml::Value {
-    claude_review_steps(job)
-        .iter()
-        .find(|step| {
-            step.get("uses")
-                .and_then(serde_yaml::Value::as_str)
-                .is_some_and(|uses| uses.starts_with(action))
+fn repository_workflow_names() -> (std::path::PathBuf, Vec<String>) {
+    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let workflows_dir = manifest_dir.join(".github/workflows");
+    let mut workflows = std::fs::read_dir(&workflows_dir)
+        .expect("the GitHub workflow directory must be readable")
+        .map(|entry| {
+            let entry = entry.expect("every GitHub workflow entry must be readable");
+            assert!(
+                entry
+                    .file_type()
+                    .expect("every GitHub workflow type must be readable")
+                    .is_file(),
+                "the workflow directory must contain only regular files"
+            );
+            entry
+                .file_name()
+                .into_string()
+                .expect("workflow file names must be UTF-8")
         })
-        .unwrap_or_else(|| panic!("Claude review action {action} must exist"))
+        .collect::<Vec<_>>();
+    workflows.sort();
+    (workflows_dir, workflows)
 }
 
-fn claude_review_step_with_id<'a>(job: &'a serde_yaml::Value, id: &str) -> &'a serde_yaml::Value {
-    claude_review_steps(job)
-        .iter()
-        .find(|step| step.get("id").and_then(serde_yaml::Value::as_str) == Some(id))
-        .unwrap_or_else(|| panic!("Claude review step id {id} must exist"))
-}
-
-fn claude_review_inputs(step: &serde_yaml::Value) -> &serde_yaml::Mapping {
-    step.get("with")
-        .and_then(serde_yaml::Value::as_mapping)
-        .expect("Claude review action inputs must be a mapping")
-}
-
-fn claude_input<'a>(inputs: &'a serde_yaml::Mapping, name: &str) -> Option<&'a serde_yaml::Value> {
-    inputs.get(serde_yaml::Value::String(name.into()))
-}
-
-fn normalized_job_admission(job: &serde_yaml::Value) -> String {
-    job.get("if")
-        .and_then(serde_yaml::Value::as_str)
-        .expect("Claude review job must gate its event")
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
-}
-
-fn assert_claude_review_triggers(workflow: &serde_yaml::Value) {
-    let workflow_run = workflow
-        .get("on")
-        .and_then(serde_yaml::Value::as_mapping)
-        .and_then(|triggers| triggers.get(serde_yaml::Value::String("workflow_run".into())))
-        .and_then(serde_yaml::Value::as_mapping)
-        .expect("bot reviews must use a trusted workflow_run follow-up");
-    let source_workflows: Vec<_> = workflow_run
-        .get(serde_yaml::Value::String("workflows".into()))
-        .and_then(serde_yaml::Value::as_sequence)
-        .expect("workflow_run must name its source workflow")
-        .iter()
-        .filter_map(serde_yaml::Value::as_str)
-        .collect();
-    assert_eq!(
-        source_workflows,
-        ["CI"],
-        "bot reviews must be coupled to the unprivileged CI request"
-    );
-    let activity_types: Vec<_> = workflow_run
-        .get(serde_yaml::Value::String("types".into()))
-        .and_then(serde_yaml::Value::as_sequence)
-        .expect("workflow_run must restrict its activity type")
-        .iter()
-        .filter_map(serde_yaml::Value::as_str)
-        .collect();
-    assert_eq!(
-        activity_types,
-        ["requested"],
-        "the trusted bot follow-up must start without waiting for CI completion"
-    );
-}
-
-fn assert_direct_claude_review_boundaries(workflow: &serde_yaml::Value) {
-    let job = claude_review_job(workflow, "claude-review");
-    assert_eq!(
-        normalized_job_admission(job),
-        "github.event_name == 'pull_request' && github.event.sender.type == 'User'",
-        "direct reviews must remain limited to User-triggered pull_request events"
-    );
-    let inputs = claude_review_inputs(claude_review_step_using(
-        job,
-        "anthropics/claude-code-action@",
-    ));
-    assert_eq!(
-        claude_input(inputs, "track_progress").and_then(serde_yaml::Value::as_bool),
-        Some(true),
-        "direct reviews must retain their tracking comment"
-    );
+fn assert_retired_review_providers_absent(label: &str, source: &str) {
+    let forbidden_provider_tokens = [
+        ["clau", "de"].concat(),
+        ["anth", "ropic"].concat(),
+        ["co", "dex"].concat(),
+        ["open", "ai"].concat(),
+    ];
+    let source = source.to_ascii_lowercase();
     assert!(
-        claude_input(inputs, "allowed_bots").is_none()
-            && claude_input(inputs, "allowed_non_write_users").is_none(),
-        "the direct User path must not contain an actor bypass"
-    );
-}
-
-fn assert_bot_claude_review_admission(workflow: &serde_yaml::Value) {
-    let job = claude_review_job(workflow, "claude-bot-review");
-    assert_eq!(
-        normalized_job_admission(job),
-        "github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.actor.type != 'User' && github.event.workflow_run.pull_requests[0]",
-        "the trusted follow-up must admit only non-User PR workflow runs"
-    );
-    let permissions = job
-        .get("permissions")
-        .and_then(serde_yaml::Value::as_mapping)
-        .expect("trusted Claude bot review permissions must be explicit");
-    assert!(
-        !permissions.contains_key(serde_yaml::Value::String("id-token".into())),
-        "the untrusted-diff review path must not receive OIDC minting authority"
-    );
-    let concurrency = job
-        .get("concurrency")
-        .and_then(serde_yaml::Value::as_mapping)
-        .expect("trusted Claude bot reviews must serialize per pull request");
-    assert_eq!(
-        claude_input(concurrency, "group").and_then(serde_yaml::Value::as_str),
-        Some("claude-bot-review-${{ github.event.workflow_run.pull_requests[0].number }}"),
-        "bot reviews must use a pull-request-specific concurrency group"
-    );
-    assert_eq!(
-        claude_input(concurrency, "cancel-in-progress").and_then(serde_yaml::Value::as_bool),
-        Some(true),
-        "a newer bot review must retire an in-progress predecessor"
-    );
-}
-
-fn assert_bot_claude_review_checkout(workflow: &serde_yaml::Value) {
-    let job = claude_review_job(workflow, "claude-bot-review");
-    let checkouts: Vec<_> = claude_review_steps(job)
-        .iter()
-        .filter(|step| {
-            step.get("uses")
-                .and_then(serde_yaml::Value::as_str)
-                .is_some_and(|uses| uses.starts_with("actions/checkout@"))
-        })
-        .collect();
-    assert_eq!(
-        checkouts.len(),
-        1,
-        "the privileged job must perform exactly one trusted checkout"
-    );
-    let inputs = claude_review_inputs(checkouts[0]);
-    assert_eq!(
-        claude_input(inputs, "ref").and_then(serde_yaml::Value::as_str),
-        Some("${{ github.sha }}"),
-        "workflow_run must check out only its trusted default-branch SHA"
-    );
-    assert_eq!(
-        claude_input(inputs, "persist-credentials").and_then(serde_yaml::Value::as_bool),
-        Some(false),
-        "the privileged checkout must not persist its job token"
-    );
-}
-
-fn bot_claude_review_input_script(workflow: &serde_yaml::Value) -> &str {
-    claude_review_step_named(
-        claude_review_job(workflow, "claude-bot-review"),
-        "Prepare inert PR diff",
-    )
-    .get("run")
-    .and_then(serde_yaml::Value::as_str)
-    .expect("bot review input preparation must be a shell script")
-}
-
-fn assert_bot_claude_review_input_revision(workflow: &serde_yaml::Value) {
-    let script = bot_claude_review_input_script(workflow);
-    assert!(
-        script.starts_with("set -euo pipefail\n"),
-        "trusted input preparation must fail closed on shell and pipeline errors"
-    );
-    assert!(
-        script.contains("--json baseRefOid,headRefOid,state")
-            && script.contains(".baseRefOid == $base")
-            && script.contains(".headRefOid == $head")
-            && script.contains("\"repos/$GITHUB_REPOSITORY/compare/$BASE_SHA...$HEAD_SHA\"")
-            && !script.contains("gh pr diff"),
-        "bot reviews must bind both admission and diff retrieval to the triggering revision"
-    );
-}
-
-fn assert_bot_claude_review_input_limits(workflow: &serde_yaml::Value) {
-    let script = bot_claude_review_input_script(workflow);
-    assert!(
-        script.contains("head -c 50000")
-            && script.contains("tr -d '\\000-\\010\\013\\014\\016-\\037\\177'")
-            && script.contains("[Diff truncated at 50,000 bytes.]"),
-        "the normalized diff must remain below the action's per-environment-string limit"
-    );
-    assert!(
-        script.contains("if ! gh api \\")
-            && script.contains("Compare diff unavailable; skipping bot review.")
-            && script.matches("current=false").count() >= 2,
-        "an unavailable comparison must use the established no-review path"
-    );
-}
-
-fn assert_bot_claude_review_input_boundary(workflow: &serde_yaml::Value) {
-    let script = bot_claude_review_input_script(workflow);
-    assert!(
-        script.contains("delimiter=\"DIFF_$(cat /proc/sys/kernel/random/uuid)\"")
-            && script
-                .contains("prompt_boundary=\"UNTRUSTED_DIFF_$(cat /proc/sys/kernel/random/uuid)\"")
-            && script.contains("printf 'prompt_boundary=%s\\n' \"$prompt_boundary\""),
-        "the prompt boundary must be unpredictable when the proposed diff is authored"
-    );
-}
-
-fn assert_bot_claude_review_action_inputs(workflow: &serde_yaml::Value) {
-    let action = claude_review_step_with_id(
-        claude_review_job(workflow, "claude-bot-review"),
-        "bot-review",
-    );
-    let inputs = claude_review_inputs(action);
-    assert_eq!(
-        claude_input(inputs, "allowed_bots").and_then(serde_yaml::Value::as_str),
-        Some("*"),
-        "Claude review must admit every GitHub Bot/App actor"
-    );
-    assert_eq!(
-        claude_input(inputs, "github_token").and_then(serde_yaml::Value::as_str),
-        Some("${{ github.token }}"),
-        "the bot path must use only the short-lived, job-scoped GitHub token"
-    );
-    for input in [
-        "classify_inline_comments",
-        "display_report",
-        "include_fix_links",
-    ] {
-        assert_eq!(
-            claude_input(inputs, input).and_then(serde_yaml::Value::as_bool),
-            Some(false),
-            "the tool-free bot path must disable action side-channel output"
-        );
-    }
-    assert!(
-        claude_input(inputs, "allowed_non_write_users").is_none()
-            && claude_input(inputs, "track_progress").is_none(),
-        "bot admission must not bypass write-permission checks for ordinary User actors"
-    );
-}
-
-fn assert_bot_claude_review_tools(workflow: &serde_yaml::Value) {
-    let action = claude_review_step_with_id(
-        claude_review_job(workflow, "claude-bot-review"),
-        "bot-review",
-    );
-    let args = claude_input(claude_review_inputs(action), "claude_args")
-        .and_then(serde_yaml::Value::as_str)
-        .expect("tool-free bot review must constrain Claude arguments");
-    assert!(
-        args.contains("--tools \"Read\"")
-            && args.contains("--allowedTools \"mcp__disabled__no_tools\"")
-            && args.contains("--disallowedTools \"Bash,Read,")
-            && args.contains("\"maxLength\":12000")
-            && args.contains("\"pattern\":\"^[^\\\\u0000"),
-        "the sole advertised built-in must also be bare-denied in the schema-constrained session"
-    );
-    assert_eq!(
-        action.get("if").and_then(serde_yaml::Value::as_str),
-        Some("steps.bot-input.outputs.current == 'true'"),
-        "Claude must not run after a stale revision is detected"
-    );
-}
-
-fn assert_bot_claude_review_prompt_boundary(workflow: &serde_yaml::Value) {
-    let action = claude_review_step_with_id(
-        claude_review_job(workflow, "claude-bot-review"),
-        "bot-review",
-    );
-    let prompt = claude_input(claude_review_inputs(action), "prompt")
-        .and_then(serde_yaml::Value::as_str)
-        .expect("tool-free bot review must receive an explicit prompt");
-    let boundary = "${{ steps.bot-input.outputs.prompt_boundary }}";
-    assert_eq!(
-        prompt.matches(boundary).count(),
-        2,
-        "the hostile diff must be enclosed by matching random prompt boundaries"
-    );
-    assert!(
-        !prompt.contains("<untrusted-pr-diff>"),
-        "the hostile diff must not use a predictable author-injectable closing fence"
-    );
-}
-
-fn bot_claude_review_publisher(workflow: &serde_yaml::Value) -> &serde_yaml::Value {
-    claude_review_step_named(
-        claude_review_job(workflow, "claude-bot-review"),
-        "Publish structured bot review",
-    )
-}
-
-fn bot_claude_review_publish_script(workflow: &serde_yaml::Value) -> &str {
-    bot_claude_review_publisher(workflow)
-        .get("run")
-        .and_then(serde_yaml::Value::as_str)
-        .expect("structured review publication must be a fixed shell script")
-}
-
-fn assert_bot_claude_review_publisher_gate(workflow: &serde_yaml::Value) {
-    let publisher = bot_claude_review_publisher(workflow);
-    let publication_gate = publisher
-        .get("if")
-        .and_then(serde_yaml::Value::as_str)
-        .expect("the trusted publisher must gate structured output")
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ");
-    assert_eq!(
-        publication_gate,
-        "steps.bot-input.outputs.current == 'true' && steps.bot-review.outputs.structured_output != ''",
-        "the trusted publisher must require current, nonempty structured output"
-    );
-}
-
-fn assert_bot_claude_review_publisher_revalidation(workflow: &serde_yaml::Value) {
-    let script = bot_claude_review_publish_script(workflow);
-    assert!(
-        script.starts_with("set -euo pipefail\n"),
-        "trusted publication must fail closed on shell and pipeline errors"
-    );
-    assert!(
-        script.contains("--json baseRefOid,headRefOid,state")
-            && script.contains(".baseRefOid == $base")
-            && script.contains(".headRefOid == $head"),
-        "the publisher must discard results made stale while Claude was running"
-    );
-}
-
-fn assert_bot_claude_review_publisher_rendering(workflow: &serde_yaml::Value) {
-    let script = bot_claude_review_publish_script(workflow);
-    assert!(
-        script.contains("tr -d '\\000-\\010\\013\\014\\016-\\037\\177'")
-            && script.contains("tr -d '[:space:]'")
-            && script.contains("[ ! -s \"$RUNNER_TEMP/bot-review-nonblank.txt\" ]")
-            && script.contains("Claude returned a blank review; skipping publication.")
-            && script.contains("sed 's/^/    /' \"$RUNNER_TEMP/bot-review.txt\"")
-            && !script.contains("--body \"$REVIEW\""),
-        "blank output must be skipped and nonblank model output rendered as inert text"
-    );
-}
-
-fn assert_bot_claude_review_publisher_idempotency(workflow: &serde_yaml::Value) {
-    let script = bot_claude_review_publish_script(workflow);
-    assert!(
-        script.contains("marker='<!-- claude-bot-review:v1 -->'")
-            && script.contains(".user.login == \"github-actions[bot]\"")
-            && script.contains("startswith(\"<!-- claude-bot-review:v1 -->\\n\")")
-            && !script.contains("contains(\"<!-- claude-bot-review:v1 -->")
-            && script.contains("jq -n --rawfile body \"$RUNNER_TEMP/bot-review.md\"")
-            && script.contains("--method PATCH")
-            && script.contains("--method POST")
-            && script
-                .matches("--input \"$RUNNER_TEMP/bot-review-request.json\"")
-                .count()
-                == 2
-            && !script.contains("-F \"body=@"),
-        "publication must update only its actor-owned marked comment or create it once"
+        forbidden_provider_tokens
+            .iter()
+            .all(|token| !source.contains(token)),
+        "{label} must not restore a retired AI reviewer provider"
     );
 }
 
 #[test]
-fn claude_review_accepts_bot_prs_without_opening_the_non_write_user_gate() {
-    let workflow = claude_review_workflow();
-    assert_claude_review_triggers(&workflow);
+fn hosted_ai_reviewer_remains_decommissioned() {
+    let (workflows_dir, workflows) = repository_workflow_names();
+    assert_eq!(
+        workflows,
+        [
+            "ci.yml",
+            "dependabot-automerge.yml",
+            "fuzz.yml",
+            "release.yml"
+        ],
+        "the complete workflow set must stay explicit; review every addition"
+    );
 
-    assert_direct_claude_review_boundaries(&workflow);
+    for workflow in &workflows {
+        let source = std::fs::read_to_string(workflows_dir.join(workflow))
+            .unwrap_or_else(|error| panic!("workflow {workflow} must be readable text: {error}"));
+        assert_retired_review_providers_absent(&format!("workflow {workflow}"), &source);
+    }
+    assert_retired_review_providers_absent("refinery policy", REFINERY_CONFIG);
 
-    assert_bot_claude_review_admission(&workflow);
-
-    assert_bot_claude_review_checkout(&workflow);
-
-    assert_bot_claude_review_input_revision(&workflow);
-    assert_bot_claude_review_input_limits(&workflow);
-    assert_bot_claude_review_input_boundary(&workflow);
-
-    assert_bot_claude_review_action_inputs(&workflow);
-    assert_bot_claude_review_tools(&workflow);
-    assert_bot_claude_review_prompt_boundary(&workflow);
-
-    assert_bot_claude_review_publisher_gate(&workflow);
-    assert_bot_claude_review_publisher_revalidation(&workflow);
-    assert_bot_claude_review_publisher_rendering(&workflow);
-    assert_bot_claude_review_publisher_idempotency(&workflow);
+    assert!(
+        REFINERY_CONFIG.contains("GLM 5.3 reviewer")
+            && REFINERY_CONFIG
+                .contains("Repository-owned AI review workflows are deliberately absent")
+            && REFINERY_CONFIG.contains("not GitHub Actions"),
+        "refinery policy must bind operational review to the local reviewer, not GitHub Actions"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Removes the packaging test's stale include of the deleted reviewer workflow, replaces its policy coverage with a negative decommissioning regression across active workflows, and retires the hosted reviewer wait documentation in favor of the locally configured GLM 5.3 reviewer. Validation: cargo fmt --all -- --check; cargo test --locked --test packaging_metadata (26 passed).