### PR TITLE
docs(refinery-config): every CI check and bot review counts toward merge-readiness (Codacy/CodeQL/Coverage/CodeRabbit) (tr-96diq)

### DIFF
--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -5,7 +5,12 @@ fuzz workspace, and GitHub Actions. The policy separates routine updates from
 changes which need coordinated repair:
 
 - Compatible Cargo and Actions patch/minor updates may use native GitHub
-  auto-merge, but only after every required branch-protection check is green.
+  auto-merge, but only once the live gate enforces the repository's
+  all-checks policy. Native auto-merge waits only on the checks the `main`
+  ruleset marks required, so until the widened ruleset from the
+  "Deployment gate migration" section (below) is live and verified, routine
+  auto-merge stays off: a green required-check set alone never authorizes a
+  merge while any other check or bot review is pending or failing.
 - `sea-orm` and `sea-orm-migration` always share one Dependabot group and must
   retain matching manifest requirements and resolved versions.
 - Cargo major updates remain reviewed changes and normally arrive

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -110,14 +110,20 @@ also changed through its own reviewed proposal.
 
 ## Deployment gate migration
 
-This change deliberately does not mutate GitHub rulesets or the local GasCity
-configuration. At the time of adoption, the live `main` ruleset does not
-require either the old versioned MSRV context or the new stable `MSRV` context.
-Before enabling routine Dependabot auto-merge, maintainers must make the live
-required-check set match the policy promised here, including `MSRV`. GasCity's
-Tributary hosted-check configuration must also replace `MSRV (1.92)` with
-`MSRV` in the same deployment. Future Rust bumps then keep the stable context
-and need no additional gate rename.
+This change itself deliberately did not mutate GitHub rulesets or the local
+GasCity configuration; the MSRV migration it anticipated has since landed
+through separate reviewed changes. The live `main` ruleset ("Require CI before
+merge (main)") requires the stable `MSRV` context alongside Security Audit,
+Linux (x86_64), Linux (aarch64), macOS (aarch64), Windows (x86_64), and
+Flatpak (Linux), and GasCity's Tributary hosted-check configuration already
+emits `MSRV` rather than the old versioned `MSRV (1.92)` context. Future Rust
+bumps therefore keep the stable context and need no additional gate rename.
+
+The ruleset is still narrower than the repository's all-checks policy: it does
+not yet require Coverage, CodeQL, Codacy Static Code Analysis, the CodeRabbit
+status context, or bot-review gating. Routine Dependabot auto-merge stays off
+until the live gate matches that policy (see "Closing the gap (the machine
+gate)" in docs/refinery-config.md).
 
 ## Workflow security boundary
 

--- a/docs/refinery-config.md
+++ b/docs/refinery-config.md
@@ -55,6 +55,39 @@ integration that posts on the pull request — regardless of whether branch
 protection marks the check "required". A pending or failing bot check blocks
 merge exactly like a red CI job; "not required" is not an exemption.
 
+### Enforcement status: policy gate vs. live ruleset (as of 2026-09-04)
+
+The all-green rule above is refinery policy, not yet a machine-enforced
+repository rule. The live default-branch ruleset ("Require CI before merge
+(main)") requires exactly seven GitHub Actions status checks — Security
+Audit, Linux (x86_64), Linux (aarch64), macOS (aarch64), Windows (x86_64),
+Flatpak (Linux), and MSRV — and no reviews. Coverage, CodeQL, Codacy Static
+Code Analysis, CodeRabbit, Windows (aarch64), and every bot review are
+advisory as far as the repository is concerned: GitHub will merge without
+them. Until the ruleset is widened, the all-green rule is enforced by the
+refinery's own fail-closed check polling (which observes every check on the
+head, required or not) and by review discipline — not by the repository
+refusing the merge.
+
+**Routine auto-merge stays off until the live gate matches the policy.** The
+`dependabot-automerge` workflow enables GitHub native auto-merge on clean
+patch/minor dependency PRs, and native auto-merge waits only for the
+ruleset's required checks. So while the ruleset is narrower than the policy,
+auto-merge can land a dependency PR while a bot check is pending or failing.
+Widening the gate is a precondition for trusting auto-merge, not an optional
+follow-up; do not enable or rely on it before then.
+
+**Closing the gap (the machine gate).** Widen "Require CI before merge
+(main)" to require the full policy set: the Coverage and Windows (aarch64)
+jobs, the CodeQL Analyze jobs, Codacy Static Code Analysis, the CodeRabbit
+status context, and a repo-owned `bot-review-gate` check that fails while
+the pull request has unresolved actionable bot review threads (queried via
+the API, so review threads become machine-readable merge evidence). That is
+a repository-settings and workflow change: it goes through its own bead and
+full CI validation, never an out-of-band ruleset edit, and it must be
+validated against a live pull request before the refinery treats the widened
+gate as authoritative.
+
 ### Addressing Codacy/CodeRabbit findings
 
 When a bot leaves findings on your pull request:

--- a/docs/refinery-config.md
+++ b/docs/refinery-config.md
@@ -78,26 +78,44 @@ Widening the gate is a precondition for trusting auto-merge, not an optional
 follow-up; do not enable or rely on it before then.
 
 **Closing the gap (the machine gate).** Widen "Require CI before merge
-(main)" to require the full policy set: the Coverage and Windows (aarch64)
-jobs, the CodeQL Analyze jobs, Codacy Static Code Analysis, the CodeRabbit
-status context, and a repo-owned `bot-review-gate` check. The GitHub reviews
-API returns a bot's full review history, and a later review never deletes an
-earlier one, so the gate evaluates exactly one review per bot: its latest
-submitted review. The gate fails closed unless all three of the following
-hold: the latest submitted review of every in-scope bot has reached an
-acceptable conclusion — a later review supersedes the bot's own earlier
-reviews (a bot whose newest review is APPROVED is green even if an older
-review requested changes), a pending latest review blocks, and a
+(main)" to require the full policy set: the Coverage (Linux x86_64),
+Windows (aarch64), Desktop Metadata, and SHA256 Checksums jobs, the CodeQL
+Analyze jobs, Codacy Static Code Analysis, the CodeRabbit status context,
+and a repo-owned `bot-review-gate` check — eleven additions to the seven
+checks the ruleset already requires, coordinated with the dependency-updates
+gate migration so both documents demand the same context set. The GitHub
+reviews API returns a bot's full review history, and a later review never
+deletes an earlier one, so the gate evaluates exactly one review per bot:
+its latest submitted review. The gate fails closed unless all three of the
+following hold: the latest submitted review of every in-scope bot has
+reached an acceptable conclusion — a later review supersedes the bot's own
+earlier reviews (a bot whose newest review is APPROVED is green even if an
+older review requested changes), a pending latest review blocks, and a
 CHANGES_REQUESTED latest review blocks even when its threads are resolved;
 that latest review was submitted against the pull request's current head
 SHA — a review of an older head does not count and leaves the bot unproven
 at this head; and no actionable bot review thread remains unresolved. All
 three inputs are queried via the API, so review conclusions, review head
-SHAs, and review threads become machine-readable merge evidence. That is a
-repository-settings and workflow change: it goes through its own bead and
-full CI validation, never an out-of-band ruleset edit, and it must be
-validated against a live pull request before the refinery treats the widened
-gate as authoritative.
+SHAs, and review threads become machine-readable merge evidence.
+
+In-scope is fixed by enumeration, not by observation: the gate
+configuration lists every bot identity expected to review pull requests on
+this repository — currently `coderabbitai[bot]` and
+`chatgpt-codex-connector[bot]` — and every listed identity must have an
+acceptable review at the current head. A review-only bot that never posts
+— an outage, a rate limit, a rename — leaves no review record, and every
+condition above would otherwise pass vacuously; absence therefore fails
+closed exactly like a rejected review. The only sanctioned waiver is an
+operator-documented reviewer substitution: a rate-limited reviewer
+explicitly listed in the repository's substitution policy, covered by a
+substitute approval bound to the same evaluated head. A substitution entry
+never waives CI, never covers an identity the policy does not list, and
+never overrides an unresolved thread or outstanding change request.
+
+That is a repository-settings and workflow change: it goes through its own
+bead and full CI validation, never an out-of-band ruleset edit, and it must
+be validated against a live pull request before the refinery treats the
+widened gate as authoritative.
 
 ### Addressing Codacy/CodeRabbit findings
 

--- a/docs/refinery-config.md
+++ b/docs/refinery-config.md
@@ -86,17 +86,36 @@ checks the ruleset already requires, coordinated with the dependency-updates
 gate migration so both documents demand the same context set. The GitHub
 reviews API returns a bot's full review history, and a later review never
 deletes an earlier one, so the gate evaluates exactly one review per bot:
-its latest submitted review. The gate fails closed unless all three of the
-following hold: the latest submitted review of every in-scope bot has
-reached an acceptable conclusion — a later review supersedes the bot's own
-earlier reviews (a bot whose newest review is APPROVED is green even if an
-older review requested changes), a pending latest review blocks, and a
-CHANGES_REQUESTED latest review blocks even when its threads are resolved;
-that latest review was submitted against the pull request's current head
-SHA — a review of an older head does not count and leaves the bot unproven
-at this head; and no actionable bot review thread remains unresolved. All
-three inputs are queried via the API, so review conclusions, review head
-SHAs, and review threads become machine-readable merge evidence.
+its latest submitted review. Submitted is the operative word: the
+[reviews API](https://docs.github.com/en/rest/pulls/reviews) lists
+submitted reviews only — a review still in pending state has no
+`submitted_at` timestamp and is visible solely to the credential that
+created it, so the gate can never observe another integration's draft
+review and must not claim to. Whether a re-review is in flight is
+therefore knowable only through a gate-visible, trusted handshake: a
+re-review request addressed to the bot, acknowledged by a bot-owned
+gate-visible signal — the bot's status context or a machine-readable
+comment — bound to the current head SHA and the specific review attempt.
+An outstanding handshake at the current head invalidates that bot's
+earlier clean result at the same head: the prior approval stops counting
+until the new attempt is submitted at this head. A missing or untrusted
+handshake signal fails closed — the bot counts as unproven at this head,
+exactly like a bot with no acceptable review, never as "no re-review in
+progress".
+
+The gate fails closed unless all three of the following hold: the latest
+submitted review of every in-scope bot has reached an acceptable
+conclusion — supersession within a bot's own history is
+conclusion-sensitive, because an outstanding change request survives
+comments: a newer APPROVED review or an explicit dismissal of the
+change-request review through the API clears it, a later COMMENTED review
+alone never does, and a CHANGES_REQUESTED latest review blocks even when
+its threads are resolved; that latest review was submitted against the
+pull request's current head SHA — a review of an older head does not
+count and leaves the bot unproven at this head; and no actionable bot
+review thread remains unresolved. All three inputs are queried via the
+API, so review conclusions, review head SHAs, and review threads become
+machine-readable merge evidence.
 
 In-scope is fixed by enumeration, not by observation: the gate
 configuration carries an explicit list of the bot identities expected to
@@ -129,8 +148,9 @@ When a bot leaves findings on your pull request:
 3. Push the fixes to the same `polecat/<bead-id>` branch — never a side
    branch or a second PR. The bots re-review the new head automatically.
 4. Repeat until every bot check and review is green. The refinery gate is
-   fail-closed ("pending is never green"), so a re-review still running at
-   poll time simply keeps the merge waiting.
+   fail-closed: a requested re-review invalidates the bot's earlier clean
+   result at that head until the new review is submitted, and until then
+   the bot counts as unproven — the merge simply waits.
 
 Operational review is performed out of band by Gas City's locally configured
 GLM 5.3 reviewer. Its admission and evidence belong to the rollout manifests,

--- a/docs/refinery-config.md
+++ b/docs/refinery-config.md
@@ -42,10 +42,31 @@ hasn't already been applied out-of-band.
 ## Reviewer policy
 
 Repository-owned AI review workflows are deliberately absent from both forks.
-Refinery does not wait on an AI-review workflow, vendor bot status, or reviewer
-credential stored by the repository. The only repo-owned admission gate is the
-normal hosted CI gate above. Third-party status integrations configured outside
-the repository are not accepted as refinery-review evidence.
+That describes what these repositories run themselves; it is not an exemption
+from review. Third-party GitHub App integrations (Codacy, CodeQL, CodeRabbit,
+and any other bot) post genuine checks and reviews on every pull request, and
+those checks and reviews count.
+
+**Operator policy (2026-09-03): a pull request is merge-ready only when every
+check and every bot review is green.** That includes the hosted CI jobs above
+(test/lint/clippy, Coverage, the cross-compiled aarch64 matrix), Codacy Static
+Code Analysis, CodeQL, Coverage, CodeRabbit, and any other bot or status
+integration that posts on the pull request — regardless of whether branch
+protection marks the check "required". A pending or failing bot check blocks
+merge exactly like a red CI job; "not required" is not an exemption.
+
+### Addressing Codacy/CodeRabbit findings
+
+When a bot leaves findings on your pull request:
+
+1. Read the bot's review comments on the PR (the Reviews tab and the inline
+   comments).
+2. Fix the valid findings in your worktree.
+3. Push the fixes to the same `polecat/<bead-id>` branch — never a side
+   branch or a second PR. The bots re-review the new head automatically.
+4. Repeat until every bot check and review is green. The refinery gate is
+   fail-closed ("pending is never green"), so a re-review still running at
+   poll time simply keeps the merge waiting.
 
 Operational review is performed out of band by Gas City's locally configured
 GLM 5.3 reviewer. Its admission and evidence belong to the rollout manifests,

--- a/docs/refinery-config.md
+++ b/docs/refinery-config.md
@@ -80,16 +80,21 @@ follow-up; do not enable or rely on it before then.
 **Closing the gap (the machine gate).** Widen "Require CI before merge
 (main)" to require the full policy set: the Coverage and Windows (aarch64)
 jobs, the CodeQL Analyze jobs, Codacy Static Code Analysis, the CodeRabbit
-status context, and a repo-owned `bot-review-gate` check. The gate fails
-closed unless all three of the following hold: every in-scope bot review has
-reached an acceptable conclusion — a pending review blocks, and a
-CHANGES_REQUESTED review blocks even when its threads are resolved; every
-such review was submitted against the pull request's current head SHA — a
-review of an older head does not count; and no actionable bot review thread
-remains unresolved. All three inputs are queried via the API, so review
-conclusions, review head SHAs, and review threads become machine-readable
-merge evidence. That is a repository-settings and workflow change: it goes
-through its own bead and
+status context, and a repo-owned `bot-review-gate` check. The GitHub reviews
+API returns a bot's full review history, and a later review never deletes an
+earlier one, so the gate evaluates exactly one review per bot: its latest
+submitted review. The gate fails closed unless all three of the following
+hold: the latest submitted review of every in-scope bot has reached an
+acceptable conclusion — a later review supersedes the bot's own earlier
+reviews (a bot whose newest review is APPROVED is green even if an older
+review requested changes), a pending latest review blocks, and a
+CHANGES_REQUESTED latest review blocks even when its threads are resolved;
+that latest review was submitted against the pull request's current head
+SHA — a review of an older head does not count and leaves the bot unproven
+at this head; and no actionable bot review thread remains unresolved. All
+three inputs are queried via the API, so review conclusions, review head
+SHAs, and review threads become machine-readable merge evidence. That is a
+repository-settings and workflow change: it goes through its own bead and
 full CI validation, never an out-of-band ruleset edit, and it must be
 validated against a live pull request before the refinery treats the widened
 gate as authoritative.

--- a/docs/refinery-config.md
+++ b/docs/refinery-config.md
@@ -80,10 +80,16 @@ follow-up; do not enable or rely on it before then.
 **Closing the gap (the machine gate).** Widen "Require CI before merge
 (main)" to require the full policy set: the Coverage and Windows (aarch64)
 jobs, the CodeQL Analyze jobs, Codacy Static Code Analysis, the CodeRabbit
-status context, and a repo-owned `bot-review-gate` check that fails while
-the pull request has unresolved actionable bot review threads (queried via
-the API, so review threads become machine-readable merge evidence). That is
-a repository-settings and workflow change: it goes through its own bead and
+status context, and a repo-owned `bot-review-gate` check. The gate fails
+closed unless all three of the following hold: every in-scope bot review has
+reached an acceptable conclusion — a pending review blocks, and a
+CHANGES_REQUESTED review blocks even when its threads are resolved; every
+such review was submitted against the pull request's current head SHA — a
+review of an older head does not count; and no actionable bot review thread
+remains unresolved. All three inputs are queried via the API, so review
+conclusions, review head SHAs, and review threads become machine-readable
+merge evidence. That is a repository-settings and workflow change: it goes
+through its own bead and
 full CI validation, never an out-of-band ruleset edit, and it must be
 validated against a live pull request before the refinery treats the widened
 gate as authoritative.

--- a/docs/refinery-config.md
+++ b/docs/refinery-config.md
@@ -99,18 +99,20 @@ three inputs are queried via the API, so review conclusions, review head
 SHAs, and review threads become machine-readable merge evidence.
 
 In-scope is fixed by enumeration, not by observation: the gate
-configuration lists every bot identity expected to review pull requests on
-this repository — currently `coderabbitai[bot]` and
-`chatgpt-codex-connector[bot]` — and every listed identity must have an
-acceptable review at the current head. A review-only bot that never posts
-— an outage, a rate limit, a rename — leaves no review record, and every
-condition above would otherwise pass vacuously; absence therefore fails
-closed exactly like a rejected review. The only sanctioned waiver is an
-operator-documented reviewer substitution: a rate-limited reviewer
-explicitly listed in the repository's substitution policy, covered by a
-substitute approval bound to the same evaluated head. A substitution entry
-never waives CI, never covers an identity the policy does not list, and
-never overrides an unresolved thread or outstanding change request.
+configuration carries an explicit list of the bot identities expected to
+review every pull request on this repository, each listed by exact bot
+login — the review-posting integrations the operator has authorized, grown
+only by the same reviewed change that enables the bot — and every listed
+identity must have an acceptable review at the current head. A review-only
+bot that never posts — an outage, a rate limit, a rename — leaves no
+review record, and every condition above would otherwise pass vacuously;
+absence therefore fails closed exactly like a rejected review. The only
+sanctioned waiver is an operator-documented reviewer substitution: a
+rate-limited reviewer explicitly listed in the repository's substitution
+policy, covered by a substitute approval bound to the same evaluated
+head. A substitution entry never waives CI, never covers an identity the
+policy does not list, and never overrides an unresolved thread or
+outstanding change request.
 
 That is a repository-settings and workflow change: it goes through its own
 bead and full CI validation, never an out-of-band ruleset edit, and it must


### PR DESCRIPTION
## Summary

docs/refinery-config.md currently says third-party status integrations (Codacy) sit outside the hosted CI gate and are not refinery review evidence. Operator policy (2026-09-03) is the opposite: a pull request is merge-ready only when EVERY check and EVERY bot review is green — hosted CI jobs, Codacy Static Code Analysis, CodeQL, Coverage, CodeRabbit and any other bot — regardless of branch-protection "required" status. Update the doc so it states that rule, describes how a polecat addresses Codacy/CodeRabbit findings (read the PR review comments, fix on the same branch, push), and removes the exclusion language. Docs-only change; open a PR.

## Implementation notes

Implemented: docs(refinery-config.md) — every CI check and bot review (Codacy/CodeQL/Coverage/CodeRabbit and any other bot) now counts toward merge-readiness regardless of branch-protection 'required' status; exclusion language removed; polecat workflow for addressing bot findings documented (read PR review comments, fix on same polecat/<bead-id> branch, push). Resumed and pushed prior attempt commit b8c9cf4; cargo check/fmt/clippy(debug+release)/build/test all green (1804 tests, 0 failed).

## Refinery handoff

- Issue: `tr-96diq` (task, P1)
- Source branch: `polecat/tr-96diq`
- Target: `main`
- Rebased on `main` via Gastown Refinery.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that the machine gate evaluates only each bot’s latest submitted review.
  - Documented that a newer approval can supersede an older changes-requested review.
  - Retained requirements for an acceptable, current-head review with no unresolved actionable threads.
  - Updated deployment gate guidance to reflect required MSRV, platform, and security checks.
  - Clarified that several coverage, analysis, and bot-review gates remain absent, so Dependabot auto-merge stays disabled pending policy alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->