### PR TITLE
docs(playback): document first-valid-file OS-open discard semantics (tr-pps)

### DIFF
--- a/docs/architecture/source-lifecycle.md
+++ b/docs/architecture/source-lifecycle.md
@@ -667,7 +667,11 @@ queue can extend the same ephemeral-source rule explicitly.
 - Each accepted OS-opened file owns a hidden registry adapter with fresh independent random source
   and track identities plus the exact adopted epoch. Ordered first-accepted-audio admission runs on
   a blocking worker and rechecks its exact generation under the shutdown/publication gate before
-  identity is minted or the retained already-open file is adopted. Its one-item queue is pathless;
+  identity is minted or the retained already-open file is adopted. One delivery is one ordered
+  playback intent: candidates after the first successfully admitted audio file are deliberately
+  discarded rather than queued, and a later delivery supersedes an earlier one through the same
+  generation gate. Preserving every occurrence as a multi-file ephemeral queue is a deliberate
+  current limitation pending product approval, not committed work. Its one-item queue is pathless;
   stream resolution returns only a lease-checked file capability, embedded art clones that
   capability after output acceptance, and every terminal or superseding boundary retires the
   ephemeral adapter idempotently. Count-only OS-open diagnostics expose no path.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -669,8 +669,9 @@ license, distribution, key-material provenance, and interoperability review.
 - Direct Apple/iTunes XML, Google Takeout CSV, M3U, and service-specific playlist imports are not
   implemented. The documented conversion to XSPF is the current interoperability path, and fuzzy
   “similar name” matching is intentionally avoided.
-- OS-open delivery admits the first valid playable candidate. A multi-file ephemeral queue is a
-  possible future extension, not a committed feature.
+- OS-open delivery admits the first valid playable candidate; the remaining candidates in the same
+  delivery are discarded rather than queued. A multi-file occurrence-preserving ephemeral queue is
+  a possible future extension gated on product approval, not a committed feature.
 - A stronger platform-native removable file identifier and explicit saved-server endpoint rebind
   are possible future schema extensions, not scheduled work.
 - Proper Apple code signing/notarization and the intentionally deferred release-workflow exercise


### PR DESCRIPTION
Docs-only interim deliverable for tr-pps.

- `docs/architecture/source-lifecycle.md`: one delivery is one ordered playback intent — candidates after the first successfully admitted audio file are deliberately discarded rather than queued; a later delivery supersedes an earlier one through the same generation gate. Multi-file ephemeral queue documented as a deliberate current limitation pending product approval.
- `docs/roadmap.md`: matching roadmap wording; multi-file occurrence-preserving queue stays a possible future extension gated on product approval, not committed work.

Refinery verification (rebased on main@ab1c3f2, no-op rebase): diff review (docs-only, no tables, all added lines <=100 chars per MD013); cargo fmt --check, clippy --all-targets -D warnings, cargo test --all-targets 1804 passed / 0 failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that OS-open audio delivery uses only the first valid, playable candidate.
  - Documented that additional candidates from the same delivery are discarded.
  - Clarified that newer audio deliveries supersede earlier ones.
  - Updated the roadmap to identify multi-file, occurrence-preserving delivery as a future capability requiring product approval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->