### PR TITLE
Pre-existing flake: lastfm client test response_body_and_deadline_are_bounded races under full-suite parallel load (tr-wbzb2)

### DIFF
--- a/src/lastfm/client.rs
+++ b/src/lastfm/client.rs
@@ -2240,21 +2240,36 @@ mod tests {
             ])])
             .await;
         let endpoint = format!("{}/2.0/", service.base_url());
-        let client = LastFmClient::with_test_policy(
+        // Each bound is exercised with the other held slack so full-suite
+        // parallel load cannot reorder which limit fires. Sharing one tight
+        // policy (the production shape) made BodyLimit versus Timeout a
+        // scheduler race: the request-level timeout also covers connect and
+        // header wait, so a starved runtime lost the oversized-body race
+        // before the size check could run.
+        let body_limited = LastFmClient::with_test_policy(
             &endpoint,
             credentials(),
             RequestPolicy {
-                timeout: Duration::from_millis(25),
+                timeout: Duration::from_secs(5),
                 maximum_response_bytes: 64,
                 maximum_form_bytes: MAX_FORM_BODY_BYTES,
             },
         );
         assert_eq!(
-            client.request_auth_token().await.err(),
+            body_limited.request_auth_token().await.err(),
             Some(LastFmClientError::BodyLimit)
         );
+        let deadline_bounded = LastFmClient::with_test_policy(
+            &endpoint,
+            credentials(),
+            RequestPolicy {
+                timeout: Duration::from_millis(25),
+                maximum_response_bytes: MAX_RESPONSE_BODY_BYTES,
+                maximum_form_bytes: MAX_FORM_BODY_BYTES,
+            },
+        );
         assert_eq!(
-            client.request_auth_token().await.err(),
+            deadline_bounded.request_auth_token().await.err(),
             Some(LastFmClientError::Timeout)
         );
         service.finish().await;


### PR DESCRIPTION
## Summary

Timing-sensitive assertion in src/lastfm/client.rs:2252 (test response_body_and_deadline_are_bounded) asserts Some(BodyLimit) wins over Some(Timeout), but under full-suite parallel cargo test --all-targets load the deadline path can win instead (observed: left Some(Timeout), right Some(BodyLimit)).

Evidence from refinery patrol on tr-7aksm (branch polecat/tr-7aksm, base dd7d751):
- Full suite on branch: 1 failure (this test); 1748 passed
- Same test in isolation on branch: passes 3/3
- Full suite on branch, second run: all green
- Full suite on origin/main dd7d751: all green (single sample)
- Branch does not modify src/lastfm/client.rs

The racy assertion is identical on target; added parallel test load (e.g. new lastfm policy tests) increases the probability of losing the race. The assertion should either accept either bounded-error kind or serialize/determinize the race (e.g. loopback server controlling timing). Filed by refinery during tr-7aksm merge patrol; merge proceeded since failure was not caused by the branch.

## Refinery handoff

- Issue: `tr-wbzb2` (bug, P1)
- Source branch: `polecat/tr-wbzb2`
- Target: `main`
- Rebased on `main` via Gastown Refinery.
