### PR TITLE
feat(authority): typed retained mutation authority before Properties/tag writes for pathless sources (tr-mms4s)

### DIFF
--- a/docs/task.md
+++ b/docs/task.md
@@ -485,12 +485,16 @@ full acceptance is binding; the checklist below indexes it. No new record has a 
 
 ### P3.3 — Authority and queue extensions
 
-- [ ] **P3.3-A** — Add typed retained mutation authority before enabling Properties/tag writes for
+- [x] **P3.3-A** — Add typed retained mutation authority before enabling Properties/tag writes for
   pathless removable rows; revalidate the mount, ancestry, exact file, write rights, and replacement
   target through commit.
 
-  In flight; #232 / `tr-mms4s`. Coordinate common authority with R1 without treating
-  path-only local preflight as removable authority. Retain stale-target rollback and repeat-save tests.
+  Done on #232 / `tr-mms4s`. `MountedRootAuthority::open_mutation_target` binds the mount,
+  ancestry, and exact accepted file into a retained target whose commit sections revalidate
+  everything before any byte moves, and removable Properties edits flow through it — so a remount,
+  rename, or swapped file fails closed instead of retargeting the overwrite. Common authority is
+  coordinated with R1; path-only local preflight is not treated as removable authority.
+  Stale-target rollback and repeat-save tests are retained.
 
 - [ ] **P3.3-B** — If product-approved, turn multi-file OS-open deliveries into an
   occurrence-preserving ephemeral queue; keep the current first-valid-file behavior documented until

--- a/src/local/resolver.rs
+++ b/src/local/resolver.rs
@@ -16,8 +16,8 @@ use thiserror::Error;
 use crate::architecture::media::MediaLease;
 use crate::db::entities::{library_root, track};
 
-pub use super::root_authority::MountedRootAuthority;
 use super::root_authority::{BoundFile, RootAuthorityLease};
+pub use super::root_authority::{MountedMutationTarget, MountedRootAuthority};
 
 /// A dead or remote filesystem must not leave GTK waiting indefinitely for a
 /// local load decision. SQLite has its own five-second busy timeout; use the

--- a/src/local/root_authority.rs
+++ b/src/local/root_authority.rs
@@ -13,6 +13,7 @@ use std::fmt;
 use std::fs::File;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use uuid::Uuid;
 
@@ -470,6 +471,169 @@ impl MountedRootAuthority {
     pub(crate) fn validate(&self) -> io::Result<()> {
         validate_root_binding(self)
     }
+
+    /// Open and retain one exact accepted descendant as a mutation target.
+    ///
+    /// The descendant must be a real regular file named by strict mount-
+    /// relative components. The retained mount authority, its ancestor chain,
+    /// and the exact file handle stay bound for the target's entire lifetime;
+    /// a commit section revalidates all of them immediately before the atomic
+    /// replacement is allowed to proceed.
+    pub(crate) fn open_mutation_target(
+        self: &Arc<Self>,
+        relative: &Path,
+    ) -> io::Result<MountedMutationTarget> {
+        let bound = self.open_relative_regular_file(relative)?;
+        Ok(MountedMutationTarget {
+            authority: Arc::clone(self),
+            relative_path: bound
+                .path
+                .strip_prefix(&self.root)
+                .map_err(|_| {
+                    invalid_input("mutation target path must descend from its mounted root")
+                })?
+                .to_path_buf(),
+            path: bound.path.clone(),
+            file: Mutex::new(bound),
+        })
+    }
+}
+
+/// Typed retained authority to atomically replace one exact regular file
+/// beneath a live mounted root.
+///
+/// A path alone cannot prove that the file a user selected is still the file
+/// a later write would replace. A [`MountedMutationTarget`] retains the
+/// mounted root authority and the exact accepted file object, serializes its
+/// commit sections, and requires — immediately before each replacement — that
+/// the mount, the retained ancestry, and the exact pathname still name the
+/// file the authority admitted. Any uncertainty fails the commit closed and
+/// leaves the filesystem untouched.
+pub struct MountedMutationTarget {
+    authority: Arc<MountedRootAuthority>,
+    relative_path: PathBuf,
+    path: PathBuf,
+    file: Mutex<BoundFile>,
+}
+
+impl fmt::Debug for MountedMutationTarget {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("MountedMutationTarget")
+            .finish_non_exhaustive()
+    }
+}
+
+impl MountedMutationTarget {
+    /// Return the mount-relative pathname this target was admitted under.
+    ///
+    /// The native mount location is deliberately absent: only the mount-
+    /// relative identity the source catalogue published may cross a boundary.
+    pub(crate) fn relative_path(&self) -> &Path {
+        &self.relative_path
+    }
+
+    /// Return the exact native pathname an authorized replacement renames
+    /// over. This is private machinery for the local tag writer and must not
+    /// be logged or formatted.
+    pub(crate) fn replacement_path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Re-bind the retained exact file to the object now admitted at this
+    /// target's accepted mount-relative path.
+    ///
+    /// A successful atomic replacement deliberately retires the object the
+    /// commit section copied from: the pathname names the replacement. A
+    /// follow-up commit (a batch retry, or a second edit) must anchor to that
+    /// exact current object instead of failing against the displaced one.
+    /// Failure here is not a commit failure; the next commit section
+    /// revalidates fail-closed regardless.
+    pub(crate) fn rebind(&self) -> io::Result<()> {
+        let mut file = self
+            .file
+            .lock()
+            .map_err(|_| io::Error::other("mutation target commit section is unavailable"))?;
+        let rebound = self
+            .authority
+            .open_relative_regular_file(&self.relative_path)?;
+        *file = rebound;
+        Ok(())
+    }
+
+    /// Revalidate the retained mount binding and exact file object.
+    ///
+    /// Every error is a loss of authority. This reopens the mount path and
+    /// compares it against the retained root, boundary, ancestor chain, mount
+    /// generation, and exact file identity; it never falls back to looser
+    /// evidence such as canonical-path equality.
+    pub(crate) fn validate(&self) -> io::Result<()> {
+        let file = self
+            .file
+            .lock()
+            .map_err(|_| io::Error::other("mutation target commit section is unavailable"))?;
+        validate_mounted_bound(self.authority.as_ref(), &file)
+    }
+
+    /// Begin one serialized commit section over this exact target.
+    ///
+    /// The retained mount binding and exact file object are revalidated
+    /// before the section starts and the section holds the target's commit
+    /// lock until the guard is dropped, so overlapping commits observe either
+    /// the pre-commit or post-rebind object — never a mixed one.
+    pub(crate) fn begin_commit(&self) -> io::Result<MountedMutationCommit<'_>> {
+        let file = self
+            .file
+            .lock()
+            .map_err(|_| io::Error::other("mutation target commit section is unavailable"))?;
+        validate_mounted_bound(self.authority.as_ref(), &file)?;
+        Ok(MountedMutationCommit { target: self, file })
+    }
+}
+
+/// One serialized commit section over a [`MountedMutationTarget`].
+pub struct MountedMutationCommit<'a> {
+    target: &'a MountedMutationTarget,
+    file: MutexGuard<'a, BoundFile>,
+}
+
+impl MountedMutationCommit<'_> {
+    /// Clone the exact admitted file object as the mutation's read source.
+    ///
+    /// The clone is taken from the retained handle, never from the pathname,
+    /// so the copied bytes are the bytes the authority admitted even if the
+    /// pathname was disturbed while the section was preparing.
+    pub(crate) fn source_file(&self) -> io::Result<File> {
+        self.file.object.validate_live()?;
+        self.file.object.file.try_clone()
+    }
+
+    /// Prove the replacement target immediately before an atomic rename.
+    ///
+    /// The mounted root is revalidated against its retained identity, and the
+    /// exact pathname must still name the retained object. A file that was
+    /// renamed away, replaced, or removed refuses the replacement: the write
+    /// is authorized for the file the user selected, not for whatever now
+    /// occupies its old name.
+    pub(crate) fn confirm_replacement_target(&self) -> io::Result<()> {
+        self.target.authority.validate()?;
+        self.file.object.validate_live()?;
+        let current = File::open(&self.target.path)?;
+        if object_identity(&current)? != self.file.object.identity {
+            return Err(authority_changed(
+                "mutation target no longer names the retained file",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Verify a mounted bound against its retained mount authority.
+fn validate_mounted_bound(authority: &MountedRootAuthority, bound: &BoundFile) -> io::Result<()> {
+    validate_bound_token(authority, bound.lease_token)?;
+    bound.object.validate_live()?;
+    validate_retained_objects(&bound.parent_guards)?;
+    authority.validate()
 }
 
 impl RootAuthorityLease {
@@ -1642,6 +1806,94 @@ mod tests {
         assert!(bound
             .try_clone_for_mounted_consumption(&second_authority)
             .is_err());
+    }
+
+    #[test]
+    fn mutation_target_retains_the_exact_file_through_a_commit_section() {
+        let directory = TestDirectory::new("mutation-commit");
+        let album = directory.path().join("album");
+        fs::create_dir(&album).expect("create album");
+        fs::write(album.join("song.flac"), b"mounted audio").expect("write song");
+
+        let authority =
+            Arc::new(MountedRootAuthority::acquire(directory.path()).expect("acquire authority"));
+        let target = authority
+            .open_mutation_target(Path::new("album/song.flac"))
+            .expect("open mutation target");
+        assert_eq!(target.relative_path(), Path::new("album/song.flac"));
+        target.validate().expect("validate retained target");
+
+        // The commit section reads from the retained handle — never a path
+        // lookup — and proves the pathname still names the admitted object.
+        let commit = target.begin_commit().expect("begin commit section");
+        let mut source = commit.source_file().expect("clone retained source");
+        let mut contents = Vec::new();
+        source.read_to_end(&mut contents).expect("read source");
+        assert_eq!(contents, b"mounted audio");
+        commit
+            .confirm_replacement_target()
+            .expect("confirm untouched replacement target");
+    }
+
+    #[test]
+    fn mutation_target_refuses_replacement_after_the_path_names_another_file() {
+        let directory = TestDirectory::new("mutation-swap");
+        let song = directory.path().join("song.flac");
+        fs::write(&song, b"original audio").expect("write song");
+
+        let authority =
+            Arc::new(MountedRootAuthority::acquire(directory.path()).expect("acquire authority"));
+        let target = authority
+            .open_mutation_target(Path::new("song.flac"))
+            .expect("open mutation target");
+
+        // Swap the pathname between selection and commit, as an outside
+        // writer could. The retained object stays live and still reads its
+        // admitted bytes, but the pathname no longer names it — so the
+        // commit must refuse rather than replace whatever took its place.
+        let displaced = directory.path().join("displaced.flac");
+        fs::rename(&song, &displaced).expect("displace the admitted file");
+        fs::write(&song, b"replacement audio").expect("install different bytes");
+
+        target.validate().expect("retained object is still live");
+        let commit = target.begin_commit().expect("commit section opens");
+        let mut source = commit.source_file().expect("clone retained source");
+        let mut contents = Vec::new();
+        source.read_to_end(&mut contents).expect("read source");
+        assert_eq!(contents, b"original audio");
+        commit
+            .confirm_replacement_target()
+            .expect_err("the pathname no longer names the admitted file");
+    }
+
+    #[test]
+    fn mutation_target_rebind_anchors_to_the_object_now_at_its_path() {
+        let directory = TestDirectory::new("mutation-rebind");
+        let song = directory.path().join("song.flac");
+        fs::write(&song, b"original audio").expect("write song");
+
+        let authority =
+            Arc::new(MountedRootAuthority::acquire(directory.path()).expect("acquire authority"));
+        let target = authority
+            .open_mutation_target(Path::new("song.flac"))
+            .expect("open mutation target");
+
+        let displaced = directory.path().join("displaced.flac");
+        fs::rename(&song, &displaced).expect("displace the admitted file");
+        fs::write(&song, b"replacement audio").expect("install different bytes");
+
+        // A successful replacement retires the object the section copied
+        // from; rebind anchors the evidence to the object now at the path so
+        // a follow-up commit is authorized for the file that exists now.
+        target.rebind().expect("rebind to the replacement");
+        let commit = target.begin_commit().expect("begin section after rebind");
+        commit
+            .confirm_replacement_target()
+            .expect("the rebound object is the admitted one");
+        let mut source = commit.source_file().expect("clone rebound source");
+        let mut contents = Vec::new();
+        source.read_to_end(&mut contents).expect("read source");
+        assert_eq!(contents, b"replacement audio");
     }
 
     #[cfg(unix)]

--- a/src/local/root_authority.rs
+++ b/src/local/root_authority.rs
@@ -945,7 +945,7 @@ impl MountedMutationCommit<'_> {
                 // displaced objects stay under their quarantine names: debris,
                 // never destruction.
                 let _ =
-                    std::fs::rename(&self.target.path, &parent_dir.join(quarantine_name(&leaf)));
+                    std::fs::rename(&self.target.path, parent_dir.join(quarantine_name(&leaf)));
                 let _ = rename_noreplace(&quarantine_path, &self.target.path);
                 return Err(authority_changed(
                     "the mutation target leaf was recreated during the commit",

--- a/src/local/root_authority.rs
+++ b/src/local/root_authority.rs
@@ -2824,6 +2824,26 @@ mod tests {
         assert!(parse_fdinfo_mount_generation("mnt_id:\t1\nmnt_id:\t2\n").is_err());
     }
 
+    /// Assert that a refused commit left no quarantine sibling behind: the
+    /// caller's staging name must already be cleaned up so only replacement
+    /// debris could match.
+    fn assert_no_quarantine_sibling_remains(directory: &TestDirectory) {
+        let leftovers: Vec<PathBuf> = fs::read_dir(directory.path())
+            .expect("list the directory")
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.contains("tributary-replaced"))
+            })
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "a refused commit must restore the displaced leaf and leave no quarantine sibling: {leftovers:?}"
+        );
+    }
+
     /// The replacement must be conditional on the confirmed leaf identity.
     /// An external writer that swaps the leaf after the confirm step has
     /// proven it — precisely what a plain rename over the name would
@@ -2894,20 +2914,7 @@ mod tests {
             "the staged copy must survive a refused commit for the caller to clean up"
         );
         fs::remove_file(&staged).expect("remove the staged copy");
-        let leftovers: Vec<PathBuf> = fs::read_dir(directory.path())
-            .expect("list the directory")
-            .filter_map(|entry| entry.ok())
-            .map(|entry| entry.path())
-            .filter(|path| {
-                path.file_name()
-                    .and_then(|name| name.to_str())
-                    .is_some_and(|name| name.contains("tributary-replaced"))
-            })
-            .collect();
-        assert!(
-            leftovers.is_empty(),
-            "a refused commit must restore the swapped leaf and leave no quarantine sibling: {leftovers:?}"
-        );
+        assert_no_quarantine_sibling_remains(&directory);
     }
 
     /// Two targets admitted for the same leaf at different times must

--- a/src/local/root_authority.rs
+++ b/src/local/root_authority.rs
@@ -3079,6 +3079,42 @@ mod tests {
         );
     }
 
+    /// Assert the refused commit returned the confirmed original to its own
+    /// name, byte-exact.
+    fn assert_confirmed_original_restored_to_its_name(leaf: &Path) {
+        assert_eq!(
+            fs::read(leaf).expect("read the leaf back"),
+            b"original audio",
+            "the refused commit must restore the confirmed original to its own name"
+        );
+    }
+
+    /// Assert the recreated newcomer survived the refused install —
+    /// displaced under exactly one fresh quarantine sibling, byte-for-byte
+    /// intact.
+    fn assert_recreated_newcomer_displaced_under_one_fresh_sibling(directory: &TestDirectory) {
+        let siblings: Vec<PathBuf> = fs::read_dir(directory.path())
+            .expect("list the directory")
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.contains("tributary-replaced"))
+            })
+            .collect();
+        assert_eq!(
+            siblings.len(),
+            1,
+            "exactly the recreated newcomer may remain, displaced under one fresh sibling: {siblings:?}"
+        );
+        assert_eq!(
+            fs::read(&siblings[0]).expect("read the displaced newcomer"),
+            b"newcomer audio",
+            "the preserved newcomer must be byte-for-byte intact"
+        );
+    }
+
     /// The replacement must be conditional on the confirmed leaf identity.
     /// An external writer that swaps the leaf after the confirm step has
     /// proven it — precisely what a plain rename over the name would
@@ -3196,35 +3232,11 @@ mod tests {
             },
         );
 
-        // The confirmed original is back under its own name, byte-exact.
-        assert_eq!(
-            fs::read(&song).expect("read the leaf back"),
-            b"original audio",
-            "the refused commit must restore the confirmed original to its own name"
-        );
-
-        // The newcomer survives — displaced under a fresh quarantine sibling,
+        // The confirmed original is back under its own name, byte-exact, and
+        // the newcomer survives — displaced under a fresh quarantine sibling,
         // never destroyed by the refused install.
-        let siblings: Vec<PathBuf> = fs::read_dir(directory.path())
-            .expect("list the directory")
-            .filter_map(|entry| entry.ok())
-            .map(|entry| entry.path())
-            .filter(|path| {
-                path.file_name()
-                    .and_then(|name| name.to_str())
-                    .is_some_and(|name| name.contains("tributary-replaced"))
-            })
-            .collect();
-        assert_eq!(
-            siblings.len(),
-            1,
-            "exactly the recreated newcomer may remain, displaced under one fresh sibling: {siblings:?}"
-        );
-        assert_eq!(
-            fs::read(&siblings[0]).expect("read the displaced newcomer"),
-            b"newcomer audio",
-            "the preserved newcomer must be byte-for-byte intact"
-        );
+        assert_confirmed_original_restored_to_its_name(&song);
+        assert_recreated_newcomer_displaced_under_one_fresh_sibling(&directory);
 
         // A refused commit does not consume the staged copy; the caller
         // cleans it up.

--- a/src/local/root_authority.rs
+++ b/src/local/root_authority.rs
@@ -8,7 +8,12 @@
 //! mount-generation checks to an ephemeral mounted root without requiring the
 //! removable filesystem to contain an application marker.
 
-use std::ffi::{OsStr, OsString};
+// `OsStr` is only referenced by `#[cfg(unix)]` helpers (e.g.
+// `open_unix_regular_at`); importing it unconditionally breaks the Windows
+// build with an unused-import error under `-D warnings`.
+#[cfg(unix)]
+use std::ffi::OsStr;
+use std::ffi::OsString;
 use std::fmt;
 use std::fs::File;
 use std::io::{self, Read};

--- a/src/local/root_authority.rs
+++ b/src/local/root_authority.rs
@@ -595,10 +595,10 @@ pub struct MountedMutationCommit<'a> {
 /// object's identity — ext4 hands recently freed inodes to the next file
 /// created in the same directory, so an unlink-plus-recreate swap can
 /// produce a different object with the same `(device, inode)` pair. The
-/// open handle pins the published object: on unix it exposes the link
-/// count that proves the object was not unlinked, and on every platform
-/// an object with an open handle still exists and holds its identity, so
-/// no later creation can alias it.
+/// open handle pins the published object: on unix and Windows it exposes
+/// the link count that proves the object was not unlinked, and on every
+/// platform an object with an open handle still exists and holds its
+/// identity, so no later creation can alias it.
 struct InstalledReplacement {
     identity: ObjectIdentity,
     published: File,
@@ -608,7 +608,11 @@ impl InstalledReplacement {
     /// Prove the published object is still live and linked, returning the
     /// identity the re-anchor may condition on.
     ///
-    /// On unix a handle to an unlinked object reports zero links: without
+    /// A handle to an unlinked object reports zero links — on unix through
+    /// `st_nlink`, and on Windows through `GetFileInformationByHandle`'s
+    /// `nNumberOfLinks`, which drops to zero when the object's last name is
+    /// removed under POSIX delete semantics even though the open handle
+    /// keeps working and a plain `metadata()` read keeps succeeding. Without
     /// this check, a leaf swap whose stranger recycled the published
     /// object's identity would pass the re-anchor's identity comparison
     /// and anchor the target to a file the user never selected.
@@ -629,7 +633,15 @@ impl InstalledReplacement {
                 ));
             }
         }
-        #[cfg(not(unix))]
+        #[cfg(windows)]
+        {
+            if windows_published_link_count(&self.published)? == 0 {
+                return Err(authority_changed(
+                    "the proven replacement was removed before the target could re-anchor",
+                ));
+            }
+        }
+        #[cfg(not(any(unix, windows)))]
         {
             let _ = self.published.metadata()?;
         }
@@ -2004,6 +2016,39 @@ fn object_identity(file: &File) -> io::Result<ObjectIdentity> {
         volume: u64::from(legacy.dwVolumeSerialNumber),
         file_id: WindowsFileId::Legacy(legacy_id),
     })
+}
+
+/// Read the link count of an open file through its handle on Windows.
+///
+/// `GetFileInformationByHandle` reports the same liveness signal unix
+/// exposes through `st_nlink`: when a file's last name is removed under
+/// POSIX delete semantics, the reported count drops to zero while the open
+/// handle keeps working — and a plain `metadata()` read keeps succeeding,
+/// so the link count, not the read's success, is the deleted-object proof.
+/// The call reads the object through the handle itself, never through a
+/// name, so a removed or replaced directory entry cannot influence it. A
+/// failed read means liveness cannot be proven and the caller fails closed.
+#[cfg(windows)]
+fn windows_published_link_count(file: &File) -> io::Result<u32> {
+    use std::mem::MaybeUninit;
+    use std::os::windows::io::AsRawHandle;
+
+    use windows_sys::Win32::Foundation::HANDLE;
+    use windows_sys::Win32::Storage::FileSystem::{
+        GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION,
+    };
+
+    let handle = file.as_raw_handle() as HANDLE;
+    let mut info = MaybeUninit::<BY_HANDLE_FILE_INFORMATION>::zeroed();
+    // SAFETY: `handle` is live and `info` is a correctly sized, aligned
+    // output buffer that is fully initialized on success.
+    let result = unsafe { GetFileInformationByHandle(handle, info.as_mut_ptr()) };
+    if result == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: the successful call above initialized the complete structure.
+    let info = unsafe { info.assume_init() };
+    Ok(info.nNumberOfLinks)
 }
 
 #[cfg(not(any(unix, windows)))]

--- a/src/local/root_authority.rs
+++ b/src/local/root_authority.rs
@@ -629,10 +629,10 @@ impl MountedMutationCommit<'_> {
     /// planted at the target name.
     pub(crate) fn confirm_replacement_target(&self) -> io::Result<()> {
         validate_mounted_bound(self.target.authority.as_ref(), &self.file)?;
-        let parent = self.retained_parent();
         let leaf = self.target.relative_leaf()?;
         #[cfg(unix)]
         {
+            let parent = self.retained_parent();
             let current = open_unix_regular_at(&parent.file, &leaf)?;
             if object_identity(&current)? != self.file.object.identity {
                 return Err(authority_changed(
@@ -651,7 +651,6 @@ impl MountedMutationCommit<'_> {
             // documented discipline: revalidate the mount, then prove the
             // pathname still names the admitted object through a fresh open
             // and an exact identity comparison.
-            let _ = parent;
             let _ = leaf;
             let current = File::open(&self.target.path)?;
             if object_identity(&current)? != self.file.object.identity {

--- a/src/local/root_authority.rs
+++ b/src/local/root_authority.rs
@@ -700,7 +700,11 @@ impl MountedMutationCommit<'_> {
     /// directory leaf — shared by every target for that leaf — and not to the
     /// target object.
     fn with_leaf_commit_exclusion(&self, run: impl FnOnce() -> io::Result<()>) -> io::Result<()> {
-        with_leaf_commit_lock(self.leaf_commit_key()?, run)
+        #[cfg(unix)]
+        let key = self.leaf_commit_key()?;
+        #[cfg(not(unix))]
+        let key = self.leaf_commit_key();
+        with_leaf_commit_lock(key, run)
     }
 
     /// Identify the directory leaf this section would replace.
@@ -719,16 +723,22 @@ impl MountedMutationCommit<'_> {
     /// Windows keeps no retained parent handle; the admitted target's
     /// normalized absolute pathname is the leaf identity every target object
     /// for that leaf shares.
+    ///
+    /// Infallible by construction: the admitted path is already normalized,
+    /// so unlike the unix form there is no resolution left to fail. A
+    /// `Result` wrapper that can never hold an error fails the `-D warnings`
+    /// clippy gate on Windows (`unnecessary_wraps`).
     #[cfg(windows)]
-    fn leaf_commit_key(&self) -> io::Result<LeafCommitKey> {
-        Ok(LeafCommitKey::AdmittedPath(self.target.path.clone()))
+    fn leaf_commit_key(&self) -> LeafCommitKey {
+        LeafCommitKey::AdmittedPath(self.target.path.clone())
     }
 
     /// Non-unix, non-Windows targets have no retained parent either; the
-    /// admitted pathname identifies the leaf.
+    /// admitted pathname identifies the leaf. Direct return for the same
+    /// clippy reason as the Windows form above.
     #[cfg(not(any(unix, windows)))]
-    fn leaf_commit_key(&self) -> io::Result<LeafCommitKey> {
-        Ok(LeafCommitKey::AdmittedPath(self.target.path.clone()))
+    fn leaf_commit_key(&self) -> LeafCommitKey {
+        LeafCommitKey::AdmittedPath(self.target.path.clone())
     }
 
     /// Resolve the retained directory that must contain the replacement.

--- a/src/local/root_authority.rs
+++ b/src/local/root_authority.rs
@@ -578,6 +578,35 @@ impl MountedMutationTarget {
         validate_mounted_bound(self.authority.as_ref(), &file)?;
         Ok(MountedMutationCommit { target: self, file })
     }
+
+    /// The retained directory that must contain the replacement — the exact
+    /// parent directory handle plus the admitted leaf name — for read-only
+    /// capability rehearsals.
+    ///
+    /// This is the same directory object the commit section resolves (the
+    /// retained parent guard, or the retained root for a mount-top target),
+    /// so a rehearsal run through it exercises the true directory even when
+    /// an ancestor pathname was displaced after admission and an impostor
+    /// directory now occupies the old name. A pathname-based rehearsal
+    /// would instead probe inside whatever occupies the path now — outside
+    /// the admitted mount — or reject a target the anchored writer could
+    /// safely update.
+    ///
+    /// The handle is a clone; the target's retained evidence is untouched.
+    #[cfg(unix)]
+    pub(crate) fn retained_directory_handle(&self) -> io::Result<(File, OsString)> {
+        let file = self
+            .file
+            .lock()
+            .map_err(|_| io::Error::other("mutation target commit section is unavailable"))?;
+        let parent = if let Some(guard) = file.parent_guards.last() {
+            guard
+        } else {
+            self.authority.root_handle()
+        };
+        parent.validate_live()?;
+        Ok((parent.file.try_clone()?, self.relative_leaf()?))
+    }
 }
 
 /// One serialized commit section over a [`MountedMutationTarget`].

--- a/src/local/root_authority.rs
+++ b/src/local/root_authority.rs
@@ -770,12 +770,15 @@ impl MountedMutationCommit<'_> {
     ///   recently freed identities to the next created file); on platforms
     ///   without a link-count primitive, holding the handle open already
     ///   keeps the object alive and its identity unrecyclable;
-    /// * the leaf is reopened and must carry the published object's exact
-    ///   identity. A live object's identity is unique, so with the handle
-    ///   still open the match can only name that same object. Anything else
-    ///   means a leaf swap landed between the landing proof and this
-    ///   reopen; anchoring it would authorize a later commit to overwrite a
-    ///   file the user never selected.
+    /// * the leaf is reopened while the published object's handle is still
+    ///   held — the order matters, because only an open handle keeps the
+    ///   published object alive and its identity unrecyclable — and must
+    ///   carry the published object's exact identity. A live object's
+    ///   identity is unique, so with the handle still open the match can
+    ///   only name that same object. Anything else means a leaf swap landed
+    ///   between the landing proof and this reopen; anchoring it would
+    ///   authorize a later commit to overwrite a file the user never
+    ///   selected.
     ///
     /// Either failure leaves the retained binding pointing at the retired
     /// pre-commit object, which makes every later revalidation fail closed:
@@ -786,12 +789,12 @@ impl MountedMutationCommit<'_> {
     /// replacement — never through the mount-relative pathname, which a
     /// parent displaced mid-commit would resolve to an impostor directory.
     fn reanchor_target_to_installed(&mut self, installed: InstalledReplacement) -> io::Result<()> {
-        let expected = installed.proven_identity()?;
         #[cfg(unix)]
         {
             let parent = self.retained_parent();
             let leaf = self.target.relative_leaf()?;
             let reopened = open_unix_regular_at(&parent.file, &leaf)?;
+            let expected = installed.proven_identity()?;
             if object_identity(&reopened)? != expected {
                 return Err(authority_changed(
                     "the replaced leaf changed again before the target could re-anchor",
@@ -814,10 +817,13 @@ impl MountedMutationCommit<'_> {
             // Platforms without retained parent handles keep their documented
             // discipline: the landing proof and this re-anchor both reopen the
             // admitted pathname, and the re-anchor accepts only the exact
-            // identity the landing proved — whose handle is still open, so a
-            // deleted replacement holds its identity against the stranger the
-            // pathname may name now.
+            // identity the landing proved. The leaf is reopened while the
+            // published handle is still held — the order matters, because
+            // only an open handle keeps the published object alive and its
+            // identity unrecyclable — so a deleted replacement holds its
+            // identity against the stranger the pathname may name now.
             let reopened = File::open(&self.target.path)?;
+            let expected = installed.proven_identity()?;
             if object_identity(&reopened)? != expected {
                 return Err(authority_changed(
                     "the replaced leaf changed again before the target could re-anchor",

--- a/src/local/root_authority.rs
+++ b/src/local/root_authority.rs
@@ -586,6 +586,57 @@ pub struct MountedMutationCommit<'a> {
     file: MutexGuard<'a, BoundFile>,
 }
 
+/// The exact object a commit section published, together with its retained
+/// handle.
+///
+/// The handle is kept open from the staged copy through the landing proof
+/// into the re-anchor. An identity alone cannot distinguish the installed
+/// object from a later stranger whose creation recycled the unlinked
+/// object's identity — ext4 hands recently freed inodes to the next file
+/// created in the same directory, so an unlink-plus-recreate swap can
+/// produce a different object with the same `(device, inode)` pair. The
+/// open handle pins the published object: on unix it exposes the link
+/// count that proves the object was not unlinked, and on every platform
+/// an object with an open handle still exists and holds its identity, so
+/// no later creation can alias it.
+struct InstalledReplacement {
+    identity: ObjectIdentity,
+    published: File,
+}
+
+impl InstalledReplacement {
+    /// Prove the published object is still live and linked, returning the
+    /// identity the re-anchor may condition on.
+    ///
+    /// On unix a handle to an unlinked object reports zero links: without
+    /// this check, a leaf swap whose stranger recycled the published
+    /// object's identity would pass the re-anchor's identity comparison
+    /// and anchor the target to a file the user never selected.
+    ///
+    /// On every platform the handle is still open here, and an object with
+    /// an open handle still exists and holds its identity — deletion
+    /// completes only at the last handle close — so no later creation can
+    /// recycle the identity. A handle whose metadata can no longer be read
+    /// has lost its object: fail closed rather than trust the identity.
+    fn proven_identity(self) -> io::Result<ObjectIdentity> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+
+            if self.published.metadata()?.nlink() == 0 {
+                return Err(authority_changed(
+                    "the proven replacement was removed before the target could re-anchor",
+                ));
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = self.published.metadata()?;
+        }
+        Ok(self.identity)
+    }
+}
+
 impl MountedMutationCommit<'_> {
     /// Clone the exact admitted file object as the mutation's read source.
     ///
@@ -680,9 +731,10 @@ impl MountedMutationCommit<'_> {
     /// After the replacement is proven landed, the section re-anchors the
     /// target's retained binding to the exact installed object — reopened
     /// through the retained parent and identity-checked against the proven
-    /// landing — while the section's guard is still held (see
-    /// [`Self::reanchor_target_to_installed`]). A pathname is never opened
-    /// for the re-anchor outside this guard.
+    /// landing, whose handle is still held so the proven object must still
+    /// be live (see [`Self::reanchor_target_to_installed`]) — while the
+    /// section's guard is still held. A pathname is never opened for the
+    /// re-anchor outside this guard.
     pub(crate) fn commit_replacement(&mut self, staged: &Path) -> io::Result<()> {
         #[cfg(unix)]
         let key = self.leaf_commit_key()?;
@@ -692,10 +744,10 @@ impl MountedMutationCommit<'_> {
             self.confirm_replacement_target()?;
             #[cfg(test)]
             run_post_confirm_interpose(self);
-            let staged_identity = self.replace_confirmed_staging(staged)?;
+            let installed = self.replace_confirmed_staging(staged)?;
             #[cfg(test)]
             run_pre_reanchor_interpose(self);
-            self.reanchor_target_to_installed(staged_identity)
+            self.reanchor_target_to_installed(installed)
         })
     }
 
@@ -708,21 +760,33 @@ impl MountedMutationCommit<'_> {
     ///
     /// The re-anchor happens inside the commit section — while this guard
     /// still holds the target's commit lock — so it can never interleave
-    /// with another section, and it is identity-conditioned: the installed
-    /// object is reopened and the reopened object must be the exact object
-    /// whose landing was just proven. Anything else means a leaf swap
-    /// landed between the landing proof and this reopen; anchoring it would
-    /// authorize a later commit to overwrite a file the user never
-    /// selected. The section therefore refuses to install the stranger and
-    /// leaves the retained binding pointing at the retired pre-commit
-    /// object, which makes every later revalidation fail closed: the target
-    /// invalidates itself.
+    /// with another section, and it is conditioned on the exact object the
+    /// landing proved, through two independent checks:
+    ///
+    /// * the published object's retained handle must still be linked — an
+    ///   unlinked object reports zero links, and a leaf swap that unlinked
+    ///   the replacement must refuse even when the stranger's creation
+    ///   recycled the replacement's identity (filesystems such as ext4 hand
+    ///   recently freed identities to the next created file); on platforms
+    ///   without a link-count primitive, holding the handle open already
+    ///   keeps the object alive and its identity unrecyclable;
+    /// * the leaf is reopened and must carry the published object's exact
+    ///   identity. A live object's identity is unique, so with the handle
+    ///   still open the match can only name that same object. Anything else
+    ///   means a leaf swap landed between the landing proof and this
+    ///   reopen; anchoring it would authorize a later commit to overwrite a
+    ///   file the user never selected.
+    ///
+    /// Either failure leaves the retained binding pointing at the retired
+    /// pre-commit object, which makes every later revalidation fail closed:
+    /// the target invalidates itself.
     ///
     /// The reopen goes through the same evidence the landing proof used —
     /// the retained parent directory where the section installed the
     /// replacement — never through the mount-relative pathname, which a
     /// parent displaced mid-commit would resolve to an impostor directory.
-    fn reanchor_target_to_installed(&mut self, expected: ObjectIdentity) -> io::Result<()> {
+    fn reanchor_target_to_installed(&mut self, installed: InstalledReplacement) -> io::Result<()> {
+        let expected = installed.proven_identity()?;
         #[cfg(unix)]
         {
             let parent = self.retained_parent();
@@ -750,7 +814,9 @@ impl MountedMutationCommit<'_> {
             // Platforms without retained parent handles keep their documented
             // discipline: the landing proof and this re-anchor both reopen the
             // admitted pathname, and the re-anchor accepts only the exact
-            // identity the landing proved.
+            // identity the landing proved — whose handle is still open, so a
+            // deleted replacement holds its identity against the stranger the
+            // pathname may name now.
             let reopened = File::open(&self.target.path)?;
             if object_identity(&reopened)? != expected {
                 return Err(authority_changed(
@@ -840,8 +906,10 @@ impl MountedMutationCommit<'_> {
     /// the proof — the loss detected after it happened. Here a failed proof
     /// means the quarantined original is still intact; it is restored
     /// (conditioned) to its name and the stranger is displaced to a sibling.
+    /// The published object's handle is returned with its identity so the
+    /// re-anchor can prove the published object is still live and linked.
     #[cfg(unix)]
-    fn replace_confirmed_staging(&self, staged: &Path) -> io::Result<ObjectIdentity> {
+    fn replace_confirmed_staging(&self, staged: &Path) -> io::Result<InstalledReplacement> {
         let parent = self.retained_parent();
         let leaf = self.target.relative_leaf()?;
         let staged_leaf = staged
@@ -893,10 +961,14 @@ impl MountedMutationCommit<'_> {
 
         // The landing is proven; only now retire the admitted original under
         // its quarantine name. A removal failure here leaves it as a
-        // quarantine sibling — debris, never destruction.
-        drop(staged_file);
+        // quarantine sibling — debris, never destruction. The published
+        // object's handle stays open and moves to the re-anchor as its
+        // liveness evidence.
         let _ = rustix::fs::unlinkat(&parent.file, quarantine_leaf, rustix::fs::AtFlags::empty());
-        Ok(staged_identity)
+        Ok(InstalledReplacement {
+            identity: staged_identity,
+            published: staged_file,
+        })
     }
 
     /// Recover the admitted original after a failed landing proof.
@@ -1054,14 +1126,15 @@ impl MountedMutationCommit<'_> {
     /// landing is proved against it exactly like the unix form, and the
     /// displaced admitted original is retired only after that proof
     /// succeeds — mirroring the unix fix for the staged-entry swap window.
-    /// Returns the exact identity of the object the section published, for
-    /// the caller's re-anchor step.
+    /// The published object's handle is returned with its identity so the
+    /// re-anchor can hold the published object open while it re-proves the
+    /// leaf.
     ///
     /// Errors surfaced here are rebuilt path-free: the std payloads embed
     /// the native pathnames, which must never leak into logs (see
     /// `replacement_path`).
     #[cfg(not(unix))]
-    fn replace_confirmed_staging(&self, staged: &Path) -> io::Result<ObjectIdentity> {
+    fn replace_confirmed_staging(&self, staged: &Path) -> io::Result<InstalledReplacement> {
         let leaf = self.target.relative_leaf()?;
         let quarantine_leaf = quarantine_name(&leaf);
         let Some(parent_dir) = self.target.path.parent() else {
@@ -1165,10 +1238,14 @@ impl MountedMutationCommit<'_> {
 
         // The landing is proven; only now retire the admitted original under
         // its quarantine name. A removal failure here leaves it as a
-        // quarantine sibling — debris, never destruction.
-        drop(staged_file);
+        // quarantine sibling — debris, never destruction. The published
+        // object's handle stays open and moves to the re-anchor as its
+        // liveness evidence.
         let _ = std::fs::remove_file(&quarantine_path);
-        Ok(staged_identity)
+        Ok(InstalledReplacement {
+            identity: staged_identity,
+            published: staged_file,
+        })
     }
 
     /// Return one displaced entry to `leaf` through the retained parent
@@ -2847,6 +2924,87 @@ mod tests {
         follow_up
             .confirm_replacement_target()
             .expect_err("the target must fail closed after a refused re-anchor");
+    }
+
+    /// An identity match alone cannot prove the leaf is the installed
+    /// replacement: once the section unlinks a file, a stranger created in
+    /// the same directory can receive the recycled identity — ext4 hands
+    /// recently freed inodes to the next created file — so an identity-only
+    /// re-anchor would adopt a file the user never selected. The section
+    /// therefore holds the published object's handle open and refuses when
+    /// it reports zero links: the replacement was removed after its landing
+    /// was proven, whatever the leaf's identity says now. The target must
+    /// invalidate itself.
+    #[test]
+    fn commit_replacement_refuses_when_the_installed_replacement_was_unlinked_before_the_re_anchor()
+    {
+        let directory = TestDirectory::new("mutation-reanchor-unlinked");
+        let song = directory.path().join("song.flac");
+        fs::write(&song, b"original audio").expect("write song");
+
+        let authority =
+            Arc::new(MountedRootAuthority::acquire(directory.path()).expect("acquire authority"));
+        let target = authority
+            .open_mutation_target(Path::new("song.flac"))
+            .expect("open mutation target");
+
+        // The staged copy sits beside the target, as the tag writer stages it.
+        let staged = directory.path().join(".song.tributary-tag-tmp.flac");
+        fs::write(&staged, b"tagged audio").expect("stage the replacement");
+        let watched_leaf = song.clone();
+
+        with_pre_reanchor_interpose(
+            Box::new(move |commit| {
+                if commit.target.path != watched_leaf {
+                    return;
+                }
+                // The landing proof has already passed on the installed
+                // replacement. Unlink it and recreate the leaf with the
+                // replacement's own bytes — the hostile case where a
+                // stranger's creation can recycle the replacement's identity
+                // and an identity-only re-anchor would adopt it.
+                let path = commit.target.path.clone();
+                fs::remove_file(&path).expect("unlink the installed replacement");
+                fs::write(&path, b"tagged audio")
+                    .expect("recreate the leaf over the unlinked replacement");
+            }),
+            || {
+                let mut commit = target.begin_commit().expect("begin commit section");
+                let error = commit
+                    .commit_replacement(&staged)
+                    .expect_err("the re-anchor must refuse a removed replacement");
+                assert!(
+                    error
+                        .to_string()
+                        .contains("removed before the target could re-anchor"),
+                    "the refusal must come from the published object's liveness proof, not a \
+                     later check: {error}"
+                );
+            },
+        );
+
+        // The recreated leaf keeps the name: the refused re-anchor must not
+        // touch it, and the retired original must not be resurrected over it.
+        assert_eq!(
+            fs::read(&song).expect("read the leaf back"),
+            b"tagged audio",
+            "the refused re-anchor must leave the leaf exactly as the external writer left it"
+        );
+        // The landing was proven, so the section retired the quarantined
+        // original and consumed the staged copy before the unlink.
+        assert!(
+            !staged.exists(),
+            "the landing preceded the unlink, so the staged copy was consumed"
+        );
+        assert_no_quarantine_sibling_remains(&directory);
+
+        // The target invalidated itself: the binding still names the retired
+        // pre-commit object, so the follow-up section must refuse even though
+        // the leaf now holds the replacement's exact bytes.
+        let follow_up = target.begin_commit().expect("begin the follow-up section");
+        follow_up
+            .confirm_replacement_target()
+            .expect_err("the target must fail closed after the replacement was unlinked");
     }
 
     /// The replacement must be performed relative to the retained parent

--- a/src/local/root_authority.rs
+++ b/src/local/root_authority.rs
@@ -821,10 +821,24 @@ impl MountedMutationCommit<'_> {
         #[cfg(test)]
         run_pre_install_interpose(self);
         Self::install_staged_leaf_into_vacant_leaf(parent, staged_leaf, &leaf, &quarantine_leaf)?;
+        Self::prove_replacement_landed(parent, &leaf, &staged_identity)
+    }
 
-        // Prove the replacement landed on the exact directory entry.
-        let replaced = open_unix_regular_at(&parent.file, &leaf)?;
-        if object_identity(&replaced)? != staged_identity {
+    /// Prove the installed leaf names the exact object the staged copy held.
+    ///
+    /// The install renames the staged copy into the vacant leaf name, so the
+    /// entry the name points at afterwards must carry the staged copy's exact
+    /// identity. Anything else means the leaf was disturbed again after the
+    /// conditioned install; the commit refuses rather than claim a
+    /// replacement it cannot prove.
+    #[cfg(unix)]
+    fn prove_replacement_landed(
+        parent: &RetainedObject,
+        leaf: &OsStr,
+        staged_identity: &ObjectIdentity,
+    ) -> io::Result<()> {
+        let replaced = open_unix_regular_at(&parent.file, leaf)?;
+        if object_identity(&replaced)? != *staged_identity {
             return Err(authority_changed(
                 "the tagged replacement did not land on the retained mutation target",
             ));

--- a/src/local/root_authority.rs
+++ b/src/local/root_authority.rs
@@ -550,27 +550,6 @@ impl MountedMutationTarget {
             .ok_or_else(|| invalid_input("mutation target has no leaf file name"))
     }
 
-    /// Re-bind the retained exact file to the object now admitted at this
-    /// target's accepted mount-relative path.
-    ///
-    /// A successful atomic replacement deliberately retires the object the
-    /// commit section copied from: the pathname names the replacement. A
-    /// follow-up commit (a batch retry, or a second edit) must anchor to that
-    /// exact current object instead of failing against the displaced one.
-    /// Failure here is not a commit failure; the next commit section
-    /// revalidates fail-closed regardless.
-    pub(crate) fn rebind(&self) -> io::Result<()> {
-        let mut file = self
-            .file
-            .lock()
-            .map_err(|_| io::Error::other("mutation target commit section is unavailable"))?;
-        let rebound = self
-            .authority
-            .open_relative_regular_file(&self.relative_path)?;
-        *file = rebound;
-        Ok(())
-    }
-
     /// Revalidate the retained mount binding and exact file object.
     ///
     /// Every error is a loss of authority. This reopens the mount path and
@@ -590,7 +569,7 @@ impl MountedMutationTarget {
     /// The retained mount binding and exact file object are revalidated
     /// before the section starts and the section holds the target's commit
     /// lock until the guard is dropped, so overlapping commits observe either
-    /// the pre-commit or post-rebind object — never a mixed one.
+    /// the pre-commit or re-anchored object — never a mixed one.
     pub(crate) fn begin_commit(&self) -> io::Result<MountedMutationCommit<'_>> {
         let file = self
             .file
@@ -679,10 +658,10 @@ impl MountedMutationCommit<'_> {
     ///
     /// The whole section — validation and rename together — first excludes
     /// every other Tributary-side committer for the same directory leaf (see
-    /// [`Self::with_leaf_commit_exclusion`]): the per-target commit lock
-    /// serializes one [`MountedMutationTarget`] object, but two targets
-    /// admitted at different times can name the same leaf, and their
-    /// confirm-and-rename spans must never interleave.
+    /// [`with_leaf_commit_lock`]): the per-target commit lock serializes one
+    /// [`MountedMutationTarget`] object, but two targets admitted at
+    /// different times can name the same leaf, and their confirm-and-rename
+    /// spans must never interleave.
     ///
     /// Confirmation then proves the mount, the retained ancestry, and the
     /// exact leaf identity (see [`Self::confirm_replacement_target`]). On
@@ -697,27 +676,96 @@ impl MountedMutationCommit<'_> {
     /// the exact retained parent directory; anything else is a lost staging
     /// area and is refused rather than re-resolved by path. Any uncertainty
     /// fails closed and leaves both files untouched.
-    pub(crate) fn commit_replacement(&self, staged: &Path) -> io::Result<()> {
-        self.with_leaf_commit_exclusion(|| {
-            self.confirm_replacement_target()?;
-            #[cfg(test)]
-            run_post_confirm_interpose(self);
-            self.replace_confirmed_staging(staged)
-        })
-    }
-
-    /// Run one replacement section while holding the process-wide exclusion
-    /// for this target's leaf.
     ///
-    /// See [`with_leaf_commit_lock`] for why the lock is scoped to the
-    /// directory leaf — shared by every target for that leaf — and not to the
-    /// target object.
-    fn with_leaf_commit_exclusion(&self, run: impl FnOnce() -> io::Result<()>) -> io::Result<()> {
+    /// After the replacement is proven landed, the section re-anchors the
+    /// target's retained binding to the exact installed object — reopened
+    /// through the retained parent and identity-checked against the proven
+    /// landing — while the section's guard is still held (see
+    /// [`Self::reanchor_target_to_installed`]). A pathname is never opened
+    /// for the re-anchor outside this guard.
+    pub(crate) fn commit_replacement(&mut self, staged: &Path) -> io::Result<()> {
         #[cfg(unix)]
         let key = self.leaf_commit_key()?;
         #[cfg(not(unix))]
         let key = self.leaf_commit_key();
-        with_leaf_commit_lock(key, run)
+        with_leaf_commit_lock(key, || {
+            self.confirm_replacement_target()?;
+            #[cfg(test)]
+            run_post_confirm_interpose(self);
+            let staged_identity = self.replace_confirmed_staging(staged)?;
+            #[cfg(test)]
+            run_pre_reanchor_interpose(self);
+            self.reanchor_target_to_installed(staged_identity)
+        })
+    }
+
+    /// Re-anchor the target's retained binding to the installed replacement.
+    ///
+    /// A successful replacement deliberately retires the object this section
+    /// copied from; the pathname names the replacement now. The retained
+    /// evidence must follow it, or the next commit section would revalidate
+    /// against the retired object and refuse a legitimate follow-up write.
+    ///
+    /// The re-anchor happens inside the commit section — while this guard
+    /// still holds the target's commit lock — so it can never interleave
+    /// with another section, and it is identity-conditioned: the installed
+    /// object is reopened and the reopened object must be the exact object
+    /// whose landing was just proven. Anything else means a leaf swap
+    /// landed between the landing proof and this reopen; anchoring it would
+    /// authorize a later commit to overwrite a file the user never
+    /// selected. The section therefore refuses to install the stranger and
+    /// leaves the retained binding pointing at the retired pre-commit
+    /// object, which makes every later revalidation fail closed: the target
+    /// invalidates itself.
+    ///
+    /// The reopen goes through the same evidence the landing proof used —
+    /// the retained parent directory where the section installed the
+    /// replacement — never through the mount-relative pathname, which a
+    /// parent displaced mid-commit would resolve to an impostor directory.
+    fn reanchor_target_to_installed(&mut self, expected: ObjectIdentity) -> io::Result<()> {
+        #[cfg(unix)]
+        {
+            let parent = self.retained_parent();
+            let leaf = self.target.relative_leaf()?;
+            let reopened = open_unix_regular_at(&parent.file, &leaf)?;
+            if object_identity(&reopened)? != expected {
+                return Err(authority_changed(
+                    "the replaced leaf changed again before the target could re-anchor",
+                ));
+            }
+            let rebound = BoundFile {
+                lease_token: self.target.authority.token,
+                path: self.target.path.clone(),
+                object: RetainedObject::new(reopened)?,
+                // The reopened object's retained directory is this section's
+                // retained parent, so pin that directory: later revalidations
+                // keep proving the object through the exact directory it was
+                // anchored from.
+                parent_guards: vec![RetainedObject::new(parent.file.try_clone()?)?],
+            };
+            *self.file = rebound;
+        }
+        #[cfg(not(unix))]
+        {
+            // Platforms without retained parent handles keep their documented
+            // discipline: the landing proof and this re-anchor both reopen the
+            // admitted pathname, and the re-anchor accepts only the exact
+            // identity the landing proved.
+            let reopened = File::open(&self.target.path)?;
+            if object_identity(&reopened)? != expected {
+                return Err(authority_changed(
+                    "the replaced leaf changed again before the target could re-anchor",
+                ));
+            }
+            let rebound = BoundFile {
+                lease_token: self.target.authority.token,
+                path: self.target.path.clone(),
+                object: RetainedObject::new(reopened)?,
+                parent_guards: Vec::new(),
+            };
+            *self.file = rebound;
+        }
+        Ok(())
     }
 
     /// Identify the directory leaf this section would replace.
@@ -767,7 +815,9 @@ impl MountedMutationCommit<'_> {
 
     /// Rename the staged copy over the confirmed target through the retained
     /// parent, conditioning the destination on its confirmed identity, then
-    /// prove the replacement landed on that exact entry.
+    /// prove the replacement landed on that exact entry. Returns the exact
+    /// identity of the object the section published, for the caller's
+    /// re-anchor step.
     ///
     /// A plain rename over the leaf would silently overwrite whatever an
     /// external writer swapped into the name after the confirm step proved
@@ -791,7 +841,7 @@ impl MountedMutationCommit<'_> {
     /// means the quarantined original is still intact; it is restored
     /// (conditioned) to its name and the stranger is displaced to a sibling.
     #[cfg(unix)]
-    fn replace_confirmed_staging(&self, staged: &Path) -> io::Result<()> {
+    fn replace_confirmed_staging(&self, staged: &Path) -> io::Result<ObjectIdentity> {
         let parent = self.retained_parent();
         let leaf = self.target.relative_leaf()?;
         let staged_leaf = staged
@@ -846,7 +896,7 @@ impl MountedMutationCommit<'_> {
         // quarantine sibling — debris, never destruction.
         drop(staged_file);
         let _ = rustix::fs::unlinkat(&parent.file, quarantine_leaf, rustix::fs::AtFlags::empty());
-        Ok(())
+        Ok(staged_identity)
     }
 
     /// Recover the admitted original after a failed landing proof.
@@ -863,7 +913,7 @@ impl MountedMutationCommit<'_> {
         leaf: &OsStr,
         quarantine_leaf: &OsStr,
     ) {
-        let _ = rustix::fs::renameat(&parent.file, leaf, &parent.file, &quarantine_name(leaf));
+        let _ = rustix::fs::renameat(&parent.file, leaf, &parent.file, quarantine_name(leaf));
         let _ = Self::restore_displaced_entry(parent, quarantine_leaf, leaf);
     }
 
@@ -999,8 +1049,19 @@ impl MountedMutationCommit<'_> {
     /// copy into the vacancy through a no-replace rename, so a leaf recreated
     /// inside the install window is preserved and refuses the commit exactly
     /// like the unix form.
+    ///
+    /// The staged object's evidence is retained through the install, the
+    /// landing is proved against it exactly like the unix form, and the
+    /// displaced admitted original is retired only after that proof
+    /// succeeds — mirroring the unix fix for the staged-entry swap window.
+    /// Returns the exact identity of the object the section published, for
+    /// the caller's re-anchor step.
+    ///
+    /// Errors surfaced here are rebuilt path-free: the std payloads embed
+    /// the native pathnames, which must never leak into logs (see
+    /// `replacement_path`).
     #[cfg(not(unix))]
-    fn replace_confirmed_staging(&self, staged: &Path) -> io::Result<()> {
+    fn replace_confirmed_staging(&self, staged: &Path) -> io::Result<ObjectIdentity> {
         let leaf = self.target.relative_leaf()?;
         let quarantine_leaf = quarantine_name(&leaf);
         let Some(parent_dir) = self.target.path.parent() else {
@@ -1010,6 +1071,16 @@ impl MountedMutationCommit<'_> {
         };
         let quarantine_path = parent_dir.join(&quarantine_leaf);
 
+        // Retain the staged object's evidence through the install and the
+        // landing proof, exactly like the unix form.
+        let staged_file = std::fs::File::open(staged).map_err(|error| {
+            io::Error::new(
+                error.kind(),
+                "the staged tag replacement could not be opened",
+            )
+        })?;
+        let staged_identity = object_identity(&staged_file)?;
+
         // Displace the confirmed entry under the fresh quarantine name. A
         // rename to a name that did not exist a moment ago never replaces an
         // existing entry, so this cannot clobber anything.
@@ -1017,7 +1088,11 @@ impl MountedMutationCommit<'_> {
             return Err(if error.kind() == io::ErrorKind::NotFound {
                 authority_changed("the confirmed mutation target no longer exists")
             } else {
-                error
+                io::Error::new(
+                    error.kind(),
+                    "the confirmed mutation target could not be displaced under \
+                     its quarantine name",
+                )
             });
         }
 
@@ -1065,12 +1140,35 @@ impl MountedMutationCommit<'_> {
             }
         }
 
-        // Retire the displaced original — the entry a plain rename over the
-        // target would have consumed. The replacement has already landed, so
-        // a removal failure here leaves the prior object under the
-        // quarantine sibling rather than failing the committed write.
+        // Prove the landing on the exact staged object before anything is
+        // retired, mirroring the unix form. A failed proof means a stranger
+        // was swapped over the staging name or the leaf; the admitted
+        // original is still intact under its quarantine name — put it back
+        // (conditioned) and refuse with both objects preserved.
+        let replaced = std::fs::File::open(&self.target.path).map_err(|error| {
+            io::Error::new(
+                error.kind(),
+                "the installed replacement could not be re-opened for its landing proof",
+            )
+        });
+        let landed = match replaced {
+            Ok(file) => object_identity(&file),
+            Err(error) => Err(error),
+        };
+        if !landed.is_ok_and(|identity| identity == staged_identity) {
+            let _ = std::fs::rename(&self.target.path, parent_dir.join(quarantine_name(&leaf)));
+            let _ = rename_noreplace(&quarantine_path, &self.target.path);
+            return Err(authority_changed(
+                "the tagged replacement did not land on the retained mutation target",
+            ));
+        }
+
+        // The landing is proven; only now retire the admitted original under
+        // its quarantine name. A removal failure here leaves it as a
+        // quarantine sibling — debris, never destruction.
+        drop(staged_file);
         let _ = std::fs::remove_file(&quarantine_path);
-        Ok(())
+        Ok(staged_identity)
     }
 
     /// Return one displaced entry to `leaf` through the retained parent
@@ -1361,6 +1459,38 @@ fn with_pre_install_interpose(interpose: Box<PreInstallInterpose>, run: impl FnO
 
 #[cfg(test)]
 static PRE_INSTALL_INTERPOSE_SERIAL: Mutex<()> = Mutex::new(());
+
+/// Test-only seam: run the registered pre-re-anchor interposition, if any.
+///
+/// The re-anchor refusal is only reachable when the leaf is swapped between
+/// the landing proof and the re-anchor's authority reopen — nanoseconds wide
+/// in production. A regression test registers a closure here that swaps the
+/// leaf deterministically in that window. Never compiled outside `cargo
+/// test`.
+#[cfg(test)]
+fn run_pre_reanchor_interpose(commit: &MountedMutationCommit<'_>) {
+    if let Some(interpose) = PRE_REANCHOR_INTERPOSE.lock().unwrap().as_ref() {
+        interpose(commit);
+    }
+}
+
+#[cfg(test)]
+type PreReanchorInterpose = dyn Fn(&MountedMutationCommit<'_>) + Send + Sync;
+
+#[cfg(test)]
+static PRE_REANCHOR_INTERPOSE: Mutex<Option<Box<PreReanchorInterpose>>> = Mutex::new(None);
+
+/// Serialize tests that use the pre-re-anchor interposition seam.
+#[cfg(test)]
+fn with_pre_reanchor_interpose(interpose: Box<PreReanchorInterpose>, run: impl FnOnce()) {
+    let _serial = PRE_REANCHOR_INTERPOSE_SERIAL.lock().unwrap();
+    *PRE_REANCHOR_INTERPOSE.lock().unwrap() = Some(interpose);
+    run();
+    *PRE_REANCHOR_INTERPOSE.lock().unwrap() = None;
+}
+
+#[cfg(test)]
+static PRE_REANCHOR_INTERPOSE_SERIAL: Mutex<()> = Mutex::new(());
 
 /// Verify a mounted bound against its retained mount authority.
 fn validate_mounted_bound(authority: &MountedRootAuthority, bound: &BoundFile) -> io::Result<()> {
@@ -2601,8 +2731,8 @@ mod tests {
     }
 
     #[test]
-    fn mutation_target_rebind_anchors_to_the_object_now_at_its_path() {
-        let directory = TestDirectory::new("mutation-rebind");
+    fn commit_replacement_reanchors_the_target_to_the_installed_object() {
+        let directory = TestDirectory::new("mutation-reanchor-success");
         let song = directory.path().join("song.flac");
         fs::write(&song, b"original audio").expect("write song");
 
@@ -2612,22 +2742,111 @@ mod tests {
             .open_mutation_target(Path::new("song.flac"))
             .expect("open mutation target");
 
-        let displaced = directory.path().join("displaced.flac");
-        fs::rename(&song, &displaced).expect("displace the admitted file");
-        fs::write(&song, b"replacement audio").expect("install different bytes");
+        // The staged copy sits beside the target, as the tag writer stages it.
+        let staged = directory.path().join(".song.tributary-tag-tmp.flac");
+        fs::write(&staged, b"tagged audio").expect("stage the replacement");
 
         // A successful replacement retires the object the section copied
-        // from; rebind anchors the evidence to the object now at the path so
-        // a follow-up commit is authorized for the file that exists now.
-        target.rebind().expect("rebind to the replacement");
-        let commit = target.begin_commit().expect("begin section after rebind");
-        commit
+        // from; the section re-anchors the retained evidence to the exact
+        // installed object — identity-checked against the proven landing,
+        // inside the commit guard — so a follow-up commit is authorized for
+        // the file that exists now, without ever reopening the leaf by path
+        // outside the section.
+        // The commit section holds the target's commit lock until its guard
+        // is dropped, so the first section must end before the follow-up
+        // section begins — a nested begin_commit on the same target would
+        // self-deadlock on the non-reentrant Mutex.
+        {
+            let mut commit = target.begin_commit().expect("begin commit section");
+            commit
+                .commit_replacement(&staged)
+                .expect("the replacement commits and re-anchors the target");
+            assert!(
+                !staged.exists(),
+                "a successful install consumes the staging name"
+            );
+        }
+
+        let follow_up = target.begin_commit().expect("begin the follow-up section");
+        follow_up
             .confirm_replacement_target()
-            .expect("the rebound object is the admitted one");
-        let mut source = commit.source_file().expect("clone rebound source");
+            .expect("the re-anchored object is the admitted one");
+        let mut source = follow_up.source_file().expect("clone re-anchored source");
         let mut contents = Vec::new();
         source.read_to_end(&mut contents).expect("read source");
-        assert_eq!(contents, b"replacement audio");
+        assert_eq!(
+            contents, b"tagged audio",
+            "the re-anchored evidence must read the installed replacement"
+        );
+    }
+
+    /// The re-anchor must stay conditional on the proven landing: an external
+    /// writer that swaps the leaf between the landing proof and the
+    /// re-anchor's authority reopen must not be adopted as the retained
+    /// evidence — a later commit anchored to that stranger would overwrite a
+    /// file the user never selected. The section must refuse, and the target
+    /// must invalidate itself: its binding still names the retired pre-commit
+    /// object, so every later revalidation fails closed.
+    #[test]
+    fn commit_replacement_refuses_a_leaf_swapped_after_the_landing_proof_and_invalidates_the_target(
+    ) {
+        let directory = TestDirectory::new("mutation-reanchor-swap");
+        let song = directory.path().join("song.flac");
+        fs::write(&song, b"original audio").expect("write song");
+
+        let authority =
+            Arc::new(MountedRootAuthority::acquire(directory.path()).expect("acquire authority"));
+        let target = authority
+            .open_mutation_target(Path::new("song.flac"))
+            .expect("open mutation target");
+
+        // The staged copy sits beside the target, as the tag writer stages it.
+        let staged = directory.path().join(".song.tributary-tag-tmp.flac");
+        fs::write(&staged, b"tagged audio").expect("stage the replacement");
+        let watched_leaf = song.clone();
+
+        with_pre_reanchor_interpose(
+            Box::new(move |commit| {
+                if commit.target.path != watched_leaf {
+                    return;
+                }
+                // The landing proof has already passed on the staged copy.
+                // Swap the leaf now — unlink plus recreate, a different
+                // object — exactly where a stranger would be adopted by an
+                // unconstrained post-commit rebind.
+                let path = commit.target.path.clone();
+                fs::remove_file(&path).expect("unlink the installed replacement");
+                fs::write(&path, b"stranger audio").expect("install a stranger at the leaf");
+            }),
+            || {
+                let mut commit = target.begin_commit().expect("begin commit section");
+                commit
+                    .commit_replacement(&staged)
+                    .expect_err("a leaf swapped before the re-anchor must refuse the commit");
+            },
+        );
+
+        // The stranger keeps the name: the refused re-anchor must not touch
+        // the leaf, and the retired original must not be resurrected over it.
+        assert_eq!(
+            fs::read(&song).expect("read the leaf back"),
+            b"stranger audio",
+            "the refused re-anchor must leave the leaf exactly as the external writer left it"
+        );
+        // The landing was proven, so the section retired the quarantined
+        // original and consumed the staged copy before the swap.
+        assert!(
+            !staged.exists(),
+            "the landing preceded the swap, so the staged copy was consumed"
+        );
+        assert_no_quarantine_sibling_remains(&directory);
+
+        // The target invalidated itself: the binding still names the retired
+        // pre-commit object, so the follow-up section must refuse.
+        let follow_up = target.begin_commit().expect("begin the follow-up section");
+        follow_up
+            .confirm_replacement_target()
+            .expect_err("the target must fail closed after a refused re-anchor");
     }
 
     /// The replacement must be performed relative to the retained parent
@@ -2663,7 +2882,7 @@ mod tests {
         let staged = displaced_album.join(".tributary-tag-staged.flac");
         fs::write(&staged, b"tagged audio").expect("stage the replacement");
 
-        let commit = target.begin_commit().expect("begin commit section");
+        let mut commit = target.begin_commit().expect("begin commit section");
         commit
             .commit_replacement(&staged)
             .expect("commit through the retained parent");
@@ -3251,7 +3470,7 @@ mod tests {
                 fs::write(&path, b"newcomer audio").expect("install a newcomer at the leaf");
             }),
             || {
-                let commit = target.begin_commit().expect("begin commit section");
+                let mut commit = target.begin_commit().expect("begin commit section");
                 commit
                     .commit_replacement(&staged)
                     .expect_err("a leaf swapped after confirm must refuse the commit");
@@ -3320,7 +3539,7 @@ mod tests {
                     .expect("recreate the leaf in the install window");
             }),
             || {
-                let commit = target.begin_commit().expect("begin commit section");
+                let mut commit = target.begin_commit().expect("begin commit section");
                 commit
                     .commit_replacement(&staged)
                     .expect_err("a leaf recreated in the install window must refuse the commit");
@@ -3387,7 +3606,7 @@ mod tests {
                     .expect("install a stranger at the staging name");
             }),
             || {
-                let commit = target.begin_commit().expect("begin commit section");
+                let mut commit = target.begin_commit().expect("begin commit section");
                 commit
                     .commit_replacement(&staged)
                     .expect_err("a stranger swapped over the staging name must refuse the commit");
@@ -3467,7 +3686,7 @@ mod tests {
         let staged = directory.path().join(".staged-one.flac");
         fs::write(&staged, b"tagged audio").expect("stage the first replacement");
         {
-            let commit = first
+            let mut commit = first
                 .begin_commit()
                 .expect("begin the first commit section");
             commit
@@ -3485,7 +3704,7 @@ mod tests {
         let staged_second = directory.path().join(".staged-two.flac");
         fs::write(&staged_second, b"second audio").expect("stage the second replacement");
         {
-            let commit = second
+            let mut commit = second
                 .begin_commit()
                 .expect("begin the second commit section");
             commit

--- a/src/local/root_authority.rs
+++ b/src/local/root_authority.rs
@@ -798,14 +798,56 @@ impl MountedMutationCommit<'_> {
         let staged_identity = object_identity(&staged_file)?;
         drop(staged_file);
 
-        // Displace whatever occupies the leaf. This rename is atomic and its
-        // destination is a fresh unique name, so it cannot destroy anything:
-        // afterwards the confirmed object — or whatever replaced it since the
-        // confirm step — sits under the quarantine name and the leaf is
-        // vacant.
-        let quarantine_leaf = quarantine_name(&leaf);
+        // Displace whatever occupies the leaf under a fresh quarantine name,
+        // then prove the displaced entry is the exact object the confirm step
+        // verified. Anything else means the leaf was swapped between confirm
+        // and quarantine: the newcomer is put back — byte-exact, under its
+        // own name, through the conditioned restore — and the commit refuses.
+        let quarantine_leaf = Self::displace_leaf_under_fresh_quarantine_name(parent, &leaf)?;
+        Self::refuse_unless_displaced_entry_is_confirmed(
+            parent,
+            &quarantine_leaf,
+            &leaf,
+            &self.file.object.identity,
+        )?;
+
+        // Install the staged copy into the vacant leaf name. The install
+        // itself is conditioned: a no-replace rename refuses an occupied
+        // destination atomically, so an external writer that recreates the
+        // leaf inside the quarantine-to-install window is preserved and
+        // refuses the commit exactly like every earlier disturbance — the
+        // write is authorized for the file the authority admitted, not for
+        // whatever now occupies the name.
+        #[cfg(test)]
+        run_pre_install_interpose(self);
+        Self::install_staged_leaf_into_vacant_leaf(parent, staged_leaf, &leaf, &quarantine_leaf)?;
+
+        // Prove the replacement landed on the exact directory entry.
+        let replaced = open_unix_regular_at(&parent.file, &leaf)?;
+        if object_identity(&replaced)? != staged_identity {
+            return Err(authority_changed(
+                "the tagged replacement did not land on the retained mutation target",
+            ));
+        }
+        Ok(())
+    }
+
+    /// Displace whatever occupies `leaf` under a fresh unique quarantine
+    /// sibling and return that name.
+    ///
+    /// The rename is atomic and its destination is a fresh unique name, so it
+    /// cannot destroy anything: afterwards the confirmed object — or whatever
+    /// replaced it since the confirm step — sits under the quarantine name
+    /// and the leaf is vacant. A leaf that vanished after the confirm step
+    /// refuses without touching anything.
+    #[cfg(unix)]
+    fn displace_leaf_under_fresh_quarantine_name(
+        parent: &RetainedObject,
+        leaf: &OsStr,
+    ) -> io::Result<OsString> {
+        let quarantine_leaf = quarantine_name(leaf);
         if let Err(error) =
-            rustix::fs::renameat(&parent.file, &leaf, &parent.file, &quarantine_leaf)
+            rustix::fs::renameat(&parent.file, leaf, &parent.file, &quarantine_leaf)
         {
             return Err(
                 if io::Error::from(error).kind() == io::ErrorKind::NotFound {
@@ -817,31 +859,51 @@ impl MountedMutationCommit<'_> {
                 },
             );
         }
+        Ok(quarantine_leaf)
+    }
 
-        // Prove the displaced entry is the exact object the confirm step
-        // verified. Anything else means the leaf was swapped between confirm
-        // and quarantine: put the newcomer back — byte-exact, under its own
-        // name, through the conditioned restore — and refuse.
-        let displaced_is_confirmed = open_unix_regular_at(&parent.file, &quarantine_leaf)
+    /// Prove the displaced entry is the exact object the confirm step
+    /// verified; restore a swapped newcomer — byte-exact, under its own
+    /// name, through the conditioned restore — and refuse otherwise.
+    #[cfg(unix)]
+    fn refuse_unless_displaced_entry_is_confirmed(
+        parent: &RetainedObject,
+        quarantine_leaf: &OsStr,
+        leaf: &OsStr,
+        expected: &ObjectIdentity,
+    ) -> io::Result<()> {
+        let displaced_is_confirmed = open_unix_regular_at(&parent.file, quarantine_leaf)
             .and_then(|displaced| object_identity(&displaced))
-            .is_ok_and(|identity| identity == self.file.object.identity);
+            .is_ok_and(|identity| identity == *expected);
         if !displaced_is_confirmed {
-            Self::restore_displaced_entry(parent, &quarantine_leaf, &leaf)?;
+            Self::restore_displaced_entry(parent, quarantine_leaf, leaf)?;
             return Err(authority_changed(
                 "the confirmed mutation target was replaced before the commit",
             ));
         }
+        Ok(())
+    }
 
-        // Install the staged copy into the vacant leaf name. The install
-        // itself is conditioned: a no-replace rename refuses an occupied
-        // destination atomically, so an external writer that recreates the
-        // leaf inside the quarantine-to-install window is preserved and
-        // refuses the commit exactly like every earlier disturbance — the
-        // write is authorized for the file the authority admitted, not for
-        // whatever now occupies the name.
-        #[cfg(test)]
-        run_pre_install_interpose(self);
-        match rename_noreplace_at(parent, staged_leaf, &leaf) {
+    /// Install the staged copy into the vacant leaf name through the
+    /// conditioned no-replace rename, then retire the displaced original.
+    ///
+    /// A no-replace rename refuses an occupied destination atomically, so an
+    /// external writer that recreates the leaf inside the quarantine-to-
+    /// install window is preserved under a fresh sibling and the commit
+    /// refuses exactly like every earlier disturbance — the write is
+    /// authorized for the file the authority admitted, not for whatever now
+    /// occupies the name. The install consumes the staging entry, so only
+    /// the displaced original remains to retire; the replacement has already
+    /// landed, so a removal failure there leaves it under the quarantine
+    /// sibling rather than failing the committed write.
+    #[cfg(unix)]
+    fn install_staged_leaf_into_vacant_leaf(
+        parent: &RetainedObject,
+        staged_leaf: &OsStr,
+        leaf: &OsStr,
+        quarantine_leaf: &OsStr,
+    ) -> io::Result<()> {
+        match rename_noreplace_at(parent, staged_leaf, leaf) {
             Ok(()) => {}
             Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
                 // A newcomer recreated the leaf after the quarantine proof.
@@ -852,8 +914,8 @@ impl MountedMutationCommit<'_> {
                 // displaced objects stay under their quarantine names: debris,
                 // never destruction.
                 let _ =
-                    rustix::fs::renameat(&parent.file, &leaf, &parent.file, quarantine_name(&leaf));
-                let _ = Self::restore_displaced_entry(parent, &quarantine_leaf, &leaf);
+                    rustix::fs::renameat(&parent.file, leaf, &parent.file, quarantine_name(leaf));
+                let _ = Self::restore_displaced_entry(parent, quarantine_leaf, leaf);
                 return Err(authority_changed(
                     "the mutation target leaf was recreated during the commit",
                 ));
@@ -863,26 +925,12 @@ impl MountedMutationCommit<'_> {
                 // Return the confirmed original to its name (best effort —
                 // the caller sees the install error either way) and fail
                 // closed rather than stranding it under the quarantine name.
-                let _ = Self::restore_displaced_entry(parent, &quarantine_leaf, &leaf);
+                let _ = Self::restore_displaced_entry(parent, quarantine_leaf, leaf);
                 return Err(error);
             }
         }
 
-        // The install rename consumed the staging entry — rename moves the
-        // source name onto the destination — so only the displaced original,
-        // the same directory entry a plain rename over the leaf would have
-        // consumed, remains to retire. The replacement has already landed,
-        // so a removal failure here leaves the prior object under the
-        // quarantine sibling rather than failing the committed write.
-        let _ = rustix::fs::unlinkat(&parent.file, &quarantine_leaf, rustix::fs::AtFlags::empty());
-
-        // Prove the replacement landed on the exact directory entry.
-        let replaced = open_unix_regular_at(&parent.file, &leaf)?;
-        if object_identity(&replaced)? != staged_identity {
-            return Err(authority_changed(
-                "the tagged replacement did not land on the retained mutation target",
-            ));
-        }
+        let _ = rustix::fs::unlinkat(&parent.file, quarantine_leaf, rustix::fs::AtFlags::empty());
         Ok(())
     }
 

--- a/src/local/root_authority.rs
+++ b/src/local/root_authority.rs
@@ -8,7 +8,7 @@
 //! mount-generation checks to an ephemeral mounted root without requiring the
 //! removable filesystem to contain an application marker.
 
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::fmt;
 use std::fs::File;
 use std::io::{self, Read};
@@ -540,6 +540,15 @@ impl MountedMutationTarget {
         &self.path
     }
 
+    /// Return the admitted leaf name, relative to the retained parent
+    /// directory. Private machinery for the retained-parent commit.
+    fn relative_leaf(&self) -> io::Result<OsString> {
+        self.relative_path
+            .file_name()
+            .map(|name| name.to_os_string())
+            .ok_or_else(|| invalid_input("mutation target has no leaf file name"))
+    }
+
     /// Re-bind the retained exact file to the object now admitted at this
     /// target's accepted mount-relative path.
     ///
@@ -614,17 +623,114 @@ impl MountedMutationCommit<'_> {
     /// exact pathname must still name the retained object. A file that was
     /// renamed away, replaced, or removed refuses the replacement: the write
     /// is authorized for the file the user selected, not for whatever now
-    /// occupies its old name.
+    /// occupies its old name. The proof opens the leaf name through the
+    /// retained parent directory — never an absolute pathname lookup, which a
+    /// replaced parent could retarget and which would follow a symlink
+    /// planted at the target name.
     pub(crate) fn confirm_replacement_target(&self) -> io::Result<()> {
-        self.target.authority.validate()?;
-        self.file.object.validate_live()?;
-        let current = File::open(&self.target.path)?;
-        if object_identity(&current)? != self.file.object.identity {
+        validate_mounted_bound(self.target.authority.as_ref(), &self.file)?;
+        let parent = self.retained_parent();
+        let leaf = self.target.relative_leaf()?;
+        #[cfg(unix)]
+        {
+            let current = open_unix_regular_at(&parent.file, &leaf)?;
+            if object_identity(&current)? != self.file.object.identity {
+                return Err(authority_changed(
+                    "mutation target no longer names the retained file",
+                ));
+            }
+            // Close the check window on the authority side before the caller
+            // proceeds, mirroring the double-validation discipline of every
+            // other retained-evidence path.
+            parent.validate_live()?;
+            self.target.authority.validate()
+        }
+        #[cfg(not(unix))]
+        {
+            // Platforms without retained parent handles (Windows) keep the
+            // documented discipline: revalidate the mount, then prove the
+            // pathname still names the admitted object through a fresh open
+            // and an exact identity comparison.
+            let _ = parent;
+            let _ = leaf;
+            let current = File::open(&self.target.path)?;
+            if object_identity(&current)? != self.file.object.identity {
+                return Err(authority_changed(
+                    "mutation target no longer names the retained file",
+                ));
+            }
+            self.target.authority.validate()
+        }
+    }
+
+    /// Confirm the replacement target and perform the atomic replacement with
+    /// the staged copy at `staged`.
+    ///
+    /// Confirmation runs first (mount, retained ancestry, exact file identity
+    /// — see [`Self::confirm_replacement_target`]). On platforms with
+    /// retained parent handles the replacement itself is then performed
+    /// relative to that retained parent directory on both sides, so no
+    /// pathname resolution — root, ancestor, or leaf — can retarget the
+    /// rename after the confirmation. The staged copy must live inside the
+    /// exact retained parent directory; anything else is a lost staging area
+    /// and is refused rather than re-resolved by path. Any uncertainty fails
+    /// closed and leaves both files untouched.
+    pub(crate) fn commit_replacement(&self, staged: &Path) -> io::Result<()> {
+        self.confirm_replacement_target()?;
+        self.replace_confirmed_staging(staged)
+    }
+
+    /// Resolve the retained directory that must contain the replacement.
+    #[cfg(unix)]
+    fn retained_parent(&self) -> &RetainedObject {
+        if let Some(parent) = self.file.parent_guards.last() {
+            return parent;
+        }
+        // A target at the top of the mount has no retained ancestor chain;
+        // the retained root itself is the parent.
+        self.target.authority.root_handle()
+    }
+
+    /// Rename the staged copy over the confirmed target through the retained
+    /// parent, then prove the replacement landed on that exact entry.
+    #[cfg(unix)]
+    fn replace_confirmed_staging(&self, staged: &Path) -> io::Result<()> {
+        let parent = self.retained_parent();
+        let leaf = self.target.relative_leaf()?;
+        let staged_leaf = staged
+            .file_name()
+            .ok_or_else(|| invalid_input("staged tag replacement has no file name"))?;
+
+        // The staged copy must be reachable through this exact retained
+        // directory. Opening it here — rather than trusting the staging
+        // pathname — proves the rename below will move the object this
+        // section created, and refuses a parent that was disturbed enough to
+        // strand the staging area elsewhere.
+        let staged_file = open_unix_regular_at(&parent.file, staged_leaf)?;
+        let staged_identity = object_identity(&staged_file)?;
+        drop(staged_file);
+
+        // Both rename sides are relative to the retained parent handle: a
+        // concurrent parent or mount replacement cannot redirect the
+        // replacement because the kernel never resolves an absolute path.
+        rustix::fs::renameat(&parent.file, staged_leaf, &parent.file, &leaf)
+            .map_err(io::Error::from)?;
+
+        // Prove the replacement landed on the exact directory entry.
+        let replaced = open_unix_regular_at(&parent.file, &leaf)?;
+        if object_identity(&replaced)? != staged_identity {
             return Err(authority_changed(
-                "mutation target no longer names the retained file",
+                "the tagged replacement did not land on the retained mutation target",
             ));
         }
         Ok(())
+    }
+
+    /// Platforms without retained parent handles replace through the staged
+    /// and target pathnames after the confirm above.
+    #[cfg(not(unix))]
+    fn replace_confirmed_staging(&self, staged: &Path) -> io::Result<()> {
+        std::fs::rename(staged, &self.target.path)
     }
 }
 
@@ -1227,7 +1333,7 @@ fn open_unix_directory_at(parent: &File, name: &OsString) -> io::Result<File> {
 }
 
 #[cfg(unix)]
-fn open_unix_regular_at(parent: &File, name: &OsString) -> io::Result<File> {
+fn open_unix_regular_at(parent: &File, name: &OsStr) -> io::Result<File> {
     use rustix::fs::{Mode, OFlags};
 
     let descriptor = rustix::fs::openat(
@@ -1894,6 +2000,91 @@ mod tests {
         let mut contents = Vec::new();
         source.read_to_end(&mut contents).expect("read source");
         assert_eq!(contents, b"replacement audio");
+    }
+
+    /// The replacement must be performed relative to the retained parent
+    /// directory, never by resolving the target pathname: a parent displaced
+    /// between selection and commit must not redirect the write into
+    /// whatever now occupies the old name.
+    #[cfg(unix)]
+    #[test]
+    fn mutation_target_replacement_lands_through_the_retained_parent_after_parent_displacement() {
+        let directory = TestDirectory::new("mutation-parent-displace");
+        let album = directory.path().join("album");
+        fs::create_dir(&album).expect("create album");
+        let song = album.join("song.flac");
+        fs::write(&song, b"original audio").expect("write song");
+
+        let authority =
+            Arc::new(MountedRootAuthority::acquire(directory.path()).expect("acquire authority"));
+        let target = authority
+            .open_mutation_target(Path::new("album/song.flac"))
+            .expect("open mutation target");
+
+        // Displace the retained parent and install an impostor directory at
+        // its old pathname, as an outside writer could between selection and
+        // commit. A path-based rename would land the replacement on the
+        // impostor; the retained parent cannot.
+        let displaced_album = directory.path().join("displaced-album");
+        fs::rename(&album, &displaced_album).expect("displace retained parent");
+        fs::create_dir(&album).expect("install impostor parent");
+        fs::write(album.join("song.flac"), b"impostor audio").expect("install impostor file");
+
+        // Stage inside the retained parent — the directory object the
+        // authority still holds — not beside the now-impostor pathname.
+        let staged = displaced_album.join(".tributary-tag-staged.flac");
+        fs::write(&staged, b"tagged audio").expect("stage the replacement");
+
+        let commit = target.begin_commit().expect("begin commit section");
+        commit
+            .commit_replacement(&staged)
+            .expect("commit through the retained parent");
+
+        assert_eq!(
+            fs::read(displaced_album.join("song.flac")).expect("read replaced file"),
+            b"tagged audio",
+            "the replacement must land beside the admitted file in the retained directory"
+        );
+        assert_eq!(
+            fs::read(album.join("song.flac")).expect("read impostor file"),
+            b"impostor audio",
+            "the impostor directory must never receive the write"
+        );
+    }
+
+    /// A symlink installed at the target name must never be followed by the
+    /// commit-time identity proof: the proof opens the leaf through the
+    /// retained parent with no-follow semantics, so a displaced-and-linked
+    /// name refuses the replacement instead of re-finding the retained
+    /// identity behind the link.
+    #[cfg(unix)]
+    #[test]
+    fn mutation_target_confirm_refuses_a_symlink_installed_at_the_target_name() {
+        use std::os::unix::fs::symlink;
+
+        let directory = TestDirectory::new("mutation-symlink-name");
+        let song = directory.path().join("song.flac");
+        fs::write(&song, b"original audio").expect("write song");
+
+        let authority =
+            Arc::new(MountedRootAuthority::acquire(directory.path()).expect("acquire authority"));
+        let target = authority
+            .open_mutation_target(Path::new("song.flac"))
+            .expect("open mutation target");
+
+        let displaced = directory.path().join("displaced.flac");
+        fs::rename(&song, &displaced).expect("displace the admitted file");
+        symlink(&displaced, &song).expect("install a symlink at the target name");
+
+        let commit = target.begin_commit().expect("begin commit section");
+        commit
+            .confirm_replacement_target()
+            .expect_err("a symlink at the target name must never be followed");
+        assert_eq!(
+            fs::read(&displaced).expect("read displaced file"),
+            b"original audio",
+            "the retained original must stay byte-for-byte intact"
+        );
     }
 
     #[cfg(unix)]

--- a/src/local/root_authority.rs
+++ b/src/local/root_authority.rs
@@ -1038,31 +1038,23 @@ fn rename_noreplace_at(parent: &RetainedObject, from: &OsStr, to: &OsStr) -> io:
 
 /// Rename `from` to `to`, refusing an existing destination.
 ///
-/// `std::fs::rename` always passes `MOVEFILE_REPLACE_EXISTING` on Windows, so
-/// the conditioned install and restores call `MoveFileExW` directly without
-/// that flag: the rename then fails with `ERROR_ALREADY_EXISTS` when the
-/// destination exists — the same atomic refusal `RENAME_NOREPLACE` provides
-/// on Unix. `MOVEFILE_WRITE_THROUGH` matches the durability `std::fs::rename`
-/// already provides.
+/// Windows has no no-replace rename primitive in the standard library, and
+/// reaching `MoveFileExW` directly would put raw FFI `unsafe` into the
+/// authority's publish path. `std::fs::hard_link` provides the same
+/// conditioned refusal: it fails atomically with `AlreadyExists` when the
+/// destination exists — the same refusal `RENAME_NOREPLACE` provides on
+/// Unix — and because a hard link names the very same file object, the
+/// published destination carries the source's exact identity, which the
+/// replacement proof re-verifies after the install. The source name is then
+/// retired best effort: a failure there only strands a second name for the
+/// already-published object (debris, never destruction). On filesystems
+/// without hard-link support the only available primitive is the plain
+/// rename, and the caller's quarantine proof bounds the residual window
+/// exactly as it does for the flagless unix fallback documented below.
 #[cfg(windows)]
 fn rename_noreplace(from: &Path, to: &Path) -> io::Result<()> {
-    use std::os::windows::ffi::OsStrExt;
-    use windows_sys::Win32::Storage::FileSystem::{MoveFileExW, MOVEFILE_WRITE_THROUGH};
-
-    fn wide_path(path: &Path) -> Vec<u16> {
-        let mut encoded: Vec<u16> = path.as_os_str().encode_wide().collect();
-        encoded.push(0);
-        encoded
-    }
-
-    let from_wide = wide_path(from);
-    let to_wide = wide_path(to);
-    // SAFETY: both pointers are null-terminated wide strings that outlive the
-    // call; MoveFileExW only reads them.
-    let ok = unsafe { MoveFileExW(from_wide.as_ptr(), to_wide.as_ptr(), MOVEFILE_WRITE_THROUGH) };
-    if ok == 0 {
-        return Err(io::Error::last_os_error());
-    }
+    std::fs::hard_link(from, to)?;
+    let _ = std::fs::remove_file(from);
     Ok(())
 }
 

--- a/src/local/root_authority.rs
+++ b/src/local/root_authority.rs
@@ -1110,12 +1110,15 @@ impl MountedMutationCommit<'_> {
 /// `renameat2(RENAME_NOREPLACE)` — `renameatx_np(RENAME_EXCL)` on macOS —
 /// makes the refusal atomic: no separate existence check can be interleaved
 /// between the decision and the rename, which is exactly the property the
-/// conditioned install and restores need. On a kernel or filesystem with no
-/// flag support (`ENOSYS` from a pre-10.12 macOS, `EINVAL` from a filesystem
-/// that never implemented the flag) the only available primitive is the plain
-/// rename; the caller's quarantine proof then bounds the residual window to
-/// what it was before this conditioning existed, and that residual is
-/// documented at the install site. Every other error propagates fail-closed.
+/// conditioned install and restores need.
+///
+/// A kernel or filesystem with no flag support (`ENOSYS` from a pre-10.12
+/// macOS, `EINVAL` from a filesystem that never implemented the flag) fails
+/// the call closed: the only primitive left would be the plain overwriting
+/// rename, and silently degrading to it would destroy a leaf recreated
+/// inside the vacancy and report success — precisely the clobber every
+/// other conditioning in this section exists to prevent. The commit refuses
+/// instead, leaving both files untouched.
 #[cfg(unix)]
 fn rename_noreplace_at(parent: &RetainedObject, from: &OsStr, to: &OsStr) -> io::Result<()> {
     match rustix::fs::renameat_with(
@@ -1132,7 +1135,12 @@ fn rename_noreplace_at(parent: &RetainedObject, from: &OsStr, to: &OsStr) -> io:
                 error.kind(),
                 io::ErrorKind::Unsupported | io::ErrorKind::InvalidInput
             ) {
-                rustix::fs::renameat(&parent.file, from, &parent.file, to).map_err(io::Error::from)
+                Err(io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    "this filesystem does not support the atomic no-replace rename \
+                     the conditioned replacement requires; the commit refused \
+                     without touching either file",
+                ))
             } else {
                 Err(error)
             }

--- a/src/local/root_authority.rs
+++ b/src/local/root_authority.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 use std::ffi::{OsStr, OsString};
 use std::fmt;
 use std::fs::File;
-use std::io::{self, Read};
+use std::io::{self, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 
@@ -613,9 +613,20 @@ impl MountedMutationCommit<'_> {
     /// The clone is taken from the retained handle, never from the pathname,
     /// so the copied bytes are the bytes the authority admitted even if the
     /// pathname was disturbed while the section was preparing.
+    ///
+    /// The clone is rewound to offset zero before it is returned. A
+    /// `try_clone` handle shares the retained handle's underlying file
+    /// description, so it inherits the retained read cursor: a copy attempt
+    /// that consumed the cursor — a failed flush, a refused commit, a batch
+    /// retry — leaves it at end-of-file, and a clone taken from there would
+    /// stage an empty or partial file instead of rereading the admitted
+    /// audio. The cursor is a read cursor only; nothing reads the retained
+    /// handle positionally, so rewinding the shared description is safe.
     pub(crate) fn source_file(&self) -> io::Result<File> {
         self.file.object.validate_live()?;
-        self.file.object.file.try_clone()
+        let mut source = self.file.object.file.try_clone()?;
+        source.seek(SeekFrom::Start(0))?;
+        Ok(source)
     }
 
     /// Prove the replacement target immediately before an atomic rename.
@@ -3182,6 +3193,40 @@ mod tests {
             "the staged copy must survive a refused commit for the caller to clean up"
         );
         fs::remove_file(&staged).expect("remove the staged copy");
+    }
+
+    /// A cloned read source shares the retained handle's underlying file
+    /// description, so a copy attempt that consumed the cursor must not leave
+    /// the next retry staging bytes from end-of-file: every `source_file()`
+    /// clone is returned rewound to offset zero.
+    #[test]
+    fn source_file_starts_at_zero_after_a_prior_copy_consumed_the_cursor() {
+        let directory = TestDirectory::new("mutation-source-cursor");
+        let song = directory.path().join("song.flac");
+        fs::write(&song, b"original audio").expect("write song");
+
+        let authority =
+            Arc::new(MountedRootAuthority::acquire(directory.path()).expect("acquire authority"));
+        let target = authority
+            .open_mutation_target(Path::new("song.flac"))
+            .expect("open mutation target");
+
+        let commit = target.begin_commit().expect("begin commit section");
+        let mut first = commit.source_file().expect("clone the retained source");
+        let mut consumed = Vec::new();
+        std::io::Read::read_to_end(&mut first, &mut consumed).expect("consume the first copy");
+        assert_eq!(consumed, b"original audio");
+        drop(first);
+
+        // The shared cursor now sits at end-of-file; the next clone must
+        // still read the full admitted bytes.
+        let mut second = commit.source_file().expect("re-clone the retained source");
+        let mut retried = Vec::new();
+        std::io::Read::read_to_end(&mut second, &mut retried).expect("read the retry copy");
+        assert_eq!(
+            retried, b"original audio",
+            "a retry must stage the full admitted bytes, not a cursor-at-EOF tail"
+        );
     }
 
     /// Two targets admitted for the same leaf at different times must

--- a/src/local/root_authority.rs
+++ b/src/local/root_authority.rs
@@ -89,14 +89,14 @@ struct RetainedObject {
 
 #[cfg(unix)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub(crate) struct ObjectIdentity {
+pub struct ObjectIdentity {
     device: u64,
     inode: u64,
 }
 
 #[cfg(windows)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub(crate) struct ObjectIdentity {
+pub struct ObjectIdentity {
     volume: u64,
     file_id: WindowsFileId,
 }
@@ -2059,7 +2059,7 @@ fn join_components(root: &Path, components: &[OsString]) -> PathBuf {
 }
 
 #[cfg(unix)]
-pub(crate) fn object_identity(file: &File) -> io::Result<ObjectIdentity> {
+pub fn object_identity(file: &File) -> io::Result<ObjectIdentity> {
     use std::os::unix::fs::MetadataExt;
 
     let metadata = file.metadata()?;
@@ -2070,7 +2070,7 @@ pub(crate) fn object_identity(file: &File) -> io::Result<ObjectIdentity> {
 }
 
 #[cfg(windows)]
-pub(crate) fn object_identity(file: &File) -> io::Result<ObjectIdentity> {
+pub fn object_identity(file: &File) -> io::Result<ObjectIdentity> {
     use std::mem::{size_of, MaybeUninit};
     use std::os::windows::io::AsRawHandle;
 

--- a/src/local/root_authority.rs
+++ b/src/local/root_authority.rs
@@ -607,6 +607,66 @@ impl MountedMutationTarget {
         parent.validate_live()?;
         Ok((parent.file.try_clone()?, self.relative_leaf()?))
     }
+
+    /// Point-in-time proof that the retained parent's leaf name still names
+    /// the admitted object — the advisory preflight's twin of the commit
+    /// section's leaf proof (see
+    /// [`MountedMutationCommit::confirm_replacement_target`]).
+    ///
+    /// [`Self::validate`] deliberately checks only the retained object, the
+    /// parent guards, and the root authority: a leaf renamed or replaced
+    /// while its retained inode stays open keeps validating, and the swap is
+    /// proven only inside the commit section. A preflight built on validate
+    /// alone would therefore report a write-capable target whose every
+    /// future commit is guaranteed to refuse. This check opens the leaf name
+    /// through the retained parent directory — never an absolute pathname
+    /// lookup, which a replaced parent could retarget — and compares exact
+    /// identity against the admitted object.
+    #[cfg(unix)]
+    pub(crate) fn confirm_leaf_names_admitted_object(&self) -> io::Result<()> {
+        let file = self
+            .file
+            .lock()
+            .map_err(|_| io::Error::other("mutation target commit section is unavailable"))?;
+        validate_mounted_bound(self.authority.as_ref(), &file)?;
+        let leaf = self.relative_leaf()?;
+        let parent = if let Some(guard) = file.parent_guards.last() {
+            guard
+        } else {
+            self.authority.root_handle()
+        };
+        let current = open_unix_regular_at(&parent.file, &leaf)?;
+        if object_identity(&current)? != file.object.identity {
+            return Err(authority_changed(
+                "mutation target no longer names the retained file",
+            ));
+        }
+        // Close the check window on the authority side, mirroring the
+        // double-validation discipline of every other retained-evidence
+        // path.
+        parent.validate_live()?;
+        self.authority.validate()
+    }
+
+    /// Windows twin of [`Self::confirm_leaf_names_admitted_object`]:
+    /// platforms without retained parent handles prove the pathname still
+    /// names the admitted object through a fresh open and an exact identity
+    /// comparison, exactly as the commit-side confirmation does.
+    #[cfg(not(unix))]
+    pub(crate) fn confirm_leaf_names_admitted_object(&self) -> io::Result<()> {
+        let file = self
+            .file
+            .lock()
+            .map_err(|_| io::Error::other("mutation target commit section is unavailable"))?;
+        validate_mounted_bound(self.authority.as_ref(), &file)?;
+        let current = File::open(&self.path)?;
+        if object_identity(&current)? != file.object.identity {
+            return Err(authority_changed(
+                "mutation target no longer names the retained file",
+            ));
+        }
+        self.authority.validate()
+    }
 }
 
 /// One serialized commit section over a [`MountedMutationTarget`].

--- a/src/local/root_authority.rs
+++ b/src/local/root_authority.rs
@@ -678,9 +678,11 @@ impl MountedMutationCommit<'_> {
     /// platforms with retained parent handles the replacement itself is then
     /// performed relative to that retained parent directory on both sides, so
     /// no pathname resolution — root, ancestor, or leaf — can retarget the
-    /// rename after the confirmation, and the destination entry is displaced
+    /// rename after the confirmation; the destination entry is displaced
     /// and re-proved before anything is installed over its name (see
-    /// [`Self::replace_confirmed_staging`]). The staged copy must live inside
+    /// [`Self::replace_confirmed_staging`]), and the install itself is a
+    /// no-replace rename that refuses a leaf recreated inside the vacancy.
+    /// The staged copy must live inside
     /// the exact retained parent directory; anything else is a lost staging
     /// area and is refused rather than re-resolved by path. Any uncertainty
     /// fails closed and leaves both files untouched.
@@ -761,10 +763,13 @@ impl MountedMutationCommit<'_> {
     /// it. Instead the confirmed entry is first displaced under a unique
     /// quarantine sibling — a rename to a fresh name can never clobber
     /// anything — the displaced object is proved to be the exact admitted
-    /// file, and the staged copy is installed only into the vacancy. If the
-    /// displaced object is not the admitted file, the newcomer is returned
-    /// byte-exact to its own name and the commit refuses with both objects
-    /// untouched.
+    /// file, and the staged copy is installed with a no-replace rename that
+    /// refuses an occupied destination (see [`Self::rename_noreplace_at`]),
+    /// so even a leaf recreated inside the quarantine-to-install vacancy is
+    /// preserved and refused rather than overwritten. If the displaced object
+    /// is not the admitted file, the newcomer is returned byte-exact to its
+    /// own name — through the same conditioned primitive — and the commit
+    /// refuses with every object untouched.
     #[cfg(unix)]
     fn replace_confirmed_staging(&self, staged: &Path) -> io::Result<()> {
         let parent = self.retained_parent();
@@ -805,29 +810,52 @@ impl MountedMutationCommit<'_> {
         // Prove the displaced entry is the exact object the confirm step
         // verified. Anything else means the leaf was swapped between confirm
         // and quarantine: put the newcomer back — byte-exact, under its own
-        // name — and refuse.
+        // name, through the conditioned restore — and refuse.
         let displaced_is_confirmed = open_unix_regular_at(&parent.file, &quarantine_leaf)
             .and_then(|displaced| object_identity(&displaced))
             .is_ok_and(|identity| identity == self.file.object.identity);
         if !displaced_is_confirmed {
-            rustix::fs::renameat(&parent.file, &quarantine_leaf, &parent.file, &leaf)
-                .map_err(io::Error::from)?;
+            Self::restore_displaced_entry(parent, &quarantine_leaf, &leaf)?;
             return Err(authority_changed(
                 "the confirmed mutation target was replaced before the commit",
             ));
         }
 
-        // Install the staged copy into the vacant leaf name. The quarantine
-        // above closed the confirm-to-install window for swaps; the residual
-        // hazard is an external writer recreating the leaf inside the
-        // install's own nanosecond-scale vacancy, which portable rename
-        // primitives cannot detect on every removable-media filesystem
-        // (FAT-family media supports neither hard links nor rename flags).
-        // A recreate there is replaced by the authorized replacement of the
-        // same user-visible name; every pre-existing object is proven and
-        // preserved by the quarantine proof above.
-        rustix::fs::renameat(&parent.file, staged_leaf, &parent.file, &leaf)
-            .map_err(io::Error::from)?;
+        // Install the staged copy into the vacant leaf name. The install
+        // itself is conditioned: a no-replace rename refuses an occupied
+        // destination atomically, so an external writer that recreates the
+        // leaf inside the quarantine-to-install window is preserved and
+        // refuses the commit exactly like every earlier disturbance — the
+        // write is authorized for the file the authority admitted, not for
+        // whatever now occupies the name.
+        #[cfg(test)]
+        run_pre_install_interpose(self);
+        match rename_noreplace_at(parent, staged_leaf, &leaf) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                // A newcomer recreated the leaf after the quarantine proof.
+                // Preserve it under a fresh unique sibling — a rename to a
+                // fresh name cannot clobber anything — put the confirmed
+                // original back, and refuse with both objects intact. If even
+                // the conditioned restore loses a second recreate race, the
+                // displaced objects stay under their quarantine names: debris,
+                // never destruction.
+                let _ =
+                    rustix::fs::renameat(&parent.file, &leaf, &parent.file, quarantine_name(&leaf));
+                let _ = Self::restore_displaced_entry(parent, &quarantine_leaf, &leaf);
+                return Err(authority_changed(
+                    "the mutation target leaf was recreated during the commit",
+                ));
+            }
+            Err(error) => {
+                // The install never landed and the leaf is still vacant.
+                // Return the confirmed original to its name (best effort —
+                // the caller sees the install error either way) and fail
+                // closed rather than stranding it under the quarantine name.
+                let _ = Self::restore_displaced_entry(parent, &quarantine_leaf, &leaf);
+                return Err(error);
+            }
+        }
 
         // The install rename consumed the staging entry — rename moves the
         // source name onto the destination — so only the displaced original,
@@ -852,18 +880,13 @@ impl MountedMutationCommit<'_> {
     /// displace the confirmed entry under a unique quarantine sibling, prove
     /// the displaced object is the exact admitted file, restore a swapped
     /// newcomer byte-exact to its own name, and only then install the staged
-    /// copy into the vacancy.
-    ///
-    /// Residual window, documented for review: an external writer recreating
-    /// the leaf between the quarantine proof and the install rename would be
-    /// overwritten by the install. No portable Windows rename primitive
-    /// refuses an existing destination, so this nanosecond-scale recreate
-    /// race cannot be closed mechanically here; every object that existed
-    /// when the commit began is still proven and preserved by the quarantine
-    /// proof above.
+    /// copy into the vacancy through a no-replace rename, so a leaf recreated
+    /// inside the install window is preserved and refuses the commit exactly
+    /// like the unix form.
     #[cfg(not(unix))]
     fn replace_confirmed_staging(&self, staged: &Path) -> io::Result<()> {
-        let quarantine_leaf = quarantine_name(&self.target.relative_leaf()?);
+        let leaf = self.target.relative_leaf()?;
+        let quarantine_leaf = quarantine_name(&leaf);
         let Some(parent_dir) = self.target.path.parent() else {
             return Err(invalid_input(
                 "mutation target has no parent directory to stage the replacement in",
@@ -883,24 +906,48 @@ impl MountedMutationCommit<'_> {
         }
 
         // Prove the displaced entry is the exact admitted file; return a
-        // swapped newcomer to its own name and refuse otherwise.
+        // swapped newcomer to its own name through the conditioned restore
+        // and refuse otherwise.
         let displaced_is_confirmed = std::fs::File::open(&quarantine_path)
             .and_then(|displaced| object_identity(&displaced))
             .is_ok_and(|identity| identity == self.file.object.identity);
         if !displaced_is_confirmed {
-            std::fs::rename(&quarantine_path, &self.target.path)?;
+            rename_noreplace(&quarantine_path, &self.target.path)?;
             return Err(authority_changed(
                 "the confirmed mutation target was replaced before the commit",
             ));
         }
 
-        // Install the staged copy into the vacant name (see the unix
-        // comment above for the documented recreate-window residual).
-        if let Err(error) = std::fs::rename(staged, &self.target.path) {
-            // The leaf is vacant and the staged copy never landed: restore
-            // the admitted original to its name and refuse.
-            let _ = std::fs::rename(&quarantine_path, &self.target.path);
-            return Err(error);
+        // Install the staged copy into the vacant leaf name through a
+        // no-replace rename, so a leaf recreated inside the quarantine-to-
+        // install window is preserved and refuses the commit instead of
+        // being overwritten.
+        #[cfg(test)]
+        run_pre_install_interpose(self);
+        match rename_noreplace(staged, &self.target.path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                // A newcomer recreated the leaf after the quarantine proof.
+                // Preserve it under a fresh unique sibling, put the confirmed
+                // original back, and refuse with both objects intact. If even
+                // the conditioned restore loses a second recreate race, the
+                // displaced objects stay under their quarantine names: debris,
+                // never destruction.
+                let _ =
+                    std::fs::rename(&self.target.path, &parent_dir.join(quarantine_name(&leaf)));
+                let _ = rename_noreplace(&quarantine_path, &self.target.path);
+                return Err(authority_changed(
+                    "the mutation target leaf was recreated during the commit",
+                ));
+            }
+            Err(error) => {
+                // The install never landed and the leaf is still vacant.
+                // Return the confirmed original to its name (best effort —
+                // the caller sees the install error either way) and fail
+                // closed rather than stranding it under the quarantine name.
+                let _ = rename_noreplace(&quarantine_path, &self.target.path);
+                return Err(error);
+            }
         }
 
         // Retire the displaced original — the entry a plain rename over the
@@ -910,6 +957,111 @@ impl MountedMutationCommit<'_> {
         let _ = std::fs::remove_file(&quarantine_path);
         Ok(())
     }
+
+    /// Return one displaced entry to `leaf` through the retained parent
+    /// without ever overwriting the name's current occupant.
+    ///
+    /// A refused replacement restores a displaced object to its own name
+    /// while an external writer may be recreating entries in the same
+    /// directory, so even the restore is conditioned: a plain rename here
+    /// could destroy a newcomer exactly like the install it guards against.
+    /// If the name is occupied, the occupant is displaced under a fresh
+    /// unique sibling — a rename to a fresh name cannot clobber anything —
+    /// and the restore is retried once; if a second recreate wins that
+    /// nanosecond race, the displaced object stays under its quarantine name
+    /// and the propagated error refuses the commit with both objects
+    /// preserved.
+    #[cfg(unix)]
+    fn restore_displaced_entry(
+        parent: &RetainedObject,
+        from: &OsStr,
+        leaf: &OsStr,
+    ) -> io::Result<()> {
+        match rename_noreplace_at(parent, from, leaf) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                rustix::fs::renameat(&parent.file, leaf, &parent.file, quarantine_name(leaf))
+                    .map_err(io::Error::from)?;
+                rename_noreplace_at(parent, from, leaf)
+            }
+            Err(error) => Err(error),
+        }
+    }
+}
+
+/// Rename `from` to `to` through the retained parent, refusing an existing
+/// destination.
+///
+/// `renameat2(RENAME_NOREPLACE)` — `renameatx_np(RENAME_EXCL)` on macOS —
+/// makes the refusal atomic: no separate existence check can be interleaved
+/// between the decision and the rename, which is exactly the property the
+/// conditioned install and restores need. On a kernel or filesystem with no
+/// flag support (`ENOSYS` from a pre-10.12 macOS, `EINVAL` from a filesystem
+/// that never implemented the flag) the only available primitive is the plain
+/// rename; the caller's quarantine proof then bounds the residual window to
+/// what it was before this conditioning existed, and that residual is
+/// documented at the install site. Every other error propagates fail-closed.
+#[cfg(unix)]
+fn rename_noreplace_at(parent: &RetainedObject, from: &OsStr, to: &OsStr) -> io::Result<()> {
+    match rustix::fs::renameat_with(
+        &parent.file,
+        from,
+        &parent.file,
+        to,
+        rustix::fs::RenameFlags::NOREPLACE,
+    ) {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            let error = io::Error::from(error);
+            if matches!(
+                error.kind(),
+                io::ErrorKind::Unsupported | io::ErrorKind::InvalidInput
+            ) {
+                rustix::fs::renameat(&parent.file, from, &parent.file, to).map_err(io::Error::from)
+            } else {
+                Err(error)
+            }
+        }
+    }
+}
+
+/// Rename `from` to `to`, refusing an existing destination.
+///
+/// `std::fs::rename` always passes `MOVEFILE_REPLACE_EXISTING` on Windows, so
+/// the conditioned install and restores call `MoveFileExW` directly without
+/// that flag: the rename then fails with `ERROR_ALREADY_EXISTS` when the
+/// destination exists — the same atomic refusal `RENAME_NOREPLACE` provides
+/// on Unix. `MOVEFILE_WRITE_THROUGH` matches the durability `std::fs::rename`
+/// already provides.
+#[cfg(windows)]
+fn rename_noreplace(from: &Path, to: &Path) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{MoveFileExW, MOVEFILE_WRITE_THROUGH};
+
+    fn wide_path(path: &Path) -> Vec<u16> {
+        let mut encoded: Vec<u16> = path.as_os_str().encode_wide().collect();
+        encoded.push(0);
+        encoded
+    }
+
+    let from_wide = wide_path(from);
+    let to_wide = wide_path(to);
+    // SAFETY: both pointers are null-terminated wide strings that outlive the
+    // call; MoveFileExW only reads them.
+    let ok = unsafe { MoveFileExW(from_wide.as_ptr(), to_wide.as_ptr(), MOVEFILE_WRITE_THROUGH) };
+    if ok == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Platforms with neither retained parent handles nor a no-replace rename
+/// primitive keep the plain rename. The caller's quarantine proof bounds the
+/// residual recreate window exactly as it does for the flagless unix
+/// fallback; the residual is documented at the install site.
+#[cfg(not(any(unix, windows)))]
+fn rename_noreplace(from: &Path, to: &Path) -> io::Result<()> {
+    std::fs::rename(from, to)
 }
 
 /// The key that identifies one replaceable directory leaf across every
@@ -1034,6 +1186,38 @@ fn with_post_confirm_interpose(interpose: Box<PostConfirmInterpose>, run: impl F
 
 #[cfg(test)]
 static POST_CONFIRM_INTERPOSE_SERIAL: Mutex<()> = Mutex::new(());
+
+/// Test-only seam: run the registered pre-install interposition, if any.
+///
+/// The install-window refusal is only reachable when the leaf is recreated
+/// between the quarantine proof and the install rename — nanoseconds wide in
+/// production. A regression test registers a closure here that recreates the
+/// leaf deterministically in that vacancy. Never compiled outside
+/// `cargo test`.
+#[cfg(test)]
+fn run_pre_install_interpose(commit: &MountedMutationCommit<'_>) {
+    if let Some(interpose) = PRE_INSTALL_INTERPOSE.lock().unwrap().as_ref() {
+        interpose(commit);
+    }
+}
+
+#[cfg(test)]
+type PreInstallInterpose = dyn Fn(&MountedMutationCommit<'_>) + Send + Sync;
+
+#[cfg(test)]
+static PRE_INSTALL_INTERPOSE: Mutex<Option<Box<PreInstallInterpose>>> = Mutex::new(None);
+
+/// Serialize tests that use the pre-install interposition seam.
+#[cfg(test)]
+fn with_pre_install_interpose(interpose: Box<PreInstallInterpose>, run: impl FnOnce()) {
+    let _serial = PRE_INSTALL_INTERPOSE_SERIAL.lock().unwrap();
+    *PRE_INSTALL_INTERPOSE.lock().unwrap() = Some(interpose);
+    run();
+    *PRE_INSTALL_INTERPOSE.lock().unwrap() = None;
+}
+
+#[cfg(test)]
+static PRE_INSTALL_INTERPOSE_SERIAL: Mutex<()> = Mutex::new(());
 
 /// Verify a mounted bound against its retained mount authority.
 fn validate_mounted_bound(authority: &MountedRootAuthority, bound: &BoundFile) -> io::Result<()> {
@@ -2915,6 +3099,89 @@ mod tests {
         );
         fs::remove_file(&staged).expect("remove the staged copy");
         assert_no_quarantine_sibling_remains(&directory);
+    }
+
+    /// The replacement must stay conditional on the destination remaining
+    /// vacant through the quarantine-to-install window: an external writer
+    /// that recreates the leaf after the confirmed original was displaced —
+    /// exactly what a plain overwriting install rename would silently
+    /// destroy — must be preserved under a fresh sibling and must refuse the
+    /// commit with the confirmed original restored byte-exact to its own
+    /// name.
+    #[test]
+    fn commit_replacement_refuses_a_leaf_recreated_in_the_install_window_and_preserves_the_newcomer(
+    ) {
+        let directory = TestDirectory::new("mutation-install-window-recreate");
+        let song = directory.path().join("song.flac");
+        fs::write(&song, b"original audio").expect("write song");
+
+        let authority =
+            Arc::new(MountedRootAuthority::acquire(directory.path()).expect("acquire authority"));
+        let target = authority
+            .open_mutation_target(Path::new("song.flac"))
+            .expect("open mutation target");
+
+        // The staged copy sits beside the target, as the tag writer stages it.
+        let staged = directory.path().join(".song.tributary-tag-tmp.flac");
+        fs::write(&staged, b"tagged audio").expect("stage the replacement");
+        let watched_leaf = song.clone();
+
+        with_pre_install_interpose(
+            Box::new(move |commit| {
+                if commit.target.path != watched_leaf {
+                    return;
+                }
+                // The quarantine step displaced the confirmed original and
+                // proved it; the leaf is vacant. Recreate it, as an external
+                // writer would inside the install window.
+                fs::write(&commit.target.path, b"newcomer audio")
+                    .expect("recreate the leaf in the install window");
+            }),
+            || {
+                let commit = target.begin_commit().expect("begin commit section");
+                commit
+                    .commit_replacement(&staged)
+                    .expect_err("a leaf recreated in the install window must refuse the commit");
+            },
+        );
+
+        // The confirmed original is back under its own name, byte-exact.
+        assert_eq!(
+            fs::read(&song).expect("read the leaf back"),
+            b"original audio",
+            "the refused commit must restore the confirmed original to its own name"
+        );
+
+        // The newcomer survives — displaced under a fresh quarantine sibling,
+        // never destroyed by the refused install.
+        let siblings: Vec<PathBuf> = fs::read_dir(directory.path())
+            .expect("list the directory")
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.contains("tributary-replaced"))
+            })
+            .collect();
+        assert_eq!(
+            siblings.len(),
+            1,
+            "exactly the recreated newcomer may remain, displaced under one fresh sibling: {siblings:?}"
+        );
+        assert_eq!(
+            fs::read(&siblings[0]).expect("read the displaced newcomer"),
+            b"newcomer audio",
+            "the preserved newcomer must be byte-for-byte intact"
+        );
+
+        // A refused commit does not consume the staged copy; the caller
+        // cleans it up.
+        assert!(
+            staged.exists(),
+            "the staged copy must survive a refused commit for the caller to clean up"
+        );
+        fs::remove_file(&staged).expect("remove the staged copy");
     }
 
     /// Two targets admitted for the same leaf at different times must

--- a/src/local/root_authority.rs
+++ b/src/local/root_authority.rs
@@ -846,8 +846,7 @@ impl MountedMutationCommit<'_> {
         leaf: &OsStr,
     ) -> io::Result<OsString> {
         let quarantine_leaf = quarantine_name(leaf);
-        if let Err(error) =
-            rustix::fs::renameat(&parent.file, leaf, &parent.file, &quarantine_leaf)
+        if let Err(error) = rustix::fs::renameat(&parent.file, leaf, &parent.file, &quarantine_leaf)
         {
             return Err(
                 if io::Error::from(error).kind() == io::ErrorKind::NotFound {
@@ -992,8 +991,7 @@ impl MountedMutationCommit<'_> {
                 // the conditioned restore loses a second recreate race, the
                 // displaced objects stay under their quarantine names: debris,
                 // never destruction.
-                let _ =
-                    std::fs::rename(&self.target.path, parent_dir.join(quarantine_name(&leaf)));
+                let _ = std::fs::rename(&self.target.path, parent_dir.join(quarantine_name(&leaf)));
                 let _ = rename_noreplace(&quarantine_path, &self.target.path);
                 return Err(authority_changed(
                     "the mutation target leaf was recreated during the commit",

--- a/src/local/root_authority.rs
+++ b/src/local/root_authority.rs
@@ -781,6 +781,15 @@ impl MountedMutationCommit<'_> {
     /// is not the admitted file, the newcomer is returned byte-exact to its
     /// own name — through the same conditioned primitive — and the commit
     /// refuses with every object untouched.
+    ///
+    /// The staged object's evidence stays retained through the install and
+    /// the landing proof, and the displaced admitted original is retired only
+    /// after that proof succeeds: an external rename over the staging name in
+    /// the capture-to-install window would otherwise install the stranger,
+    /// destroy the admitted original inside the install, and only then fail
+    /// the proof — the loss detected after it happened. Here a failed proof
+    /// means the quarantined original is still intact; it is restored
+    /// (conditioned) to its name and the stranger is displaced to a sibling.
     #[cfg(unix)]
     fn replace_confirmed_staging(&self, staged: &Path) -> io::Result<()> {
         let parent = self.retained_parent();
@@ -793,10 +802,11 @@ impl MountedMutationCommit<'_> {
         // directory. Opening it here — rather than trusting the staging
         // pathname — proves the install below will publish the object this
         // section created, and refuses a parent that was disturbed enough to
-        // strand the staging area elsewhere.
+        // strand the staging area elsewhere. The handle is retained through
+        // the install and the landing proof as the evidence for the object
+        // this section is publishing.
         let staged_file = open_unix_regular_at(&parent.file, staged_leaf)?;
         let staged_identity = object_identity(&staged_file)?;
-        drop(staged_file);
 
         // Displace whatever occupies the leaf under a fresh quarantine name,
         // then prove the displaced entry is the exact object the confirm step
@@ -821,7 +831,40 @@ impl MountedMutationCommit<'_> {
         #[cfg(test)]
         run_pre_install_interpose(self);
         Self::install_staged_leaf_into_vacant_leaf(parent, staged_leaf, &leaf, &quarantine_leaf)?;
-        Self::prove_replacement_landed(parent, &leaf, &staged_identity)
+        if let Err(error) = Self::prove_replacement_landed(parent, &leaf, &staged_identity) {
+            // The landing proof failed: an external writer swapped a stranger
+            // over the staging name before the install, or over the leaf
+            // after it. The admitted original is still intact under its
+            // quarantine name — the install no longer retires it — so put it
+            // back (conditioned) and refuse with both objects preserved.
+            Self::recover_original_after_failed_landing_proof(parent, &leaf, &quarantine_leaf);
+            return Err(error);
+        }
+
+        // The landing is proven; only now retire the admitted original under
+        // its quarantine name. A removal failure here leaves it as a
+        // quarantine sibling — debris, never destruction.
+        drop(staged_file);
+        let _ = rustix::fs::unlinkat(&parent.file, quarantine_leaf, rustix::fs::AtFlags::empty());
+        Ok(())
+    }
+
+    /// Recover the admitted original after a failed landing proof.
+    ///
+    /// Whatever the failed install left at the leaf is displaced under a
+    /// fresh unique quarantine sibling — a rename to a fresh name cannot
+    /// clobber anything — and the original is returned to its name through
+    /// the conditioned restore. Best effort by design: if an external writer
+    /// wins a recreate race during the recovery, the displaced objects stay
+    /// under their quarantine names — debris, never destruction.
+    #[cfg(unix)]
+    fn recover_original_after_failed_landing_proof(
+        parent: &RetainedObject,
+        leaf: &OsStr,
+        quarantine_leaf: &OsStr,
+    ) {
+        let _ = rustix::fs::renameat(&parent.file, leaf, &parent.file, &quarantine_name(leaf));
+        let _ = Self::restore_displaced_entry(parent, quarantine_leaf, leaf);
     }
 
     /// Prove the installed leaf names the exact object the staged copy held.
@@ -898,17 +941,20 @@ impl MountedMutationCommit<'_> {
     }
 
     /// Install the staged copy into the vacant leaf name through the
-    /// conditioned no-replace rename, then retire the displaced original.
+    /// conditioned no-replace rename.
     ///
     /// A no-replace rename refuses an occupied destination atomically, so an
     /// external writer that recreates the leaf inside the quarantine-to-
     /// install window is preserved under a fresh sibling and the commit
     /// refuses exactly like every earlier disturbance — the write is
     /// authorized for the file the authority admitted, not for whatever now
-    /// occupies the name. The install consumes the staging entry, so only
-    /// the displaced original remains to retire; the replacement has already
-    /// landed, so a removal failure there leaves it under the quarantine
-    /// sibling rather than failing the committed write.
+    /// occupies the name.
+    ///
+    /// The install deliberately does not retire the displaced original under
+    /// its quarantine name: the landing proof has not run yet, so retiring
+    /// here would destroy the admitted original before the section knows
+    /// whether the installed object is the one it staged. The caller retires
+    /// the quarantined original only after the landing proof succeeds.
     #[cfg(unix)]
     fn install_staged_leaf_into_vacant_leaf(
         parent: &RetainedObject,
@@ -942,8 +988,6 @@ impl MountedMutationCommit<'_> {
                 return Err(error);
             }
         }
-
-        let _ = rustix::fs::unlinkat(&parent.file, quarantine_leaf, rustix::fs::AtFlags::empty());
         Ok(())
     }
 
@@ -3104,7 +3148,10 @@ mod tests {
     /// Assert the recreated newcomer survived the refused install —
     /// displaced under exactly one fresh quarantine sibling, byte-for-byte
     /// intact.
-    fn assert_recreated_newcomer_displaced_under_one_fresh_sibling(directory: &TestDirectory) {
+    fn assert_recreated_newcomer_displaced_under_one_fresh_sibling(
+        directory: &TestDirectory,
+        expected: &[u8],
+    ) {
         let siblings: Vec<PathBuf> = fs::read_dir(directory.path())
             .expect("list the directory")
             .filter_map(|entry| entry.ok())
@@ -3118,12 +3165,12 @@ mod tests {
         assert_eq!(
             siblings.len(),
             1,
-            "exactly the recreated newcomer may remain, displaced under one fresh sibling: {siblings:?}"
+            "exactly the displaced stranger may remain, under one fresh sibling: {siblings:?}"
         );
         assert_eq!(
-            fs::read(&siblings[0]).expect("read the displaced newcomer"),
-            b"newcomer audio",
-            "the preserved newcomer must be byte-for-byte intact"
+            fs::read(&siblings[0]).expect("read the displaced object"),
+            expected,
+            "the preserved object must be byte-for-byte intact"
         );
     }
 
@@ -3248,7 +3295,7 @@ mod tests {
         // the newcomer survives — displaced under a fresh quarantine sibling,
         // never destroyed by the refused install.
         assert_confirmed_original_restored_to_its_name(&song);
-        assert_recreated_newcomer_displaced_under_one_fresh_sibling(&directory);
+        assert_recreated_newcomer_displaced_under_one_fresh_sibling(&directory, b"newcomer audio");
 
         // A refused commit does not consume the staged copy; the caller
         // cleans it up.
@@ -3257,6 +3304,74 @@ mod tests {
             "the staged copy must survive a refused commit for the caller to clean up"
         );
         fs::remove_file(&staged).expect("remove the staged copy");
+    }
+
+    /// The staged object's evidence must stay retained through the install,
+    /// and the admitted original must be retired only after the landing
+    /// proof succeeds. An external rename over the staging name inside the
+    /// capture-to-install window makes the install publish a stranger; the
+    /// commit must detect that at the landing proof, restore the admitted
+    /// original byte-exact to its own name, and refuse — not destroy the
+    /// original inside the install and only then discover the loss.
+    #[cfg(unix)]
+    #[test]
+    fn commit_replacement_refuses_a_staging_name_swapped_before_the_install_and_restores_the_original(
+    ) {
+        let directory = TestDirectory::new("mutation-staging-swap");
+        let song = directory.path().join("song.flac");
+        fs::write(&song, b"original audio").expect("write song");
+
+        let authority =
+            Arc::new(MountedRootAuthority::acquire(directory.path()).expect("acquire authority"));
+        let target = authority
+            .open_mutation_target(Path::new("song.flac"))
+            .expect("open mutation target");
+
+        // The staged copy sits beside the target, as the tag writer stages it.
+        let staged = directory.path().join(".song.tributary-tag-tmp.flac");
+        fs::write(&staged, b"tagged audio").expect("stage the replacement");
+        let stolen = directory.path().join("stolen.flac");
+        let stolen_for_closure = stolen.clone();
+        let watched_staged = staged.clone();
+        let watched_leaf = song.clone();
+
+        with_pre_install_interpose(
+            Box::new(move |commit| {
+                if commit.target.path != watched_leaf {
+                    return;
+                }
+                // The quarantine step displaced the confirmed original and
+                // proved it, and the staged identity has already been
+                // captured. Swap the staging name now — exactly the window
+                // where a stranger would be installed and the original
+                // destroyed before the landing proof could run.
+                fs::rename(&watched_staged, &stolen_for_closure)
+                    .expect("move the staged copy aside");
+                fs::write(&watched_staged, b"stranger audio")
+                    .expect("install a stranger at the staging name");
+            }),
+            || {
+                let commit = target.begin_commit().expect("begin commit section");
+                commit
+                    .commit_replacement(&staged)
+                    .expect_err("a stranger swapped over the staging name must refuse the commit");
+            },
+        );
+
+        // The admitted original is back under its own name, byte-exact: the
+        // refused install must never destroy the displaced original.
+        assert_confirmed_original_restored_to_its_name(&song);
+        // The true staged copy survives where the external writer moved it.
+        assert_eq!(
+            fs::read(&stolen).expect("read the moved staged copy"),
+            b"tagged audio",
+            "the true staged copy must survive the refused commit untouched"
+        );
+        fs::remove_file(&stolen).expect("remove the moved staged copy");
+        // The stranger the install briefly published survives displaced
+        // under exactly one fresh quarantine sibling — debris, never
+        // destruction.
+        assert_recreated_newcomer_displaced_under_one_fresh_sibling(&directory, b"stranger audio");
     }
 
     /// A cloned read source shares the retained handle's underlying file

--- a/src/local/root_authority.rs
+++ b/src/local/root_authority.rs
@@ -671,6 +671,26 @@ impl MountedMutationCommit<'_> {
         Ok(source)
     }
 
+    /// Clone the retained parent directory handle and admitted leaf name
+    /// that anchor the staged tag sibling.
+    ///
+    /// Private machinery for the local tag writer's anchored unix staging.
+    /// The staged copy is created, written, flushed, and — on every failure
+    /// path — cleaned up beneath this exact retained parent object, never by
+    /// resolving the target pathname, so an ancestor displaced after this
+    /// section's validation can neither strand the staging area inside an
+    /// impostor directory nor leak the complete tagged copy of the admitted
+    /// file across a symlink planted at an old name. The commit already
+    /// refuses a staged leaf it cannot find beneath this parent, so
+    /// anchoring staging here makes staging and install agree on one
+    /// directory object for the whole section.
+    #[cfg(unix)]
+    pub(crate) fn retained_staging_anchor(&self) -> io::Result<(File, OsString)> {
+        let parent = self.retained_parent();
+        parent.validate_live()?;
+        Ok((parent.file.try_clone()?, self.target.relative_leaf()?))
+    }
+
     /// Prove the replacement target immediately before an atomic rename.
     ///
     /// The mounted root is revalidated against its retained identity, and the

--- a/src/local/root_authority.rs
+++ b/src/local/root_authority.rs
@@ -89,14 +89,14 @@ struct RetainedObject {
 
 #[cfg(unix)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-struct ObjectIdentity {
+pub(crate) struct ObjectIdentity {
     device: u64,
     inode: u64,
 }
 
 #[cfg(windows)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-struct ObjectIdentity {
+pub(crate) struct ObjectIdentity {
     volume: u64,
     file_id: WindowsFileId,
 }
@@ -110,7 +110,7 @@ enum WindowsFileId {
 
 #[cfg(not(any(unix, windows)))]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-struct ObjectIdentity;
+pub(crate) struct ObjectIdentity;
 
 #[cfg(target_os = "linux")]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -767,7 +767,21 @@ impl MountedMutationCommit<'_> {
     /// be live (see [`Self::reanchor_target_to_installed`]) — while the
     /// section's guard is still held. A pathname is never opened for the
     /// re-anchor outside this guard.
-    pub(crate) fn commit_replacement(&mut self, staged: &Path) -> io::Result<()> {
+    ///
+    /// `expected_staged_identity` carries the identity of the exact object
+    /// the caller tagged, captured from its retained handle before the
+    /// staging pathname is consulted again. When supplied, the commit
+    /// verifies that the staged leaf still names that exact object before
+    /// anything is displaced, so a stranger swapped over the staging name
+    /// in the tag-to-commit window refuses the commit instead of being
+    /// installed with the tagged identity. Callers without a retained
+    /// staging handle (the documented path-based flows) pass `None` and
+    /// keep their pathname-identity proof.
+    pub(crate) fn commit_replacement(
+        &mut self,
+        staged: &Path,
+        expected_staged_identity: Option<&ObjectIdentity>,
+    ) -> io::Result<()> {
         #[cfg(unix)]
         let key = self.leaf_commit_key()?;
         #[cfg(not(unix))]
@@ -776,7 +790,7 @@ impl MountedMutationCommit<'_> {
             self.confirm_replacement_target()?;
             #[cfg(test)]
             run_post_confirm_interpose(self);
-            let installed = self.replace_confirmed_staging(staged)?;
+            let installed = self.replace_confirmed_staging(staged, expected_staged_identity)?;
             #[cfg(test)]
             run_pre_reanchor_interpose(self);
             self.reanchor_target_to_installed(installed)
@@ -947,7 +961,11 @@ impl MountedMutationCommit<'_> {
     /// The published object's handle is returned with its identity so the
     /// re-anchor can prove the published object is still live and linked.
     #[cfg(unix)]
-    fn replace_confirmed_staging(&self, staged: &Path) -> io::Result<InstalledReplacement> {
+    fn replace_confirmed_staging(
+        &self,
+        staged: &Path,
+        expected_staged_identity: Option<&ObjectIdentity>,
+    ) -> io::Result<InstalledReplacement> {
         let parent = self.retained_parent();
         let leaf = self.target.relative_leaf()?;
         let staged_leaf = staged
@@ -963,6 +981,19 @@ impl MountedMutationCommit<'_> {
         // this section is publishing.
         let staged_file = open_unix_regular_at(&parent.file, staged_leaf)?;
         let staged_identity = object_identity(&staged_file)?;
+
+        // The opened object must be the exact object the caller tagged.
+        // The tagging half captured this identity from its retained handle
+        // before dropping it, so a stranger swapped over the staging name
+        // in the tag-to-commit window is detected here — before anything
+        // is displaced — and the commit refuses with every file untouched.
+        if let Some(expected) = expected_staged_identity {
+            if staged_identity != *expected {
+                return Err(authority_changed(
+                    "the staged tag copy was disturbed before the commit",
+                ));
+            }
+        }
 
         // Displace whatever occupies the leaf under a fresh quarantine name,
         // then prove the displaced entry is the exact object the confirm step
@@ -1172,7 +1203,11 @@ impl MountedMutationCommit<'_> {
     /// the native pathnames, which must never leak into logs (see
     /// `replacement_path`).
     #[cfg(not(unix))]
-    fn replace_confirmed_staging(&self, staged: &Path) -> io::Result<InstalledReplacement> {
+    fn replace_confirmed_staging(
+        &self,
+        staged: &Path,
+        expected_staged_identity: Option<&ObjectIdentity>,
+    ) -> io::Result<InstalledReplacement> {
         let leaf = self.target.relative_leaf()?;
         let quarantine_leaf = quarantine_name(&leaf);
         let Some(parent_dir) = self.target.path.parent() else {
@@ -1191,6 +1226,39 @@ impl MountedMutationCommit<'_> {
             )
         })?;
         let staged_identity = object_identity(&staged_file)?;
+
+        // The opened object must be the exact object the caller tagged (the
+        // anchored callers capture this identity from their retained handle
+        // before the staging name is consulted again). Like every refusal
+        // below, this happens before anything is displaced.
+        if let Some(expected) = expected_staged_identity {
+            if staged_identity != *expected {
+                return Err(authority_changed(
+                    "the staged tag copy was disturbed before the commit",
+                ));
+            }
+        }
+
+        // Probe the no-replace publish primitive before the first
+        // displacement. On volumes without hard-link support (FAT/exFAT
+        // removable media) every `rename_noreplace` below would fail, and a
+        // post-quarantine failure of the conditioned restore would strand
+        // the admitted original under its quarantine name with its leaf
+        // vacant. Linking the staged copy to a fresh throwaway name is the
+        // exact primitive and volume the install uses: if the probe fails,
+        // the commit refuses while the admitted file still sits untouched
+        // at its own name. The probe link is removed before the commit
+        // proceeds; a failed removal leaves only a private debris sibling.
+        let probe_leaf = quarantine_name(&leaf);
+        if let Err(error) = std::fs::hard_link(staged, parent_dir.join(&probe_leaf)) {
+            return Err(io::Error::new(
+                error.kind(),
+                "this filesystem cannot publish the conditioned no-replace \
+                 replacement; the commit refused before displacing the \
+                 admitted file",
+            ));
+        }
+        let _ = std::fs::remove_file(parent_dir.join(&probe_leaf));
 
         // Displace the confirmed entry under the fresh quarantine name. A
         // rename to a name that did not exist a moment ago never replaces an
@@ -1962,7 +2030,7 @@ fn join_components(root: &Path, components: &[OsString]) -> PathBuf {
 }
 
 #[cfg(unix)]
-fn object_identity(file: &File) -> io::Result<ObjectIdentity> {
+pub(crate) fn object_identity(file: &File) -> io::Result<ObjectIdentity> {
     use std::os::unix::fs::MetadataExt;
 
     let metadata = file.metadata()?;
@@ -1973,7 +2041,7 @@ fn object_identity(file: &File) -> io::Result<ObjectIdentity> {
 }
 
 #[cfg(windows)]
-fn object_identity(file: &File) -> io::Result<ObjectIdentity> {
+pub(crate) fn object_identity(file: &File) -> io::Result<ObjectIdentity> {
     use std::mem::{size_of, MaybeUninit};
     use std::os::windows::io::AsRawHandle;
 
@@ -2072,7 +2140,7 @@ fn windows_published_link_count(file: &File) -> io::Result<u32> {
 }
 
 #[cfg(not(any(unix, windows)))]
-fn object_identity(_file: &File) -> io::Result<ObjectIdentity> {
+pub(crate) fn object_identity(_file: &File) -> io::Result<ObjectIdentity> {
     Err(unsupported_platform())
 }
 
@@ -2907,7 +2975,7 @@ mod tests {
         {
             let mut commit = target.begin_commit().expect("begin commit section");
             commit
-                .commit_replacement(&staged)
+                .commit_replacement(&staged, None)
                 .expect("the replacement commits and re-anchors the target");
             assert!(
                 !staged.exists(),
@@ -2969,7 +3037,7 @@ mod tests {
             || {
                 let mut commit = target.begin_commit().expect("begin commit section");
                 commit
-                    .commit_replacement(&staged)
+                    .commit_replacement(&staged, None)
                     .expect_err("a leaf swapped before the re-anchor must refuse the commit");
             },
         );
@@ -3042,7 +3110,7 @@ mod tests {
             || {
                 let mut commit = target.begin_commit().expect("begin commit section");
                 let error = commit
-                    .commit_replacement(&staged)
+                    .commit_replacement(&staged, None)
                     .expect_err("the re-anchor must refuse a removed replacement");
                 assert!(
                     error
@@ -3113,7 +3181,7 @@ mod tests {
 
         let mut commit = target.begin_commit().expect("begin commit section");
         commit
-            .commit_replacement(&staged)
+            .commit_replacement(&staged, None)
             .expect("commit through the retained parent");
 
         assert_eq!(
@@ -3701,7 +3769,7 @@ mod tests {
             || {
                 let mut commit = target.begin_commit().expect("begin commit section");
                 commit
-                    .commit_replacement(&staged)
+                    .commit_replacement(&staged, None)
                     .expect_err("a leaf swapped after confirm must refuse the commit");
             },
         );
@@ -3770,7 +3838,7 @@ mod tests {
             || {
                 let mut commit = target.begin_commit().expect("begin commit section");
                 commit
-                    .commit_replacement(&staged)
+                    .commit_replacement(&staged, None)
                     .expect_err("a leaf recreated in the install window must refuse the commit");
             },
         );
@@ -3837,7 +3905,7 @@ mod tests {
             || {
                 let mut commit = target.begin_commit().expect("begin commit section");
                 commit
-                    .commit_replacement(&staged)
+                    .commit_replacement(&staged, None)
                     .expect_err("a stranger swapped over the staging name must refuse the commit");
             },
         );
@@ -3856,6 +3924,99 @@ mod tests {
         // under exactly one fresh quarantine sibling — debris, never
         // destruction.
         assert_recreated_newcomer_displaced_under_one_fresh_sibling(&directory, b"stranger audio");
+    }
+
+    /// The tagged staging object's identity is conditioned into the commit:
+    /// when a stranger replaces the staging name after the tagged handle's
+    /// identity was captured — the tag-to-commit window — the commit refuses
+    /// before anything is displaced, and both the admitted original and the
+    /// stranger's victims stay untouched.
+    #[test]
+    fn commit_replacement_refuses_when_the_opened_staging_object_is_not_the_expected_identity() {
+        let directory = TestDirectory::new("mutation-staged-identity-mismatch");
+        let song = directory.path().join("song.flac");
+        fs::write(&song, b"original audio").expect("write song");
+
+        let authority =
+            Arc::new(MountedRootAuthority::acquire(directory.path()).expect("acquire authority"));
+        let target = authority
+            .open_mutation_target(Path::new("song.flac"))
+            .expect("open mutation target");
+
+        // The tagged copy sits beside the target; its identity is captured
+        // from the handle, exactly as the anchored tag writer captures it.
+        let staged = directory.path().join(".song.tributary-tag-tmp.flac");
+        fs::write(&staged, b"tagged audio").expect("stage the replacement");
+        let expected = object_identity(&fs::File::open(&staged).expect("open the staged copy"))
+            .expect("identity of the tagged staging object");
+
+        // A stranger takes over the staging name after the capture.
+        let moved = directory.path().join("moved.flac");
+        fs::rename(&staged, &moved).expect("move the true staged copy aside");
+        fs::write(&staged, b"stranger audio").expect("plant a stranger at the staging name");
+
+        let mut commit = target.begin_commit().expect("begin commit section");
+        let error = commit
+            .commit_replacement(&staged, Some(&expected))
+            .expect_err("a disturbed staging object must refuse the commit");
+        assert_eq!(
+            error.kind(),
+            io::ErrorKind::PermissionDenied,
+            "the staged-object conditioning must refuse like every other disturbance"
+        );
+
+        // The refusal happened before the displacement: the admitted
+        // original is untouched at its own name, and the stranger still sits
+        // at the staging name it stole.
+        assert_eq!(
+            fs::read(&song).expect("read the leaf back"),
+            b"original audio",
+            "a staged-object refusal must leave the admitted original untouched"
+        );
+        assert_eq!(
+            fs::read(&staged).expect("read the stranger back"),
+            b"stranger audio",
+            "a staged-object refusal must leave the staging name alone"
+        );
+        assert_eq!(
+            fs::read(&moved).expect("read the true staged copy back"),
+            b"tagged audio",
+            "the true staged copy must survive the refusal untouched"
+        );
+    }
+
+    /// Supplying the exact tagged identity does not disturb the happy path:
+    /// the commit installs the staged copy that matches it.
+    #[test]
+    fn commit_replacement_accepts_a_staged_object_matching_the_expected_identity() {
+        let directory = TestDirectory::new("mutation-staged-identity-match");
+        let song = directory.path().join("song.flac");
+        fs::write(&song, b"original audio").expect("write song");
+
+        let authority =
+            Arc::new(MountedRootAuthority::acquire(directory.path()).expect("acquire authority"));
+        let target = authority
+            .open_mutation_target(Path::new("song.flac"))
+            .expect("open mutation target");
+
+        let staged = directory.path().join(".song.tributary-tag-tmp.flac");
+        fs::write(&staged, b"tagged audio").expect("stage the replacement");
+        let expected = object_identity(&fs::File::open(&staged).expect("open the staged copy"))
+            .expect("identity of the tagged staging object");
+
+        let mut commit = target.begin_commit().expect("begin commit section");
+        commit
+            .commit_replacement(&staged, Some(&expected))
+            .expect("the matching staged copy commits");
+        assert_eq!(
+            fs::read(&song).expect("read the leaf back"),
+            b"tagged audio",
+            "the conditioned commit must install the exact staged object"
+        );
+        assert!(
+            !staged.exists(),
+            "a successful install consumes the staging name"
+        );
     }
 
     /// A cloned read source shares the retained handle's underlying file
@@ -3919,7 +4080,7 @@ mod tests {
                 .begin_commit()
                 .expect("begin the first commit section");
             commit
-                .commit_replacement(&staged)
+                .commit_replacement(&staged, None)
                 .expect("the first replacement commits");
         }
         assert!(
@@ -3937,7 +4098,7 @@ mod tests {
                 .begin_commit()
                 .expect("begin the second commit section");
             commit
-                .commit_replacement(&staged_second)
+                .commit_replacement(&staged_second, None)
                 .expect_err("the displaced target must refuse the commit");
         }
         assert_eq!(

--- a/src/local/root_authority.rs
+++ b/src/local/root_authority.rs
@@ -1159,24 +1159,52 @@ fn rename_noreplace_at(parent: &RetainedObject, from: &OsStr, to: &OsStr) -> io:
 /// published destination carries the source's exact identity, which the
 /// replacement proof re-verifies after the install. The source name is then
 /// retired best effort: a failure there only strands a second name for the
-/// already-published object (debris, never destruction). On filesystems
-/// without hard-link support the only available primitive is the plain
-/// rename, and the caller's quarantine proof bounds the residual window
-/// exactly as it does for the flagless unix fallback documented below.
+/// already-published object (debris, never destruction).
+///
+/// There is deliberately no fallback for filesystems without hard-link
+/// support (FAT/exFAT removable media): the only primitive left would be
+/// the plain overwriting rename, and silently degrading to it would destroy
+/// a leaf recreated inside the vacancy — the exact clobber this section
+/// refuses to commit. Such a filesystem fails the commit closed instead,
+/// with an error that names the platform limitation. The OS payload is
+/// dropped when rebuilding that error: it embeds the native pathnames,
+/// which must never leak into logs (see `replacement_path`).
 #[cfg(windows)]
 fn rename_noreplace(from: &Path, to: &Path) -> io::Result<()> {
-    std::fs::hard_link(from, to)?;
-    let _ = std::fs::remove_file(from);
-    Ok(())
+    match std::fs::hard_link(from, to) {
+        Ok(()) => {
+            let _ = std::fs::remove_file(from);
+            Ok(())
+        }
+        // The destination exists: the conditioned refusal itself. Propagated
+        // unchanged so the install and restore callers keep their
+        // AlreadyExists contract.
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => Err(error),
+        // No hard links available (or any other failure): the conditioned
+        // no-replace publish cannot happen, so nothing happens — fail closed
+        // with a path-free error.
+        Err(error) => Err(io::Error::new(
+            error.kind(),
+            "this filesystem does not support the atomic no-replace publish \
+             the conditioned replacement requires; the commit refused \
+             without touching either file",
+        )),
+    }
 }
 
 /// Platforms with neither retained parent handles nor a no-replace rename
-/// primitive keep the plain rename. The caller's quarantine proof bounds the
-/// residual recreate window exactly as it does for the flagless unix
-/// fallback; the residual is documented at the install site.
+/// primitive have no way to publish a replacement without first refusing an
+/// occupied destination, and a plain overwriting rename would destroy a leaf
+/// recreated inside the vacancy. They fail every conditioned publish closed
+/// rather than silently degrade to that rename.
 #[cfg(not(any(unix, windows)))]
-fn rename_noreplace(from: &Path, to: &Path) -> io::Result<()> {
-    std::fs::rename(from, to)
+fn rename_noreplace(_from: &Path, _to: &Path) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "this platform does not provide the atomic no-replace rename \
+         the conditioned replacement requires; the commit refused \
+         without touching either file",
+    ))
 }
 
 /// The key that identifies one replaceable directory leaf across every

--- a/src/local/root_authority.rs
+++ b/src/local/root_authority.rs
@@ -8,17 +8,13 @@
 //! mount-generation checks to an ephemeral mounted root without requiring the
 //! removable filesystem to contain an application marker.
 
-// `OsStr` is only referenced by `#[cfg(unix)]` helpers (e.g.
-// `open_unix_regular_at`); importing it unconditionally breaks the Windows
-// build with an unused-import error under `-D warnings`.
-#[cfg(unix)]
-use std::ffi::OsStr;
-use std::ffi::OsString;
+use std::collections::HashMap;
+use std::ffi::{OsStr, OsString};
 use std::fmt;
 use std::fs::File;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 
 use uuid::Uuid;
 
@@ -92,28 +88,28 @@ struct RetainedObject {
 }
 
 #[cfg(unix)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 struct ObjectIdentity {
     device: u64,
     inode: u64,
 }
 
 #[cfg(windows)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 struct ObjectIdentity {
     volume: u64,
     file_id: WindowsFileId,
 }
 
 #[cfg(windows)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 enum WindowsFileId {
     Extended([u8; 16]),
     Legacy(u64),
 }
 
 #[cfg(not(any(unix, windows)))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 struct ObjectIdentity;
 
 #[cfg(target_os = "linux")]
@@ -670,18 +666,69 @@ impl MountedMutationCommit<'_> {
     /// Confirm the replacement target and perform the atomic replacement with
     /// the staged copy at `staged`.
     ///
-    /// Confirmation runs first (mount, retained ancestry, exact file identity
-    /// — see [`Self::confirm_replacement_target`]). On platforms with
-    /// retained parent handles the replacement itself is then performed
-    /// relative to that retained parent directory on both sides, so no
-    /// pathname resolution — root, ancestor, or leaf — can retarget the
-    /// rename after the confirmation. The staged copy must live inside the
-    /// exact retained parent directory; anything else is a lost staging area
-    /// and is refused rather than re-resolved by path. Any uncertainty fails
-    /// closed and leaves both files untouched.
+    /// The whole section — validation and rename together — first excludes
+    /// every other Tributary-side committer for the same directory leaf (see
+    /// [`Self::with_leaf_commit_exclusion`]): the per-target commit lock
+    /// serializes one [`MountedMutationTarget`] object, but two targets
+    /// admitted at different times can name the same leaf, and their
+    /// confirm-and-rename spans must never interleave.
+    ///
+    /// Confirmation then proves the mount, the retained ancestry, and the
+    /// exact leaf identity (see [`Self::confirm_replacement_target`]). On
+    /// platforms with retained parent handles the replacement itself is then
+    /// performed relative to that retained parent directory on both sides, so
+    /// no pathname resolution — root, ancestor, or leaf — can retarget the
+    /// rename after the confirmation, and the destination entry is displaced
+    /// and re-proved before anything is installed over its name (see
+    /// [`Self::replace_confirmed_staging`]). The staged copy must live inside
+    /// the exact retained parent directory; anything else is a lost staging
+    /// area and is refused rather than re-resolved by path. Any uncertainty
+    /// fails closed and leaves both files untouched.
     pub(crate) fn commit_replacement(&self, staged: &Path) -> io::Result<()> {
-        self.confirm_replacement_target()?;
-        self.replace_confirmed_staging(staged)
+        self.with_leaf_commit_exclusion(|| {
+            self.confirm_replacement_target()?;
+            #[cfg(test)]
+            run_post_confirm_interpose(self);
+            self.replace_confirmed_staging(staged)
+        })
+    }
+
+    /// Run one replacement section while holding the process-wide exclusion
+    /// for this target's leaf.
+    ///
+    /// See [`with_leaf_commit_lock`] for why the lock is scoped to the
+    /// directory leaf — shared by every target for that leaf — and not to the
+    /// target object.
+    fn with_leaf_commit_exclusion(&self, run: impl FnOnce() -> io::Result<()>) -> io::Result<()> {
+        with_leaf_commit_lock(self.leaf_commit_key()?, run)
+    }
+
+    /// Identify the directory leaf this section would replace.
+    ///
+    /// On platforms with retained parent handles the leaf is identified by
+    /// the retained parent's exact filesystem object plus the leaf name —
+    /// never by a pathname spelling, which a displaced parent could retarget.
+    #[cfg(unix)]
+    fn leaf_commit_key(&self) -> io::Result<LeafCommitKey> {
+        Ok(LeafCommitKey::Retained {
+            parent: self.retained_parent().identity,
+            leaf: self.target.relative_leaf()?,
+        })
+    }
+
+    /// Windows keeps no retained parent handle; the admitted target's
+    /// normalized absolute pathname is the leaf identity every target object
+    /// for that leaf shares.
+    #[cfg(windows)]
+    fn leaf_commit_key(&self) -> io::Result<LeafCommitKey> {
+        Ok(LeafCommitKey::AdmittedPath(self.target.path.clone()))
+    }
+
+    /// Non-unix, non-Windows targets have no retained parent either; the
+    /// admitted pathname identifies the leaf.
+    #[cfg(not(any(unix, windows)))]
+    fn leaf_commit_key(&self) -> io::Result<LeafCommitKey> {
+        Ok(LeafCommitKey::AdmittedPath(self.target.path.clone()))
     }
 
     /// Resolve the retained directory that must contain the replacement.
@@ -696,7 +743,18 @@ impl MountedMutationCommit<'_> {
     }
 
     /// Rename the staged copy over the confirmed target through the retained
-    /// parent, then prove the replacement landed on that exact entry.
+    /// parent, conditioning the destination on its confirmed identity, then
+    /// prove the replacement landed on that exact entry.
+    ///
+    /// A plain rename over the leaf would silently overwrite whatever an
+    /// external writer swapped into the name after the confirm step proved
+    /// it. Instead the confirmed entry is first displaced under a unique
+    /// quarantine sibling — a rename to a fresh name can never clobber
+    /// anything — the displaced object is proved to be the exact admitted
+    /// file, and the staged copy is installed only into the vacancy. If the
+    /// displaced object is not the admitted file, the newcomer is returned
+    /// byte-exact to its own name and the commit refuses with both objects
+    /// untouched.
     #[cfg(unix)]
     fn replace_confirmed_staging(&self, staged: &Path) -> io::Result<()> {
         let parent = self.retained_parent();
@@ -707,18 +765,67 @@ impl MountedMutationCommit<'_> {
 
         // The staged copy must be reachable through this exact retained
         // directory. Opening it here — rather than trusting the staging
-        // pathname — proves the rename below will move the object this
+        // pathname — proves the install below will publish the object this
         // section created, and refuses a parent that was disturbed enough to
         // strand the staging area elsewhere.
         let staged_file = open_unix_regular_at(&parent.file, staged_leaf)?;
         let staged_identity = object_identity(&staged_file)?;
         drop(staged_file);
 
-        // Both rename sides are relative to the retained parent handle: a
-        // concurrent parent or mount replacement cannot redirect the
-        // replacement because the kernel never resolves an absolute path.
+        // Displace whatever occupies the leaf. This rename is atomic and its
+        // destination is a fresh unique name, so it cannot destroy anything:
+        // afterwards the confirmed object — or whatever replaced it since the
+        // confirm step — sits under the quarantine name and the leaf is
+        // vacant.
+        let quarantine_leaf = quarantine_name(&leaf);
+        if let Err(error) =
+            rustix::fs::renameat(&parent.file, &leaf, &parent.file, &quarantine_leaf)
+        {
+            return Err(
+                if io::Error::from(error).kind() == io::ErrorKind::NotFound {
+                    // The leaf vanished after the confirm step. Nothing has
+                    // been displaced; refuse without touching anything.
+                    authority_changed("the confirmed mutation target no longer exists")
+                } else {
+                    io::Error::from(error)
+                },
+            );
+        }
+
+        // Prove the displaced entry is the exact object the confirm step
+        // verified. Anything else means the leaf was swapped between confirm
+        // and quarantine: put the newcomer back — byte-exact, under its own
+        // name — and refuse.
+        let displaced_is_confirmed = open_unix_regular_at(&parent.file, &quarantine_leaf)
+            .and_then(|displaced| object_identity(&displaced))
+            .is_ok_and(|identity| identity == self.file.object.identity);
+        if !displaced_is_confirmed {
+            rustix::fs::renameat(&parent.file, &quarantine_leaf, &parent.file, &leaf)
+                .map_err(io::Error::from)?;
+            return Err(authority_changed(
+                "the confirmed mutation target was replaced before the commit",
+            ));
+        }
+
+        // Install the staged copy into the vacant leaf name. The quarantine
+        // above closed the confirm-to-install window for swaps; the residual
+        // hazard is an external writer recreating the leaf inside the
+        // install's own nanosecond-scale vacancy, which portable rename
+        // primitives cannot detect on every removable-media filesystem
+        // (FAT-family media supports neither hard links nor rename flags).
+        // A recreate there is replaced by the authorized replacement of the
+        // same user-visible name; every pre-existing object is proven and
+        // preserved by the quarantine proof above.
         rustix::fs::renameat(&parent.file, staged_leaf, &parent.file, &leaf)
             .map_err(io::Error::from)?;
+
+        // The install rename consumed the staging entry — rename moves the
+        // source name onto the destination — so only the displaced original,
+        // the same directory entry a plain rename over the leaf would have
+        // consumed, remains to retire. The replacement has already landed,
+        // so a removal failure here leaves the prior object under the
+        // quarantine sibling rather than failing the committed write.
+        let _ = rustix::fs::unlinkat(&parent.file, &quarantine_leaf, rustix::fs::AtFlags::empty());
 
         // Prove the replacement landed on the exact directory entry.
         let replaced = open_unix_regular_at(&parent.file, &leaf)?;
@@ -731,12 +838,192 @@ impl MountedMutationCommit<'_> {
     }
 
     /// Platforms without retained parent handles replace through the staged
-    /// and target pathnames after the confirm above.
+    /// and target pathnames, with the same conditional-destination discipline:
+    /// displace the confirmed entry under a unique quarantine sibling, prove
+    /// the displaced object is the exact admitted file, restore a swapped
+    /// newcomer byte-exact to its own name, and only then install the staged
+    /// copy into the vacancy.
+    ///
+    /// Residual window, documented for review: an external writer recreating
+    /// the leaf between the quarantine proof and the install rename would be
+    /// overwritten by the install. No portable Windows rename primitive
+    /// refuses an existing destination, so this nanosecond-scale recreate
+    /// race cannot be closed mechanically here; every object that existed
+    /// when the commit began is still proven and preserved by the quarantine
+    /// proof above.
     #[cfg(not(unix))]
     fn replace_confirmed_staging(&self, staged: &Path) -> io::Result<()> {
-        std::fs::rename(staged, &self.target.path)
+        let quarantine_leaf = quarantine_name(&self.target.relative_leaf()?);
+        let Some(parent_dir) = self.target.path.parent() else {
+            return Err(invalid_input(
+                "mutation target has no parent directory to stage the replacement in",
+            ));
+        };
+        let quarantine_path = parent_dir.join(&quarantine_leaf);
+
+        // Displace the confirmed entry under the fresh quarantine name. A
+        // rename to a name that did not exist a moment ago never replaces an
+        // existing entry, so this cannot clobber anything.
+        if let Err(error) = std::fs::rename(&self.target.path, &quarantine_path) {
+            return Err(if error.kind() == io::ErrorKind::NotFound {
+                authority_changed("the confirmed mutation target no longer exists")
+            } else {
+                error
+            });
+        }
+
+        // Prove the displaced entry is the exact admitted file; return a
+        // swapped newcomer to its own name and refuse otherwise.
+        let displaced_is_confirmed = std::fs::File::open(&quarantine_path)
+            .and_then(|displaced| object_identity(&displaced))
+            .is_ok_and(|identity| identity == self.file.object.identity);
+        if !displaced_is_confirmed {
+            std::fs::rename(&quarantine_path, &self.target.path)?;
+            return Err(authority_changed(
+                "the confirmed mutation target was replaced before the commit",
+            ));
+        }
+
+        // Install the staged copy into the vacant name (see the unix
+        // comment above for the documented recreate-window residual).
+        if let Err(error) = std::fs::rename(staged, &self.target.path) {
+            // The leaf is vacant and the staged copy never landed: restore
+            // the admitted original to its name and refuse.
+            let _ = std::fs::rename(&quarantine_path, &self.target.path);
+            return Err(error);
+        }
+
+        // Retire the displaced original — the entry a plain rename over the
+        // target would have consumed. The replacement has already landed, so
+        // a removal failure here leaves the prior object under the
+        // quarantine sibling rather than failing the committed write.
+        let _ = std::fs::remove_file(&quarantine_path);
+        Ok(())
     }
 }
+
+/// The key that identifies one replaceable directory leaf across every
+/// mutation target that resolves to it.
+///
+/// On platforms with retained parent handles the key is the retained parent's
+/// exact filesystem object plus the leaf name, so a pathname spelling can
+/// never widen or split the exclusion. Platforms without retained parents
+/// fall back to the admitted absolute pathname.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+enum LeafCommitKey {
+    #[cfg(unix)]
+    Retained {
+        parent: ObjectIdentity,
+        leaf: OsString,
+    },
+    #[cfg(not(unix))]
+    AdmittedPath(PathBuf),
+}
+
+/// The process-wide registry of per-leaf replacement exclusions.
+static LEAF_COMMIT_LOCKS: OnceLock<Mutex<HashMap<LeafCommitKey, Arc<Mutex<()>>>>> = OnceLock::new();
+
+/// Run one replacement section while holding the process-wide exclusion for
+/// one directory leaf.
+///
+/// The per-target commit lock serializes commit sections through one
+/// [`MountedMutationTarget`] object, but nothing about that object is unique
+/// to the leaf it names: two targets admitted at different times can name the
+/// same directory entry, and each carries only its own admitted object. Their
+/// confirm-and-rename spans must never interleave, or the later confirm would
+/// prove a leaf that the earlier rename then overwrites with a different
+/// object. The exclusion is therefore scoped to the leaf itself — identified
+/// by retained parent object plus leaf name — and shared by every target for
+/// that leaf.
+///
+/// The registry entry is removed when the section's lock is released and no
+/// other committer holds or waits for that leaf, so the registry cannot grow
+/// without bound. The strong-count re-check happens under the registry lock,
+/// which every committer must hold to clone the entry, so a removal never
+/// strands a waiter on an orphaned lock.
+fn with_leaf_commit_lock(
+    key: LeafCommitKey,
+    run: impl FnOnce() -> io::Result<()>,
+) -> io::Result<()> {
+    let registry = LEAF_COMMIT_LOCKS.get_or_init(|| Mutex::new(HashMap::new()));
+    let entry = {
+        let mut table = registry
+            .lock()
+            .map_err(|_| io::Error::other("leaf commit registry is unavailable"))?;
+        Arc::clone(table.entry(key.clone()).or_default())
+    };
+    let result = {
+        let _leaf_lock = entry
+            .lock()
+            .map_err(|_| io::Error::other("leaf commit section is unavailable"))?;
+        run()
+    };
+    // Two strong references — the registry table and this section's own
+    // clone — mean no other committer holds or waits for this leaf, so the
+    // entry can be retired. The re-check under the registry lock, which
+    // every committer must hold to clone the entry, closes the window
+    // against a concurrent clone between the two checks: a removal never
+    // strands a waiter on an orphaned lock, and a waiter that clones first
+    // raises the count past two so the entry stays.
+    if Arc::strong_count(&entry) == 2 {
+        if let Ok(mut table) = registry.lock() {
+            if let Some(existing) = table.get(&key) {
+                if Arc::strong_count(existing) == 2 && Arc::ptr_eq(existing, &entry) {
+                    table.remove(&key);
+                }
+            }
+        }
+    }
+    result
+}
+
+/// A fresh hidden sibling name for the quarantine step of a conditional
+/// replacement. The uuid makes the name unpredictable and collision-free,
+/// and the original leaf contributes a bounded prefix so a long leaf cannot
+/// exceed the filesystem's name limit once the suffix is appended.
+fn quarantine_name(leaf: &OsStr) -> OsString {
+    let lossy = leaf.to_string_lossy();
+    let mut prefix = String::new();
+    for character in lossy.chars() {
+        if prefix.len() + character.len_utf8() > 96 {
+            break;
+        }
+        prefix.push(character);
+    }
+    format!(".{}.tributary-replaced-{}", prefix, Uuid::new_v4().simple()).into()
+}
+
+/// Test-only seam: run the registered post-confirm interposition, if any.
+///
+/// The conditional replacement's refusal logic is only reachable when the
+/// leaf is swapped inside the confirm-to-replace window — microseconds wide
+/// in production. A regression test registers a closure here that performs
+/// that swap deterministically between the confirm step and the replace
+/// step. Never compiled outside `cargo test`.
+#[cfg(test)]
+fn run_post_confirm_interpose(commit: &MountedMutationCommit<'_>) {
+    if let Some(interpose) = POST_CONFIRM_INTERPOSE.lock().unwrap().as_ref() {
+        interpose(commit);
+    }
+}
+
+#[cfg(test)]
+type PostConfirmInterpose = dyn Fn(&MountedMutationCommit<'_>) + Send + Sync;
+
+#[cfg(test)]
+static POST_CONFIRM_INTERPOSE: Mutex<Option<Box<PostConfirmInterpose>>> = Mutex::new(None);
+
+/// Serialize tests that use the post-confirm interposition seam.
+#[cfg(test)]
+fn with_post_confirm_interpose(interpose: Box<PostConfirmInterpose>, run: impl FnOnce()) {
+    let _serial = POST_CONFIRM_INTERPOSE_SERIAL.lock().unwrap();
+    *POST_CONFIRM_INTERPOSE.lock().unwrap() = Some(interpose);
+    run();
+    *POST_CONFIRM_INTERPOSE.lock().unwrap() = None;
+}
+
+#[cfg(test)]
+static POST_CONFIRM_INTERPOSE_SERIAL: Mutex<()> = Mutex::new(());
 
 /// Verify a mounted bound against its retained mount authority.
 fn validate_mounted_bound(authority: &MountedRootAuthority, bound: &BoundFile) -> io::Result<()> {
@@ -2525,5 +2812,148 @@ mod tests {
         assert!(parse_fdinfo_mount_generation("pos:\t0\n").is_err());
         assert!(parse_fdinfo_mount_generation("mnt_id:\tnot-a-number\n").is_err());
         assert!(parse_fdinfo_mount_generation("mnt_id:\t1\nmnt_id:\t2\n").is_err());
+    }
+
+    /// The replacement must be conditional on the confirmed leaf identity.
+    /// An external writer that swaps the leaf after the confirm step has
+    /// proven it — precisely what a plain rename over the name would
+    /// silently overwrite — must be detected, restored byte-exact to its
+    /// own name, and the commit refused with every pre-existing object
+    /// untouched and no quarantine sibling left behind.
+    #[test]
+    fn commit_replacement_refuses_a_leaf_swapped_after_confirm_and_restores_the_newcomer() {
+        let directory = TestDirectory::new("mutation-post-confirm-swap");
+        let song = directory.path().join("song.flac");
+        fs::write(&song, b"original audio").expect("write song");
+
+        let authority =
+            Arc::new(MountedRootAuthority::acquire(directory.path()).expect("acquire authority"));
+        let target = authority
+            .open_mutation_target(Path::new("song.flac"))
+            .expect("open mutation target");
+
+        // The staged copy sits beside the target, as the tag writer stages it.
+        let staged = directory.path().join(".song.tributary-tag-tmp.flac");
+        fs::write(&staged, b"tagged audio").expect("stage the replacement");
+        let displaced_original = directory.path().join("displaced.flac");
+        let displaced_for_closure = displaced_original.clone();
+        // The seam is process-global and the harness runs tests in parallel,
+        // so the closure must act only on this test's own leaf: a concurrent
+        // test's commit section must pass through the seam untouched.
+        let watched_leaf = song.clone();
+
+        with_post_confirm_interpose(
+            Box::new(move |commit| {
+                if commit.target.path != watched_leaf {
+                    return;
+                }
+                // Swap the leaf after the confirm step proved it: the
+                // admitted object is moved aside and a different object
+                // takes the name, as an external writer would mid-commit.
+                let path = commit.target.path.clone();
+                fs::rename(&path, &displaced_for_closure).expect("displace the confirmed leaf");
+                fs::write(&path, b"newcomer audio").expect("install a newcomer at the leaf");
+            }),
+            || {
+                let commit = target.begin_commit().expect("begin commit section");
+                commit
+                    .commit_replacement(&staged)
+                    .expect_err("a leaf swapped after confirm must refuse the commit");
+            },
+        );
+
+        // The newcomer keeps its name and exact bytes: the refused write
+        // must not replace whatever took the name.
+        assert_eq!(
+            fs::read(&song).expect("read the leaf back"),
+            b"newcomer audio",
+            "the refused write must not replace whatever took the name"
+        );
+        // The displaced admitted object is untouched where the external
+        // writer moved it.
+        assert_eq!(
+            fs::read(&displaced_original).expect("read the displaced original"),
+            b"original audio",
+            "the admitted object must be byte-for-byte untouched"
+        );
+        // A refused commit does not consume the staged copy; the caller
+        // cleans it up. Remove it here, then require that the refusal left
+        // no quarantine sibling behind.
+        assert!(
+            staged.exists(),
+            "the staged copy must survive a refused commit for the caller to clean up"
+        );
+        fs::remove_file(&staged).expect("remove the staged copy");
+        let leftovers: Vec<PathBuf> = fs::read_dir(directory.path())
+            .expect("list the directory")
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.contains("tributary-replaced"))
+            })
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "a refused commit must restore the swapped leaf and leave no quarantine sibling: {leftovers:?}"
+        );
+    }
+
+    /// Two targets admitted for the same leaf at different times must
+    /// serialize on the leaf itself, not on each other's object: the first
+    /// replacement retires the object the second target admitted, and the
+    /// second commit must then refuse closed — without deadlocking the
+    /// leaf exclusion both sections share.
+    #[test]
+    fn two_targets_for_one_leaf_serialize_and_the_displaced_one_refuses() {
+        let directory = TestDirectory::new("mutation-two-targets-one-leaf");
+        let song = directory.path().join("song.flac");
+        fs::write(&song, b"original audio").expect("write song");
+
+        let authority =
+            Arc::new(MountedRootAuthority::acquire(directory.path()).expect("acquire authority"));
+        let first = authority
+            .open_mutation_target(Path::new("song.flac"))
+            .expect("open the first target");
+        let second = authority
+            .open_mutation_target(Path::new("song.flac"))
+            .expect("open the second target");
+
+        let staged = directory.path().join(".staged-one.flac");
+        fs::write(&staged, b"tagged audio").expect("stage the first replacement");
+        {
+            let commit = first
+                .begin_commit()
+                .expect("begin the first commit section");
+            commit
+                .commit_replacement(&staged)
+                .expect("the first replacement commits");
+        }
+        assert!(
+            !staged.exists(),
+            "a successful install consumes the staging name"
+        );
+
+        // The second target's admitted object was retired by the first
+        // replacement; its commit must refuse and leave the first
+        // replacement installed and exact.
+        let staged_second = directory.path().join(".staged-two.flac");
+        fs::write(&staged_second, b"second audio").expect("stage the second replacement");
+        {
+            let commit = second
+                .begin_commit()
+                .expect("begin the second commit section");
+            commit
+                .commit_replacement(&staged_second)
+                .expect_err("the displaced target must refuse the commit");
+        }
+        assert_eq!(
+            fs::read(&song).expect("read the leaf back"),
+            b"tagged audio",
+            "the refused second commit must not replace the first replacement"
+        );
+        fs::remove_file(&staged_second)
+            .expect("a refused commit leaves its staging name to the caller");
     }
 }

--- a/src/local/tag_writer.rs
+++ b/src/local/tag_writer.rs
@@ -680,40 +680,80 @@ fn atomic_tag_replacement(
 
     let (temp, destination) = TempFile::create_beside(target_path)?;
     #[cfg(target_os = "windows")]
-    let mut destination = {
-        let security_result = source_dacl.apply_to(&destination).with_context(|| {
-            format!(
-                "Failed to protect the tagged copy of {} with its original Windows DACL",
-                target_path.display()
-            )
-        });
-        drop(destination);
-        security_result?;
-        temp.reopen_exclusive_for_tagging().with_context(|| {
-            format!(
-                "The original Windows DACL of {} does not permit writing the tagged copy",
-                target_path.display()
-            )
-        })?
-    };
+    let mut destination = open_tag_copy_destination(source_dacl, destination, &temp, target_path)?;
     #[cfg(not(target_os = "windows"))]
     let mut destination = destination;
-    let copy_result = std::io::copy(&mut source, &mut destination)
-        .map(|_| ())
-        .with_context(|| format!("Failed to copy {} for tag writing", target_path.display()));
+    let copy_result = copy_source_into_destination(&mut source, &mut destination, target_path);
     drop(source);
     drop(destination);
     copy_result?;
 
     write_tags_to(temp.path(), edits)?;
+    flush_and_confirm_tagged_copy(&temp, target_path, confirm_replacement)?;
 
+    temp.persist_to(target_path)?;
+    tracing::debug!("Tags written successfully");
+    Ok(())
+}
+
+/// Protect the tagged copy with the source file's original DACL and reopen it
+/// exclusively for tagging.
+///
+/// Windows attribute inheritance applies at creation: the complete DACL must
+/// be installed before the first copied byte, and installing it can strip the
+/// creation handle's write access, so tagging reopens a fresh exclusive
+/// handle afterwards.
+#[cfg(target_os = "windows")]
+fn open_tag_copy_destination(
+    source_dacl: WindowsDacl,
+    destination: File,
+    temp: &TempFile,
+    target_path: &Path,
+) -> Result<File> {
+    let security_result = source_dacl.apply_to(&destination).with_context(|| {
+        format!(
+            "Failed to protect the tagged copy of {} with its original Windows DACL",
+            target_path.display()
+        )
+    });
+    drop(destination);
+    security_result?;
+    temp.reopen_exclusive_for_tagging().with_context(|| {
+        format!(
+            "The original Windows DACL of {} does not permit writing the tagged copy",
+            target_path.display()
+        )
+    })
+}
+
+/// Copy the source bytes into the tagged copy, reporting but not raising a
+/// copy failure so the caller can release both handles before surfacing it.
+fn copy_source_into_destination(
+    source: &mut File,
+    destination: &mut File,
+    target_path: &Path,
+) -> Result<()> {
+    std::io::copy(source, destination)
+        .map(|_| ())
+        .with_context(|| format!("Failed to copy {} for tag writing", target_path.display()))
+}
+
+/// Flush the tagged copy, carry over the replaced file's Unix permissions,
+/// and run the caller's final replacement gate.
+///
+/// The flush happens *before* the permission copy: replacing a read-only file
+/// would otherwise make the temp read-only too, and a read-only file cannot
+/// be flushed. Windows installs the complete DACL before the first copied
+/// byte; its std Permissions value represents only the DOS read-only
+/// attribute, so the permission carry-over is Unix-only.
+fn flush_and_confirm_tagged_copy(
+    temp: &TempFile,
+    target_path: &Path,
+    confirm_replacement: impl FnOnce() -> Result<()>,
+) -> Result<()> {
     // Flush the tagged copy before it becomes the user's file. Without this a
     // crash between rename and writeback can leave a truncated file where the
     // original used to be.
-    //
-    // This happens *before* the permission copy below: replacing a read-only
-    // file would otherwise make the temp read-only too, and a read-only file
-    // cannot be flushed.
     flush_to_disk(temp.path()).with_context(|| {
         format!(
             "Failed to flush the tagged copy of {}",
@@ -722,8 +762,6 @@ fn atomic_tag_replacement(
     })?;
 
     // Best-effort: match the Unix permissions of the file being replaced.
-    // Windows installs the complete DACL before the first copied byte above;
-    // its std Permissions value represents only the DOS read-only attribute.
     #[cfg(unix)]
     if let Ok(metadata) = std::fs::metadata(target_path) {
         let _ = std::fs::set_permissions(temp.path(), metadata.permissions());
@@ -732,11 +770,7 @@ fn atomic_tag_replacement(
     // Last gate before the replacement becomes visible: an authority-checked
     // caller refuses here if the pathname no longer names the exact file it
     // copied from.
-    confirm_replacement()?;
-
-    temp.persist_to(target_path)?;
-    tracing::debug!("Tags written successfully");
-    Ok(())
+    confirm_replacement()
 }
 
 /// Flush a file's contents to disk.

--- a/src/local/tag_writer.rs
+++ b/src/local/tag_writer.rs
@@ -645,6 +645,12 @@ pub fn write_tags_with_mutation_target(
     // follow-up commit (a batch retry, or a second edit) is authorized for
     // the file that exists now. Failure is advisory: the next commit section
     // revalidates fail-closed regardless.
+    //
+    // The commit section's guard must be released before rebind: rebind
+    // serializes on the same target lock this section is still holding, and
+    // a std Mutex is not reentrant — relocking it here would deadlock the
+    // writer thread forever.
+    drop(commit);
     let _ = target.rebind();
     Ok(())
 }

--- a/src/local/tag_writer.rs
+++ b/src/local/tag_writer.rs
@@ -26,6 +26,7 @@
 //! - **The replacement is durable**: the tagged copy is `fsync`ed before the
 //!   rename, so a crash cannot leave a truncated file in place of the original.
 
+use std::fs::File;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -33,6 +34,8 @@ use lofty::config::WriteOptions;
 use lofty::file::TaggedFileExt;
 use lofty::tag::{Accessor, ItemKey, ItemValue, TagExt, TagItem};
 use uuid::Uuid;
+
+use super::root_authority::MountedMutationTarget;
 
 /// Reserved filename prefix for the private sibling used by atomic tag writes.
 const TAG_WRITE_TEMP_PREFIX: &str = ".tributary-tag-";
@@ -586,25 +589,96 @@ pub fn write_tags(path: &Path, edits: &TagEdits) -> Result<()> {
         }
     }
 
-    // Copy the file to an exclusively created sibling, tag the copy, then
-    // atomically rename it back, so a power loss, panic, or full disk
-    // mid-write leaves the original audio file untouched. The cost is one full
-    // file copy per save, which is fine for interactive tag editing.
-    //
-    // `temp` removes itself on every early return below.
-    let mut source = std::fs::File::open(path)
+    let source = std::fs::File::open(path)
         .with_context(|| format!("Failed to open {} for tag writing", path.display()))?;
-    #[cfg(target_os = "windows")]
-    let source_dacl = WindowsDacl::read_from(&source)
-        .with_context(|| format!("Failed to read the Windows DACL of {}", path.display()))?;
+    atomic_tag_replacement(source, path, edits, || Ok(()))
+}
 
-    let (temp, destination) = TempFile::create_beside(path)?;
+/// Write tag edits to one exact file beneath a retained mounted authority.
+///
+/// This is the removable-media form of [`write_tags`]. The read source is the
+/// retained exact file object — never a pathname lookup — and the atomic
+/// replacement is refused unless the mounted root, the retained ancestry, and
+/// the exact pathname still name the file the authority admitted, revalidated
+/// immediately before the rename. Every failure leaves the target untouched.
+/// This is a blocking operation — call from a background thread.
+pub fn write_tags_with_mutation_target(
+    target: &MountedMutationTarget,
+    edits: &TagEdits,
+) -> Result<()> {
+    if edits.is_empty() {
+        return Ok(());
+    }
+
+    // Reject the whole edit before touching the authority. A file must never
+    // be rewritten for an edit we are going to silently discard.
+    edits.validate()?;
+
+    if !supports_tag_writes(target.replacement_path()) {
+        anyhow::bail!(
+            "Unsupported format for tag writing: {}",
+            target
+                .replacement_path()
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .unwrap_or("unknown")
+        );
+    }
+
+    // Open the serialized commit section first: it revalidates the mount,
+    // the retained ancestry, and the exact retained file before any byte is
+    // read, and holds the target's commit lock through the replacement.
+    let commit = target.begin_commit().map_err(|error| {
+        anyhow::anyhow!("The retained mutation authority is no longer valid: {error}")
+    })?;
+    let source = commit
+        .source_file()
+        .with_context(|| "Failed to read the exact retained mutation target".to_string())?;
+    atomic_tag_replacement(source, target.replacement_path(), edits, || {
+        commit
+            .confirm_replacement_target()
+            .context("The exact file to replace changed before the tagged copy was committed")
+    })?;
+
+    // A successful replacement retired the object this section copied from.
+    // Re-anchor the retained evidence to the exact current object so a
+    // follow-up commit (a batch retry, or a second edit) is authorized for
+    // the file that exists now. Failure is advisory: the next commit section
+    // revalidates fail-closed regardless.
+    let _ = target.rebind();
+    Ok(())
+}
+
+/// Copy `source` to an exclusively created sibling of `target_path`, tag the
+/// copy, flush it, and atomically rename it over `target_path`.
+///
+/// `confirm_replacement` runs between the flush and the rename and must
+/// prove — for authority-checked callers — that `target_path` still names
+/// the exact file `source` was cloned from. Path-based callers have no
+/// retained identity to compare and pass a no-op; the rename itself is their
+/// point-in-time replacement.
+fn atomic_tag_replacement(
+    source: File,
+    target_path: &Path,
+    edits: &TagEdits,
+    confirm_replacement: impl FnOnce() -> Result<()>,
+) -> Result<()> {
+    let mut source = source;
+    #[cfg(target_os = "windows")]
+    let source_dacl = WindowsDacl::read_from(&source).with_context(|| {
+        format!(
+            "Failed to read the Windows DACL of {}",
+            target_path.display()
+        )
+    })?;
+
+    let (temp, destination) = TempFile::create_beside(target_path)?;
     #[cfg(target_os = "windows")]
     let mut destination = {
         let security_result = source_dacl.apply_to(&destination).with_context(|| {
             format!(
                 "Failed to protect the tagged copy of {} with its original Windows DACL",
-                path.display()
+                target_path.display()
             )
         });
         drop(destination);
@@ -612,7 +686,7 @@ pub fn write_tags(path: &Path, edits: &TagEdits) -> Result<()> {
         temp.reopen_exclusive_for_tagging().with_context(|| {
             format!(
                 "The original Windows DACL of {} does not permit writing the tagged copy",
-                path.display()
+                target_path.display()
             )
         })?
     };
@@ -620,7 +694,7 @@ pub fn write_tags(path: &Path, edits: &TagEdits) -> Result<()> {
     let mut destination = destination;
     let copy_result = std::io::copy(&mut source, &mut destination)
         .map(|_| ())
-        .with_context(|| format!("Failed to copy {} for tag writing", path.display()));
+        .with_context(|| format!("Failed to copy {} for tag writing", target_path.display()));
     drop(source);
     drop(destination);
     copy_result?;
@@ -634,18 +708,27 @@ pub fn write_tags(path: &Path, edits: &TagEdits) -> Result<()> {
     // This happens *before* the permission copy below: replacing a read-only
     // file would otherwise make the temp read-only too, and a read-only file
     // cannot be flushed.
-    flush_to_disk(temp.path())
-        .with_context(|| format!("Failed to flush the tagged copy of {}", path.display()))?;
+    flush_to_disk(temp.path()).with_context(|| {
+        format!(
+            "Failed to flush the tagged copy of {}",
+            target_path.display()
+        )
+    })?;
 
     // Best-effort: match the Unix permissions of the file being replaced.
     // Windows installs the complete DACL before the first copied byte above;
     // its std Permissions value represents only the DOS read-only attribute.
     #[cfg(unix)]
-    if let Ok(metadata) = std::fs::metadata(path) {
+    if let Ok(metadata) = std::fs::metadata(target_path) {
         let _ = std::fs::set_permissions(temp.path(), metadata.permissions());
     }
 
-    temp.persist_to(path)?;
+    // Last gate before the replacement becomes visible: an authority-checked
+    // caller refuses here if the pathname no longer names the exact file it
+    // copied from.
+    confirm_replacement()?;
+
+    temp.persist_to(target_path)?;
     tracing::debug!("Tags written successfully");
     Ok(())
 }
@@ -1142,6 +1225,96 @@ mod tests {
         assert_eq!(tag.track(), Some(7));
         assert_eq!(tag.disk(), Some(2));
         assert_eq!(tag.comment().as_deref(), Some("Fixture comment"));
+    }
+
+    /// A removable-media write through a retained mutation target must
+    /// succeed exactly like the path-based happy path, and the rebind after
+    /// the atomic rename must authorize a follow-up write through the same
+    /// target object.
+    #[test]
+    fn a_mutation_target_write_round_trips_and_reanchors_for_a_follow_up() {
+        let directory = TestDirectory::new("mutation-write");
+        let track = directory.audio_file(
+            "silence.flac",
+            include_bytes!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/tests/fixtures/audio/silence.flac"
+            )),
+        );
+        let authority = std::sync::Arc::new(
+            crate::local::root_authority::MountedRootAuthority::acquire(&directory.path)
+                .expect("acquire mounted authority"),
+        );
+        let target = authority
+            .open_mutation_target(Path::new("silence.flac"))
+            .expect("open mutation target");
+
+        write_tags_with_mutation_target(&target, &year("2026"))
+            .expect("write through the retained authority");
+        assert!(
+            directory.temp_files().is_empty(),
+            "a successful write must not leave its sibling temp file behind"
+        );
+
+        // The replacement retired the copied-from object; the rebind in the
+        // write must have re-anchored the target, so a second edit through
+        // the same retained authority is still authorized.
+        write_tags_with_mutation_target(&target, &year("2027"))
+            .expect("follow-up write after the re-anchor");
+
+        let tagged_file = lofty::read_from_path(&track).expect("reopen tagged FLAC");
+        let tag = tagged_file
+            .primary_tag()
+            .expect("tagged FLAC must have a primary tag");
+        assert_eq!(tag.get_string(ItemKey::Year), Some("2027"));
+    }
+
+    /// The bug this authority exists for: if the pathname is swapped between
+    /// selection and commit, the write must fail closed — the swap stays
+    /// untouched, the admitted file keeps its exact bytes, and no private
+    /// sibling is left behind.
+    #[test]
+    fn a_mutation_target_write_refuses_a_swapped_file_and_leaves_both_untouched() {
+        let directory = TestDirectory::new("mutation-refuse");
+        let track = directory.audio_file(
+            "silence.flac",
+            include_bytes!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/tests/fixtures/audio/silence.flac"
+            )),
+        );
+        let original = std::fs::read(&track).expect("read fixture bytes");
+
+        let authority = std::sync::Arc::new(
+            crate::local::root_authority::MountedRootAuthority::acquire(&directory.path)
+                .expect("acquire mounted authority"),
+        );
+        let target = authority
+            .open_mutation_target(Path::new("silence.flac"))
+            .expect("open mutation target");
+
+        // Swap the pathname after the authority admitted the exact file.
+        let displaced = directory.path.join("displaced.flac");
+        std::fs::rename(&track, &displaced).expect("displace the admitted file");
+        std::fs::write(&track, b"not the admitted file").expect("install different bytes");
+
+        write_tags_with_mutation_target(&target, &year("2026"))
+            .expect_err("the pathname no longer names the admitted file; the commit must refuse");
+
+        assert_eq!(
+            std::fs::read(&track).expect("read swapped path back"),
+            b"not the admitted file",
+            "the refused write must not replace whatever took the name"
+        );
+        assert_eq!(
+            std::fs::read(&displaced).expect("read displaced file back"),
+            original,
+            "the admitted file must be byte-for-byte untouched"
+        );
+        assert!(
+            directory.temp_files().is_empty(),
+            "a refused commit leaves no private sibling behind"
+        );
     }
 
     #[test]

--- a/src/local/tag_writer.rs
+++ b/src/local/tag_writer.rs
@@ -704,7 +704,7 @@ fn atomic_tag_replacement(
     let mut source = source;
     #[cfg(target_os = "windows")]
     let source_dacl = WindowsDacl::read_from(&source)
-        .with_context(|| format!("Failed to read the Windows DACL of {target_label}",))?;
+        .with_context(|| format!("Failed to read the Windows DACL of {target_label}"))?;
 
     let (mut temp, destination) = TempFile::create_beside(target_path, target_label)?;
     #[cfg(target_os = "windows")]

--- a/src/local/tag_writer.rs
+++ b/src/local/tag_writer.rs
@@ -18,7 +18,11 @@
 //!   filename shape.
 //! - **The temp path is unguessable and exclusively created** (`O_EXCL` via
 //!   `create_new`), so two concurrent saves to the same file cannot collide and
-//!   the copy cannot be redirected through a pre-planted symlink.
+//!   the copy cannot be redirected through a pre-planted symlink. For a
+//!   retained-authority write the staging never resolves a pathname at all:
+//!   the sibling is created, written, flushed, and cleaned up beneath the
+//!   retained parent handle, so no displaced ancestor or planted symlink can
+//!   observe or receive any part of the copy.
 //! - **A Windows copy is never exposed through an inherited DACL.** Its handle
 //!   denies competing opens from creation until the source DACL and protection
 //!   state are installed; a fresh exclusive write handle must then pass that
@@ -26,6 +30,7 @@
 //! - **The replacement is durable**: the tagged copy is `fsync`ed before the
 //!   rename, so a crash cannot leave a truncated file in place of the original.
 
+use std::ffi::OsStr;
 use std::fs::File;
 use std::path::{Path, PathBuf};
 
@@ -35,7 +40,7 @@ use lofty::file::{TaggedFile, TaggedFileExt};
 use lofty::tag::{Accessor, ItemKey, ItemValue, Tag, TagExt, TagItem};
 use uuid::Uuid;
 
-use super::root_authority::MountedMutationTarget;
+use super::root_authority::{MountedMutationCommit, MountedMutationTarget};
 
 /// Reserved filename prefix for the private sibling used by atomic tag writes.
 const TAG_WRITE_TEMP_PREFIX: &str = ".tributary-tag-";
@@ -283,6 +288,35 @@ impl Drop for WindowsDacl {
 struct TempFile {
     path: PathBuf,
     persisted: bool,
+    /// Unix authority-based staging: the retained parent directory the
+    /// staged sibling is anchored at. Set only when `path` holds the bare
+    /// leaf name of a sibling created beneath a retained parent handle; the
+    /// drop cleanup then unlinks that leaf through the handle — never
+    /// through a pathname — so the cleanup cannot mutate a displaced
+    /// impostor directory.
+    #[cfg(unix)]
+    anchored_parent: Option<File>,
+}
+
+/// Randomized staged-sibling leaf name, preserving the final extension.
+///
+/// `lofty` infers the format from the final extension, and the retained
+/// commit machinery addresses the staged copy by this exact leaf, so
+/// preserve only that extension: including the whole source name could
+/// overflow a filesystem's component-length limit for an otherwise valid
+/// long filename.
+fn staged_sibling_name(target_leaf: &OsStr) -> std::ffi::OsString {
+    let extension = Path::new(target_leaf)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(str::to_ascii_lowercase);
+    let mut candidate_name =
+        std::ffi::OsString::from(format!("{TAG_WRITE_TEMP_PREFIX}{}", Uuid::new_v4()));
+    if let Some(extension) = extension.as_deref() {
+        candidate_name.push(".");
+        candidate_name.push(extension);
+    }
+    candidate_name
 }
 
 impl TempFile {
@@ -298,23 +332,9 @@ impl TempFile {
     /// not leak into logs (see `replacement_path`).
     fn create_beside(target: &Path, target_label: &str) -> Result<(Self, std::fs::File)> {
         let directory = target.parent().unwrap_or_else(|| Path::new("."));
-        let extension = target
-            .extension()
-            .and_then(|extension| extension.to_str())
-            .map(str::to_ascii_lowercase);
 
         for _ in 0..8 {
-            // `lofty::read_from_path` infers the format from the final
-            // extension. Preserve only that extension: including the whole
-            // source name could overflow a filesystem's component-length
-            // limit for an otherwise valid long filename.
-            let mut candidate_name =
-                std::ffi::OsString::from(format!("{TAG_WRITE_TEMP_PREFIX}{}", Uuid::new_v4()));
-            if let Some(extension) = extension.as_deref() {
-                candidate_name.push(".");
-                candidate_name.push(extension);
-            }
-            let candidate = directory.join(candidate_name);
+            let candidate = directory.join(staged_sibling_name(target.as_os_str()));
 
             let mut options = std::fs::OpenOptions::new();
             options.write(true).create_new(true);
@@ -346,9 +366,58 @@ impl TempFile {
                         Self {
                             path: candidate,
                             persisted: false,
+                            #[cfg(unix)]
+                            anchored_parent: None,
                         },
                         file,
                     ))
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!("Failed to create a temp file beside {target_label}")
+                    })
+                }
+            }
+        }
+
+        anyhow::bail!("Failed to create a unique temp file beside {target_label}")
+    }
+
+    /// Create an empty, exclusively owned temp file beside the admitted leaf
+    /// *through the retained parent handle* — the unix authority-based twin
+    /// of [`TempFile::create_beside`].
+    ///
+    /// The sibling is created with `openat(O_RDWR|O_CREAT|O_EXCL|O_NOFOLLOW)`
+    /// beneath the retained parent directory, so creation can neither
+    /// traverse a displaced ancestor nor follow a symlink planted at the
+    /// candidate name, and the copy starts from that handle without a
+    /// reopening window. The temp's `path` records only the bare leaf name:
+    /// every consumer — tagging, flush, commit, and the drop cleanup —
+    /// addresses the staged leaf through the retained parent, never through
+    /// a pathname. Error contexts name the target by `target_label`, never
+    /// by any path.
+    #[cfg(unix)]
+    fn create_beside_retained(
+        parent: &File,
+        leaf: &OsStr,
+        target_label: &str,
+    ) -> Result<(Self, std::fs::File)> {
+        for _ in 0..8 {
+            let candidate_name = staged_sibling_name(leaf);
+            match create_retained_sibling_exclusive(parent, &candidate_name) {
+                Ok(staged) => {
+                    let cleanup_parent = parent.try_clone().with_context(|| {
+                        format!("Failed to retain the staging parent of {target_label}")
+                    })?;
+                    return Ok((
+                        Self {
+                            path: PathBuf::from(candidate_name),
+                            persisted: false,
+                            anchored_parent: Some(cleanup_parent),
+                        },
+                        staged,
+                    ));
                 }
                 Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
                 Err(error) => {
@@ -432,6 +501,19 @@ impl TempFile {
 impl Drop for TempFile {
     fn drop(&mut self) {
         if !self.persisted {
+            #[cfg(unix)]
+            if let Some(parent) = &self.anchored_parent {
+                // Anchored staging: unlink the staged leaf through the
+                // retained parent. `unlinkat` never follows a symlink at the
+                // leaf and resolves nothing above it, so the cleanup removes
+                // exactly the entry this section created and can never
+                // mutate a directory the authority did not admit — the
+                // pre-anchoring cleanup walked the absolute pathname and
+                // removed its stranded sibling from whatever directory an
+                // external writer had installed at the old ancestor name.
+                let _ = rustix::fs::unlinkat(parent, &self.path, rustix::fs::AtFlags::empty());
+                return;
+            }
             let _ = std::fs::remove_file(&self.path);
         }
     }
@@ -651,37 +733,222 @@ pub fn write_tags_with_mutation_target(
     let source = commit
         .source_file()
         .with_context(|| "Failed to read the exact retained mutation target".to_string())?;
-    // The replacement path is a native mount path whose contract forbids
-    // logging or formatting it, so every error context below names the
-    // target by a redacted label instead of the path — the removable-media
-    // error branch surfaces the whole chain to the user.
-    atomic_tag_replacement(
+    write_tag_edits_for_commit(&mut commit, source, target, edits)
+}
+
+/// Perform the staged tag replacement for an open commit section.
+///
+/// The replacement path is a native mount path whose contract forbids
+/// logging or formatting it, so every error context names the target by a
+/// redacted label instead of the path — the removable-media error branch
+/// surfaces the whole chain to the user.
+#[cfg(unix)]
+fn write_tag_edits_for_commit(
+    commit: &mut MountedMutationCommit<'_>,
+    source: File,
+    _target: &MountedMutationTarget,
+    edits: &TagEdits,
+) -> Result<()> {
+    // Anchor the staging at the retained parent before anything is staged:
+    // the pinned parent identity makes staging and the later install agree
+    // on one directory object, and no step below ever resolves an absolute
+    // pathname.
+    let (staging_parent, staged_leaf) = commit.retained_staging_anchor().map_err(|error| {
+        anyhow::Error::new(error).context("The retained mutation authority lost the staging parent")
+    })?;
+    #[cfg(test)]
+    run_pre_staging_interpose(_target);
+    anchored_atomic_tag_replacement(
         source,
-        target.replacement_path(),
+        &staging_parent,
+        &staged_leaf,
         "the retained mutation target",
         edits,
-        |temp| {
-            // The replacement and the re-anchor of the retained evidence to the
-            // installed object both happen inside this commit section, while its
-            // guard still holds the target's commit lock — the re-anchor is
-            // identity-conditioned on the proven landing, so no pathname is ever
-            // opened outside the guard and no leaf swap between the landing and
-            // the re-anchor can be silently adopted.
-            commit.commit_replacement(temp.path()).map_err(|error| {
-                anyhow::Error::new(error)
-                    .context("The retained mutation authority refused the tagged replacement")
-            })?;
-            // The retained authority renamed the staged copy into place; the
-            // staging name no longer exists for the drop guard to remove.
-            temp.disarm_cleanup();
-            Ok(())
-        },
+        |temp| finish_committed_tag_replacement(commit, temp),
     )
+}
+
+/// Platforms without retained parent handles keep the documented path-based
+/// staging discipline: the commit re-proves the admitted identity through
+/// the pathname before anything is installed, and a staging area stranded
+/// by a displaced ancestor is refused and cleaned up by pathname.
+#[cfg(not(unix))]
+fn write_tag_edits_for_commit(
+    commit: &mut MountedMutationCommit<'_>,
+    source: File,
+    target: &MountedMutationTarget,
+    edits: &TagEdits,
+) -> Result<()> {
+    let replacement_path = target.replacement_path().to_path_buf();
+    atomic_tag_replacement(
+        source,
+        &replacement_path,
+        "the retained mutation target",
+        edits,
+        |temp| finish_committed_tag_replacement(commit, temp),
+    )
+}
+
+/// Rename the staged copy into place through the retained authority and
+/// disarm the staging cleanup once the authority owns the name.
+///
+/// The replacement and the re-anchor of the retained evidence to the
+/// installed object both happen inside the commit section, while its guard
+/// still holds the target's commit lock — the re-anchor is
+/// identity-conditioned on the proven landing, so no pathname is ever
+/// opened outside the guard and no leaf swap between the landing and the
+/// re-anchor can be silently adopted.
+fn finish_committed_tag_replacement(
+    commit: &mut MountedMutationCommit<'_>,
+    temp: &mut TempFile,
+) -> Result<()> {
+    commit.commit_replacement(temp.path()).map_err(|error| {
+        anyhow::Error::new(error)
+            .context("The retained mutation authority refused the tagged replacement")
+    })?;
+    // The retained authority renamed the staged copy into place; the
+    // staging name no longer exists for the drop guard to remove.
+    temp.disarm_cleanup();
+    Ok(())
+}
+
+/// Stage and tag the admitted file's replacement with every staged access
+/// anchored at the retained parent handle (unix).
+///
+/// [`TempFile::create_beside_retained`] creates the exclusively-created
+/// sibling beneath the retained parent; the admitted bytes are copied into
+/// that handle; tagging reads and saves through the same handle; and the
+/// flush, permission carry-over, and — on every failure path — the drop
+/// cleanup address the staged leaf through the retained parent as well.
+/// [`finish_committed_tag_replacement`] then consumes the staged copy by
+/// leaf name through the retained parent. No step resolves an absolute
+/// pathname, so an ancestor displaced after the section's validation can
+/// neither strand the staging area in an impostor directory nor leak the
+/// complete tagged copy of the admitted file across a symlink planted at
+/// an old name.
+#[cfg(unix)]
+fn anchored_atomic_tag_replacement(
+    mut source: File,
+    staging_parent: &File,
+    staged_leaf: &OsStr,
+    target_label: &str,
+    edits: &TagEdits,
+    commit_replacement: impl FnOnce(&mut TempFile) -> Result<()>,
+) -> Result<()> {
+    let (mut temp, mut staged) =
+        TempFile::create_beside_retained(staging_parent, staged_leaf, target_label)?;
+    let copy_result = copy_source_into_destination(&mut source, &mut staged, target_label);
+    // Capture the replacement's Unix permissions from the exact source
+    // object while the handle is still open — never from a lookup at any
+    // pathname, which an external writer can retarget (same discipline as
+    // the path-based flow).
+    let retained_permissions = source
+        .metadata()
+        .ok()
+        .map(|metadata| metadata.permissions());
+    drop(source);
+    copy_result?;
+
+    write_tags_to_retained(&mut staged, target_label, edits)?;
+    flush_and_prepare_tagged_copy_retained(&mut staged, target_label, retained_permissions)?;
+    drop(staged);
+    commit_replacement(&mut temp)?;
+
+    tracing::debug!("Tags written successfully");
+    Ok(())
+}
+
+/// Probe, edit, and save the staged copy through its retained handle — the
+/// anchored twin of [`write_tags_to`], never touching a pathname.
+///
+/// lofty's own `save_to_path` is *open a fresh read/write handle, then*
+/// `save_to`, so driving the same `save_to` through the anchored sibling
+/// handle at position zero is behavior-identical to the path-based flow;
+/// the format is guessed from the content instead of the staged name, which
+/// the name's random prefix would not identify anyway.
+#[cfg(unix)]
+fn write_tags_to_retained(staged: &mut File, target_label: &str, edits: &TagEdits) -> Result<()> {
+    use std::io::Seek;
+
+    staged
+        .rewind()
+        .with_context(|| format!("Failed to read tags from {target_label}"))?;
+    let probe = lofty::probe::Probe::new(&mut *staged)
+        .guess_file_type()
+        .map_err(anyhow::Error::from)
+        .with_context(|| format!("Failed to read tags from {target_label}"))?;
+    let mut tagged_file = probe
+        .read()
+        .with_context(|| format!("Failed to read tags from {target_label}"))?;
+
+    let tag = ensure_primary_tag(&mut tagged_file, target_label)?;
+    apply_tag_edits(tag, edits)?;
+
+    staged
+        .rewind()
+        .with_context(|| format!("Failed to write tags to {target_label}"))?;
+    tag.save_to(staged, WriteOptions::default())
+        .with_context(|| format!("Failed to write tags to {target_label}"))?;
+    Ok(())
+}
+
+/// Flush the tagged copy and carry over the source permissions, addressing
+/// the staged leaf through its retained handle — the anchored twin of
+/// [`flush_and_prepare_tagged_copy`]. The flush happens *before* the
+/// permission copy, exactly like the path-based flow: a read-only file
+/// cannot be flushed.
+#[cfg(unix)]
+fn flush_and_prepare_tagged_copy_retained(
+    staged: &mut File,
+    target_label: &str,
+    retained_permissions: Option<std::fs::Permissions>,
+) -> Result<()> {
+    staged
+        .sync_all()
+        .with_context(|| format!("Failed to flush the tagged copy of {target_label}"))?;
+
+    // Best-effort, exactly like the path-based flow: a capture failure
+    // skips the carry-over rather than failing the write.
+    if let Some(permissions) = retained_permissions {
+        let _ = staged.set_permissions(permissions);
+    }
+
+    Ok(())
+}
+
+/// `openat(parent, name, O_RDWR|O_CREAT|O_EXCL|O_NOFOLLOW|O_CLOEXEC, 0o600)`
+/// — the creation twin of the retained-parent opens the commit machinery
+/// already performs. Resolution starts at the retained parent handle, the
+/// final component never follows a symlink, the exclusive create refuses an
+/// occupied name, and the private mode keeps a full source copy unexposed
+/// before final permissions are applied.
+#[cfg(unix)]
+fn create_retained_sibling_exclusive(
+    parent: &File,
+    name: &OsStr,
+) -> std::io::Result<std::fs::File> {
+    use rustix::fs::{Mode, OFlags};
+
+    let descriptor = rustix::fs::openat(
+        parent,
+        name,
+        OFlags::RDWR | OFlags::CREATE | OFlags::EXCL | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+        Mode::from_raw_mode(0o600),
+    )
+    .map_err(std::io::Error::from)?;
+    Ok(std::fs::File::from(descriptor))
 }
 
 /// Copy `source` to an exclusively created sibling of `target_path`, tag the
 /// copy, flush it, and hand it to `commit_replacement` for the atomic
 /// replacement of `target_path`.
+///
+/// This is the path-based staging flow: the user-visible pathname writer
+/// uses it directly, and platforms without retained parent handles keep it
+/// as their documented authority-based staging discipline (their commit
+/// re-proves the admitted identity through the pathname before anything is
+/// installed). Unix authority-based callers stage through the retained
+/// parent instead — see [`anchored_atomic_tag_replacement`].
 ///
 /// `commit_replacement` runs after the flush and permission carry-over and
 /// owns the entire final gate: authority-checked callers prove the exact
@@ -978,6 +1245,38 @@ fn apply_comment_edit(tag: &mut Tag, edits: &TagEdits) {
             tag.set_comment(comment.clone());
         }
     }
+}
+
+/// Test-only seam: runs between the commit section's validation and the
+/// staging of the tagged copy, driving the exact window an external writer
+/// needs to displace an ancestor after validation and before staging. The
+/// regression tests plant an impostor directory or symlink at the displaced
+/// ancestor's old name here and assert the staged copy never appears on the
+/// other side.
+#[cfg(all(test, unix))]
+type PreStagingInterpose = dyn Fn(&MountedMutationTarget) + Send + Sync;
+
+#[cfg(all(test, unix))]
+static PRE_STAGING_INTERPOSE: std::sync::Mutex<Option<Box<PreStagingInterpose>>> =
+    std::sync::Mutex::new(None);
+
+#[cfg(all(test, unix))]
+static PRE_STAGING_INTERPOSE_SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(all(test, unix))]
+fn run_pre_staging_interpose(target: &MountedMutationTarget) {
+    if let Some(interpose) = PRE_STAGING_INTERPOSE.lock().unwrap().as_ref() {
+        interpose(target);
+    }
+}
+
+/// Serialize tests that use the pre-staging interposition seam.
+#[cfg(all(test, unix))]
+fn with_pre_staging_interpose(interpose: Box<PreStagingInterpose>, run: impl FnOnce()) {
+    let _serial = PRE_STAGING_INTERPOSE_SERIAL.lock().unwrap();
+    *PRE_STAGING_INTERPOSE.lock().unwrap() = Some(interpose);
+    run();
+    *PRE_STAGING_INTERPOSE.lock().unwrap() = None;
 }
 
 #[cfg(test)]
@@ -1489,14 +1788,15 @@ mod tests {
         );
     }
 
-    /// A parent directory displaced between selection and commit strands the
-    /// staging area inside whatever now occupies the old pathname. The
-    /// retained authority stages and replaces only through its retained
-    /// parent object, so the commit must refuse, leave the impostor
-    /// untouched, and clean up the stranded sibling.
+    /// A parent directory displaced between selection and commit must not
+    /// strand the staging area inside whatever now occupies the old
+    /// pathname: the retained authority stages and replaces only through its
+    /// retained parent object, so the write lands beside the admitted file
+    /// in the retained directory and the impostor never receives anything
+    /// at all — not the staged sibling, not the tagged copy.
     #[cfg(unix)]
     #[test]
-    fn a_mutation_target_write_refuses_when_the_parent_directory_was_displaced() {
+    fn a_mutation_target_write_lands_beside_the_retained_parent_when_it_was_displaced() {
         let directory = TestDirectory::new("mutation-parent-e2e");
         let album = directory.path.join("album");
         std::fs::create_dir(&album).expect("create album");
@@ -1524,39 +1824,132 @@ mod tests {
         std::fs::write(&track, b"impostor audio").expect("install impostor file");
 
         write_tags_with_mutation_target(&target, &year("2026"))
-            .expect_err("a stranded staging area must refuse the commit");
+            .expect("staging and replacement run through the retained parent");
 
-        assert_refused_displacement_left_files_untouched(
-            &track,
-            &displaced_album.join("silence.flac"),
-        );
-        assert_no_stranded_tag_write_siblings(&[&album, &displaced_album]);
-    }
-
-    /// Both files the displaced-parent scenario can observe must be untouched
-    /// by the refused commit: the impostor now occupying the old pathname
-    /// never receives the replacement, and the displaced admitted file keeps
-    /// its original tags.
-    #[cfg(unix)]
-    fn assert_refused_displacement_left_files_untouched(
-        impostor_track: &Path,
-        displaced_track: &Path,
-    ) {
+        // The replacement landed beside the admitted file in the retained
+        // (displaced) directory.
+        let tagged_file = lofty::read_from_path(displaced_album.join("silence.flac"))
+            .expect("reopen the replaced admitted file");
         assert_eq!(
-            std::fs::read(impostor_track).expect("read impostor file"),
-            b"impostor audio",
-            "the impostor directory must never receive the replacement"
-        );
-        let displaced_tagged =
-            lofty::read_from_path(displaced_track).expect("reopen the displaced admitted file");
-        assert_ne!(
-            displaced_tagged
+            tagged_file
                 .primary_tag()
                 .expect("primary tag")
                 .get_string(ItemKey::Year),
             Some("2026"),
-            "the admitted file must be untouched by the refused commit"
+            "the replacement must land beside the admitted file in the retained directory"
         );
+
+        // The impostor keeps exactly what it had. Under path-resolved
+        // staging it transiently received the staged sibling and the
+        // complete tagged copy of the admitted file before the commit
+        // refused; anchored staging never resolves its name at all.
+        assert_eq!(
+            std::fs::read(&track).expect("read impostor file"),
+            b"impostor audio",
+            "the impostor directory must never receive the replacement"
+        );
+        let impostor_entries: Vec<std::ffi::OsString> = std::fs::read_dir(&album)
+            .expect("list impostor directory")
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name())
+            .collect();
+        assert_eq!(
+            impostor_entries,
+            [std::ffi::OsString::from("silence.flac")],
+            "the impostor directory must never receive a staged sibling"
+        );
+        assert_no_stranded_tag_write_siblings(&[&album, &displaced_album]);
+    }
+
+    /// The staging of a retained-authority copy must never traverse the
+    /// absolute-path ancestry. This drives the exact window an external
+    /// writer needs — after the commit section validated the retained chain,
+    /// before the writer stages the sibling — and installs a symlink at the
+    /// displaced ancestor's old name, pointing outside the mount. Path-
+    /// resolved staging would create the staged sibling through that symlink
+    /// and leak the complete tagged copy of the admitted file outside the
+    /// retained authority; anchored staging resolves nothing, so the write
+    /// lands beside the admitted file in the retained directory and the
+    /// symlink's target stays empty.
+    #[cfg(unix)]
+    #[test]
+    fn a_mutation_target_write_stages_beside_the_retained_parent_never_through_a_displaced_ancestor()
+    {
+        use std::os::unix::fs::symlink;
+
+        let directory = TestDirectory::new("mutation-stage-anchor");
+        let album = directory.path.join("album");
+        std::fs::create_dir(&album).expect("create album");
+        let track = album.join("silence.flac");
+        std::fs::write(
+            &track,
+            include_bytes!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/tests/fixtures/audio/silence.flac"
+            )),
+        )
+        .expect("write fixture");
+
+        let outside = TestDirectory::new("mutation-stage-outside");
+
+        let authority = std::sync::Arc::new(
+            crate::local::root_authority::MountedRootAuthority::acquire(&directory.path)
+                .expect("acquire mounted authority"),
+        );
+        let target = authority
+            .open_mutation_target(Path::new("album/silence.flac"))
+            .expect("open mutation target");
+
+        let displaced_album = directory.path.join("displaced-album");
+        let impostor_album = album.clone();
+        let outside_root = outside.path.clone();
+        let watched = track.clone();
+        let closure_displaced_album = displaced_album.clone();
+        with_pre_staging_interpose(
+            Box::new(move |interposed| {
+                if interposed.replacement_path() != watched.as_path() {
+                    return;
+                }
+                // Displace the retained ancestor inside the staging window
+                // and plant a symlink at its old name.
+                std::fs::rename(&watched.parent().expect("album parent"), &closure_displaced_album)
+                    .expect("displace retained parent");
+                symlink(&outside_root, &impostor_album)
+                    .expect("install symlink impostor at the old name");
+            }),
+            || {
+                write_tags_with_mutation_target(&target, &year("2026")).expect(
+                    "anchored staging must land the write through the retained parent",
+                );
+            },
+        );
+
+        // The replacement landed beside the admitted file in the retained
+        // (displaced) directory.
+        let tagged_file = lofty::read_from_path(displaced_album.join("silence.flac"))
+            .expect("reopen the replaced admitted file");
+        assert_eq!(
+            tagged_file
+                .primary_tag()
+                .expect("primary tag")
+                .get_string(ItemKey::Year),
+            Some("2026"),
+            "the replacement must land beside the admitted file in the retained directory"
+        );
+
+        // Nothing — staged sibling or tagged copy — may ever have crossed
+        // the symlink into the impostor's target.
+        let outside_entries: Vec<std::ffi::OsString> = std::fs::read_dir(&outside.path)
+            .expect("list the symlink impostor's target")
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name())
+            .collect();
+        assert!(
+            outside_entries.is_empty(),
+            "the displaced ancestor's symlink target must never receive anything: \
+             {outside_entries:?}"
+        );
+        assert_no_stranded_tag_write_siblings(&[&displaced_album]);
     }
 
     /// A refused commit must clean up its stranded staging sibling in every

--- a/src/local/tag_writer.rs
+++ b/src/local/tag_writer.rs
@@ -301,6 +301,33 @@ struct TempFile {
     /// impostor directory.
     #[cfg(unix)]
     anchored_parent: Option<File>,
+    /// Unix: dev/ino of the object this section created, read from the
+    /// creation handle. The anchored cleanup unlinks the staged leaf only
+    /// while the leaf still names this exact object, so a name an external
+    /// writer reused after stealing the leaf is preserved debris, never
+    /// destroyed.
+    #[cfg(unix)]
+    created_identity: Option<(u64, u64)>,
+}
+
+/// dev/ino of an open file object — the identity pair the anchored cleanups
+/// compare before unlinking a leaf name.
+#[cfg(unix)]
+fn retained_handle_identity(file: &File) -> std::io::Result<(u64, u64)> {
+    use std::os::unix::fs::MetadataExt;
+
+    let metadata = file.metadata()?;
+    Ok((metadata.dev(), metadata.ino()))
+}
+
+/// dev/ino of whatever entry `leaf` currently names beneath the retained
+/// parent, resolved through the directory handle without following a leaf
+/// symlink.
+#[cfg(unix)]
+fn retained_leaf_identity(parent: &File, leaf: &OsStr) -> std::io::Result<(u64, u64)> {
+    let stat = rustix::fs::statat(parent, leaf, rustix::fs::AtFlags::SYMLINK_NOFOLLOW)
+        .map_err(std::io::Error::from)?;
+    Ok((stat.st_dev, stat.st_ino))
 }
 
 /// Randomized staged-sibling leaf name, preserving the final extension.
@@ -373,6 +400,8 @@ impl TempFile {
                             persisted: false,
                             #[cfg(unix)]
                             anchored_parent: None,
+                            #[cfg(unix)]
+                            created_identity: None,
                         },
                         file,
                     ))
@@ -412,6 +441,13 @@ impl TempFile {
             let candidate_name = staged_sibling_name(leaf);
             match create_retained_sibling_exclusive(parent, &candidate_name) {
                 Ok(staged) => {
+                    // Capture the sibling's identity from the creation
+                    // handle: every later cleanup of this leaf proves the
+                    // entry still names this exact object before unlinking.
+                    let created_identity =
+                        retained_handle_identity(&staged).with_context(|| {
+                            format!("Failed to identity the staged sibling of {target_label}")
+                        })?;
                     let cleanup_parent = parent.try_clone().with_context(|| {
                         format!("Failed to retain the staging parent of {target_label}")
                     })?;
@@ -420,6 +456,7 @@ impl TempFile {
                             path: PathBuf::from(candidate_name),
                             persisted: false,
                             anchored_parent: Some(cleanup_parent),
+                            created_identity: Some(created_identity),
                         },
                         staged,
                     ));
@@ -510,16 +547,39 @@ impl Drop for TempFile {
             if let Some(parent) = &self.anchored_parent {
                 // Anchored staging: unlink the staged leaf through the
                 // retained parent. `unlinkat` never follows a symlink at the
-                // leaf and resolves nothing above it, so the cleanup removes
-                // exactly the entry this section created and can never
-                // mutate a directory the authority did not admit — the
-                // pre-anchoring cleanup walked the absolute pathname and
-                // removed its stranded sibling from whatever directory an
-                // external writer had installed at the old ancestor name.
-                let _ = rustix::fs::unlinkat(parent, &self.path, rustix::fs::AtFlags::empty());
+                // leaf and resolves nothing above it, and the unlink fires
+                // only while the leaf still names the object this section
+                // created (exact dev/ino, read through the same handle) —
+                // the cleanup removes exactly the entry this section created
+                // and can never mutate a directory the authority did not
+                // admit. An entry an external writer swapped into the name
+                // after stealing the staged leaf is debris we must preserve,
+                // never destroy.
+                if self.leaf_names_created_object(parent) {
+                    let _ = rustix::fs::unlinkat(parent, &self.path, rustix::fs::AtFlags::empty());
+                }
                 return;
             }
             let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+impl TempFile {
+    /// Whether the anchored leaf still names the object this section
+    /// created.
+    ///
+    /// An unprovable identity (the leaf vanished, or the creation handle's
+    /// identity was never captured) fails closed: the caller preserves the
+    /// entry instead of unlinking a name it cannot prove is its own.
+    #[cfg(unix)]
+    fn leaf_names_created_object(&self, parent: &File) -> bool {
+        match (
+            self.created_identity,
+            retained_leaf_identity(parent, self.path.as_os_str()),
+        ) {
+            (Some(created), Ok(landed)) => landed == created,
+            _ => false,
         }
     }
 }
@@ -708,7 +768,12 @@ pub fn preflight_tag_write_directory_retained(
     // flag support) refuses the rehearsal instead of being overwritten.
     let vacant_name = staged_sibling_name(leaf);
     #[cfg(all(test, unix))]
-    run_retained_preflight_interpose(parent, replacement.path().as_os_str(), &vacant_name);
+    run_retained_preflight_interpose(
+        RetainedPreflightPhase::BeforeInstall,
+        parent,
+        replacement.path().as_os_str(),
+        &vacant_name,
+    );
     rustix::fs::renameat_with(
         parent,
         replacement.path().as_os_str(),
@@ -719,10 +784,31 @@ pub fn preflight_tag_write_directory_retained(
     .map_err(|_| TagWritePreflightError::Unavailable)?;
 
     // The probe now lives at the vacant name. Aim the drop guard's
-    // anchored cleanup at that leaf so a failed explicit cleanup below
-    // still backstops through the retained parent, then remove it: a
-    // capability check is successful only when cleanup succeeds.
+    // anchored cleanup at that leaf, then prove the landed leaf still
+    // names this section's probe (exact dev/ino through the retained
+    // parent) before removing it: inside the rename→cleanup window an
+    // external writer can swap the entry, and the cleanup removes exactly
+    // the entry this section created — a swapped-in newcomer is preserved
+    // debris and the rehearsal refuses, because a capability check is
+    // successful only when its own cleanup provably succeeded.
     replacement.path = PathBuf::from(&vacant_name);
+    #[cfg(all(test, unix))]
+    run_retained_preflight_interpose(
+        RetainedPreflightPhase::BeforeCleanup,
+        parent,
+        replacement.path().as_os_str(),
+        &vacant_name,
+    );
+    if !replacement.leaf_names_created_object(parent) {
+        // The landed leaf no longer provably names this section's probe: an
+        // external writer swapped the entry inside the rename→cleanup
+        // window, or it vanished. Preserve the newcomer (and the stolen
+        // probe, now debris) — debris is never destruction — disarm the
+        // guard, and refuse: a capability check is successful only when
+        // its own cleanup provably succeeded.
+        replacement.disarm_cleanup();
+        return Err(TagWritePreflightError::Unavailable);
+    }
     rustix::fs::unlinkat(parent, &vacant_name, rustix::fs::AtFlags::empty())
         .map_err(|_| TagWritePreflightError::Unavailable)?;
     replacement.disarm_cleanup();
@@ -1390,15 +1476,31 @@ fn with_pre_staging_interpose(interpose: Box<PreStagingInterpose>, run: impl FnO
     *PRE_STAGING_INTERPOSE.lock().unwrap() = None;
 }
 
-/// Test-only seam: runs immediately before the retained preflight
-/// rehearsal's no-replace rename, receiving the retained parent handle, the
-/// staged probe sibling's leaf, and the fresh vacant candidate leaf the
-/// rehearsal is about to rename onto. The regression tests observe the
-/// rehearsal's exact shape (a staged probe; a rename target that is vacant)
-/// and occupy the candidate name to prove the rehearsal's rename refuses a
-/// replacement — the no-replace primitive the anchored commit installs with.
+/// The retained-preflight rehearsal windows a regression test can observe.
 #[cfg(all(test, unix))]
-type RetainedPreflightInterpose = dyn Fn(&std::fs::File, &OsStr, &OsStr) + Send + Sync;
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum RetainedPreflightPhase {
+    /// Immediately before the no-replace install rename: the probe sibling
+    /// is staged and the rename candidate is still vacant.
+    BeforeInstall,
+    /// Immediately after the install rename landed, before the landed-probe
+    /// cleanup proves and removes it: the external-swap window the cleanup's
+    /// identity proof guards.
+    BeforeCleanup,
+}
+
+/// Test-only seam: runs at each [`RetainedPreflightPhase`] of the retained
+/// preflight rehearsal, receiving the phase, the retained parent handle, the
+/// staged probe sibling's leaf, and the fresh vacant candidate leaf the
+/// rehearsal renames onto. The regression tests observe the rehearsal's
+/// exact shape (a staged probe; a rename target that is vacant; a landed
+/// probe before cleanup) — occupying the candidate name proves the rename
+/// refuses a replacement (the no-replace primitive the anchored commit
+/// installs with), and swapping the landed probe proves the cleanup removes
+/// exactly the entry the rehearsal created.
+#[cfg(all(test, unix))]
+type RetainedPreflightInterpose =
+    dyn Fn(RetainedPreflightPhase, &std::fs::File, &OsStr, &OsStr) + Send + Sync;
 
 #[cfg(all(test, unix))]
 static RETAINED_PREFLIGHT_INTERPOSE: std::sync::Mutex<Option<Box<RetainedPreflightInterpose>>> =
@@ -1408,9 +1510,14 @@ static RETAINED_PREFLIGHT_INTERPOSE: std::sync::Mutex<Option<Box<RetainedPreflig
 static RETAINED_PREFLIGHT_INTERPOSE_SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[cfg(all(test, unix))]
-fn run_retained_preflight_interpose(parent: &std::fs::File, probe: &OsStr, vacant: &OsStr) {
+fn run_retained_preflight_interpose(
+    phase: RetainedPreflightPhase,
+    parent: &std::fs::File,
+    probe: &OsStr,
+    vacant: &OsStr,
+) {
     if let Some(interpose) = RETAINED_PREFLIGHT_INTERPOSE.lock().unwrap().as_ref() {
-        interpose(parent, probe, vacant);
+        interpose(phase, parent, probe, vacant);
     }
 }
 
@@ -2181,8 +2288,14 @@ mod tests {
         let occupied_candidate = Arc::new(Mutex::new(None::<std::ffi::OsString>));
         let closure_candidate = occupied_candidate.clone();
         with_retained_preflight_interpose(
-            Box::new(move |interposed_parent, probe_leaf, vacant_leaf| {
+            Box::new(move |phase, interposed_parent, probe_leaf, vacant_leaf| {
                 use rustix::fs::AtFlags;
+
+                // This regression shapes the install window only; the
+                // landed-probe cleanup window has its own regression.
+                if phase != RetainedPreflightPhase::BeforeInstall {
+                    return;
+                }
 
                 // The rehearsal renames onto a fresh vacant name: the probe
                 // sibling exists and the rename target does not. A rehearsal
@@ -2272,6 +2385,136 @@ mod tests {
             retained_entries,
             vec![std::ffi::OsString::from("silence.flac")],
             "the refused rehearsal must leave no probe sibling behind"
+        );
+    }
+
+    /// The newcomer an external writer swapped into the cleanup window's
+    /// vacant name, with the exact identity it was installed under.
+    #[cfg(unix)]
+    struct SwappedNewcomer {
+        leaf: std::ffi::OsString,
+        identity: (u64, u64),
+    }
+
+    /// The landed-probe cleanup must remove exactly the entry the rehearsal
+    /// created. An external writer can rename the landed probe away and
+    /// create a newcomer at the vacant name inside the rename→cleanup
+    /// window; the rehearsal must then refuse with the newcomer preserved —
+    /// debris is never destruction — and leave none of its own residue.
+    #[cfg(unix)]
+    #[test]
+    fn retained_preflight_cleanup_preserves_a_swapped_in_newcomer() {
+        use std::sync::{Arc, Mutex};
+
+        let (directory, album, _) = anchored_album_fixture("preflight-swap");
+
+        let authority = mounted_root_authority(&directory);
+        let target = authority
+            .open_mutation_target(Path::new("album/silence.flac"))
+            .expect("open mutation target");
+        let (parent, leaf) = target
+            .retained_directory_handle()
+            .expect("retain the directory anchor");
+
+        let newcomer = Arc::new(Mutex::new(None::<SwappedNewcomer>));
+        let stolen = Arc::new(Mutex::new(None::<std::ffi::OsString>));
+        swap_a_newcomer_into_the_cleanup_window(Arc::clone(&newcomer), Arc::clone(&stolen), || {
+            assert_eq!(
+                crate::local::tag_writer::preflight_tag_write_directory_retained(
+                    &parent,
+                    &leaf,
+                    "the removable mutation target",
+                ),
+                Err(TagWritePreflightError::Unavailable),
+                "a swapped-in newcomer must refuse the rehearsal, never be destroyed"
+            );
+        });
+
+        assert_the_swap_survived_the_refused_cleanup(&parent, &album, newcomer, stolen);
+    }
+
+    /// Drive the rehearsal through the cleanup window with an external
+    /// writer's swap: rename the landed probe away (stealing it as debris)
+    /// and install a newcomer at the vacant name before the cleanup runs.
+    #[cfg(unix)]
+    fn swap_a_newcomer_into_the_cleanup_window(
+        newcomer: std::sync::Arc<std::sync::Mutex<Option<SwappedNewcomer>>>,
+        stolen: std::sync::Arc<std::sync::Mutex<Option<std::ffi::OsString>>>,
+        run: impl FnOnce(),
+    ) {
+        with_retained_preflight_interpose(
+            Box::new(move |phase, interposed_parent, _probe_leaf, vacant_leaf| {
+                if phase != RetainedPreflightPhase::BeforeCleanup {
+                    return;
+                }
+                let stolen_leaf = staged_sibling_name(std::ffi::OsStr::new("silence.flac"));
+                rustix::fs::renameat(
+                    interposed_parent,
+                    vacant_leaf,
+                    interposed_parent,
+                    &stolen_leaf,
+                )
+                .expect("steal the landed probe");
+                create_retained_sibling_exclusive(interposed_parent, vacant_leaf)
+                    .expect("install the newcomer at the vacant name");
+                let identity = retained_leaf_identity(interposed_parent, vacant_leaf)
+                    .expect("read the newcomer's identity");
+                *newcomer.lock().unwrap() = Some(SwappedNewcomer {
+                    leaf: vacant_leaf.to_os_string(),
+                    identity,
+                });
+                *stolen.lock().unwrap() = Some(stolen_leaf);
+            }),
+            run,
+        );
+    }
+
+    /// Require the refused cleanup to have preserved the swapped-in
+    /// newcomer and the stolen probe debris, then remove both and require
+    /// the directory to hold exactly the admitted file again: the refused
+    /// rehearsal leaves no probe residue of its own.
+    #[cfg(unix)]
+    fn assert_the_swap_survived_the_refused_cleanup(
+        parent: &std::fs::File,
+        album: &Path,
+        newcomer: std::sync::Arc<std::sync::Mutex<Option<SwappedNewcomer>>>,
+        stolen: std::sync::Arc<std::sync::Mutex<Option<std::ffi::OsString>>>,
+    ) {
+        use rustix::fs::AtFlags;
+
+        let newcomer = newcomer
+            .lock()
+            .unwrap()
+            .take()
+            .expect("the seam swapped a newcomer in");
+        let stolen_leaf = stolen
+            .lock()
+            .unwrap()
+            .take()
+            .expect("the seam stole the landed probe");
+        assert_eq!(
+            retained_leaf_identity(parent, &newcomer.leaf).expect("the newcomer survives"),
+            newcomer.identity,
+            "the refused cleanup must preserve the swapped-in newcomer exactly"
+        );
+        assert!(
+            rustix::fs::statat(parent, stolen_leaf.as_os_str(), AtFlags::empty()).is_ok(),
+            "the stolen probe is preserved debris, never destroyed"
+        );
+        rustix::fs::unlinkat(parent, &newcomer.leaf, AtFlags::empty())
+            .expect("remove the newcomer debris");
+        rustix::fs::unlinkat(parent, stolen_leaf.as_os_str(), AtFlags::empty())
+            .expect("remove the stolen-probe debris");
+
+        let retained_entries: Vec<std::ffi::OsString> = std::fs::read_dir(album)
+            .expect("list the retained directory")
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name())
+            .collect();
+        assert_eq!(
+            retained_entries,
+            vec![std::ffi::OsString::from("silence.flac")],
+            "the refused rehearsal must leave no probe residue of its own"
         );
     }
 

--- a/src/local/tag_writer.rs
+++ b/src/local/tag_writer.rs
@@ -292,7 +292,11 @@ impl TempFile {
     /// rename fails with `EXDEV`). The name is randomized and created with
     /// `create_new` (`O_EXCL`) so it cannot collide with a concurrent save or
     /// follow a symlink an attacker planted at a predictable path.
-    fn create_beside(target: &Path) -> Result<(Self, std::fs::File)> {
+    ///
+    /// Error contexts name the target by `target_label`, never by `target`:
+    /// an authority-based caller's target is a native mount path that must
+    /// not leak into logs (see `replacement_path`).
+    fn create_beside(target: &Path, target_label: &str) -> Result<(Self, std::fs::File)> {
         let directory = target.parent().unwrap_or_else(|| Path::new("."));
         let extension = target
             .extension()
@@ -349,16 +353,13 @@ impl TempFile {
                 Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
                 Err(error) => {
                     return Err(error).with_context(|| {
-                        format!("Failed to create a temp file beside {}", target.display())
+                        format!("Failed to create a temp file beside {target_label}")
                     })
                 }
             }
         }
 
-        anyhow::bail!(
-            "Failed to create a unique temp file beside {}",
-            target.display()
-        )
+        anyhow::bail!("Failed to create a unique temp file beside {target_label}")
     }
 
     fn path(&self) -> &Path {
@@ -507,8 +508,8 @@ pub fn preflight_tag_write_target_access(path: &Path) -> Result<(), TagWritePref
             WindowsDacl::read_from(&source).map_err(|_| TagWritePreflightError::Unavailable)?;
         drop(source);
 
-        let (probe, creation_file) =
-            TempFile::create_beside(path).map_err(|_| TagWritePreflightError::Unavailable)?;
+        let (probe, creation_file) = TempFile::create_beside(path, &path.to_string_lossy())
+            .map_err(|_| TagWritePreflightError::Unavailable)?;
         let dacl_result = source_dacl.apply_to(&creation_file);
         drop(creation_file);
         dacl_result.map_err(|_| TagWritePreflightError::Unavailable)?;
@@ -542,13 +543,14 @@ pub fn preflight_tag_write_directory(path: &Path) -> Result<(), TagWritePrefligh
     // create two exclusive siblings, flush them, replace an existing sibling,
     // and require explicit cleanup. The user's audio file is never modified.
     let (mut replacement, replacement_file) =
-        TempFile::create_beside(path).map_err(|_| TagWritePreflightError::Unavailable)?;
+        TempFile::create_beside(path, &path.to_string_lossy())
+            .map_err(|_| TagWritePreflightError::Unavailable)?;
     let replacement_result = replacement_file.sync_all();
     drop(replacement_file);
     replacement_result.map_err(|_| TagWritePreflightError::Unavailable)?;
 
-    let (destination, destination_file) =
-        TempFile::create_beside(path).map_err(|_| TagWritePreflightError::Unavailable)?;
+    let (destination, destination_file) = TempFile::create_beside(path, &path.to_string_lossy())
+        .map_err(|_| TagWritePreflightError::Unavailable)?;
     let destination_result = destination_file.sync_all();
     drop(destination_file);
     destination_result.map_err(|_| TagWritePreflightError::Unavailable)?;
@@ -597,9 +599,14 @@ pub fn write_tags(path: &Path, edits: &TagEdits) -> Result<()> {
         }
     }
 
+    // The local pathname is user-visible, so naming it in error contexts is
+    // fine here — unlike the authority-based writer below.
+    let target_label = path.to_string_lossy();
     let source = std::fs::File::open(path)
         .with_context(|| format!("Failed to open {} for tag writing", path.display()))?;
-    atomic_tag_replacement(source, path, edits, |temp| temp.persist_to(path))
+    atomic_tag_replacement(source, path, &target_label, edits, |temp| {
+        temp.persist_to(path)
+    })
 }
 
 /// Write tag edits to one exact file beneath a retained mounted authority.
@@ -638,36 +645,38 @@ pub fn write_tags_with_mutation_target(
     // Open the serialized commit section first: it revalidates the mount,
     // the retained ancestry, and the exact retained file before any byte is
     // read, and holds the target's commit lock through the replacement.
-    let commit = target.begin_commit().map_err(|error| {
+    let mut commit = target.begin_commit().map_err(|error| {
         anyhow::anyhow!("The retained mutation authority is no longer valid: {error}")
     })?;
     let source = commit
         .source_file()
         .with_context(|| "Failed to read the exact retained mutation target".to_string())?;
-    atomic_tag_replacement(source, target.replacement_path(), edits, |temp| {
-        commit.commit_replacement(temp.path()).map_err(|error| {
-            anyhow::Error::new(error)
-                .context("The exact file to replace changed before the tagged copy was committed")
-        })?;
-        // The retained authority renamed the staged copy into place; the
-        // staging name no longer exists for the drop guard to remove.
-        temp.disarm_cleanup();
-        Ok(())
-    })?;
-
-    // A successful replacement retired the object this section copied from.
-    // Re-anchor the retained evidence to the exact current object so a
-    // follow-up commit (a batch retry, or a second edit) is authorized for
-    // the file that exists now. Failure is advisory: the next commit section
-    // revalidates fail-closed regardless.
-    //
-    // The commit section's guard must be released before rebind: rebind
-    // serializes on the same target lock this section is still holding, and
-    // a std Mutex is not reentrant — relocking it here would deadlock the
-    // writer thread forever.
-    drop(commit);
-    let _ = target.rebind();
-    Ok(())
+    // The replacement path is a native mount path whose contract forbids
+    // logging or formatting it, so every error context below names the
+    // target by a redacted label instead of the path — the removable-media
+    // error branch surfaces the whole chain to the user.
+    atomic_tag_replacement(
+        source,
+        target.replacement_path(),
+        "the retained mutation target",
+        edits,
+        |temp| {
+            // The replacement and the re-anchor of the retained evidence to the
+            // installed object both happen inside this commit section, while its
+            // guard still holds the target's commit lock — the re-anchor is
+            // identity-conditioned on the proven landing, so no pathname is ever
+            // opened outside the guard and no leaf swap between the landing and
+            // the re-anchor can be silently adopted.
+            commit.commit_replacement(temp.path()).map_err(|error| {
+                anyhow::Error::new(error)
+                    .context("The retained mutation authority refused the tagged replacement")
+            })?;
+            // The retained authority renamed the staged copy into place; the
+            // staging name no longer exists for the drop guard to remove.
+            temp.disarm_cleanup();
+            Ok(())
+        },
+    )
 }
 
 /// Copy `source` to an exclusively created sibling of `target_path`, tag the
@@ -680,27 +689,29 @@ pub fn write_tags_with_mutation_target(
 /// Path-based callers have no retained identity to compare and simply rename
 /// the staged copy into place; the rename itself is their point-in-time
 /// replacement.
+///
+/// Error contexts never format `target_path`: an authority-based caller's
+/// target is a native mount path that must not leak into logs, so contexts
+/// name the target by `target_label` instead. Path-based callers pass the
+/// user-visible pathname's own text.
 fn atomic_tag_replacement(
     source: File,
     target_path: &Path,
+    target_label: &str,
     edits: &TagEdits,
     commit_replacement: impl FnOnce(&mut TempFile) -> Result<()>,
 ) -> Result<()> {
     let mut source = source;
     #[cfg(target_os = "windows")]
-    let source_dacl = WindowsDacl::read_from(&source).with_context(|| {
-        format!(
-            "Failed to read the Windows DACL of {}",
-            target_path.display()
-        )
-    })?;
+    let source_dacl = WindowsDacl::read_from(&source)
+        .with_context(|| format!("Failed to read the Windows DACL of {target_label}",))?;
 
-    let (mut temp, destination) = TempFile::create_beside(target_path)?;
+    let (mut temp, destination) = TempFile::create_beside(target_path, target_label)?;
     #[cfg(target_os = "windows")]
-    let mut destination = open_tag_copy_destination(source_dacl, destination, &temp, target_path)?;
+    let mut destination = open_tag_copy_destination(source_dacl, destination, &temp, target_label)?;
     #[cfg(not(target_os = "windows"))]
     let mut destination = destination;
-    let copy_result = copy_source_into_destination(&mut source, &mut destination, target_path);
+    let copy_result = copy_source_into_destination(&mut source, &mut destination, target_label);
     // Capture the replacement's Unix permissions from the exact source
     // object while the handle is still open. A target_path lookup here would
     // read whatever occupies the name at commit time — not necessarily the
@@ -718,9 +729,9 @@ fn atomic_tag_replacement(
 
     write_tags_to(temp.path(), edits)?;
     #[cfg(unix)]
-    flush_and_prepare_tagged_copy(&temp, target_path, retained_permissions)?;
+    flush_and_prepare_tagged_copy(&temp, target_label, retained_permissions)?;
     #[cfg(not(unix))]
-    flush_and_prepare_tagged_copy(&temp, target_path)?;
+    flush_and_prepare_tagged_copy(&temp, target_label)?;
     commit_replacement(&mut temp)?;
 
     tracing::debug!("Tags written successfully");
@@ -739,20 +750,18 @@ fn open_tag_copy_destination(
     source_dacl: WindowsDacl,
     destination: File,
     temp: &TempFile,
-    target_path: &Path,
+    target_label: &str,
 ) -> Result<File> {
     let security_result = source_dacl.apply_to(&destination).with_context(|| {
         format!(
-            "Failed to protect the tagged copy of {} with its original Windows DACL",
-            target_path.display()
+            "Failed to protect the tagged copy of {target_label} with its original Windows DACL",
         )
     });
     drop(destination);
     security_result?;
     temp.reopen_exclusive_for_tagging().with_context(|| {
         format!(
-            "The original Windows DACL of {} does not permit writing the tagged copy",
-            target_path.display()
+            "The original Windows DACL of {target_label} does not permit writing the tagged copy",
         )
     })
 }
@@ -762,11 +771,11 @@ fn open_tag_copy_destination(
 fn copy_source_into_destination(
     source: &mut File,
     destination: &mut File,
-    target_path: &Path,
+    target_label: &str,
 ) -> Result<()> {
     std::io::copy(source, destination)
         .map(|_| ())
-        .with_context(|| format!("Failed to copy {} for tag writing", target_path.display()))
+        .with_context(|| format!("Failed to copy {target_label} for tag writing"))
 }
 
 /// Flush the tagged copy and carry over the source file's Unix permissions
@@ -779,22 +788,19 @@ fn copy_source_into_destination(
 /// attribute, so the permission carry-over is Unix-only.
 ///
 /// `retained_permissions` is captured from the source file handle — the exact
-/// object whose bytes were copied — never from a `target_path` lookup, which
-/// an external writer can retarget between admission and commit.
+/// object whose bytes were copied — never from a lookup at the target's name,
+/// which an external writer can retarget between admission and commit. Error
+/// contexts name the target by `target_label`, never by its native pathname.
 fn flush_and_prepare_tagged_copy(
     temp: &TempFile,
-    target_path: &Path,
+    target_label: &str,
     #[cfg(unix)] retained_permissions: Option<std::fs::Permissions>,
 ) -> Result<()> {
     // Flush the tagged copy before it becomes the user's file. Without this a
     // crash between rename and writeback can leave a truncated file where the
     // original used to be.
-    flush_to_disk(temp.path()).with_context(|| {
-        format!(
-            "Failed to flush the tagged copy of {}",
-            target_path.display()
-        )
-    })?;
+    flush_to_disk(temp.path())
+        .with_context(|| format!("Failed to flush the tagged copy of {target_label}"))?;
 
     // Best-effort: match the Unix permissions of the exact file object the
     // bytes were copied from. A capture failure skips the carry-over rather
@@ -1092,7 +1098,8 @@ mod tests {
 
         let directory = TestDirectory::new("private-mode");
         let track = directory.path.join("song.flac");
-        let (temp, file) = TempFile::create_beside(&track).expect("create private sibling");
+        let (temp, file) = TempFile::create_beside(&track, &track.to_string_lossy())
+            .expect("create private sibling");
         let mode = std::fs::metadata(temp.path())
             .expect("read sibling metadata")
             .permissions()
@@ -1131,7 +1138,8 @@ mod tests {
         std::fs::set_permissions(&stranger, std::fs::Permissions::from_mode(0o644))
             .expect("make the stranger permissive");
 
-        let (temp, destination) = TempFile::create_beside(&track).expect("create the staging copy");
+        let (temp, destination) = TempFile::create_beside(&track, &track.to_string_lossy())
+            .expect("create the staging copy");
         drop(destination);
 
         // Swap the pathname to the permissive stranger for the carry-over,
@@ -1145,7 +1153,7 @@ mod tests {
             .metadata()
             .expect("stat the retained source handle")
             .permissions();
-        flush_and_prepare_tagged_copy(&temp, &track, Some(retained_permissions))
+        flush_and_prepare_tagged_copy(&temp, &track.to_string_lossy(), Some(retained_permissions))
             .expect("prepare the tagged copy");
 
         let mode = std::fs::metadata(temp.path())
@@ -1170,7 +1178,8 @@ mod tests {
         let track = directory.audio_file("song.flac", b"readable fixture bytes");
         let source = std::fs::File::open(&track).expect("open source");
         let source_dacl = WindowsDacl::read_from(&source).expect("read source DACL");
-        let (temp, destination) = TempFile::create_beside(&track).expect("create private sibling");
+        let (temp, destination) = TempFile::create_beside(&track, &track.to_string_lossy())
+            .expect("create private sibling");
 
         source_dacl
             .apply_to(&destination)
@@ -1285,7 +1294,8 @@ mod tests {
     fn probe_cleanup_failure_is_reported_before_success() {
         let directory = TestDirectory::new("preflight-cleanup-failure");
         let track = directory.path.join("song.flac");
-        let (temp, file) = TempFile::create_beside(&track).expect("create private sibling");
+        let (temp, file) = TempFile::create_beside(&track, &track.to_string_lossy())
+            .expect("create private sibling");
         let temp_path = temp.path().to_path_buf();
         drop(file);
 
@@ -1357,8 +1367,8 @@ mod tests {
     }
 
     /// A removable-media write through a retained mutation target must
-    /// succeed exactly like the path-based happy path, and the rebind after
-    /// the atomic rename must authorize a follow-up write through the same
+    /// succeed exactly like the path-based happy path, and the in-section
+    /// re-anchor must authorize a follow-up write through the same
     /// target object.
     #[test]
     fn a_mutation_target_write_round_trips_and_reanchors_for_a_follow_up() {
@@ -1385,8 +1395,8 @@ mod tests {
             "a successful write must not leave its sibling temp file behind"
         );
 
-        // The replacement retired the copied-from object; the rebind in the
-        // write must have re-anchored the target, so a second edit through
+        // The replacement retired the copied-from object; the in-section
+        // re-anchor must have re-bound the target, so a second edit through
         // the same retained authority is still authorized.
         write_tags_with_mutation_target(&target, &year("2027"))
             .expect("follow-up write after the re-anchor");
@@ -1562,8 +1572,10 @@ mod tests {
         let directory = TestDirectory::new("exclusive");
         let track = directory.path.join(format!("{}.FLAC", "x".repeat(220)));
 
-        let (first, first_handle) = TempFile::create_beside(&track).expect("first temp");
-        let (second, second_handle) = TempFile::create_beside(&track).expect("second temp");
+        let (first, first_handle) =
+            TempFile::create_beside(&track, &track.to_string_lossy()).expect("first temp");
+        let (second, second_handle) =
+            TempFile::create_beside(&track, &track.to_string_lossy()).expect("second temp");
 
         assert_ne!(first.path(), second.path());
         assert!(first.path().exists());

--- a/src/local/tag_writer.rs
+++ b/src/local/tag_writer.rs
@@ -660,19 +660,28 @@ pub fn preflight_tag_write(path: &Path) -> Result<(), TagWritePreflightError> {
 /// retained parent handle — the anchored twin of
 /// [`preflight_tag_write_directory`].
 ///
-/// The rehearsal exclusively creates two private siblings beneath the
-/// retained parent, flushes them, replaces one with the other through the
-/// retained directory, and unlinks the result: the same create, replace,
-/// and remove shapes the anchored writer performs, addressed entirely
-/// through the directory handle. No absolute pathname is resolved, so an
-/// ancestor displaced after the authority's validation can neither take
-/// the probe outside the admitted mount directory nor reject a rehearsal
-/// the anchored writer could safely perform.
+/// The rehearsal exclusively creates one private probe sibling beneath the
+/// retained parent, flushes it, renames it onto a fresh vacant candidate
+/// name with the anchored commit's own no-replace install primitive
+/// (`renameat2(RENAME_NOREPLACE)` through the retained directory), and
+/// unlinks the result: the same create, install, and remove shapes the
+/// anchored writer performs, addressed entirely through the directory
+/// handle. No absolute pathname is resolved, so an ancestor displaced
+/// after the authority's validation can neither take the probe outside
+/// the admitted mount directory nor reject a rehearsal the anchored
+/// writer could safely perform.
+///
+/// Rehearsing the no-replace primitive itself is the point: the commit
+/// fails closed on filesystems without `RENAME_NOREPLACE` support, so a
+/// rehearsal that only exercised a plain overwriting rename would report
+/// such volumes write-capable and doom every later commit to fail. Here
+/// the unsupported primitive refuses the rehearsal, surfacing the
+/// limitation before the user edits.
 ///
 /// `leaf` is the admitted file's leaf name; it only seeds the randomized
 /// probe names' extension. Error contexts name the target by
 /// `target_label`, never by any path. On any failure the dropped probe
-/// siblings clean themselves up through the retained parent.
+/// sibling cleans itself up through the retained parent.
 ///
 /// This performs blocking filesystem I/O and must not run on the GTK
 /// thread.
@@ -682,6 +691,9 @@ pub fn preflight_tag_write_directory_retained(
     leaf: &OsStr,
     target_label: &str,
 ) -> Result<(), TagWritePreflightError> {
+    // Create and flush one private probe sibling beneath the retained
+    // parent — the create-and-flush shape the anchored commit performs on
+    // its staged copy.
     let (mut replacement, replacement_file) =
         TempFile::create_beside_retained(parent, leaf, target_label)
             .map_err(|_| TagWritePreflightError::Unavailable)?;
@@ -690,35 +702,30 @@ pub fn preflight_tag_write_directory_retained(
         .map_err(|_| TagWritePreflightError::Unavailable)?;
     drop(replacement_file);
 
-    let (mut destination, destination_file) =
-        TempFile::create_beside_retained(parent, leaf, target_label)
-            .map_err(|_| TagWritePreflightError::Unavailable)?;
-    destination_file
-        .sync_all()
-        .map_err(|_| TagWritePreflightError::Unavailable)?;
-    drop(destination_file);
-
-    // Replace the destination sibling with the replacement sibling — the
-    // rename shape the anchored commit's install performs.
-    rustix::fs::renameat(
+    // Install the probe with the anchored commit's own primitive: a
+    // no-replace rename onto a fresh vacant candidate name through the
+    // retained parent. An occupied destination (or a filesystem without
+    // flag support) refuses the rehearsal instead of being overwritten.
+    let vacant_name = staged_sibling_name(leaf);
+    #[cfg(all(test, unix))]
+    run_retained_preflight_interpose(parent, replacement.path().as_os_str(), &vacant_name);
+    rustix::fs::renameat_with(
         parent,
         replacement.path().as_os_str(),
         parent,
-        destination.path().as_os_str(),
+        &vacant_name,
+        rustix::fs::RenameFlags::NOREPLACE,
     )
     .map_err(|_| TagWritePreflightError::Unavailable)?;
-    replacement.disarm_cleanup();
 
-    // A capability check is successful only when cleanup succeeds: the
-    // probe sibling is removed through the retained parent and the drop
-    // guard disarmed.
-    rustix::fs::unlinkat(
-        parent,
-        destination.path().as_os_str(),
-        rustix::fs::AtFlags::empty(),
-    )
-    .map_err(|_| TagWritePreflightError::Unavailable)?;
-    destination.disarm_cleanup();
+    // The probe now lives at the vacant name. Aim the drop guard's
+    // anchored cleanup at that leaf so a failed explicit cleanup below
+    // still backstops through the retained parent, then remove it: a
+    // capability check is successful only when cleanup succeeds.
+    replacement.path = PathBuf::from(&vacant_name);
+    rustix::fs::unlinkat(parent, &vacant_name, rustix::fs::AtFlags::empty())
+        .map_err(|_| TagWritePreflightError::Unavailable)?;
+    replacement.disarm_cleanup();
     Ok(())
 }
 
@@ -1381,6 +1388,42 @@ fn with_pre_staging_interpose(interpose: Box<PreStagingInterpose>, run: impl FnO
     *PRE_STAGING_INTERPOSE.lock().unwrap() = Some(interpose);
     run();
     *PRE_STAGING_INTERPOSE.lock().unwrap() = None;
+}
+
+/// Test-only seam: runs immediately before the retained preflight
+/// rehearsal's no-replace rename, receiving the retained parent handle, the
+/// staged probe sibling's leaf, and the fresh vacant candidate leaf the
+/// rehearsal is about to rename onto. The regression tests observe the
+/// rehearsal's exact shape (a staged probe; a rename target that is vacant)
+/// and occupy the candidate name to prove the rehearsal's rename refuses a
+/// replacement — the no-replace primitive the anchored commit installs with.
+#[cfg(all(test, unix))]
+type RetainedPreflightInterpose = dyn Fn(&std::fs::File, &OsStr, &OsStr) + Send + Sync;
+
+#[cfg(all(test, unix))]
+static RETAINED_PREFLIGHT_INTERPOSE: std::sync::Mutex<Option<Box<RetainedPreflightInterpose>>> =
+    std::sync::Mutex::new(None);
+
+#[cfg(all(test, unix))]
+static RETAINED_PREFLIGHT_INTERPOSE_SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(all(test, unix))]
+fn run_retained_preflight_interpose(parent: &std::fs::File, probe: &OsStr, vacant: &OsStr) {
+    if let Some(interpose) = RETAINED_PREFLIGHT_INTERPOSE.lock().unwrap().as_ref() {
+        interpose(parent, probe, vacant);
+    }
+}
+
+/// Serialize tests that use the retained-preflight interposition seam.
+#[cfg(all(test, unix))]
+fn with_retained_preflight_interpose(
+    interpose: Box<RetainedPreflightInterpose>,
+    run: impl FnOnce(),
+) {
+    let _serial = RETAINED_PREFLIGHT_INTERPOSE_SERIAL.lock().unwrap();
+    *RETAINED_PREFLIGHT_INTERPOSE.lock().unwrap() = Some(interpose);
+    run();
+    *RETAINED_PREFLIGHT_INTERPOSE.lock().unwrap() = None;
 }
 
 #[cfg(test)]
@@ -2110,6 +2153,91 @@ mod tests {
             retained_entries,
             vec![std::ffi::OsString::from("silence.flac")],
             "the rehearsal must leave only the admitted file in the retained directory"
+        );
+    }
+
+    /// The retained rehearsal must exercise the anchored commit's no-replace
+    /// install primitive, not a plain overwriting rename. Its rename target
+    /// must be a fresh vacant name it does not pre-create, and when that
+    /// name is occupied the no-replace rename must refuse the rehearsal
+    /// with the probe cleaned up — the exact behavior that refuses
+    /// no-replace-incapable volumes at preflight instead of reporting them
+    /// write-capable and dooming every later commit to fail closed.
+    #[cfg(unix)]
+    #[test]
+    fn retained_preflight_rehearsal_refuses_an_occupied_rename_target() {
+        use std::sync::{Arc, Mutex};
+
+        let (directory, album, _) = anchored_album_fixture("preflight-no-replace");
+
+        let authority = mounted_root_authority(&directory);
+        let target = authority
+            .open_mutation_target(Path::new("album/silence.flac"))
+            .expect("open mutation target");
+        let (parent, leaf) = target
+            .retained_directory_handle()
+            .expect("retain the directory anchor");
+
+        let occupied_candidate = Arc::new(Mutex::new(None::<std::ffi::OsString>));
+        let closure_candidate = occupied_candidate.clone();
+        with_retained_preflight_interpose(
+            Box::new(move |interposed_parent, probe_leaf, vacant_leaf| {
+                use rustix::fs::AtFlags;
+
+                // The rehearsal renames onto a fresh vacant name: the probe
+                // sibling exists and the rename target does not. A rehearsal
+                // that pre-created a second sibling to overwrite fails here.
+                assert!(
+                    rustix::fs::statat(interposed_parent, probe_leaf, AtFlags::empty()).is_ok(),
+                    "the rehearsal must have staged its probe sibling through the retained parent"
+                );
+                assert!(
+                    rustix::fs::statat(interposed_parent, vacant_leaf, AtFlags::empty()).is_err(),
+                    "the rehearsal must rename onto a vacant name, not a pre-created sibling"
+                );
+
+                // Occupy the rename target. A plain overwriting rename would
+                // clobber this occupant and report the volume write-capable;
+                // the no-replace rename the commit installs with must refuse.
+                create_retained_sibling_exclusive(interposed_parent, vacant_leaf)
+                    .expect("occupy the rehearsal's rename target");
+                *closure_candidate.lock().unwrap() = Some(vacant_leaf.to_os_string());
+            }),
+            || {
+                assert_eq!(
+                    crate::local::tag_writer::preflight_tag_write_directory_retained(
+                        &parent,
+                        &leaf,
+                        "the removable mutation target",
+                    ),
+                    Err(TagWritePreflightError::Unavailable),
+                    "an occupied rename target must refuse the rehearsal, never be clobbered"
+                );
+            },
+        );
+
+        // The refusal path cleaned its probe sibling up through the
+        // retained parent; remove the deliberate occupant and require the
+        // directory to hold exactly the admitted file again.
+        let occupied = occupied_candidate.lock().unwrap().take();
+        rustix::fs::unlinkat(
+            &parent,
+            occupied
+                .as_deref()
+                .expect("the seam occupied the candidate"),
+            rustix::fs::AtFlags::empty(),
+        )
+        .expect("remove the deliberate occupant");
+
+        let retained_entries: Vec<std::ffi::OsString> = std::fs::read_dir(&album)
+            .expect("list the retained directory")
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name())
+            .collect();
+        assert_eq!(
+            retained_entries,
+            vec![std::ffi::OsString::from("silence.flac")],
+            "the refused rehearsal must leave no probe sibling behind"
         );
     }
 

--- a/src/local/tag_writer.rs
+++ b/src/local/tag_writer.rs
@@ -1404,14 +1404,29 @@ mod tests {
         write_tags_with_mutation_target(&target, &year("2026"))
             .expect_err("a stranded staging area must refuse the commit");
 
+        assert_refused_displacement_left_files_untouched(
+            &track,
+            &displaced_album.join("silence.flac"),
+        );
+        assert_no_stranded_tag_write_siblings(&[&album, &displaced_album]);
+    }
+
+    /// Both files the displaced-parent scenario can observe must be untouched
+    /// by the refused commit: the impostor now occupying the old pathname
+    /// never receives the replacement, and the displaced admitted file keeps
+    /// its original tags.
+    #[cfg(unix)]
+    fn assert_refused_displacement_left_files_untouched(
+        impostor_track: &Path,
+        displaced_track: &Path,
+    ) {
         assert_eq!(
-            std::fs::read(&track).expect("read impostor file"),
+            std::fs::read(impostor_track).expect("read impostor file"),
             b"impostor audio",
             "the impostor directory must never receive the replacement"
         );
-        let displaced_track = displaced_album.join("silence.flac");
         let displaced_tagged =
-            lofty::read_from_path(&displaced_track).expect("reopen the displaced admitted file");
+            lofty::read_from_path(displaced_track).expect("reopen the displaced admitted file");
         assert_ne!(
             displaced_tagged
                 .primary_tag()
@@ -1420,7 +1435,13 @@ mod tests {
             Some("2026"),
             "the admitted file must be untouched by the refused commit"
         );
-        for directory_path in [&album, &displaced_album] {
+    }
+
+    /// A refused commit must clean up its stranded staging sibling in every
+    /// directory the retained parent machinery could have staged one in.
+    #[cfg(unix)]
+    fn assert_no_stranded_tag_write_siblings(directories: &[&Path]) {
+        for directory_path in directories {
             let leftovers: Vec<PathBuf> = std::fs::read_dir(directory_path)
                 .expect("list displaced directories")
                 .filter_map(|entry| entry.ok())

--- a/src/local/tag_writer.rs
+++ b/src/local/tag_writer.rs
@@ -2219,25 +2219,10 @@ mod tests {
         // The refusal path cleaned its probe sibling up through the
         // retained parent; remove the deliberate occupant and require the
         // directory to hold exactly the admitted file again.
-        let occupied = occupied_candidate.lock().unwrap().take();
-        rustix::fs::unlinkat(
+        assert_refused_rehearsal_left_only_the_admitted_file(
             &parent,
-            occupied
-                .as_deref()
-                .expect("the seam occupied the candidate"),
-            rustix::fs::AtFlags::empty(),
-        )
-        .expect("remove the deliberate occupant");
-
-        let retained_entries: Vec<std::ffi::OsString> = std::fs::read_dir(&album)
-            .expect("list the retained directory")
-            .filter_map(|entry| entry.ok())
-            .map(|entry| entry.file_name())
-            .collect();
-        assert_eq!(
-            retained_entries,
-            vec![std::ffi::OsString::from("silence.flac")],
-            "the refused rehearsal must leave no probe sibling behind"
+            &album,
+            occupied_candidate.lock().unwrap().take(),
         );
     }
 
@@ -2257,6 +2242,37 @@ mod tests {
                 "a refused commit must clean up its stranded sibling: {leftovers:?}"
             );
         }
+    }
+
+    /// Remove the occupant the retained-preflight seam deliberately
+    /// installed at the rehearsal's rename target, then require the
+    /// directory to hold exactly the admitted file again: a refused
+    /// rehearsal must leave no probe sibling behind.
+    #[cfg(unix)]
+    fn assert_refused_rehearsal_left_only_the_admitted_file(
+        parent: &std::fs::File,
+        album: &Path,
+        occupied: Option<std::ffi::OsString>,
+    ) {
+        rustix::fs::unlinkat(
+            parent,
+            occupied
+                .as_deref()
+                .expect("the seam occupied the candidate"),
+            rustix::fs::AtFlags::empty(),
+        )
+        .expect("remove the deliberate occupant");
+
+        let retained_entries: Vec<std::ffi::OsString> = std::fs::read_dir(album)
+            .expect("list the retained directory")
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name())
+            .collect();
+        assert_eq!(
+            retained_entries,
+            vec![std::ffi::OsString::from("silence.flac")],
+            "the refused rehearsal must leave no probe sibling behind"
+        );
     }
 
     #[test]

--- a/src/local/tag_writer.rs
+++ b/src/local/tag_writer.rs
@@ -653,6 +653,72 @@ pub fn preflight_tag_write(path: &Path) -> Result<(), TagWritePreflightError> {
     preflight_tag_write_directory(path)
 }
 
+/// Rehearse the anchored replacement's directory mechanics through the
+/// retained parent handle — the anchored twin of
+/// [`preflight_tag_write_directory`].
+///
+/// The rehearsal exclusively creates two private siblings beneath the
+/// retained parent, flushes them, replaces one with the other through the
+/// retained directory, and unlinks the result: the same create, replace,
+/// and remove shapes the anchored writer performs, addressed entirely
+/// through the directory handle. No absolute pathname is resolved, so an
+/// ancestor displaced after the authority's validation can neither take
+/// the probe outside the admitted mount directory nor reject a rehearsal
+/// the anchored writer could safely perform.
+///
+/// `leaf` is the admitted file's leaf name; it only seeds the randomized
+/// probe names' extension. Error contexts name the target by
+/// `target_label`, never by any path. On any failure the dropped probe
+/// siblings clean themselves up through the retained parent.
+///
+/// This performs blocking filesystem I/O and must not run on the GTK
+/// thread.
+#[cfg(unix)]
+pub(crate) fn preflight_tag_write_directory_retained(
+    parent: &std::fs::File,
+    leaf: &OsStr,
+    target_label: &str,
+) -> Result<(), TagWritePreflightError> {
+    let (mut replacement, replacement_file) =
+        TempFile::create_beside_retained(parent, leaf, target_label)
+            .map_err(|_| TagWritePreflightError::Unavailable)?;
+    replacement_file
+        .sync_all()
+        .map_err(|_| TagWritePreflightError::Unavailable)?;
+    drop(replacement_file);
+
+    let (mut destination, destination_file) =
+        TempFile::create_beside_retained(parent, leaf, target_label)
+            .map_err(|_| TagWritePreflightError::Unavailable)?;
+    destination_file
+        .sync_all()
+        .map_err(|_| TagWritePreflightError::Unavailable)?;
+    drop(destination_file);
+
+    // Replace the destination sibling with the replacement sibling — the
+    // rename shape the anchored commit's install performs.
+    rustix::fs::renameat(
+        parent,
+        replacement.path().as_os_str(),
+        parent,
+        destination.path().as_os_str(),
+    )
+    .map_err(|_| TagWritePreflightError::Unavailable)?;
+    replacement.disarm_cleanup();
+
+    // A capability check is successful only when cleanup succeeds: the
+    // probe sibling is removed through the retained parent and the drop
+    // guard disarmed.
+    rustix::fs::unlinkat(
+        parent,
+        destination.path().as_os_str(),
+        rustix::fs::AtFlags::empty(),
+    )
+    .map_err(|_| TagWritePreflightError::Unavailable)?;
+    destination.disarm_cleanup();
+    Ok(())
+}
+
 /// Write tag edits to an audio file.
 ///
 /// Only fields that are `Some(...)` in `edits` are modified.
@@ -1985,6 +2051,61 @@ mod tests {
              {outside_entries:?}"
         );
         assert_no_stranded_tag_write_siblings(&[&displaced_album]);
+    }
+
+    /// The removable preflight's directory rehearsal must probe the
+    /// retained directory, not the pathname: after the retained parent was
+    /// displaced and an impostor directory installed at the old name, the
+    /// rehearsal's create, replace, and remove siblings happen beside the
+    /// admitted file in the retained (displaced) directory, the impostor
+    /// never receives anything, and no probe sibling survives.
+    #[cfg(unix)]
+    #[test]
+    fn retained_preflight_rehearsal_probes_the_retained_directory_after_displacement() {
+        let (directory, album, _) = anchored_album_fixture("preflight-retained-anchor");
+
+        let authority = mounted_root_authority(&directory);
+        let target = authority
+            .open_mutation_target(Path::new("album/silence.flac"))
+            .expect("open mutation target");
+        let (parent, leaf) = target
+            .retained_directory_handle()
+            .expect("retain the directory anchor");
+
+        let displaced_album = directory.path.join("displaced-album");
+        std::fs::rename(&album, &displaced_album).expect("displace retained parent");
+        std::fs::create_dir(&album).expect("install impostor directory at the old name");
+
+        crate::local::tag_writer::preflight_tag_write_directory_retained(
+            &parent,
+            &leaf,
+            "the removable mutation target",
+        )
+        .expect("the rehearsal must run through the retained parent");
+
+        // The impostor at the old pathname never saw a probe sibling.
+        let impostor_entries: Vec<std::ffi::OsString> = std::fs::read_dir(&album)
+            .expect("list the impostor directory")
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name())
+            .collect();
+        assert!(
+            impostor_entries.is_empty(),
+            "the impostor directory must receive no probe siblings: {impostor_entries:?}"
+        );
+
+        // The retained directory holds exactly the admitted file: every
+        // probe sibling was removed again through the retained parent.
+        let retained_entries: Vec<std::ffi::OsString> = std::fs::read_dir(&displaced_album)
+            .expect("list the retained directory")
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name())
+            .collect();
+        assert_eq!(
+            retained_entries,
+            vec![std::ffi::OsString::from("silence.flac")],
+            "the rehearsal must leave only the admitted file in the retained directory"
+        );
     }
 
     /// A refused commit must clean up its stranded staging sibling in every

--- a/src/local/tag_writer.rs
+++ b/src/local/tag_writer.rs
@@ -377,10 +377,14 @@ fn retained_leaf_identity(parent: &File, leaf: &OsStr) -> std::io::Result<(u64, 
 /// is never destruction. Trust boundary of the final unlink: POSIX has no
 /// unlink-by-fd, so the verify→unlink window on the private name cannot be
 /// made atomic — an external writer can swap the occupant inside it. The
-/// fd-verified post-condition (see [`unlink_fd_verified`]) detects and
-/// loudly reports such a wrong-object removal instead of silently
-/// succeeding; it converts silent destruction into a reported refusal, and
-/// an operator/coordinator decision (accept the residual or redesign the
+/// removal is gated on a provable sole link and its outcome fd-verified
+/// (see [`unlink_fd_verified`]): a concurrent removal of an unrelated hard
+/// link can no longer counterfeit the expected link-count delta, and a
+/// wrong-object removal is detected and loudly reported instead of
+/// silently succeeding. The window is not fully closed — a writer
+/// manufacturing a create-link/remove-link pair inside the fstat→fstat
+/// window can still counterfeit the post-condition — and an
+/// operator/coordinator decision (accept the residual or redesign the
 /// cleanup contract to leave contested debris) remains open for the
 /// strictly atomic form.
 #[cfg(unix)]
@@ -520,14 +524,32 @@ fn unlink_bound_private_name(
 ///
 /// Trust boundary: POSIX has no unlink-by-fd, so the verify→unlink window
 /// on the private name cannot be closed — an external writer can swap the
-/// occupant between the re-verification and the [`unlinkat`]. The pin
-/// descriptor is held across the removal and `fstat` through it (immune to
-/// directory-entry games) proves the outcome: the removed entry referenced
-/// the pinned object iff the pinned object's link count dropped by exactly
-/// one. An unchanged count means a swap landed in the window and the
-/// unlinkat destroyed a foreign entry — reported loudly and refused, never
-/// reported success. Any other outcome is unprovable and refused with
-/// everything left where it lies.
+/// occupant between the re-verification and the [`unlinkat`]. Two measures
+/// bound what that window can cost:
+///
+/// * *Sole-link gate.* `st_nlink` is inode-global, not per-directory-entry,
+///   so the removal is attempted only when the pinned object has exactly
+///   one link — the private name is its only one. With a second link
+///   alive, a concurrent writer removing THAT link inside the
+///   fstat→fstat window would drop the count by one for an unrelated
+///   reason while the unlinkat destroyed a swapped-in foreign entry,
+///   counterfeiting the expected delta; the gate refuses such a removal
+///   outright and leaves the debris, attempting no unlink at all.
+/// * *fd-verified post-condition.* With one link, no unrelated removal
+///   can decrement the count, so the pinned object's link count dropping
+///   to zero through the held pin descriptor proves the removed entry
+///   referenced the pinned object. An unchanged count means a swap landed
+///   in the window and the unlinkat destroyed a foreign entry — reported
+///   loudly and refused, never reported success. Any other outcome is
+///   unprovable and refused with everything left where it lies.
+///
+/// Narrowed residual, stated precisely: a writer that can manufacture a
+/// create-link/remove-link pair *inside* the fstat→fstat window — unlink
+/// the sole link at the private name, plant a foreign entry, and make the
+/// count fall to zero for the plant — can still counterfeit the
+/// post-condition. The window is not fully closed; POSIX offers no
+/// unlink-by-fd. A strictly atomic identity-conditional unlink remains
+/// the recorded operator/coordinator decision (PR #237 precedent).
 ///
 /// [`unlinkat`]: rustix::fs::unlinkat
 // The `u64::from` is load-bearing on macOS (`st_nlink` is `u16` there) and
@@ -542,6 +564,19 @@ fn unlink_fd_verified(parent: &File, retire_name: &OsStr, pinned: &rustix::fd::O
         return false;
     };
     let links_before = u64::from(before.st_nlink);
+    // Sole-link gate: with more than one link alive, a concurrent writer
+    // removing an unrelated hard link inside the fstat→fstat window can
+    // counterfeit the expected delta while the unlinkat destroys a
+    // swapped-in foreign entry. Refuse and leave the debris — no unlink
+    // is attempted against an object whose removal outcome could not be
+    // proven.
+    if links_before != 1 {
+        tracing::warn!(
+            "retained-cleanup probe carries extra hard links; refusing the \
+             removal and leaving the debris"
+        );
+        return false;
+    }
     if rustix::fs::unlinkat(parent, retire_name, rustix::fs::AtFlags::empty()).is_err() {
         return false;
     }
@@ -554,7 +589,10 @@ fn unlink_fd_verified(parent: &File, retire_name: &OsStr, pinned: &rustix::fd::O
         return false;
     };
     let links_after = u64::from(after.st_nlink);
-    if links_before >= 1 && links_after == links_before - 1 {
+    // links_before is provably 1 here, so the proven success shape is
+    // exactly `links_after == 0`: the sole link went away through this
+    // removal.
+    if links_after == 0 {
         return true;
     }
     if links_after == links_before {
@@ -2531,7 +2569,80 @@ mod tests {
         assert_eq!(
             retained_entries,
             vec![std::ffi::OsString::from("silence.flac")],
-            "the rehearsal must leave only the admitted file in the retained directory"
+            "the refused rehearsal must leave no probe residue of its own"
+        );
+    }
+
+    /// Drive the rehearsal under an extra-hard-link probe: the sole-link
+    /// gate must refuse the removal with `Unavailable` — no unlink
+    /// attempted, so nothing is destroyed and no contested-destruction
+    /// ERROR event is carried.
+    #[cfg(unix)]
+    fn run_sole_link_rehearsal_expect_refusal(parent: &std::fs::File, leaf: &OsStr) {
+        let errors = capture_error_events(|| {
+            assert_eq!(
+                crate::local::tag_writer::preflight_tag_write_directory_retained(
+                    parent,
+                    leaf,
+                    "the removable mutation target",
+                ),
+                Err(TagWritePreflightError::Unavailable),
+                "a probe with extra hard links must be refused: its removal \
+                 outcome cannot be proven against a concurrent link removal"
+            );
+        });
+        assert!(
+            errors.is_empty(),
+            "the sole-link refusal attempts no unlink, so it must not carry \
+             the contested-destruction ERROR event: {errors:?}"
+        );
+    }
+
+    /// Assert the sole-link refusal's outcomes: the interposed hard link
+    /// ran, the extra link still names the two-link probe (never
+    /// unlinked), exactly the relocated private name and the extra link
+    /// remain beside the untouched admitted file.
+    #[cfg(unix)]
+    fn assert_sole_link_refusal_leaves_debris(
+        linked: &std::sync::atomic::AtomicBool,
+        extra: &std::sync::Mutex<Option<std::ffi::OsString>>,
+        parent: &std::fs::File,
+        album: &Path,
+    ) {
+        use rustix::fs::AtFlags;
+        use std::sync::atomic::Ordering;
+        assert!(
+            linked.load(Ordering::SeqCst),
+            "the interposed hard link must have run"
+        );
+        let extra_leaf = extra
+            .lock()
+            .unwrap()
+            .take()
+            .expect("the probe was hard-linked");
+        let probe_stat = rustix::fs::statat(parent, &extra_leaf, AtFlags::SYMLINK_NOFOLLOW)
+            .expect("the extra hard link's debris is preserved");
+        assert_eq!(
+            probe_stat.st_nlink, 2,
+            "the refused removal never unlinked the probe"
+        );
+        let retained: Vec<std::ffi::OsString> = std::fs::read_dir(album)
+            .expect("list the retained directory")
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name())
+            .collect();
+        assert_eq!(
+            retained.len(),
+            3,
+            "exactly the probe debris remains beside the admitted file: {retained:?}"
+        );
+        assert!(
+            retained.contains(&std::ffi::OsString::from("silence.flac")),
+            "the admitted file is untouched: {retained:?}"
+        );
+        assert!(
+            retained.contains(&extra_leaf),
+            "the extra hard link survives as preserved debris: {retained:?}"
         );
     }
 
@@ -3141,6 +3252,55 @@ mod tests {
             vec![std::ffi::OsString::from("silence.flac")],
             "the clean rehearsal removes its probe completely"
         );
+    }
+
+    /// The fd-verified removal must gate on a provable sole link: a probe
+    /// carrying an extra hard link at removal time has an outcome no
+    /// link-count post-condition can prove — a concurrent writer removing
+    /// that unrelated link inside the fstat→fstat window would counterfeit
+    /// the expected delta while the unlinkat destroyed a swapped-in foreign
+    /// entry — so the removal must be refused before any unlink, the debris
+    /// left, and nothing reported as success.
+    #[cfg(unix)]
+    #[test]
+    fn retained_preflight_refuses_a_probe_with_extra_hard_links_and_leaves_debris() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::{Arc, Mutex};
+
+        let (directory, album, _) = anchored_album_fixture("preflight-sole-link");
+        let authority = mounted_root_authority(&directory);
+        let target = authority
+            .open_mutation_target(Path::new("album/silence.flac"))
+            .expect("open mutation target");
+        let (parent, leaf) = target
+            .retained_directory_handle()
+            .expect("retain the directory anchor");
+
+        let extra = Arc::new(Mutex::new(None::<std::ffi::OsString>));
+        let extra_closure = Arc::clone(&extra);
+        let linked = Arc::new(AtomicBool::new(false));
+        let linked_closure = Arc::clone(&linked);
+        with_retained_preflight_interpose(
+            Box::new(move |phase, interposed_parent, landed_leaf, _vacant_leaf| {
+                if phase != RetainedPreflightPhase::BeforeCleanup {
+                    return;
+                }
+                linked_closure.store(true, Ordering::SeqCst);
+                let extra_leaf = staged_sibling_name(std::ffi::OsStr::new("silence.flac"));
+                rustix::fs::linkat(
+                    interposed_parent,
+                    landed_leaf,
+                    interposed_parent,
+                    &extra_leaf,
+                    rustix::fs::AtFlags::empty(),
+                )
+                .expect("hard-link the landed probe");
+                *extra_closure.lock().unwrap() = Some(extra_leaf);
+            }),
+            || run_sole_link_rehearsal_expect_refusal(&parent, &leaf),
+        );
+
+        assert_sole_link_refusal_leaves_debris(&linked, &extra, &parent, &album);
     }
 
     #[test]

--- a/src/local/tag_writer.rs
+++ b/src/local/tag_writer.rs
@@ -370,13 +370,19 @@ fn retained_leaf_identity(parent: &File, leaf: &OsStr) -> std::io::Result<(u64, 
 ///    occupied candidate preserves that occupant;
 /// 4. the private name is re-verified to name exactly the pinned object (a
 ///    swap between the pin and the relocation moved a newcomer, which is
-///    renamed back where it was) — and only then unlinked.
+///    renamed back where it was) — and only then unlinked, with the pin
+///    descriptor held through the removal and the outcome fd-verified.
 ///
 /// Every unprovable step reports `false` and preserves every entry: debris
-/// is never destruction. The final unlink removes a name nothing else
-/// created and that was atomically bound to the verified object, so an
-/// external swap can strand debris but can never make this removal destroy
-/// a newcomer.
+/// is never destruction. Trust boundary of the final unlink: POSIX has no
+/// unlink-by-fd, so the verify→unlink window on the private name cannot be
+/// made atomic — an external writer can swap the occupant inside it. The
+/// fd-verified post-condition (see [`unlink_fd_verified`]) detects and
+/// loudly reports such a wrong-object removal instead of silently
+/// succeeding; it converts silent destruction into a reported refusal, and
+/// an operator/coordinator decision (accept the residual or redesign the
+/// cleanup contract to leave contested debris) remains open for the
+/// strictly atomic form.
 #[cfg(unix)]
 fn remove_anchored_leaf_bound_to_identity(
     parent: &File,
@@ -387,7 +393,7 @@ fn remove_anchored_leaf_bound_to_identity(
     // the name, and require it to be exactly the object this section
     // created. An unprovable leaf (vanished, symlinked, unopenable) is
     // preserved, as is a name a newcomer occupies.
-    let Some(_pinned) = pin_created_leaf_identity(parent, leaf, created) else {
+    let Some(pinned) = pin_created_leaf_identity(parent, leaf, created) else {
         return false;
     };
     // Test-only seam inside the proof→bind window: the pinned object is
@@ -398,7 +404,7 @@ fn remove_anchored_leaf_bound_to_identity(
     run_retained_preflight_interpose(RetainedPreflightPhase::AfterProof, parent, leaf, leaf);
 
     for _ in 0..8 {
-        if let Some(removed) = retire_leaf_bound_to_private_name(parent, leaf, created) {
+        if let Some(removed) = retire_leaf_bound_to_private_name(parent, leaf, created, &pinned) {
             return removed;
         }
     }
@@ -435,11 +441,15 @@ fn pin_created_leaf_identity(
 /// object to a name nothing else created — then prove the private name and
 /// remove it there. `Some(removed)` is definitive; `None` means the
 /// randomized candidate collided (`EXIST`) and another attempt may run.
+/// `pinned` is the descriptor holding the verified object, kept across the
+/// removal so its fd-relative post-condition cannot be spoofed by
+/// directory-entry games.
 #[cfg(unix)]
 fn retire_leaf_bound_to_private_name(
     parent: &File,
     leaf: &OsStr,
     created: (u64, u64),
+    pinned: &rustix::fd::OwnedFd,
 ) -> Option<bool> {
     let retire_name = staged_sibling_name(leaf);
     match rustix::fs::renameat_with(
@@ -454,6 +464,7 @@ fn retire_leaf_bound_to_private_name(
             &retire_name,
             created,
             leaf,
+            pinned,
         )),
         Err(rustix::io::Errno::EXIST) => None,
         // An unsupported relocation primitive cannot prove the bind:
@@ -472,10 +483,22 @@ fn unlink_bound_private_name(
     retire_name: &OsStr,
     created: (u64, u64),
     leaf: &OsStr,
+    pinned: &rustix::fd::OwnedFd,
 ) -> bool {
     match retained_leaf_identity(parent, retire_name) {
         Ok(identity) if identity == created => {
-            rustix::fs::unlinkat(parent, retire_name, rustix::fs::AtFlags::empty()).is_ok()
+            // Test-only seam inside the verify→unlink window: the private
+            // name has re-verified as the pinned object and the unlinkat
+            // has not run yet. A swap driven here exercises the
+            // fd-verified post-condition on the removal.
+            #[cfg(all(test, unix))]
+            run_retained_preflight_interpose(
+                RetainedPreflightPhase::AfterRetireVerify,
+                parent,
+                retire_name,
+                retire_name,
+            );
+            unlink_fd_verified(parent, retire_name, pinned)
         }
         _ => {
             // Restore the displaced newcomer best-effort; if the original
@@ -491,6 +514,56 @@ fn unlink_bound_private_name(
             false
         }
     }
+}
+
+/// Remove the private name with an fd-verified post-condition.
+///
+/// Trust boundary: POSIX has no unlink-by-fd, so the verify→unlink window
+/// on the private name cannot be closed — an external writer can swap the
+/// occupant between the re-verification and the [`unlinkat`]. The pin
+/// descriptor is held across the removal and `fstat` through it (immune to
+/// directory-entry games) proves the outcome: the removed entry referenced
+/// the pinned object iff the pinned object's link count dropped by exactly
+/// one. An unchanged count means a swap landed in the window and the
+/// unlinkat destroyed a foreign entry — reported loudly and refused, never
+/// reported success. Any other outcome is unprovable and refused with
+/// everything left where it lies.
+///
+/// [`unlinkat`]: rustix::fs::unlinkat
+// The `u64::from` is load-bearing on macOS (`st_nlink` is `u16` there) and
+// keeps every caller platform-uniform; on Linux it is infallible, which is
+// the only target clippy sees here.
+#[allow(clippy::useless_conversion)]
+#[cfg(unix)]
+fn unlink_fd_verified(parent: &File, retire_name: &OsStr, pinned: &rustix::fd::OwnedFd) -> bool {
+    let Ok(before) = rustix::fs::fstat(pinned) else {
+        // Unprovable: the pin's link count is unreadable, so no removal
+        // outcome could be proven.
+        return false;
+    };
+    let links_before = u64::from(before.st_nlink);
+    if rustix::fs::unlinkat(parent, retire_name, rustix::fs::AtFlags::empty()).is_err() {
+        return false;
+    }
+    let Ok(after) = rustix::fs::fstat(pinned) else {
+        // The removal landed but its post-condition is unreadable: refuse
+        // rather than claim a success that cannot be proven.
+        tracing::warn!(
+            "retained-cleanup removal landed but its fd-verified post-condition is unreadable"
+        );
+        return false;
+    };
+    let links_after = u64::from(after.st_nlink);
+    if links_before >= 1 && links_after == links_before - 1 {
+        return true;
+    }
+    if links_after == links_before {
+        tracing::error!(
+            "contested retained-cleanup destroyed an external writer's entry swapped \
+             into the verify-to-unlink window; refusing the removal"
+        );
+    }
+    false
 }
 
 /// Randomized staged-sibling leaf name, preserving the final extension.
@@ -1655,17 +1728,25 @@ enum RetainedPreflightPhase {
     /// the proof→bind window the identity-bound removal's re-verify and
     /// restore paths guard. Both leaf arguments carry the landed leaf.
     AfterProof,
+    /// Inside the bound removal, after the private name re-verified as the
+    /// pinned object and before the unlinkat removes it: the verify→unlink
+    /// window the fd-verified post-condition guards. Both leaf arguments
+    /// carry the private name about to be removed.
+    AfterRetireVerify,
 }
 
 /// Test-only seam: runs at each [`RetainedPreflightPhase`] of the retained
 /// preflight rehearsal, receiving the phase, the retained parent handle, the
 /// staged probe sibling's leaf, and the fresh vacant candidate leaf the
-/// rehearsal renames onto. The regression tests observe the rehearsal's
-/// exact shape (a staged probe; a rename target that is vacant; a landed
-/// probe before cleanup) — occupying the candidate name proves the rename
-/// refuses a replacement (the no-replace primitive the anchored commit
-/// installs with), and swapping the landed probe proves the cleanup removes
-/// exactly the entry the rehearsal created.
+/// rehearsal renames onto (for the bound-removal windows, both leaf slots
+/// carry the window's private/landed leaf name instead). The regression
+/// tests observe the rehearsal's exact shape (a staged probe; a rename
+/// target that is vacant; a landed probe before cleanup; a re-verified
+/// private name before removal) — occupying the candidate name proves the
+/// rename refuses a replacement (the no-replace primitive the anchored
+/// commit installs with), and swapping the landed probe or the re-verified
+/// private name proves the cleanup removes exactly the entry the rehearsal
+/// created and reports a contested removal instead of silently succeeding.
 #[cfg(all(test, unix))]
 type RetainedPreflightInterpose =
     dyn Fn(RetainedPreflightPhase, &std::fs::File, &OsStr, &OsStr) + Send + Sync;
@@ -2770,6 +2851,243 @@ mod tests {
         // The newcomer was restored to its own name and the stolen probe is
         // preserved debris; the refused rehearsal left nothing of its own.
         assert_the_swap_survived_the_refused_cleanup(&parent, &album, newcomer, stolen);
+    }
+
+    /// Steal the re-verified probe from the private name and install a
+    /// newcomer there inside the verify→unlink window, recording the
+    /// private name (the newcomer's, briefly) and the stolen probe's
+    /// debris name for the post-refusal assertions.
+    #[cfg(unix)]
+    fn steal_reverified_probe_install_newcomer(
+        interposed_parent: &std::fs::File,
+        retire_leaf: &OsStr,
+        contested: &std::sync::Arc<std::sync::Mutex<Option<std::ffi::OsString>>>,
+        stolen: &std::sync::Arc<std::sync::Mutex<Option<std::ffi::OsString>>>,
+    ) {
+        let stolen_leaf = staged_sibling_name(std::ffi::OsStr::new("silence.flac"));
+        rustix::fs::renameat(
+            interposed_parent,
+            retire_leaf,
+            interposed_parent,
+            &stolen_leaf,
+        )
+        .expect("steal the re-verified probe");
+        create_retained_sibling_exclusive(interposed_parent, retire_leaf)
+            .expect("install the newcomer at the private name");
+        *contested.lock().unwrap() = Some(retire_leaf.to_os_string());
+        *stolen.lock().unwrap() = Some(stolen_leaf);
+    }
+
+    /// A `tracing` layer capturing the message of every ERROR-level event
+    /// emitted under it, so a regression can require the loud signal the
+    /// contested-cleanup refusal must carry.
+    #[cfg(unix)]
+    struct ErrorEventSink(std::sync::Arc<std::sync::Mutex<Vec<String>>>);
+
+    #[cfg(unix)]
+    impl<S: tracing::Subscriber> tracing_subscriber::layer::Layer<S> for ErrorEventSink {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            if event.metadata().level() != &tracing::Level::ERROR {
+                return;
+            }
+            event.record(&mut MessageVisitor(std::sync::Arc::clone(&self.0)));
+        }
+    }
+
+    /// A `tracing` field visitor extracting the `message` field of an
+    /// ERROR-level event into the sink.
+    #[cfg(unix)]
+    struct MessageVisitor(std::sync::Arc<std::sync::Mutex<Vec<String>>>);
+
+    #[cfg(unix)]
+    impl tracing::field::Visit for MessageVisitor {
+        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+            if field.name() == "message" {
+                self.0.lock().unwrap().push(format!("{value:?}"));
+            }
+        }
+    }
+
+    /// Run `body` capturing the message of every ERROR-level tracing event
+    /// it emits on this thread.
+    #[cfg(unix)]
+    fn capture_error_events(body: impl FnOnce()) -> Vec<String> {
+        use tracing_subscriber::layer::SubscriberExt as _;
+        let sink = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber =
+            tracing_subscriber::registry().with(ErrorEventSink(std::sync::Arc::clone(&sink)));
+        // The default dispatcher is scoped to `body`; it is restored before
+        // this returns.
+        tracing::subscriber::with_default(subscriber, body);
+        let captured = sink.lock().unwrap().clone();
+        captured
+    }
+
+    /// The bound removal must survive — by refusing loudly — an external
+    /// writer's swap inside the verify→unlink window: the re-verified
+    /// private name is stolen and a newcomer installed there before the
+    /// unlinkat runs. POSIX has no unlink-by-fd, so the newcomer's entry is
+    /// destroyed, but the fd-verified post-condition proves the removal did
+    /// not touch the pinned object, reports the contested destruction at
+    /// ERROR level, and refuses — the rehearsal never reports success for a
+    /// wrong-object removal, and the stolen probe survives as preserved
+    /// debris.
+    #[cfg(unix)]
+    #[test]
+    fn retained_preflight_reports_a_newcomer_swapped_between_verify_and_unlink() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::{Arc, Mutex};
+
+        let (directory, album, _) = anchored_album_fixture("preflight-retire-verify-swap");
+        let authority = mounted_root_authority(&directory);
+        let target = authority
+            .open_mutation_target(Path::new("album/silence.flac"))
+            .expect("open mutation target");
+        let (parent, leaf) = target
+            .retained_directory_handle()
+            .expect("retain the directory anchor");
+
+        let contested = Arc::new(Mutex::new(None::<std::ffi::OsString>));
+        let stolen = Arc::new(Mutex::new(None::<std::ffi::OsString>));
+        let contested_closure = Arc::clone(&contested);
+        let stolen_closure = Arc::clone(&stolen);
+        let window_ran = Arc::new(AtomicBool::new(false));
+        let window_ran_closure = Arc::clone(&window_ran);
+        with_retained_preflight_interpose(
+            Box::new(move |phase, interposed_parent, retire_leaf, _vacant_leaf| {
+                if phase != RetainedPreflightPhase::AfterRetireVerify {
+                    return;
+                }
+                window_ran_closure.store(true, Ordering::SeqCst);
+                steal_reverified_probe_install_newcomer(
+                    interposed_parent,
+                    retire_leaf,
+                    &contested_closure,
+                    &stolen_closure,
+                );
+            }),
+            || {
+                let errors = capture_error_events(|| {
+                    assert_eq!(
+                        crate::local::tag_writer::preflight_tag_write_directory_retained(
+                            &parent,
+                            &leaf,
+                            "the removable mutation target",
+                        ),
+                        Err(TagWritePreflightError::Unavailable),
+                        "a contested cleanup must refuse the rehearsal, never report \
+                         success for a wrong-object removal"
+                    );
+                });
+                assert_eq!(
+                    errors.len(),
+                    1,
+                    "the contested cleanup must report the destroyed foreign entry \
+                     loudly exactly once: {errors:?}"
+                );
+            },
+        );
+
+        assert!(
+            window_ran.load(Ordering::SeqCst),
+            "the verify→unlink window observer must have run"
+        );
+        let contested_leaf = contested
+            .lock()
+            .unwrap()
+            .take()
+            .expect("the seam contested the private name");
+        let stolen_leaf = stolen
+            .lock()
+            .unwrap()
+            .take()
+            .expect("the seam stole the re-verified probe");
+        use rustix::fs::AtFlags;
+        assert!(
+            rustix::fs::statat(&parent, &contested_leaf, AtFlags::empty()).is_err(),
+            "the swapped-in newcomer's entry was destroyed by the contested \
+             unlink — the acknowledged, reported loss"
+        );
+        assert!(
+            rustix::fs::statat(&parent, stolen_leaf.as_os_str(), AtFlags::empty()).is_ok(),
+            "the stolen probe is preserved debris, never destroyed"
+        );
+        rustix::fs::unlinkat(&parent, stolen_leaf.as_os_str(), AtFlags::empty())
+            .expect("remove the stolen-probe debris");
+        let retained_entries: Vec<std::ffi::OsString> = std::fs::read_dir(&album)
+            .expect("list the retained directory")
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name())
+            .collect();
+        assert_eq!(
+            retained_entries,
+            vec![std::ffi::OsString::from("silence.flac")],
+            "the refused rehearsal must leave no probe residue of its own"
+        );
+    }
+
+    /// The verify→unlink window must not disturb the clean path: an
+    /// observer that watches the window (reading the re-verified identity,
+    /// touching nothing) still sees the private name removed and the
+    /// rehearsal report success.
+    #[cfg(unix)]
+    #[test]
+    fn retained_preflight_removes_the_probe_across_an_observed_verify_window() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        let (directory, album, _) = anchored_album_fixture("preflight-retire-verify-clean");
+        let authority = mounted_root_authority(&directory);
+        let target = authority
+            .open_mutation_target(Path::new("album/silence.flac"))
+            .expect("open mutation target");
+        let (parent, leaf) = target
+            .retained_directory_handle()
+            .expect("retain the directory anchor");
+
+        let window_ran = Arc::new(AtomicBool::new(false));
+        let window_ran_closure = Arc::clone(&window_ran);
+        with_retained_preflight_interpose(
+            Box::new(move |phase, interposed_parent, retire_leaf, _vacant_leaf| {
+                if phase != RetainedPreflightPhase::AfterRetireVerify {
+                    return;
+                }
+                window_ran_closure.store(true, Ordering::SeqCst);
+                retained_leaf_identity(interposed_parent, retire_leaf)
+                    .expect("the re-verified private name still names the pinned probe");
+            }),
+            || {
+                assert_eq!(
+                    crate::local::tag_writer::preflight_tag_write_directory_retained(
+                        &parent,
+                        &leaf,
+                        "the removable mutation target",
+                    ),
+                    Ok(()),
+                    "an observed-but-undisturbed window must leave the clean path \
+                     removing the probe and reporting success"
+                );
+            },
+        );
+
+        assert!(
+            window_ran.load(Ordering::SeqCst),
+            "the verify→unlink window observer must have run"
+        );
+        let retained_entries: Vec<std::ffi::OsString> = std::fs::read_dir(&album)
+            .expect("list the retained directory")
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name())
+            .collect();
+        assert_eq!(
+            retained_entries,
+            vec![std::ffi::OsString::from("silence.flac")],
+            "the clean rehearsal removes its probe completely"
+        );
     }
 
     #[test]

--- a/src/local/tag_writer.rs
+++ b/src/local/tag_writer.rs
@@ -862,6 +862,24 @@ fn anchored_atomic_tag_replacement(
     Ok(())
 }
 
+/// Rewind the staged copy and parse it through its retained handle, guessing
+/// the format from the content — the anchored twin of the path-based read
+/// half of [`write_tags_to`], never touching a pathname.
+#[cfg(unix)]
+fn read_tagged_file_retained(staged: &mut File, target_label: &str) -> Result<TaggedFile> {
+    use std::io::Seek;
+
+    staged
+        .rewind()
+        .with_context(|| format!("Failed to read tags from {target_label}"))?;
+    lofty::probe::Probe::new(&mut *staged)
+        .guess_file_type()
+        .map_err(anyhow::Error::from)
+        .with_context(|| format!("Failed to read tags from {target_label}"))?
+        .read()
+        .with_context(|| format!("Failed to read tags from {target_label}"))
+}
+
 /// Probe, edit, and save the staged copy through its retained handle — the
 /// anchored twin of [`write_tags_to`], never touching a pathname.
 ///
@@ -874,16 +892,7 @@ fn anchored_atomic_tag_replacement(
 fn write_tags_to_retained(staged: &mut File, target_label: &str, edits: &TagEdits) -> Result<()> {
     use std::io::Seek;
 
-    staged
-        .rewind()
-        .with_context(|| format!("Failed to read tags from {target_label}"))?;
-    let probe = lofty::probe::Probe::new(&mut *staged)
-        .guess_file_type()
-        .map_err(anyhow::Error::from)
-        .with_context(|| format!("Failed to read tags from {target_label}"))?;
-    let mut tagged_file = probe
-        .read()
-        .with_context(|| format!("Failed to read tags from {target_label}"))?;
+    let mut tagged_file = read_tagged_file_retained(staged, target_label)?;
 
     let tag = ensure_primary_tag(&mut tagged_file, target_label)?;
     apply_tag_edits(tag, edits)?;
@@ -1792,16 +1801,12 @@ mod tests {
         );
     }
 
-    /// A parent directory displaced between selection and commit must not
-    /// strand the staging area inside whatever now occupies the old
-    /// pathname: the retained authority stages and replaces only through its
-    /// retained parent object, so the write lands beside the admitted file
-    /// in the retained directory and the impostor never receives anything
-    /// at all — not the staged sibling, not the tagged copy.
+    /// Create an album directory holding the silence.flac fixture — the
+    /// common arrangement of the anchored-staging regression tests, whose
+    /// retained authority admits `album/silence.flac` through its parent.
     #[cfg(unix)]
-    #[test]
-    fn a_mutation_target_write_lands_beside_the_retained_parent_when_it_was_displaced() {
-        let directory = TestDirectory::new("mutation-parent-e2e");
+    fn anchored_album_fixture(name: &str) -> (TestDirectory, PathBuf, PathBuf) {
+        let directory = TestDirectory::new(name);
         let album = directory.path.join("album");
         std::fs::create_dir(&album).expect("create album");
         let track = album.join("silence.flac");
@@ -1813,11 +1818,48 @@ mod tests {
             )),
         )
         .expect("write fixture");
+        (directory, album, track)
+    }
 
-        let authority = std::sync::Arc::new(
+    /// Acquire the mounted root authority over a test directory.
+    #[cfg(unix)]
+    fn mounted_root_authority(
+        directory: &TestDirectory,
+    ) -> std::sync::Arc<crate::local::root_authority::MountedRootAuthority> {
+        std::sync::Arc::new(
             crate::local::root_authority::MountedRootAuthority::acquire(&directory.path)
                 .expect("acquire mounted authority"),
+        )
+    }
+
+    /// Assert the replacement landed beside the admitted file in the
+    /// retained (displaced) directory, carrying the written year.
+    #[cfg(unix)]
+    fn assert_replacement_landed_beside_admitted_file(displaced_album: &Path) {
+        let tagged_file = lofty::read_from_path(displaced_album.join("silence.flac"))
+            .expect("reopen the replaced admitted file");
+        assert_eq!(
+            tagged_file
+                .primary_tag()
+                .expect("primary tag")
+                .get_string(ItemKey::Year),
+            Some("2026"),
+            "the replacement must land beside the admitted file in the retained directory"
         );
+    }
+
+    /// A parent directory displaced between selection and commit must not
+    /// strand the staging area inside whatever now occupies the old
+    /// pathname: the retained authority stages and replaces only through its
+    /// retained parent object, so the write lands beside the admitted file
+    /// in the retained directory and the impostor never receives anything
+    /// at all — not the staged sibling, not the tagged copy.
+    #[cfg(unix)]
+    #[test]
+    fn a_mutation_target_write_lands_beside_the_retained_parent_when_it_was_displaced() {
+        let (directory, album, track) = anchored_album_fixture("mutation-parent-e2e");
+
+        let authority = mounted_root_authority(&directory);
         let target = authority
             .open_mutation_target(Path::new("album/silence.flac"))
             .expect("open mutation target");
@@ -1832,16 +1874,7 @@ mod tests {
 
         // The replacement landed beside the admitted file in the retained
         // (displaced) directory.
-        let tagged_file = lofty::read_from_path(displaced_album.join("silence.flac"))
-            .expect("reopen the replaced admitted file");
-        assert_eq!(
-            tagged_file
-                .primary_tag()
-                .expect("primary tag")
-                .get_string(ItemKey::Year),
-            Some("2026"),
-            "the replacement must land beside the admitted file in the retained directory"
-        );
+        assert_replacement_landed_beside_admitted_file(&displaced_album);
 
         // The impostor keeps exactly what it had. Under path-resolved
         // staging it transiently received the staged sibling and the
@@ -1881,25 +1914,10 @@ mod tests {
     ) {
         use std::os::unix::fs::symlink;
 
-        let directory = TestDirectory::new("mutation-stage-anchor");
-        let album = directory.path.join("album");
-        std::fs::create_dir(&album).expect("create album");
-        let track = album.join("silence.flac");
-        std::fs::write(
-            &track,
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/tests/fixtures/audio/silence.flac"
-            )),
-        )
-        .expect("write fixture");
-
+        let (directory, album, track) = anchored_album_fixture("mutation-stage-anchor");
         let outside = TestDirectory::new("mutation-stage-outside");
 
-        let authority = std::sync::Arc::new(
-            crate::local::root_authority::MountedRootAuthority::acquire(&directory.path)
-                .expect("acquire mounted authority"),
-        );
+        let authority = mounted_root_authority(&directory);
         let target = authority
             .open_mutation_target(Path::new("album/silence.flac"))
             .expect("open mutation target");
@@ -1932,16 +1950,7 @@ mod tests {
 
         // The replacement landed beside the admitted file in the retained
         // (displaced) directory.
-        let tagged_file = lofty::read_from_path(displaced_album.join("silence.flac"))
-            .expect("reopen the replaced admitted file");
-        assert_eq!(
-            tagged_file
-                .primary_tag()
-                .expect("primary tag")
-                .get_string(ItemKey::Year),
-            Some("2026"),
-            "the replacement must land beside the admitted file in the retained directory"
-        );
+        assert_replacement_landed_beside_admitted_file(&displaced_album);
 
         // Nothing — staged sibling or tagged copy — may ever have crossed
         // the symlink into the impostor's target.

--- a/src/local/tag_writer.rs
+++ b/src/local/tag_writer.rs
@@ -701,11 +701,25 @@ fn atomic_tag_replacement(
     #[cfg(not(target_os = "windows"))]
     let mut destination = destination;
     let copy_result = copy_source_into_destination(&mut source, &mut destination, target_path);
+    // Capture the replacement's Unix permissions from the exact source
+    // object while the handle is still open. A target_path lookup here would
+    // read whatever occupies the name at commit time — not necessarily the
+    // file whose bytes were just copied — so an external writer that
+    // temporarily swaps the pathname to a permissive file could launder those
+    // permissions onto the committed replacement.
+    #[cfg(unix)]
+    let retained_permissions = source
+        .metadata()
+        .ok()
+        .map(|metadata| metadata.permissions());
     drop(source);
     drop(destination);
     copy_result?;
 
     write_tags_to(temp.path(), edits)?;
+    #[cfg(unix)]
+    flush_and_prepare_tagged_copy(&temp, target_path, retained_permissions)?;
+    #[cfg(not(unix))]
     flush_and_prepare_tagged_copy(&temp, target_path)?;
     commit_replacement(&mut temp)?;
 
@@ -755,7 +769,7 @@ fn copy_source_into_destination(
         .with_context(|| format!("Failed to copy {} for tag writing", target_path.display()))
 }
 
-/// Flush the tagged copy and carry over the replaced file's Unix permissions
+/// Flush the tagged copy and carry over the source file's Unix permissions
 /// before the caller's final replacement gate runs.
 ///
 /// The flush happens *before* the permission copy: replacing a read-only file
@@ -763,7 +777,15 @@ fn copy_source_into_destination(
 /// be flushed. Windows installs the complete DACL before the first copied
 /// byte; its std Permissions value represents only the DOS read-only
 /// attribute, so the permission carry-over is Unix-only.
-fn flush_and_prepare_tagged_copy(temp: &TempFile, target_path: &Path) -> Result<()> {
+///
+/// `retained_permissions` is captured from the source file handle — the exact
+/// object whose bytes were copied — never from a `target_path` lookup, which
+/// an external writer can retarget between admission and commit.
+fn flush_and_prepare_tagged_copy(
+    temp: &TempFile,
+    target_path: &Path,
+    #[cfg(unix)] retained_permissions: Option<std::fs::Permissions>,
+) -> Result<()> {
     // Flush the tagged copy before it becomes the user's file. Without this a
     // crash between rename and writeback can leave a truncated file where the
     // original used to be.
@@ -774,10 +796,13 @@ fn flush_and_prepare_tagged_copy(temp: &TempFile, target_path: &Path) -> Result<
         )
     })?;
 
-    // Best-effort: match the Unix permissions of the file being replaced.
+    // Best-effort: match the Unix permissions of the exact file object the
+    // bytes were copied from. A capture failure skips the carry-over rather
+    // than failing the write; the replacement never invents permissions it
+    // could not prove.
     #[cfg(unix)]
-    if let Ok(metadata) = std::fs::metadata(target_path) {
-        let _ = std::fs::set_permissions(temp.path(), metadata.permissions());
+    if let Some(permissions) = retained_permissions {
+        let _ = std::fs::set_permissions(temp.path(), permissions);
     }
 
     Ok(())
@@ -1079,6 +1104,60 @@ mod tests {
             "writer-owned copies must not be readable or writable by group/other"
         );
         drop(file);
+        temp.remove().expect("remove private sibling");
+    }
+
+    /// The replacement must carry the permissions of the exact file object
+    /// the bytes were copied from — captured from the source handle — not
+    /// whatever the target pathname names when the carry-over runs: an
+    /// external writer that temporarily swaps the pathname to a permissive
+    /// file during the commit must not launder those permissions onto the
+    /// replacement.
+    #[cfg(unix)]
+    #[test]
+    fn tagged_copy_carries_permissions_from_the_source_handle_not_the_path() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = TestDirectory::new("permissions-from-handle");
+        let track = directory.audio_file("song.flac", b"original audio");
+        std::fs::set_permissions(&track, std::fs::Permissions::from_mode(0o600))
+            .expect("make the admitted file private");
+
+        // The source handle is the exact object being copied. The pathname
+        // meanwhile names a world-readable stranger, as a mid-commit swap
+        // would present it.
+        let source = std::fs::File::open(&track).expect("open the source handle");
+        let stranger = directory.audio_file("stranger.flac", b"stranger audio");
+        std::fs::set_permissions(&stranger, std::fs::Permissions::from_mode(0o644))
+            .expect("make the stranger permissive");
+
+        let (temp, destination) = TempFile::create_beside(&track).expect("create the staging copy");
+        drop(destination);
+
+        // Swap the pathname to the permissive stranger for the carry-over,
+        // as the race would, then prepare the copy with the permissions
+        // captured from the retained handle.
+        let displaced = directory.path.join("displaced.flac");
+        std::fs::rename(&track, &displaced).expect("displace the admitted file");
+        std::fs::rename(&stranger, &track).expect("put the stranger at the target name");
+
+        let retained_permissions = source
+            .metadata()
+            .expect("stat the retained source handle")
+            .permissions();
+        flush_and_prepare_tagged_copy(&temp, &track, Some(retained_permissions))
+            .expect("prepare the tagged copy");
+
+        let mode = std::fs::metadata(temp.path())
+            .expect("read the tagged copy's metadata")
+            .permissions()
+            .mode();
+        assert_eq!(
+            mode & 0o777,
+            0o600,
+            "the tagged copy must carry the source handle's permissions, not the swapped pathname's"
+        );
+        drop(source);
         temp.remove().expect("remove private sibling");
     }
 

--- a/src/local/tag_writer.rs
+++ b/src/local/tag_writer.rs
@@ -727,7 +727,7 @@ fn atomic_tag_replacement(
     drop(destination);
     copy_result?;
 
-    write_tags_to(temp.path(), edits)?;
+    write_tags_to(temp.path(), target_label, edits)?;
     #[cfg(unix)]
     flush_and_prepare_tagged_copy(&temp, target_label, retained_permissions)?;
     #[cfg(not(unix))]
@@ -828,9 +828,15 @@ fn flush_to_disk(path: &Path) -> std::io::Result<()> {
 }
 
 /// Apply `edits` to the tags of the file at `temp_path` in-place.
-fn write_tags_to(temp_path: &Path, edits: &TagEdits) -> Result<()> {
+///
+/// Error contexts name the target by `target_label`, never by `temp_path`:
+/// the staged copy is created beside the target, so its path points inside
+/// the target's own directory — a native mount directory for
+/// authority-based callers — and formatting it would leak exactly the
+/// location the redacted label exists to protect.
+fn write_tags_to(temp_path: &Path, target_label: &str, edits: &TagEdits) -> Result<()> {
     let mut tagged_file = lofty::read_from_path(temp_path)
-        .with_context(|| format!("Failed to read tags from {}", temp_path.display()))?;
+        .with_context(|| format!("Failed to read tags from {target_label}"))?;
 
     // Get or create the primary tag for this file type. Files with no
     // existing primary tag (e.g. a stripped MP3, or a FLAC without a Vorbis
@@ -843,10 +849,7 @@ fn write_tags_to(temp_path: &Path, edits: &TagEdits) -> Result<()> {
     }
 
     let tag = tagged_file.primary_tag_mut().ok_or_else(|| {
-        anyhow::anyhow!(
-            "No primary tag found and cannot create one for {}",
-            temp_path.display()
-        )
+        anyhow::anyhow!("No primary tag found and cannot create one for {target_label}")
     })?;
 
     // Apply edits — only touch fields that are Some.
@@ -942,7 +945,7 @@ fn write_tags_to(temp_path: &Path, edits: &TagEdits) -> Result<()> {
 
     // Save back to the temp file.
     tag.save_to_path(temp_path, WriteOptions::default())
-        .with_context(|| format!("Failed to write tags to {}", temp_path.display()))?;
+        .with_context(|| format!("Failed to write tags to {target_label}"))?;
 
     Ok(())
 }

--- a/src/local/tag_writer.rs
+++ b/src/local/tag_writer.rs
@@ -392,7 +392,7 @@ impl TempFile {
     /// Atomically move the temp file onto `target`, disarming the cleanup.
     ///
     /// On failure `self` is dropped, so the temp file is still removed.
-    fn persist_to(mut self, target: &Path) -> Result<()> {
+    fn persist_to(&mut self, target: &Path) -> Result<()> {
         std::fs::rename(&self.path, target).with_context(|| {
             format!(
                 "Failed to atomically replace {} with the tagged copy",
@@ -401,6 +401,14 @@ impl TempFile {
         })?;
         self.persisted = true;
         Ok(())
+    }
+
+    /// Disarm the drop cleanup after an external authority renamed this temp
+    /// file into place. The staging name no longer exists, and a failed
+    /// best-effort cleanup of a name that was never persisted must not
+    /// mislead the guard.
+    fn disarm_cleanup(&mut self) {
+        self.persisted = true;
     }
 
     /// Remove a probe sibling and disarm the best-effort drop cleanup.
@@ -533,7 +541,7 @@ pub fn preflight_tag_write_directory(path: &Path) -> Result<(), TagWritePrefligh
     // Rehearse the complete metadata-only shape of the atomic replacement:
     // create two exclusive siblings, flush them, replace an existing sibling,
     // and require explicit cleanup. The user's audio file is never modified.
-    let (replacement, replacement_file) =
+    let (mut replacement, replacement_file) =
         TempFile::create_beside(path).map_err(|_| TagWritePreflightError::Unavailable)?;
     let replacement_result = replacement_file.sync_all();
     drop(replacement_file);
@@ -591,17 +599,19 @@ pub fn write_tags(path: &Path, edits: &TagEdits) -> Result<()> {
 
     let source = std::fs::File::open(path)
         .with_context(|| format!("Failed to open {} for tag writing", path.display()))?;
-    atomic_tag_replacement(source, path, edits, || Ok(()))
+    atomic_tag_replacement(source, path, edits, |temp| temp.persist_to(path))
 }
 
 /// Write tag edits to one exact file beneath a retained mounted authority.
 ///
 /// This is the removable-media form of [`write_tags`]. The read source is the
 /// retained exact file object — never a pathname lookup — and the atomic
-/// replacement is refused unless the mounted root, the retained ancestry, and
-/// the exact pathname still name the file the authority admitted, revalidated
-/// immediately before the rename. Every failure leaves the target untouched.
-/// This is a blocking operation — call from a background thread.
+/// replacement is confirmed and performed by the retained authority itself:
+/// the mounted root, the retained ancestry, and the exact pathname must still
+/// name the file the authority admitted, revalidated immediately before the
+/// rename, and the rename runs relative to the retained parent directory so
+/// no pathname resolution can retarget it. Every failure leaves the target
+/// untouched. This is a blocking operation — call from a background thread.
 pub fn write_tags_with_mutation_target(
     target: &MountedMutationTarget,
     edits: &TagEdits,
@@ -634,10 +644,15 @@ pub fn write_tags_with_mutation_target(
     let source = commit
         .source_file()
         .with_context(|| "Failed to read the exact retained mutation target".to_string())?;
-    atomic_tag_replacement(source, target.replacement_path(), edits, || {
-        commit
-            .confirm_replacement_target()
-            .context("The exact file to replace changed before the tagged copy was committed")
+    atomic_tag_replacement(source, target.replacement_path(), edits, |temp| {
+        commit.commit_replacement(temp.path()).map_err(|error| {
+            anyhow::Error::new(error)
+                .context("The exact file to replace changed before the tagged copy was committed")
+        })?;
+        // The retained authority renamed the staged copy into place; the
+        // staging name no longer exists for the drop guard to remove.
+        temp.disarm_cleanup();
+        Ok(())
     })?;
 
     // A successful replacement retired the object this section copied from.
@@ -656,18 +671,20 @@ pub fn write_tags_with_mutation_target(
 }
 
 /// Copy `source` to an exclusively created sibling of `target_path`, tag the
-/// copy, flush it, and atomically rename it over `target_path`.
+/// copy, flush it, and hand it to `commit_replacement` for the atomic
+/// replacement of `target_path`.
 ///
-/// `confirm_replacement` runs between the flush and the rename and must
-/// prove — for authority-checked callers — that `target_path` still names
-/// the exact file `source` was cloned from. Path-based callers have no
-/// retained identity to compare and pass a no-op; the rename itself is their
-/// point-in-time replacement.
+/// `commit_replacement` runs after the flush and permission carry-over and
+/// owns the entire final gate: authority-checked callers prove the exact
+/// target identity there and perform the rename through retained handles.
+/// Path-based callers have no retained identity to compare and simply rename
+/// the staged copy into place; the rename itself is their point-in-time
+/// replacement.
 fn atomic_tag_replacement(
     source: File,
     target_path: &Path,
     edits: &TagEdits,
-    confirm_replacement: impl FnOnce() -> Result<()>,
+    commit_replacement: impl FnOnce(&mut TempFile) -> Result<()>,
 ) -> Result<()> {
     let mut source = source;
     #[cfg(target_os = "windows")]
@@ -678,7 +695,7 @@ fn atomic_tag_replacement(
         )
     })?;
 
-    let (temp, destination) = TempFile::create_beside(target_path)?;
+    let (mut temp, destination) = TempFile::create_beside(target_path)?;
     #[cfg(target_os = "windows")]
     let mut destination = open_tag_copy_destination(source_dacl, destination, &temp, target_path)?;
     #[cfg(not(target_os = "windows"))]
@@ -689,9 +706,9 @@ fn atomic_tag_replacement(
     copy_result?;
 
     write_tags_to(temp.path(), edits)?;
-    flush_and_confirm_tagged_copy(&temp, target_path, confirm_replacement)?;
+    flush_and_prepare_tagged_copy(&temp, target_path)?;
+    commit_replacement(&mut temp)?;
 
-    temp.persist_to(target_path)?;
     tracing::debug!("Tags written successfully");
     Ok(())
 }
@@ -738,19 +755,15 @@ fn copy_source_into_destination(
         .with_context(|| format!("Failed to copy {} for tag writing", target_path.display()))
 }
 
-/// Flush the tagged copy, carry over the replaced file's Unix permissions,
-/// and run the caller's final replacement gate.
+/// Flush the tagged copy and carry over the replaced file's Unix permissions
+/// before the caller's final replacement gate runs.
 ///
 /// The flush happens *before* the permission copy: replacing a read-only file
 /// would otherwise make the temp read-only too, and a read-only file cannot
 /// be flushed. Windows installs the complete DACL before the first copied
 /// byte; its std Permissions value represents only the DOS read-only
 /// attribute, so the permission carry-over is Unix-only.
-fn flush_and_confirm_tagged_copy(
-    temp: &TempFile,
-    target_path: &Path,
-    confirm_replacement: impl FnOnce() -> Result<()>,
-) -> Result<()> {
+fn flush_and_prepare_tagged_copy(temp: &TempFile, target_path: &Path) -> Result<()> {
     // Flush the tagged copy before it becomes the user's file. Without this a
     // crash between rename and writeback can leave a truncated file where the
     // original used to be.
@@ -767,10 +780,7 @@ fn flush_and_confirm_tagged_copy(
         let _ = std::fs::set_permissions(temp.path(), metadata.permissions());
     }
 
-    // Last gate before the replacement becomes visible: an authority-checked
-    // caller refuses here if the pathname no longer names the exact file it
-    // copied from.
-    confirm_replacement()
+    Ok(())
 }
 
 /// Flush a file's contents to disk.
@@ -1355,6 +1365,73 @@ mod tests {
             directory.temp_files().is_empty(),
             "a refused commit leaves no private sibling behind"
         );
+    }
+
+    /// A parent directory displaced between selection and commit strands the
+    /// staging area inside whatever now occupies the old pathname. The
+    /// retained authority stages and replaces only through its retained
+    /// parent object, so the commit must refuse, leave the impostor
+    /// untouched, and clean up the stranded sibling.
+    #[cfg(unix)]
+    #[test]
+    fn a_mutation_target_write_refuses_when_the_parent_directory_was_displaced() {
+        let directory = TestDirectory::new("mutation-parent-e2e");
+        let album = directory.path.join("album");
+        std::fs::create_dir(&album).expect("create album");
+        let track = album.join("silence.flac");
+        std::fs::write(
+            &track,
+            include_bytes!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/tests/fixtures/audio/silence.flac"
+            )),
+        )
+        .expect("write fixture");
+
+        let authority = std::sync::Arc::new(
+            crate::local::root_authority::MountedRootAuthority::acquire(&directory.path)
+                .expect("acquire mounted authority"),
+        );
+        let target = authority
+            .open_mutation_target(Path::new("album/silence.flac"))
+            .expect("open mutation target");
+
+        let displaced_album = directory.path.join("displaced-album");
+        std::fs::rename(&album, &displaced_album).expect("displace retained parent");
+        std::fs::create_dir(&album).expect("install impostor parent");
+        std::fs::write(&track, b"impostor audio").expect("install impostor file");
+
+        write_tags_with_mutation_target(&target, &year("2026"))
+            .expect_err("a stranded staging area must refuse the commit");
+
+        assert_eq!(
+            std::fs::read(&track).expect("read impostor file"),
+            b"impostor audio",
+            "the impostor directory must never receive the replacement"
+        );
+        let displaced_track = displaced_album.join("silence.flac");
+        let displaced_tagged =
+            lofty::read_from_path(&displaced_track).expect("reopen the displaced admitted file");
+        assert_ne!(
+            displaced_tagged
+                .primary_tag()
+                .expect("primary tag")
+                .get_string(ItemKey::Year),
+            Some("2026"),
+            "the admitted file must be untouched by the refused commit"
+        );
+        for directory_path in [&album, &displaced_album] {
+            let leftovers: Vec<PathBuf> = std::fs::read_dir(directory_path)
+                .expect("list displaced directories")
+                .filter_map(|entry| entry.ok())
+                .map(|entry| entry.path())
+                .filter(|path| is_tag_write_temp_file(path))
+                .collect();
+            assert!(
+                leftovers.is_empty(),
+                "a refused commit must clean up its stranded sibling: {leftovers:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/local/tag_writer.rs
+++ b/src/local/tag_writer.rs
@@ -743,10 +743,14 @@ pub fn write_tags_with_mutation_target(
 /// redacted label instead of the path — the removable-media error branch
 /// surfaces the whole chain to the user.
 #[cfg(unix)]
+#[cfg_attr(
+    not(test),
+    allow(unused_variables) // only the test-only staging seam reads the target
+)]
 fn write_tag_edits_for_commit(
     commit: &mut MountedMutationCommit<'_>,
     source: File,
-    _target: &MountedMutationTarget,
+    target: &MountedMutationTarget,
     edits: &TagEdits,
 ) -> Result<()> {
     // Anchor the staging at the retained parent before anything is staged:
@@ -757,7 +761,7 @@ fn write_tag_edits_for_commit(
         anyhow::Error::new(error).context("The retained mutation authority lost the staging parent")
     })?;
     #[cfg(test)]
-    run_pre_staging_interpose(_target);
+    run_pre_staging_interpose(target);
     anchored_atomic_tag_replacement(
         source,
         &staging_parent,
@@ -850,7 +854,7 @@ fn anchored_atomic_tag_replacement(
     copy_result?;
 
     write_tags_to_retained(&mut staged, target_label, edits)?;
-    flush_and_prepare_tagged_copy_retained(&mut staged, target_label, retained_permissions)?;
+    flush_and_prepare_tagged_copy_retained(&staged, target_label, retained_permissions)?;
     drop(staged);
     commit_replacement(&mut temp)?;
 
@@ -899,7 +903,7 @@ fn write_tags_to_retained(staged: &mut File, target_label: &str, edits: &TagEdit
 /// cannot be flushed.
 #[cfg(unix)]
 fn flush_and_prepare_tagged_copy_retained(
-    staged: &mut File,
+    staged: &File,
     target_label: &str,
     retained_permissions: Option<std::fs::Permissions>,
 ) -> Result<()> {
@@ -1873,8 +1877,8 @@ mod tests {
     /// symlink's target stays empty.
     #[cfg(unix)]
     #[test]
-    fn a_mutation_target_write_stages_beside_the_retained_parent_never_through_a_displaced_ancestor()
-    {
+    fn a_mutation_target_write_stages_beside_the_retained_parent_never_through_a_displaced_ancestor(
+    ) {
         use std::os::unix::fs::symlink;
 
         let directory = TestDirectory::new("mutation-stage-anchor");
@@ -1912,15 +1916,17 @@ mod tests {
                 }
                 // Displace the retained ancestor inside the staging window
                 // and plant a symlink at its old name.
-                std::fs::rename(&watched.parent().expect("album parent"), &closure_displaced_album)
-                    .expect("displace retained parent");
+                std::fs::rename(
+                    watched.parent().expect("album parent"),
+                    &closure_displaced_album,
+                )
+                .expect("displace retained parent");
                 symlink(&outside_root, &impostor_album)
                     .expect("install symlink impostor at the old name");
             }),
             || {
-                write_tags_with_mutation_target(&target, &year("2026")).expect(
-                    "anchored staging must land the write through the retained parent",
-                );
+                write_tags_with_mutation_target(&target, &year("2026"))
+                    .expect("anchored staging must land the write through the retained parent");
             },
         );
 

--- a/src/local/tag_writer.rs
+++ b/src/local/tag_writer.rs
@@ -327,7 +327,16 @@ fn retained_handle_identity(file: &File) -> std::io::Result<(u64, u64)> {
 fn retained_leaf_identity(parent: &File, leaf: &OsStr) -> std::io::Result<(u64, u64)> {
     let stat = rustix::fs::statat(parent, leaf, rustix::fs::AtFlags::SYMLINK_NOFOLLOW)
         .map_err(std::io::Error::from)?;
-    Ok((stat.st_dev, stat.st_ino))
+    // `dev_t` is `i32` on macOS while Linux's is already `u64`; normalize to
+    // the `u64` the creation identity carries (`MetadataExt::dev`). A
+    // negative device id fails closed: an unprovable identity means the
+    // caller preserves the entry, never unlinks it.
+    #[cfg(target_os = "macos")]
+    let device = u64::try_from(stat.st_dev)
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidData, "negative device id"))?;
+    #[cfg(not(target_os = "macos"))]
+    let device = stat.st_dev;
+    Ok((device, stat.st_ino))
 }
 
 /// Randomized staged-sibling leaf name, preserving the final extension.

--- a/src/local/tag_writer.rs
+++ b/src/local/tag_writer.rs
@@ -320,6 +320,27 @@ fn retained_handle_identity(file: &File) -> std::io::Result<(u64, u64)> {
     Ok((metadata.dev(), metadata.ino()))
 }
 
+/// dev/ino pair from a rustix `Stat`, normalized to the `u64` the creation
+/// identity carries.
+///
+/// `dev_t` is `i32` on macOS while Linux's is already `u64`; normalize to
+/// the `u64` the creation identity carries (`MetadataExt::dev`). A negative
+/// device id fails closed: an unprovable identity means the caller preserves
+/// the entry, never unlinks it.
+#[cfg(unix)]
+// The `Result` is load-bearing on macOS (a negative `dev_t` fails closed) and
+// keeps every caller platform-uniform; on Linux the conversion is infallible,
+// which is the only target clippy sees here.
+#[allow(clippy::unnecessary_wraps)]
+fn stat_identity(stat: &rustix::fs::Stat) -> std::io::Result<(u64, u64)> {
+    #[cfg(target_os = "macos")]
+    let device = u64::try_from(stat.st_dev)
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidData, "negative device id"))?;
+    #[cfg(not(target_os = "macos"))]
+    let device = stat.st_dev;
+    Ok((device, stat.st_ino))
+}
+
 /// dev/ino of whatever entry `leaf` currently names beneath the retained
 /// parent, resolved through the directory handle without following a leaf
 /// symlink.
@@ -327,16 +348,118 @@ fn retained_handle_identity(file: &File) -> std::io::Result<(u64, u64)> {
 fn retained_leaf_identity(parent: &File, leaf: &OsStr) -> std::io::Result<(u64, u64)> {
     let stat = rustix::fs::statat(parent, leaf, rustix::fs::AtFlags::SYMLINK_NOFOLLOW)
         .map_err(std::io::Error::from)?;
-    // `dev_t` is `i32` on macOS while Linux's is already `u64`; normalize to
-    // the `u64` the creation identity carries (`MetadataExt::dev`). A
-    // negative device id fails closed: an unprovable identity means the
-    // caller preserves the entry, never unlinks it.
-    #[cfg(target_os = "macos")]
-    let device = u64::try_from(stat.st_dev)
-        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidData, "negative device id"))?;
-    #[cfg(not(target_os = "macos"))]
-    let device = stat.st_dev;
-    Ok((device, stat.st_ino))
+    stat_identity(&stat)
+}
+
+/// Remove the anchored `leaf` only while it is provably still bound to the
+/// object `created` names.
+///
+/// A proof-then-unlink pair (statat, then unlinkat) is two directory
+/// operations: an external writer that swaps the occupant between them has
+/// its newcomer destroyed by the unlink. This binds the removal to the
+/// verified identity instead:
+///
+/// 1. the leaf is opened `O_NOFOLLOW` through the retained parent, pinning
+///    the object a held handle refers to (a planted leaf symlink fails the
+///    open, and an unopenable leaf is unprovable);
+/// 2. the pinned object is fstat-verified against `created` — a mismatch
+///    means a newcomer occupies the name, which is preserved;
+/// 3. the entry is atomically relocated with the commit's own no-replace
+///    primitive onto a fresh randomized private name — a single directory
+///    operation, so the bind cannot tear, and the no-replace refusal on an
+///    occupied candidate preserves that occupant;
+/// 4. the private name is re-verified to name exactly the pinned object (a
+///    swap between the pin and the relocation moved a newcomer, which is
+///    renamed back where it was) — and only then unlinked.
+///
+/// Every unprovable step reports `false` and preserves every entry: debris
+/// is never destruction. The final unlink removes a name nothing else
+/// created and that was atomically bound to the verified object, so an
+/// external swap can strand debris but can never make this removal destroy
+/// a newcomer.
+#[cfg(unix)]
+fn remove_anchored_leaf_bound_to_identity(
+    parent: &File,
+    leaf: &OsStr,
+    created: (u64, u64),
+) -> bool {
+    // Pin the leaf's current object without following a symlink planted at
+    // the name, and require it to be exactly the object this section
+    // created. An unprovable leaf (vanished, symlinked, unopenable) is
+    // preserved.
+    let Ok(pinned) = rustix::fs::openat(
+        parent,
+        leaf,
+        rustix::fs::OFlags::RDONLY | rustix::fs::OFlags::NOFOLLOW | rustix::fs::OFlags::CLOEXEC,
+        rustix::fs::Mode::empty(),
+    ) else {
+        return false;
+    };
+    let Ok(stat) = rustix::fs::fstat(&pinned) else {
+        return false;
+    };
+    let Ok(pinned_identity) = stat_identity(&stat) else {
+        return false;
+    };
+    if pinned_identity != created {
+        return false;
+    }
+    // Test-only seam inside the proof→bind window: the pinned object is
+    // verified, and the relocation that binds it to the private name has
+    // not run yet. A swap driven here exercises the relocation's re-verify
+    // and restore paths.
+    #[cfg(all(test, unix))]
+    run_retained_preflight_interpose(RetainedPreflightPhase::AfterProof, parent, leaf, leaf);
+
+    for _ in 0..8 {
+        // Relocate the pinned object onto a fresh randomized private name
+        // with the no-replace primitive: one atomic directory operation
+        // binds the verified object to a name nothing else created.
+        let retire_name = staged_sibling_name(leaf);
+        match rustix::fs::renameat_with(
+            parent,
+            leaf,
+            parent,
+            &retire_name,
+            rustix::fs::RenameFlags::NOREPLACE,
+        ) {
+            Ok(()) => {
+                // Re-verify the bind: the private name must now name the
+                // pinned object. A mismatch means the leaf was swapped
+                // between the pin and this relocation, so the newcomer —
+                // not the probe — moved; put it back where it was and
+                // preserve it.
+                match retained_leaf_identity(parent, &retire_name) {
+                    Ok(identity) if identity == created => {
+                        return rustix::fs::unlinkat(
+                            parent,
+                            &retire_name,
+                            rustix::fs::AtFlags::empty(),
+                        )
+                        .is_ok();
+                    }
+                    _ => {
+                        // Restore the displaced newcomer best-effort; if the
+                        // original name is occupied again, the newcomer
+                        // stays preserved at the private name.
+                        let _ = rustix::fs::renameat_with(
+                            parent,
+                            &retire_name,
+                            parent,
+                            leaf,
+                            rustix::fs::RenameFlags::NOREPLACE,
+                        );
+                        return false;
+                    }
+                }
+            }
+            Err(rustix::io::Errno::EXIST) => {}
+            // An unsupported relocation primitive cannot prove the bind:
+            // preserve the entry exactly where it is.
+            Err(_) => return false,
+        }
+    }
+    false
 }
 
 /// Randomized staged-sibling leaf name, preserving the final extension.
@@ -556,17 +679,17 @@ impl Drop for TempFile {
             if let Some(parent) = &self.anchored_parent {
                 // Anchored staging: unlink the staged leaf through the
                 // retained parent. `unlinkat` never follows a symlink at the
-                // leaf and resolves nothing above it, and the unlink fires
-                // only while the leaf still names the object this section
-                // created (exact dev/ino, read through the same handle) —
+                // leaf and resolves nothing above it, and the removal is
+                // bound to the object this section created (exact dev/ino,
+                // captured from the creation handle): the leaf is pinned by
+                // an O_NOFOLLOW open, verified, atomically relocated onto a
+                // fresh private name, re-verified, and only then unlinked —
                 // the cleanup removes exactly the entry this section created
                 // and can never mutate a directory the authority did not
                 // admit. An entry an external writer swapped into the name
                 // after stealing the staged leaf is debris we must preserve,
                 // never destroy.
-                if self.leaf_names_created_object(parent) {
-                    let _ = rustix::fs::unlinkat(parent, &self.path, rustix::fs::AtFlags::empty());
-                }
+                let _ = self.remove_bound_to_created_identity(parent);
                 return;
             }
             let _ = std::fs::remove_file(&self.path);
@@ -575,20 +698,20 @@ impl Drop for TempFile {
 }
 
 impl TempFile {
-    /// Whether the anchored leaf still names the object this section
-    /// created.
+    /// Remove this anchored temp's leaf only while it provably still names
+    /// the object this section created.
     ///
-    /// An unprovable identity (the leaf vanished, or the creation handle's
-    /// identity was never captured) fails closed: the caller preserves the
-    /// entry instead of unlinking a name it cannot prove is its own.
+    /// The removal is bound to the verified identity (see
+    /// [`remove_anchored_leaf_bound_to_identity`]): a swap between proof and
+    /// removal strands the newcomer as preserved debris instead of
+    /// destroying it. An uncaptured creation identity fails closed.
     #[cfg(unix)]
-    fn leaf_names_created_object(&self, parent: &File) -> bool {
-        match (
-            self.created_identity,
-            retained_leaf_identity(parent, self.path.as_os_str()),
-        ) {
-            (Some(created), Ok(landed)) => landed == created,
-            _ => false,
+    fn remove_bound_to_created_identity(&self, parent: &File) -> bool {
+        match self.created_identity {
+            Some(created) => {
+                remove_anchored_leaf_bound_to_identity(parent, self.path.as_os_str(), created)
+            }
+            None => false,
         }
     }
 }
@@ -793,13 +916,15 @@ pub fn preflight_tag_write_directory_retained(
     .map_err(|_| TagWritePreflightError::Unavailable)?;
 
     // The probe now lives at the vacant name. Aim the drop guard's
-    // anchored cleanup at that leaf, then prove the landed leaf still
-    // names this section's probe (exact dev/ino through the retained
-    // parent) before removing it: inside the rename→cleanup window an
-    // external writer can swap the entry, and the cleanup removes exactly
-    // the entry this section created — a swapped-in newcomer is preserved
-    // debris and the rehearsal refuses, because a capability check is
-    // successful only when its own cleanup provably succeeded.
+    // anchored cleanup at that leaf, then remove it through a removal
+    // bound to the probe's verified identity: the landed leaf is pinned
+    // by an O_NOFOLLOW open, fstat-verified, atomically relocated onto a
+    // fresh private name with the commit's own no-replace primitive,
+    // re-verified there, and only then unlinked. A swap in any window
+    // strands the newcomer on a provably-wrong identity — preserved
+    // debris, never destruction — and the rehearsal refuses, because a
+    // capability check is successful only when its own cleanup provably
+    // succeeded.
     replacement.path = PathBuf::from(&vacant_name);
     #[cfg(all(test, unix))]
     run_retained_preflight_interpose(
@@ -808,18 +933,16 @@ pub fn preflight_tag_write_directory_retained(
         replacement.path().as_os_str(),
         &vacant_name,
     );
-    if !replacement.leaf_names_created_object(parent) {
-        // The landed leaf no longer provably names this section's probe: an
-        // external writer swapped the entry inside the rename→cleanup
-        // window, or it vanished. Preserve the newcomer (and the stolen
-        // probe, now debris) — debris is never destruction — disarm the
-        // guard, and refuse: a capability check is successful only when
-        // its own cleanup provably succeeded.
+    if !replacement.remove_bound_to_created_identity(parent) {
+        // The landed leaf could not be provably removed as this section's
+        // probe: an external writer swapped the entry inside the
+        // install→cleanup window, or it vanished. Preserve the newcomer
+        // (and the stolen probe, now debris) — debris is never
+        // destruction — disarm the guard, and refuse: a capability check
+        // is successful only when its own cleanup provably succeeded.
         replacement.disarm_cleanup();
         return Err(TagWritePreflightError::Unavailable);
     }
-    rustix::fs::unlinkat(parent, &vacant_name, rustix::fs::AtFlags::empty())
-        .map_err(|_| TagWritePreflightError::Unavailable)?;
     replacement.disarm_cleanup();
     Ok(())
 }
@@ -1496,6 +1619,11 @@ enum RetainedPreflightPhase {
     /// cleanup proves and removes it: the external-swap window the cleanup's
     /// identity proof guards.
     BeforeCleanup,
+    /// Inside the bound removal, after the landed leaf's pinned object is
+    /// verified and before the relocation binds it to the private name:
+    /// the proof→bind window the identity-bound removal's re-verify and
+    /// restore paths guard. Both leaf arguments carry the landed leaf.
+    AfterProof,
 }
 
 /// Test-only seam: runs at each [`RetainedPreflightPhase`] of the retained
@@ -2525,6 +2653,79 @@ mod tests {
             vec![std::ffi::OsString::from("silence.flac")],
             "the refused rehearsal must leave no probe residue of its own"
         );
+    }
+
+    /// The identity-bound removal must survive a swap that lands between the
+    /// identity proof and the bind itself. The proof pins the landed probe
+    /// with an O_NOFOLLOW open; an external writer can then steal the probe
+    /// from the landed name and install a newcomer there before the
+    /// relocation runs. The relocation moves the newcomer — not the probe —
+    /// onto the private name, the re-verification catches the identity
+    /// mismatch, the newcomer is restored to its own name, and the rehearsal
+    /// refuses with every entry preserved: debris is never destruction.
+    #[cfg(unix)]
+    #[test]
+    fn retained_preflight_bind_preserves_a_newcomer_swapped_after_the_proof() {
+        use std::sync::{Arc, Mutex};
+
+        let (directory, album, _) = anchored_album_fixture("preflight-bind-swap");
+
+        let authority = mounted_root_authority(&directory);
+        let target = authority
+            .open_mutation_target(Path::new("album/silence.flac"))
+            .expect("open mutation target");
+        let (parent, leaf) = target
+            .retained_directory_handle()
+            .expect("retain the directory anchor");
+
+        let newcomer = Arc::new(Mutex::new(None::<SwappedNewcomer>));
+        let stolen = Arc::new(Mutex::new(None::<std::ffi::OsString>));
+        let newcomer_closure = Arc::clone(&newcomer);
+        let stolen_closure = Arc::clone(&stolen);
+        with_retained_preflight_interpose(
+            Box::new(move |phase, interposed_parent, landed_leaf, _vacant_leaf| {
+                if phase != RetainedPreflightPhase::AfterProof {
+                    return;
+                }
+                // The rehearsal's probe is pinned and identity-verified at
+                // the landed name. Steal it and install a newcomer there
+                // before the relocation binds the name: the bind must move
+                // the newcomer, catch the mismatch, and restore it.
+                let stolen_leaf = staged_sibling_name(std::ffi::OsStr::new("silence.flac"));
+                rustix::fs::renameat(
+                    interposed_parent,
+                    landed_leaf,
+                    interposed_parent,
+                    &stolen_leaf,
+                )
+                .expect("steal the pinned probe");
+                create_retained_sibling_exclusive(interposed_parent, landed_leaf)
+                    .expect("install the newcomer at the landed name");
+                let identity = retained_leaf_identity(interposed_parent, landed_leaf)
+                    .expect("read the newcomer's identity");
+                *newcomer_closure.lock().unwrap() = Some(SwappedNewcomer {
+                    leaf: landed_leaf.to_os_string(),
+                    identity,
+                });
+                *stolen_closure.lock().unwrap() = Some(stolen_leaf);
+            }),
+            || {
+                assert_eq!(
+                    crate::local::tag_writer::preflight_tag_write_directory_retained(
+                        &parent,
+                        &leaf,
+                        "the removable mutation target",
+                    ),
+                    Err(TagWritePreflightError::Unavailable),
+                    "a bind broken by a post-proof swap must refuse the rehearsal, \
+                     never destroy the newcomer"
+                );
+            },
+        );
+
+        // The newcomer was restored to its own name and the stolen probe is
+        // preserved debris; the refused rehearsal left nothing of its own.
+        assert_the_swap_survived_the_refused_cleanup(&parent, &album, newcomer, stolen);
     }
 
     #[test]

--- a/src/local/tag_writer.rs
+++ b/src/local/tag_writer.rs
@@ -386,24 +386,10 @@ fn remove_anchored_leaf_bound_to_identity(
     // Pin the leaf's current object without following a symlink planted at
     // the name, and require it to be exactly the object this section
     // created. An unprovable leaf (vanished, symlinked, unopenable) is
-    // preserved.
-    let Ok(pinned) = rustix::fs::openat(
-        parent,
-        leaf,
-        rustix::fs::OFlags::RDONLY | rustix::fs::OFlags::NOFOLLOW | rustix::fs::OFlags::CLOEXEC,
-        rustix::fs::Mode::empty(),
-    ) else {
+    // preserved, as is a name a newcomer occupies.
+    let Some(_pinned) = pin_created_leaf_identity(parent, leaf, created) else {
         return false;
     };
-    let Ok(stat) = rustix::fs::fstat(&pinned) else {
-        return false;
-    };
-    let Ok(pinned_identity) = stat_identity(&stat) else {
-        return false;
-    };
-    if pinned_identity != created {
-        return false;
-    }
     // Test-only seam inside the proof→bind window: the pinned object is
     // verified, and the relocation that binds it to the private name has
     // not run yet. A swap driven here exercises the relocation's re-verify
@@ -412,54 +398,99 @@ fn remove_anchored_leaf_bound_to_identity(
     run_retained_preflight_interpose(RetainedPreflightPhase::AfterProof, parent, leaf, leaf);
 
     for _ in 0..8 {
-        // Relocate the pinned object onto a fresh randomized private name
-        // with the no-replace primitive: one atomic directory operation
-        // binds the verified object to a name nothing else created.
-        let retire_name = staged_sibling_name(leaf);
-        match rustix::fs::renameat_with(
-            parent,
-            leaf,
-            parent,
-            &retire_name,
-            rustix::fs::RenameFlags::NOREPLACE,
-        ) {
-            Ok(()) => {
-                // Re-verify the bind: the private name must now name the
-                // pinned object. A mismatch means the leaf was swapped
-                // between the pin and this relocation, so the newcomer —
-                // not the probe — moved; put it back where it was and
-                // preserve it.
-                match retained_leaf_identity(parent, &retire_name) {
-                    Ok(identity) if identity == created => {
-                        return rustix::fs::unlinkat(
-                            parent,
-                            &retire_name,
-                            rustix::fs::AtFlags::empty(),
-                        )
-                        .is_ok();
-                    }
-                    _ => {
-                        // Restore the displaced newcomer best-effort; if the
-                        // original name is occupied again, the newcomer
-                        // stays preserved at the private name.
-                        let _ = rustix::fs::renameat_with(
-                            parent,
-                            &retire_name,
-                            parent,
-                            leaf,
-                            rustix::fs::RenameFlags::NOREPLACE,
-                        );
-                        return false;
-                    }
-                }
-            }
-            Err(rustix::io::Errno::EXIST) => {}
-            // An unsupported relocation primitive cannot prove the bind:
-            // preserve the entry exactly where it is.
-            Err(_) => return false,
+        if let Some(removed) = retire_leaf_bound_to_private_name(parent, leaf, created) {
+            return removed;
         }
     }
     false
+}
+
+/// Pin the leaf's current object with an `O_NOFOLLOW` open through the
+/// retained parent and require it to be exactly the object this section
+/// created. Returns the pinning descriptor — held across the bind so the
+/// proven object cannot be recycled mid-sequence — or `None` when the leaf
+/// is unprovable (vanished, symlinked, unopenable) or names a newcomer.
+#[cfg(unix)]
+fn pin_created_leaf_identity(
+    parent: &File,
+    leaf: &OsStr,
+    created: (u64, u64),
+) -> Option<rustix::fd::OwnedFd> {
+    let pinned = rustix::fs::openat(
+        parent,
+        leaf,
+        rustix::fs::OFlags::RDONLY | rustix::fs::OFlags::NOFOLLOW | rustix::fs::OFlags::CLOEXEC,
+        rustix::fs::Mode::empty(),
+    )
+    .ok()?;
+    let stat = rustix::fs::fstat(&pinned).ok()?;
+    if stat_identity(&stat).ok()? != created {
+        return None;
+    }
+    Some(pinned)
+}
+
+/// Relocate the verified leaf onto a fresh randomized private name with the
+/// no-replace primitive — one atomic directory operation binds the verified
+/// object to a name nothing else created — then prove the private name and
+/// remove it there. `Some(removed)` is definitive; `None` means the
+/// randomized candidate collided (`EXIST`) and another attempt may run.
+#[cfg(unix)]
+fn retire_leaf_bound_to_private_name(
+    parent: &File,
+    leaf: &OsStr,
+    created: (u64, u64),
+) -> Option<bool> {
+    let retire_name = staged_sibling_name(leaf);
+    match rustix::fs::renameat_with(
+        parent,
+        leaf,
+        parent,
+        &retire_name,
+        rustix::fs::RenameFlags::NOREPLACE,
+    ) {
+        Ok(()) => Some(unlink_bound_private_name(
+            parent,
+            &retire_name,
+            created,
+            leaf,
+        )),
+        Err(rustix::io::Errno::EXIST) => None,
+        // An unsupported relocation primitive cannot prove the bind:
+        // preserve the entry exactly where it is.
+        Err(_) => Some(false),
+    }
+}
+
+/// Re-verify the bind: the private name must name exactly the created
+/// object. A mismatch means the leaf was swapped between the pin and the
+/// relocation, so the newcomer — not the probe — moved: put it back where
+/// it was and preserve it. Reports whether the verified object was removed.
+#[cfg(unix)]
+fn unlink_bound_private_name(
+    parent: &File,
+    retire_name: &OsStr,
+    created: (u64, u64),
+    leaf: &OsStr,
+) -> bool {
+    match retained_leaf_identity(parent, retire_name) {
+        Ok(identity) if identity == created => {
+            rustix::fs::unlinkat(parent, retire_name, rustix::fs::AtFlags::empty()).is_ok()
+        }
+        _ => {
+            // Restore the displaced newcomer best-effort; if the original
+            // name is occupied again, the newcomer stays preserved at the
+            // private name.
+            let _ = rustix::fs::renameat_with(
+                parent,
+                retire_name,
+                parent,
+                leaf,
+                rustix::fs::RenameFlags::NOREPLACE,
+            );
+            false
+        }
+    }
 }
 
 /// Randomized staged-sibling leaf name, preserving the final extension.
@@ -2655,6 +2686,34 @@ mod tests {
         );
     }
 
+    /// Steal the pinned probe from the landed name and install a newcomer
+    /// there, recording both for the post-refusal assertions.
+    #[cfg(unix)]
+    fn steal_pinned_probe_install_newcomer(
+        interposed_parent: &std::fs::File,
+        landed_leaf: &OsStr,
+        newcomer: &std::sync::Arc<std::sync::Mutex<Option<SwappedNewcomer>>>,
+        stolen: &std::sync::Arc<std::sync::Mutex<Option<std::ffi::OsString>>>,
+    ) {
+        let stolen_leaf = staged_sibling_name(std::ffi::OsStr::new("silence.flac"));
+        rustix::fs::renameat(
+            interposed_parent,
+            landed_leaf,
+            interposed_parent,
+            &stolen_leaf,
+        )
+        .expect("steal the pinned probe");
+        create_retained_sibling_exclusive(interposed_parent, landed_leaf)
+            .expect("install the newcomer at the landed name");
+        let identity = retained_leaf_identity(interposed_parent, landed_leaf)
+            .expect("read the newcomer's identity");
+        *newcomer.lock().unwrap() = Some(SwappedNewcomer {
+            leaf: landed_leaf.to_os_string(),
+            identity,
+        });
+        *stolen.lock().unwrap() = Some(stolen_leaf);
+    }
+
     /// The identity-bound removal must survive a swap that lands between the
     /// identity proof and the bind itself. The proof pins the landed probe
     /// with an O_NOFOLLOW open; an external writer can then steal the probe
@@ -2687,27 +2746,12 @@ mod tests {
                 if phase != RetainedPreflightPhase::AfterProof {
                     return;
                 }
-                // The rehearsal's probe is pinned and identity-verified at
-                // the landed name. Steal it and install a newcomer there
-                // before the relocation binds the name: the bind must move
-                // the newcomer, catch the mismatch, and restore it.
-                let stolen_leaf = staged_sibling_name(std::ffi::OsStr::new("silence.flac"));
-                rustix::fs::renameat(
+                steal_pinned_probe_install_newcomer(
                     interposed_parent,
                     landed_leaf,
-                    interposed_parent,
-                    &stolen_leaf,
-                )
-                .expect("steal the pinned probe");
-                create_retained_sibling_exclusive(interposed_parent, landed_leaf)
-                    .expect("install the newcomer at the landed name");
-                let identity = retained_leaf_identity(interposed_parent, landed_leaf)
-                    .expect("read the newcomer's identity");
-                *newcomer_closure.lock().unwrap() = Some(SwappedNewcomer {
-                    leaf: landed_leaf.to_os_string(),
-                    identity,
-                });
-                *stolen_closure.lock().unwrap() = Some(stolen_leaf);
+                    &newcomer_closure,
+                    &stolen_closure,
+                );
             }),
             || {
                 assert_eq!(

--- a/src/local/tag_writer.rs
+++ b/src/local/tag_writer.rs
@@ -1751,10 +1751,22 @@ enum RetainedPreflightPhase {
 type RetainedPreflightInterpose =
     dyn Fn(RetainedPreflightPhase, &std::fs::File, &OsStr, &OsStr) + Send + Sync;
 
+// The seam slot is THREAD-LOCAL: an armed closure is visible only to
+// firings on the thread that armed it. Every seam test drives its own
+// rehearsal synchronously on its own thread, while the Rust harness runs
+// tests in parallel on distinct threads — a process-wide slot let a
+// parallel, seam-less test's rehearsal observe another test's armed
+// closure (every rehearsal passes the same phases, so the windows match),
+// stealing the probe from a foreign fixture and failing an innocent test.
+// Per-thread storage makes cross-test firing structurally impossible.
 #[cfg(all(test, unix))]
-static RETAINED_PREFLIGHT_INTERPOSE: std::sync::Mutex<Option<Box<RetainedPreflightInterpose>>> =
-    std::sync::Mutex::new(None);
+thread_local! {
+    static RETAINED_PREFLIGHT_INTERPOSE:
+        std::cell::RefCell<Option<Box<RetainedPreflightInterpose>>> =
+        std::cell::RefCell::new(None);
+}
 
+/// Serialize tests that use the retained-preflight interposition seam.
 #[cfg(all(test, unix))]
 static RETAINED_PREFLIGHT_INTERPOSE_SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
@@ -1765,21 +1777,32 @@ fn run_retained_preflight_interpose(
     probe: &OsStr,
     vacant: &OsStr,
 ) {
-    if let Some(interpose) = RETAINED_PREFLIGHT_INTERPOSE.lock().unwrap().as_ref() {
-        interpose(phase, parent, probe, vacant);
-    }
+    RETAINED_PREFLIGHT_INTERPOSE.with(|slot| {
+        if let Some(interpose) = slot.borrow().as_ref() {
+            interpose(phase, parent, probe, vacant);
+        }
+    });
 }
 
-/// Serialize tests that use the retained-preflight interposition seam.
+/// Arm `interpose` for the duration of `run` on THIS thread, serializing
+/// against other tests that use the seam. A drop guard uninstalls the
+/// closure, so a panicking observation cannot leave a stale seam armed for
+/// a later test on this thread.
 #[cfg(all(test, unix))]
 fn with_retained_preflight_interpose(
     interpose: Box<RetainedPreflightInterpose>,
     run: impl FnOnce(),
 ) {
+    struct UninstallRetainedPreflightInterpose;
+    impl Drop for UninstallRetainedPreflightInterpose {
+        fn drop(&mut self) {
+            RETAINED_PREFLIGHT_INTERPOSE.with(|slot| *slot.borrow_mut() = None);
+        }
+    }
     let _serial = RETAINED_PREFLIGHT_INTERPOSE_SERIAL.lock().unwrap();
-    *RETAINED_PREFLIGHT_INTERPOSE.lock().unwrap() = Some(interpose);
+    RETAINED_PREFLIGHT_INTERPOSE.with(|slot| *slot.borrow_mut() = Some(interpose));
+    let _uninstall = UninstallRetainedPreflightInterpose;
     run();
-    *RETAINED_PREFLIGHT_INTERPOSE.lock().unwrap() = None;
 }
 
 #[cfg(test)]
@@ -2927,6 +2950,84 @@ mod tests {
         captured
     }
 
+    /// Drive the contested rehearsal under the armed verify→unlink window:
+    /// the rehearsal must refuse with `Unavailable` — never report success
+    /// for a wrong-object removal — and the refusal must carry exactly one
+    /// ERROR-level event acknowledging the destroyed foreign entry.
+    #[cfg(unix)]
+    fn run_contested_rehearsal_expect_refusal(parent: &std::fs::File, leaf: &OsStr) {
+        let errors = capture_error_events(|| {
+            assert_eq!(
+                crate::local::tag_writer::preflight_tag_write_directory_retained(
+                    parent,
+                    leaf,
+                    "the removable mutation target",
+                ),
+                Err(TagWritePreflightError::Unavailable),
+                "a contested cleanup must refuse the rehearsal, never report \
+                 success for a wrong-object removal"
+            );
+        });
+        assert_eq!(
+            errors.len(),
+            1,
+            "the contested cleanup must report the destroyed foreign entry \
+             loudly exactly once: {errors:?}"
+        );
+    }
+
+    /// Assert the observed outcomes of the refused contested cleanup: the
+    /// verify→unlink window observer ran; the swapped-in newcomer's
+    /// destroyed entry is the acknowledged loss; the stolen probe survives
+    /// as debris (removed here as test cleanup); and the refused rehearsal
+    /// left no probe residue of its own beside the admitted file.
+    #[cfg(unix)]
+    fn assert_contested_removal_refusal_outcomes(
+        window_ran: &std::sync::atomic::AtomicBool,
+        contested: &std::sync::Arc<std::sync::Mutex<Option<std::ffi::OsString>>>,
+        stolen: &std::sync::Arc<std::sync::Mutex<Option<std::ffi::OsString>>>,
+        parent: &std::fs::File,
+        album: &Path,
+    ) {
+        use rustix::fs::AtFlags;
+        use std::sync::atomic::Ordering;
+        assert!(
+            window_ran.load(Ordering::SeqCst),
+            "the verify→unlink window observer must have run"
+        );
+        let contested_leaf = contested
+            .lock()
+            .unwrap()
+            .take()
+            .expect("the seam contested the private name");
+        let stolen_leaf = stolen
+            .lock()
+            .unwrap()
+            .take()
+            .expect("the seam stole the re-verified probe");
+        assert!(
+            rustix::fs::statat(parent, &contested_leaf, AtFlags::empty()).is_err(),
+            "the swapped-in newcomer's entry was destroyed by the contested \
+             unlink — the acknowledged, reported loss"
+        );
+        assert!(
+            rustix::fs::statat(parent, stolen_leaf.as_os_str(), AtFlags::empty()).is_ok(),
+            "the stolen probe is preserved debris, never destroyed"
+        );
+        rustix::fs::unlinkat(parent, stolen_leaf.as_os_str(), AtFlags::empty())
+            .expect("remove the stolen-probe debris");
+        let retained_entries: Vec<std::ffi::OsString> = std::fs::read_dir(album)
+            .expect("list the retained directory")
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name())
+            .collect();
+        assert_eq!(
+            retained_entries,
+            vec![std::ffi::OsString::from("silence.flac")],
+            "the refused rehearsal must leave no probe residue of its own"
+        );
+    }
+
     /// The bound removal must survive — by refusing loudly — an external
     /// writer's swap inside the verify→unlink window: the re-verified
     /// private name is stolen and a newcomer installed there before the
@@ -2970,63 +3071,15 @@ mod tests {
                     &stolen_closure,
                 );
             }),
-            || {
-                let errors = capture_error_events(|| {
-                    assert_eq!(
-                        crate::local::tag_writer::preflight_tag_write_directory_retained(
-                            &parent,
-                            &leaf,
-                            "the removable mutation target",
-                        ),
-                        Err(TagWritePreflightError::Unavailable),
-                        "a contested cleanup must refuse the rehearsal, never report \
-                         success for a wrong-object removal"
-                    );
-                });
-                assert_eq!(
-                    errors.len(),
-                    1,
-                    "the contested cleanup must report the destroyed foreign entry \
-                     loudly exactly once: {errors:?}"
-                );
-            },
+            || run_contested_rehearsal_expect_refusal(&parent, &leaf),
         );
 
-        assert!(
-            window_ran.load(Ordering::SeqCst),
-            "the verify→unlink window observer must have run"
-        );
-        let contested_leaf = contested
-            .lock()
-            .unwrap()
-            .take()
-            .expect("the seam contested the private name");
-        let stolen_leaf = stolen
-            .lock()
-            .unwrap()
-            .take()
-            .expect("the seam stole the re-verified probe");
-        use rustix::fs::AtFlags;
-        assert!(
-            rustix::fs::statat(&parent, &contested_leaf, AtFlags::empty()).is_err(),
-            "the swapped-in newcomer's entry was destroyed by the contested \
-             unlink — the acknowledged, reported loss"
-        );
-        assert!(
-            rustix::fs::statat(&parent, stolen_leaf.as_os_str(), AtFlags::empty()).is_ok(),
-            "the stolen probe is preserved debris, never destroyed"
-        );
-        rustix::fs::unlinkat(&parent, stolen_leaf.as_os_str(), AtFlags::empty())
-            .expect("remove the stolen-probe debris");
-        let retained_entries: Vec<std::ffi::OsString> = std::fs::read_dir(&album)
-            .expect("list the retained directory")
-            .filter_map(|entry| entry.ok())
-            .map(|entry| entry.file_name())
-            .collect();
-        assert_eq!(
-            retained_entries,
-            vec![std::ffi::OsString::from("silence.flac")],
-            "the refused rehearsal must leave no probe residue of its own"
+        assert_contested_removal_refusal_outcomes(
+            &window_ran,
+            &contested,
+            &stolen,
+            &parent,
+            &album,
         );
     }
 

--- a/src/local/tag_writer.rs
+++ b/src/local/tag_writer.rs
@@ -41,7 +41,7 @@ use lofty::tag::{Accessor, ItemKey, ItemValue, Tag, TagExt, TagItem};
 use uuid::Uuid;
 
 use super::root_authority::{
-    MountedMutationCommit, MountedMutationTarget, ObjectIdentity, object_identity,
+    object_identity, MountedMutationCommit, MountedMutationTarget, ObjectIdentity,
 };
 
 /// Reserved filename prefix for the private sibling used by atomic tag writes.
@@ -674,7 +674,7 @@ pub fn preflight_tag_write(path: &Path) -> Result<(), TagWritePreflightError> {
 /// This performs blocking filesystem I/O and must not run on the GTK
 /// thread.
 #[cfg(unix)]
-pub(crate) fn preflight_tag_write_directory_retained(
+pub fn preflight_tag_write_directory_retained(
     parent: &std::fs::File,
     leaf: &OsStr,
     target_label: &str,
@@ -836,7 +836,9 @@ fn write_tag_edits_for_commit(
         &staged_leaf,
         "the retained mutation target",
         edits,
-        |temp, expected_staged| finish_committed_tag_replacement(commit, temp, Some(expected_staged)),
+        |temp, expected_staged| {
+            finish_committed_tag_replacement(commit, temp, Some(expected_staged))
+        },
     )
 }
 

--- a/src/local/tag_writer.rs
+++ b/src/local/tag_writer.rs
@@ -40,7 +40,9 @@ use lofty::file::{TaggedFile, TaggedFileExt};
 use lofty::tag::{Accessor, ItemKey, ItemValue, Tag, TagExt, TagItem};
 use uuid::Uuid;
 
-use super::root_authority::{MountedMutationCommit, MountedMutationTarget};
+use super::root_authority::{
+    MountedMutationCommit, MountedMutationTarget, ObjectIdentity, object_identity,
+};
 
 /// Reserved filename prefix for the private sibling used by atomic tag writes.
 const TAG_WRITE_TEMP_PREFIX: &str = ".tributary-tag-";
@@ -768,7 +770,7 @@ fn write_tag_edits_for_commit(
         &staged_leaf,
         "the retained mutation target",
         edits,
-        |temp| finish_committed_tag_replacement(commit, temp),
+        |temp, expected_staged| finish_committed_tag_replacement(commit, temp, Some(expected_staged)),
     )
 }
 
@@ -789,7 +791,7 @@ fn write_tag_edits_for_commit(
         &replacement_path,
         "the retained mutation target",
         edits,
-        |temp| finish_committed_tag_replacement(commit, temp),
+        |temp| finish_committed_tag_replacement(commit, temp, None),
     )
 }
 
@@ -802,14 +804,23 @@ fn write_tag_edits_for_commit(
 /// identity-conditioned on the proven landing, so no pathname is ever
 /// opened outside the guard and no leaf swap between the landing and the
 /// re-anchor can be silently adopted.
+///
+/// `expected_staged_identity` is the identity captured from the tagged
+/// staging handle before the commit reopens the staging leaf: the commit
+/// verifies the leaf still names that exact object before anything is
+/// displaced. Path-based staging flows have no retained handle and pass
+/// `None`.
 fn finish_committed_tag_replacement(
     commit: &mut MountedMutationCommit<'_>,
     temp: &mut TempFile,
+    expected_staged_identity: Option<&ObjectIdentity>,
 ) -> Result<()> {
-    commit.commit_replacement(temp.path()).map_err(|error| {
-        anyhow::Error::new(error)
-            .context("The retained mutation authority refused the tagged replacement")
-    })?;
+    commit
+        .commit_replacement(temp.path(), expected_staged_identity)
+        .map_err(|error| {
+            anyhow::Error::new(error)
+                .context("The retained mutation authority refused the tagged replacement")
+        })?;
     // The retained authority renamed the staged copy into place; the
     // staging name no longer exists for the drop guard to remove.
     temp.disarm_cleanup();
@@ -837,7 +848,7 @@ fn anchored_atomic_tag_replacement(
     staged_leaf: &OsStr,
     target_label: &str,
     edits: &TagEdits,
-    commit_replacement: impl FnOnce(&mut TempFile) -> Result<()>,
+    commit_replacement: impl FnOnce(&mut TempFile, &ObjectIdentity) -> Result<()>,
 ) -> Result<()> {
     let (mut temp, mut staged) =
         TempFile::create_beside_retained(staging_parent, staged_leaf, target_label)?;
@@ -855,8 +866,17 @@ fn anchored_atomic_tag_replacement(
 
     write_tags_to_retained(&mut staged, target_label, edits)?;
     flush_and_prepare_tagged_copy_retained(&staged, target_label, retained_permissions)?;
+    // Capture the tagged staging object's identity from its retained
+    // handle before the handle is dropped. The commit reopens the staging
+    // leaf by name and verifies it still names this exact object before
+    // anything is displaced, so a stranger swapped over the staging name
+    // in the drop-to-commit window refuses the commit instead of being
+    // installed as if it were the tagged copy.
+    let staged_identity = object_identity(&staged).with_context(|| {
+        format!("The tagged staging copy of {target_label} could not be identified for the commit")
+    })?;
     drop(staged);
-    commit_replacement(&mut temp)?;
+    commit_replacement(&mut temp, &staged_identity)?;
 
     tracing::debug!("Tags written successfully");
     Ok(())

--- a/src/local/tag_writer.rs
+++ b/src/local/tag_writer.rs
@@ -40,9 +40,12 @@ use lofty::file::{TaggedFile, TaggedFileExt};
 use lofty::tag::{Accessor, ItemKey, ItemValue, Tag, TagExt, TagItem};
 use uuid::Uuid;
 
-use super::root_authority::{
-    object_identity, MountedMutationCommit, MountedMutationTarget, ObjectIdentity,
-};
+use super::root_authority::{MountedMutationCommit, MountedMutationTarget, ObjectIdentity};
+// Only the unix anchored staging flow captures a staged object identity;
+// the Windows and fallback authorities prove staging identity from the
+// pathname-side commit, so the helper import must not gate their builds.
+#[cfg(unix)]
+use super::root_authority::object_identity;
 
 /// Reserved filename prefix for the private sibling used by atomic tag writes.
 const TAG_WRITE_TEMP_PREFIX: &str = ".tributary-tag-";

--- a/src/local/tag_writer.rs
+++ b/src/local/tag_writer.rs
@@ -31,8 +31,8 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use lofty::config::WriteOptions;
-use lofty::file::TaggedFileExt;
-use lofty::tag::{Accessor, ItemKey, ItemValue, TagExt, TagItem};
+use lofty::file::{TaggedFile, TaggedFileExt};
+use lofty::tag::{Accessor, ItemKey, ItemValue, Tag, TagExt, TagItem};
 use uuid::Uuid;
 
 use super::root_authority::MountedMutationTarget;
@@ -838,21 +838,49 @@ fn write_tags_to(temp_path: &Path, target_label: &str, edits: &TagEdits) -> Resu
     let mut tagged_file = lofty::read_from_path(temp_path)
         .with_context(|| format!("Failed to read tags from {target_label}"))?;
 
-    // Get or create the primary tag for this file type. Files with no
-    // existing primary tag (e.g. a stripped MP3, or a FLAC without a Vorbis
-    // comment block) need a fresh tag of the file's primary type so new
-    // metadata can be authored on them — primary_tag_mut() alone never
-    // creates one.
+    let tag = ensure_primary_tag(&mut tagged_file, target_label)?;
+    apply_tag_edits(tag, edits)?;
+
+    // Save back to the temp file.
+    tag.save_to_path(temp_path, WriteOptions::default())
+        .with_context(|| format!("Failed to write tags to {target_label}"))?;
+
+    Ok(())
+}
+
+/// Get or create the primary tag for this file type. Files with no
+/// existing primary tag (e.g. a stripped MP3, or a FLAC without a Vorbis
+/// comment block) need a fresh tag of the file's primary type so new
+/// metadata can be authored on them — primary_tag_mut() alone never
+/// creates one.
+///
+/// Errors name the target by `target_label`, never by any path.
+fn ensure_primary_tag<'a>(
+    tagged_file: &'a mut TaggedFile,
+    target_label: &str,
+) -> Result<&'a mut Tag> {
     if tagged_file.primary_tag_mut().is_none() {
         let tag_type = tagged_file.primary_tag_type();
-        tagged_file.insert_tag(lofty::tag::Tag::new(tag_type));
+        tagged_file.insert_tag(Tag::new(tag_type));
     }
 
-    let tag = tagged_file.primary_tag_mut().ok_or_else(|| {
+    tagged_file.primary_tag_mut().ok_or_else(|| {
         anyhow::anyhow!("No primary tag found and cannot create one for {target_label}")
-    })?;
+    })
+}
 
-    // Apply edits — only touch fields that are Some.
+/// Apply every requested edit to `tag` — only touch fields that are Some —
+/// in the order the edits were declared, so field application order stays
+/// stable across refactors.
+fn apply_tag_edits(tag: &mut Tag, edits: &TagEdits) -> Result<()> {
+    apply_core_text_edits(tag, edits);
+    apply_contributor_and_genre_edits(tag, edits);
+    apply_number_edits(tag, edits)?;
+    apply_comment_edit(tag, edits);
+    Ok(())
+}
+
+fn apply_core_text_edits(tag: &mut Tag, edits: &TagEdits) {
     if let Some(ref title) = edits.title {
         if title.is_empty() {
             tag.remove_title();
@@ -876,7 +904,9 @@ fn write_tags_to(temp_path: &Path, target_label: &str, edits: &TagEdits) -> Resu
             tag.set_album(album.clone());
         }
     }
+}
 
+fn apply_contributor_and_genre_edits(tag: &mut Tag, edits: &TagEdits) {
     // The album-artist edit was previously declared and counted toward
     // `is_empty()`, but never applied — the file was rewritten and the field
     // silently ignored.
@@ -909,9 +939,11 @@ fn write_tags_to(temp_path: &Path, target_label: &str, edits: &TagEdits) -> Resu
             ));
         }
     }
+}
 
-    // These re-parse rather than trusting the caller: an unparseable value must
-    // fail the write, never vanish.
+/// These re-parse rather than trusting the caller: an unparseable value must
+/// fail the write, never vanish.
+fn apply_number_edits(tag: &mut Tag, edits: &TagEdits) -> Result<()> {
     match parse_tag_number("Year", edits.year.as_deref())? {
         NumberEdit::Unchanged => {}
         NumberEdit::Clear => tag.remove_key(ItemKey::Year),
@@ -935,6 +967,10 @@ fn write_tags_to(temp_path: &Path, target_label: &str, edits: &TagEdits) -> Resu
         NumberEdit::Set(disc) => tag.set_disk(disc),
     }
 
+    Ok(())
+}
+
+fn apply_comment_edit(tag: &mut Tag, edits: &TagEdits) {
     if let Some(ref comment) = edits.comment {
         if comment.is_empty() {
             tag.remove_comment();
@@ -942,12 +978,6 @@ fn write_tags_to(temp_path: &Path, target_label: &str, edits: &TagEdits) -> Resu
             tag.set_comment(comment.clone());
         }
     }
-
-    // Save back to the temp file.
-    tag.save_to_path(temp_path, WriteOptions::default())
-        .with_context(|| format!("Failed to write tags to {target_label}"))?;
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/platform_runtime.rs
+++ b/src/platform_runtime.rs
@@ -2063,11 +2063,26 @@ Assert-TargetFailure $newlineTarget "target #1 contains an unsupported quote or 
             return;
         };
 
+        // A managed entry point that never started never ran the script.
+        // Hosted macOS runners have been observed to crash pwsh at startup
+        // under load ("Call to 'procargs' failed with errno 5" followed by a
+        // ManagedPSEntry StartupException, with empty stdout). That is a host
+        // defect this script-level regression cannot observe, so it is the
+        // same class of environmental skip as a missing pwsh above.
+        // Script-level failures always carry script output instead.
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !cfg!(target_os = "windows")
+            && output.stdout.is_empty()
+            && stderr.contains("ManagedPSEntry")
+        {
+            return;
+        }
+
         assert!(
             output.status.success(),
             "PowerShell PE target regression failed:\nstdout: {}\nstderr: {}",
             String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
+            stderr
         );
     }
 

--- a/src/removable.rs
+++ b/src/removable.rs
@@ -22,7 +22,7 @@ use crate::source_lifecycle::{
     AdapterCloseFuture, AdapterStream, CancellationObserver, CloseAuthority, LifecycleAdapter,
 };
 use crate::source_registry::{
-    CatalogueFuture, ManagedSourceAdapter, PlaybackAttributionCapability,
+    CatalogueFuture, ManagedSourceAdapter, MutationTargetFuture, PlaybackAttributionCapability,
     PlaybackAttributionProfile, StreamFuture,
 };
 
@@ -231,6 +231,28 @@ impl ManagedSourceAdapter for RemovableMediaAdapter {
                 .map_err(|_| resolution_failed())?
                 .map(AdapterStream::File)
                 .map_err(|_| resolution_failed())
+        })
+    }
+
+    fn resolve_mutation_target(self: Arc<Self>, track_id: TrackId) -> MutationTargetFuture {
+        Box::pin(async move {
+            // The same exact-membership gate as stream resolution: only an
+            // identity the accepted scan admitted may become a write target,
+            // and only through this session's retained mount authority.
+            if !self.accepted_track_ids.contains(&track_id) {
+                return Err(resolution_failed());
+            }
+            let relative_path = track_id
+                .removable_relative_path()
+                .map_err(|_| resolution_failed())?;
+            let authority = Arc::clone(&self.authority);
+            let task = self.runtime.spawn_blocking(move || {
+                authority
+                    .open_mutation_target(&relative_path)
+                    .map_err(|_| resolution_failed())
+            });
+
+            task.await.map_err(|_| resolution_failed())?
         })
     }
 }

--- a/src/removable.rs
+++ b/src/removable.rs
@@ -8,7 +8,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use tokio::runtime::Handle;
 use uuid::Uuid;
@@ -28,18 +28,29 @@ use crate::source_registry::{
 
 const MAX_TAG_TEXT_BYTES: usize = 64 * 1024;
 
+/// Accepted catalogue content of one mounted removable session.
+///
+/// Mutable only through [`RemovableMediaAdapter::refresh_catalogue_after_mutation`]:
+/// a committed retained write swaps the refreshed entry and attribution
+/// profile for exactly the written identity under one lock, so the
+/// republished catalogue and the live attribution authority can never
+/// disagree about a mutated row.
+#[derive(Default)]
+struct RemovableCatalogue {
+    tracks: Vec<Track>,
+    playback_attribution_profiles: HashMap<TrackId, PlaybackAttributionProfile>,
+}
+
 /// One mounted removable source whose catalogue and media authority share an
 /// exact lifecycle generation.
 pub struct RemovableMediaAdapter {
-    #[cfg(test)]
     source_id: SourceId,
     authority: Arc<MountedRootAuthority>,
-    tracks: Vec<Track>,
     accepted_track_ids: HashSet<TrackId>,
-    /// Exact real-tag attribution captured by the same retained scan that
-    /// accepted `tracks`. This map is immutable for the entire source session;
-    /// synchronous lifecycle admission never waits on a parser or lock.
-    playback_attribution_profiles: HashMap<TrackId, PlaybackAttributionProfile>,
+    /// Accepted catalogue. Scan constructs it once; the post-mutation
+    /// refresh replaces entries for exact written identities under the
+    /// catalogue lock.
+    catalogue: Mutex<RemovableCatalogue>,
     runtime: Handle,
 }
 
@@ -157,12 +168,13 @@ impl RemovableMediaAdapter {
         }
 
         Ok(Some(Self {
-            #[cfg(test)]
             source_id,
             authority,
-            tracks,
             accepted_track_ids,
-            playback_attribution_profiles,
+            catalogue: Mutex::new(RemovableCatalogue {
+                tracks,
+                playback_attribution_profiles,
+            }),
             runtime,
         }))
     }
@@ -173,8 +185,17 @@ impl RemovableMediaAdapter {
     }
 
     #[cfg(test)]
-    pub fn tracks(&self) -> &[Track] {
-        &self.tracks
+    pub fn tracks(&self) -> Vec<Track> {
+        self.catalogue_tracks()
+    }
+
+    /// Snapshot of the accepted catalogue tracks under the catalogue lock.
+    fn catalogue_tracks(&self) -> Vec<Track> {
+        self.catalogue
+            .lock()
+            .expect("removable catalogue mutex poisoned")
+            .tracks
+            .clone()
     }
 }
 
@@ -196,11 +217,16 @@ impl ManagedSourceAdapter for RemovableMediaAdapter {
         &self,
         track_id: &TrackId,
     ) -> Option<PlaybackAttributionProfile> {
-        self.playback_attribution_profiles.get(track_id).cloned()
+        self.catalogue
+            .lock()
+            .expect("removable catalogue mutex poisoned")
+            .playback_attribution_profiles
+            .get(track_id)
+            .cloned()
     }
 
     fn load_initial_catalogue(self: Arc<Self>) -> CatalogueFuture {
-        Box::pin(async move { Ok(self.tracks.clone()) })
+        Box::pin(async move { Ok(self.catalogue_tracks()) })
     }
 
     fn resolve_stream(self: Arc<Self>, track_id: TrackId) -> StreamFuture {
@@ -254,6 +280,139 @@ impl ManagedSourceAdapter for RemovableMediaAdapter {
 
             task.await.map_err(|_| resolution_failed())?
         })
+    }
+
+    fn refresh_catalogue_after_mutation(
+        self: Arc<Self>,
+        written_track_ids: HashSet<TrackId>,
+        cancellation: CancellationObserver,
+    ) -> CatalogueFuture {
+        Box::pin(async move {
+            if written_track_ids.is_empty() {
+                return Ok(self.catalogue_tracks());
+            }
+            let this = Arc::clone(&self);
+            let task = self.runtime.spawn_blocking(move || {
+                this.refresh_written_identities(&written_track_ids, &cancellation)
+            });
+            match task.await {
+                Ok(result) => result,
+                Err(_) => Err(scan_failed()),
+            }
+        })
+    }
+}
+
+impl RemovableMediaAdapter {
+    /// Re-derive catalogue entries for exact identities whose retained
+    /// writes committed, and swap them into the accepted catalogue under
+    /// one lock.
+    ///
+    /// Only identities the accepted scan admitted are re-read; every other
+    /// requested identity is ignored. An identity that fails to re-read or
+    /// re-parse keeps its previous catalogue entry — the refresh is scoped
+    /// to what actually committed, and one unreadable row never fails the
+    /// whole publication. Re-reads flow through the retained mount
+    /// authority via the same [`ResolvedFileMedia::from_mounted_relative_path`]
+    /// path the scan and stream resolution use, so no native mount location
+    /// is exposed and a displaced ancestor can never retarget the lookup.
+    /// The attribution profile is rebuilt from the fresh parse on the same
+    /// real-tag provenance rules as the scan, so the republished catalogue
+    /// and the live playback-attribution authority change together.
+    ///
+    /// The swap happens only after the mount authority revalidates: a mount
+    /// that changed under the re-reads publishes nothing. Blocking — worker
+    /// threads only.
+    fn refresh_written_identities(
+        &self,
+        written: &HashSet<TrackId>,
+        cancellation: &CancellationObserver,
+    ) -> BackendResult<Vec<Track>> {
+        let mut refreshed: Vec<(TrackId, Track, Option<PlaybackAttributionProfile>)> =
+            Vec::with_capacity(written.len());
+        for track_id in written {
+            // Membership: a well-formed relative identity that appeared
+            // outside the accepted scan is not authority to read anything
+            // in this session.
+            if !self.accepted_track_ids.contains(track_id) {
+                continue;
+            }
+            if cancellation.is_cancelled() {
+                break;
+            }
+            let Ok(relative_path) = track_id.removable_relative_path() else {
+                continue;
+            };
+            let extension = extension_hint(&relative_path);
+            let Ok(media) = ResolvedFileMedia::from_mounted_relative_path(
+                Arc::clone(&self.authority),
+                &relative_path,
+                extension,
+            ) else {
+                continue;
+            };
+            let parsed = media
+                .with_serialized_seekable_file(|file| {
+                    crate::local::tag_parser::parse_audio_file_from_file(file, &relative_path)
+                })
+                .ok()
+                .and_then(Result::ok);
+            if cancellation.is_cancelled() {
+                break;
+            }
+            let Some(parsed) = parsed.filter(parsed_metadata_is_bounded) else {
+                continue;
+            };
+            let title_from_tag = parsed.title_from_tag;
+            let artist_from_tag = parsed.artist_from_tag;
+            let album_from_tag = parsed.album_from_tag;
+            let track = pathless_track(self.source_id, track_id.clone(), parsed);
+            let profile = PlaybackAttributionProfile::from_tagged_track(
+                &track,
+                title_from_tag,
+                artist_from_tag,
+                album_from_tag,
+            );
+            refreshed.push((track_id.clone(), track, profile));
+        }
+
+        if self.authority.validate().is_err() {
+            if cancellation.is_cancelled() {
+                return Ok(self.catalogue_tracks());
+            }
+            return Err(scan_failed());
+        }
+        if cancellation.is_cancelled() {
+            // A lane cancelled mid-re-read publishes nothing — the same
+            // discipline as the accepted scan, which never repopulates from
+            // a cancelled pass.
+            return Ok(self.catalogue_tracks());
+        }
+
+        let mut catalogue = self
+            .catalogue
+            .lock()
+            .expect("removable catalogue mutex poisoned");
+        for (track_id, track, profile) in refreshed {
+            if let Some(slot) = catalogue
+                .tracks
+                .iter_mut()
+                .find(|track| track.native_track_id.as_ref() == Some(&track_id))
+            {
+                *slot = track;
+            }
+            match profile {
+                Some(profile) => {
+                    catalogue
+                        .playback_attribution_profiles
+                        .insert(track_id, profile);
+                }
+                None => {
+                    catalogue.playback_attribution_profiles.remove(&track_id);
+                }
+            }
+        }
+        Ok(catalogue.tracks.clone())
     }
 }
 
@@ -699,6 +858,328 @@ mod tests {
             .expect("write replacement WAV");
 
         assert!(Arc::new(adapter).resolve_stream(track_id).await.is_err());
+        drop(owner);
+    }
+
+    #[tokio::test]
+    async fn refresh_republishes_written_identities_and_attribution() {
+        let mount = tempfile::tempdir().expect("temporary removable mount");
+        let song_path = mount.path().join("song.flac");
+        write_tagged_flac(
+            &song_path,
+            Some("Before Refresh"),
+            Some("Before Artist"),
+            Some("Before Album"),
+            None,
+            Some("1"),
+        );
+
+        let source_id = SourceId::removable("test:refresh-republish").expect("source identity");
+        let (_registry, owner, cancellation) = live_cancellation(source_id);
+        let adapter = Arc::new(
+            RemovableMediaAdapter::scan(
+                source_id,
+                mount.path().to_path_buf(),
+                &cancellation,
+                Handle::current(),
+            )
+            .expect("scan removable media")
+            .expect("scan remains current"),
+        );
+        assert_eq!(adapter.tracks().len(), 1);
+        let track_id = adapter.tracks()[0]
+            .native_track_id
+            .clone()
+            .expect("accepted identity");
+        assert_eq!(adapter.tracks()[0].title, "Before Refresh");
+
+        // A committed retained write replaced the file content at the same
+        // relative path; the refresh re-derives the row and the attribution
+        // profile from the fresh parse.
+        write_tagged_flac(
+            &song_path,
+            Some("After Refresh"),
+            Some("After Artist"),
+            Some("After Album"),
+            None,
+            Some("2"),
+        );
+        let refreshed = Arc::clone(&adapter)
+            .refresh_catalogue_after_mutation(
+                HashSet::from([track_id.clone()]),
+                cancellation.clone(),
+            )
+            .await
+            .expect("a committed write republishes");
+        assert_eq!(refreshed.len(), 1);
+        assert_eq!(refreshed[0].title, "After Refresh");
+
+        let published = adapter.tracks();
+        assert_eq!(published.len(), 1);
+        assert_eq!(published[0].title, "After Refresh");
+        assert_eq!(
+            published[0].native_track_id.as_ref(),
+            Some(&track_id),
+            "the row keeps its accepted identity"
+        );
+        let profile = adapter
+            .playback_attribution_profile(&track_id)
+            .expect("fresh real tags keep attribution authorized");
+        assert_eq!(profile.title(), "After Refresh");
+        assert_eq!(profile.track_number(), Some(2));
+        drop(owner);
+    }
+
+    #[tokio::test]
+    async fn refresh_ignores_identities_outside_the_accepted_scan() {
+        let mount = tempfile::tempdir().expect("temporary removable mount");
+        let accepted_path = mount.path().join("accepted.wav");
+        std::fs::write(&accepted_path, minimal_wav_bytes(0x80)).expect("write accepted WAV");
+
+        let source_id = SourceId::removable("test:refresh-membership").expect("source identity");
+        let (_registry, owner, cancellation) = live_cancellation(source_id);
+        let adapter = Arc::new(
+            RemovableMediaAdapter::scan(
+                source_id,
+                mount.path().to_path_buf(),
+                &cancellation,
+                Handle::current(),
+            )
+            .expect("scan removable media")
+            .expect("scan remains current"),
+        );
+        let accepted_id = adapter.tracks()[0]
+            .native_track_id
+            .clone()
+            .expect("accepted identity");
+
+        let appeared_path = mount.path().join("appeared-later.wav");
+        std::fs::write(&appeared_path, minimal_wav_bytes(0x40)).expect("write later WAV");
+        let appeared_id =
+            TrackId::removable_relative(mount.path(), &appeared_path).expect("later identity");
+
+        let refreshed = Arc::clone(&adapter)
+            .refresh_catalogue_after_mutation(
+                HashSet::from([accepted_id.clone(), appeared_id]),
+                cancellation.clone(),
+            )
+            .await
+            .expect("unaccepted identities are ignored, never a failure");
+        assert_eq!(
+            refreshed.len(),
+            1,
+            "an identity outside the accepted scan is never catalogued"
+        );
+        assert_eq!(refreshed[0].native_track_id.as_ref(), Some(&accepted_id));
+        assert_eq!(adapter.tracks().len(), 1);
+        drop(owner);
+    }
+
+    #[tokio::test]
+    async fn refresh_failed_reread_keeps_the_previous_catalogue_entry() {
+        let mount = tempfile::tempdir().expect("temporary removable mount");
+        let song_path = mount.path().join("song.flac");
+        write_tagged_flac(
+            &song_path,
+            Some("Kept Title"),
+            Some("Kept Artist"),
+            None,
+            None,
+            None,
+        );
+
+        let source_id =
+            SourceId::removable("test:refresh-reread-failure").expect("source identity");
+        let (_registry, owner, cancellation) = live_cancellation(source_id);
+        let adapter = Arc::new(
+            RemovableMediaAdapter::scan(
+                source_id,
+                mount.path().to_path_buf(),
+                &cancellation,
+                Handle::current(),
+            )
+            .expect("scan removable media")
+            .expect("scan remains current"),
+        );
+        let track_id = adapter.tracks()[0]
+            .native_track_id
+            .clone()
+            .expect("accepted identity");
+
+        std::fs::remove_file(&song_path).expect("remove the written file");
+        let refreshed = Arc::clone(&adapter)
+            .refresh_catalogue_after_mutation(
+                HashSet::from([track_id.clone()]),
+                cancellation.clone(),
+            )
+            .await
+            .expect("one unreadable row never fails the whole refresh");
+        assert_eq!(
+            refreshed[0].title, "Kept Title",
+            "an identity that fails to re-read keeps its previous entry"
+        );
+        assert!(adapter.playback_attribution_profile(&track_id).is_some());
+        drop(owner);
+    }
+
+    #[tokio::test]
+    async fn refresh_publishes_nothing_when_the_mount_changed_under_the_rereads() {
+        let parent = tempfile::tempdir().expect("mount parent");
+        let mount_path = parent.path().join("mounted");
+        let displaced_path = parent.path().join("displaced");
+        std::fs::create_dir(&mount_path).expect("create mounted root");
+        std::fs::write(mount_path.join("song.wav"), minimal_wav_bytes(0x80))
+            .expect("write accepted WAV");
+
+        let source_id = SourceId::removable("test:refresh-mount-change").expect("source identity");
+        let (_registry, owner, cancellation) = live_cancellation(source_id);
+        let adapter = Arc::new(
+            RemovableMediaAdapter::scan(
+                source_id,
+                mount_path.clone(),
+                &cancellation,
+                Handle::current(),
+            )
+            .expect("scan removable media")
+            .expect("scan remains current"),
+        );
+        let track_id = adapter.tracks()[0]
+            .native_track_id
+            .clone()
+            .expect("accepted identity");
+        let title_before = adapter.tracks()[0].title.clone();
+
+        std::fs::rename(&mount_path, &displaced_path).expect("displace mounted root");
+        std::fs::create_dir(&mount_path).expect("create replacement root");
+        std::fs::write(mount_path.join("song.wav"), minimal_wav_bytes(0x40))
+            .expect("write replacement WAV");
+
+        let error = Arc::clone(&adapter)
+            .refresh_catalogue_after_mutation(
+                HashSet::from([track_id.clone()]),
+                cancellation.clone(),
+            )
+            .await
+            .expect_err("a mount that changed under the re-reads publishes nothing");
+        assert_eq!(
+            error.to_string(),
+            "Internal error: removable media scan failed"
+        );
+        assert!(!error
+            .to_string()
+            .contains(&mount_path.display().to_string()));
+        let published = adapter.tracks();
+        assert_eq!(published.len(), 1);
+        assert_eq!(
+            published[0].title, title_before,
+            "the accepted entry is not displaced by the replacement root"
+        );
+        drop(owner);
+    }
+
+    #[tokio::test]
+    async fn cancelled_refresh_is_not_a_failure_and_publishes_nothing() {
+        let mount = tempfile::tempdir().expect("temporary removable mount");
+        let song_path = mount.path().join("song.flac");
+        write_tagged_flac(
+            &song_path,
+            Some("Before Cancel"),
+            Some("Cancel Artist"),
+            None,
+            None,
+            None,
+        );
+
+        let source_id = SourceId::removable("test:refresh-cancelled").expect("source identity");
+        let (registry, owner, cancellation) = live_cancellation(source_id);
+        let adapter = Arc::new(
+            RemovableMediaAdapter::scan(
+                source_id,
+                mount.path().to_path_buf(),
+                &cancellation,
+                Handle::current(),
+            )
+            .expect("scan removable media")
+            .expect("scan remains current"),
+        );
+        let track_id = adapter.tracks()[0]
+            .native_track_id
+            .clone()
+            .expect("accepted identity");
+        drop(owner);
+        assert!(cancellation.is_cancelled());
+
+        // Even a write that committed before the lane was cancelled must not
+        // republish: a cancelled lane publishes nothing.
+        write_tagged_flac(
+            &song_path,
+            Some("After Cancel"),
+            Some("Cancel Artist"),
+            None,
+            None,
+            None,
+        );
+        let refreshed = Arc::clone(&adapter)
+            .refresh_catalogue_after_mutation(
+                HashSet::from([track_id.clone()]),
+                cancellation.clone(),
+            )
+            .await
+            .expect("cancelled refresh is not a failure");
+        assert_eq!(refreshed[0].title, "Before Cancel");
+        assert_eq!(adapter.tracks()[0].title, "Before Cancel");
+        drop(registry);
+    }
+
+    #[tokio::test]
+    async fn refresh_drops_attribution_when_the_fresh_parse_loses_real_tags() {
+        let mount = tempfile::tempdir().expect("temporary removable mount");
+        let song_path = mount.path().join("song.flac");
+        write_tagged_flac(
+            &song_path,
+            Some("Tagged Title"),
+            Some("Tagged Artist"),
+            None,
+            None,
+            None,
+        );
+
+        let source_id =
+            SourceId::removable("test:refresh-attribution-loss").expect("source identity");
+        let (_registry, owner, cancellation) = live_cancellation(source_id);
+        let adapter = Arc::new(
+            RemovableMediaAdapter::scan(
+                source_id,
+                mount.path().to_path_buf(),
+                &cancellation,
+                Handle::current(),
+            )
+            .expect("scan removable media")
+            .expect("scan remains current"),
+        );
+        let track_id = adapter.tracks()[0]
+            .native_track_id
+            .clone()
+            .expect("accepted identity");
+        assert!(adapter.playback_attribution_profile(&track_id).is_some());
+
+        // A committed write cleared the real tags: the stale profile must not
+        // survive the refresh, because attribution authority follows the
+        // fresh parse.
+        write_tagged_flac(&song_path, None, None, None, None, None);
+        let refreshed = Arc::clone(&adapter)
+            .refresh_catalogue_after_mutation(
+                HashSet::from([track_id.clone()]),
+                cancellation.clone(),
+            )
+            .await
+            .expect("the refresh republishes the cleared row");
+        assert_eq!(refreshed.len(), 1);
+        assert!(
+            adapter.playback_attribution_profile(&track_id).is_none(),
+            "a profile the fresh parse no longer supports is dropped"
+        );
+        assert_eq!(adapter.tracks().len(), 1);
         drop(owner);
     }
 }

--- a/src/removable.rs
+++ b/src/removable.rs
@@ -309,20 +309,10 @@ impl RemovableMediaAdapter {
     /// one lock.
     ///
     /// Only identities the accepted scan admitted are re-read; every other
-    /// requested identity is ignored. An identity that fails to re-read or
-    /// re-parse keeps its previous catalogue entry — the refresh is scoped
-    /// to what actually committed, and one unreadable row never fails the
-    /// whole publication. Re-reads flow through the retained mount
-    /// authority via the same [`ResolvedFileMedia::from_mounted_relative_path`]
-    /// path the scan and stream resolution use, so no native mount location
-    /// is exposed and a displaced ancestor can never retarget the lookup.
-    /// The attribution profile is rebuilt from the fresh parse on the same
-    /// real-tag provenance rules as the scan, so the republished catalogue
-    /// and the live playback-attribution authority change together.
-    ///
-    /// The swap happens only after the mount authority revalidates: a mount
-    /// that changed under the re-reads publishes nothing. Blocking — worker
-    /// threads only.
+    /// requested identity is ignored (see [`Self::refreshed_identity`]).
+    /// One unreadable row never fails the whole publication, and a lane
+    /// cancelled mid-re-read stops re-reading and publishes nothing (see
+    /// [`Self::publish_refreshed`]). Blocking — worker threads only.
     fn refresh_written_identities(
         &self,
         written: &HashSet<TrackId>,
@@ -331,51 +321,80 @@ impl RemovableMediaAdapter {
         let mut refreshed: Vec<(TrackId, Track, Option<PlaybackAttributionProfile>)> =
             Vec::with_capacity(written.len());
         for track_id in written {
-            // Membership: a well-formed relative identity that appeared
-            // outside the accepted scan is not authority to read anything
-            // in this session.
-            if !self.accepted_track_ids.contains(track_id) {
-                continue;
-            }
             if cancellation.is_cancelled() {
                 break;
             }
-            let Ok(relative_path) = track_id.removable_relative_path() else {
-                continue;
-            };
-            let extension = extension_hint(&relative_path);
-            let Ok(media) = ResolvedFileMedia::from_mounted_relative_path(
-                Arc::clone(&self.authority),
-                &relative_path,
-                extension,
-            ) else {
-                continue;
-            };
-            let parsed = media
-                .with_serialized_seekable_file(|file| {
-                    crate::local::tag_parser::parse_audio_file_from_file(file, &relative_path)
-                })
-                .ok()
-                .and_then(Result::ok);
-            if cancellation.is_cancelled() {
-                break;
+            if let Some(row) = self.refreshed_identity(track_id, cancellation) {
+                refreshed.push(row);
             }
-            let Some(parsed) = parsed.filter(parsed_metadata_is_bounded) else {
-                continue;
-            };
-            let title_from_tag = parsed.title_from_tag;
-            let artist_from_tag = parsed.artist_from_tag;
-            let album_from_tag = parsed.album_from_tag;
-            let track = pathless_track(self.source_id, track_id.clone(), parsed);
-            let profile = PlaybackAttributionProfile::from_tagged_track(
-                &track,
-                title_from_tag,
-                artist_from_tag,
-                album_from_tag,
-            );
-            refreshed.push((track_id.clone(), track, profile));
         }
+        self.publish_refreshed(refreshed, cancellation)
+    }
 
+    /// Re-derive one accepted identity from the retained mount after its
+    /// write committed. An identity that fails to re-read or re-parse —
+    /// or one the accepted scan never admitted — yields `None` and keeps
+    /// its previous catalogue entry: the refresh is scoped to what
+    /// actually committed. Re-reads flow through the retained mount
+    /// authority via the same [`ResolvedFileMedia::from_mounted_relative_path`]
+    /// path the scan and stream resolution use, so no native mount location
+    /// is exposed and a displaced ancestor can never retarget the lookup.
+    /// The attribution profile is rebuilt from the fresh parse on the same
+    /// real-tag provenance rules as the scan, so the republished catalogue
+    /// and the live playback-attribution authority change together.
+    fn refreshed_identity(
+        &self,
+        track_id: &TrackId,
+        cancellation: &CancellationObserver,
+    ) -> Option<(TrackId, Track, Option<PlaybackAttributionProfile>)> {
+        // Membership: a well-formed relative identity that appeared
+        // outside the accepted scan is not authority to read anything
+        // in this session.
+        if !self.accepted_track_ids.contains(track_id) {
+            return None;
+        }
+        let relative_path = track_id.removable_relative_path().ok()?;
+        let extension = extension_hint(&relative_path);
+        let media = ResolvedFileMedia::from_mounted_relative_path(
+            Arc::clone(&self.authority),
+            &relative_path,
+            extension,
+        )
+        .ok()?;
+        let parsed = media
+            .with_serialized_seekable_file(|file| {
+                crate::local::tag_parser::parse_audio_file_from_file(file, &relative_path)
+            })
+            .ok()
+            .and_then(Result::ok);
+        if cancellation.is_cancelled() {
+            return None;
+        }
+        let parsed = parsed.filter(parsed_metadata_is_bounded)?;
+        let title_from_tag = parsed.title_from_tag;
+        let artist_from_tag = parsed.artist_from_tag;
+        let album_from_tag = parsed.album_from_tag;
+        let track = pathless_track(self.source_id, track_id.clone(), parsed);
+        let profile = PlaybackAttributionProfile::from_tagged_track(
+            &track,
+            title_from_tag,
+            artist_from_tag,
+            album_from_tag,
+        );
+        Some((track_id.clone(), track, profile))
+    }
+
+    /// Swap refreshed rows into the accepted catalogue under one lock.
+    ///
+    /// The swap happens only after the mount authority revalidates: a mount
+    /// that changed under the re-reads publishes nothing. A lane cancelled
+    /// mid-re-read publishes nothing — the same discipline as the accepted
+    /// scan, which never repopulates from a cancelled pass.
+    fn publish_refreshed(
+        &self,
+        refreshed: Vec<(TrackId, Track, Option<PlaybackAttributionProfile>)>,
+        cancellation: &CancellationObserver,
+    ) -> BackendResult<Vec<Track>> {
         if self.authority.validate().is_err() {
             if cancellation.is_cancelled() {
                 return Ok(self.catalogue_tracks());
@@ -383,9 +402,6 @@ impl RemovableMediaAdapter {
             return Err(scan_failed());
         }
         if cancellation.is_cancelled() {
-            // A lane cancelled mid-re-read publishes nothing — the same
-            // discipline as the accepted scan, which never repopulates from
-            // a cancelled pass.
             return Ok(self.catalogue_tracks());
         }
 
@@ -861,6 +877,50 @@ mod tests {
         drop(owner);
     }
 
+    /// Scan a one-track mount and hand back the live adapter plus the
+    /// accepted identity of its only row.
+    fn scanned_single_track(
+        source_id: SourceId,
+        mount: &Path,
+        cancellation: &CancellationObserver,
+    ) -> (Arc<RemovableMediaAdapter>, TrackId) {
+        let adapter = Arc::new(
+            RemovableMediaAdapter::scan(
+                source_id,
+                mount.to_path_buf(),
+                cancellation,
+                Handle::current(),
+            )
+            .expect("scan removable media")
+            .expect("scan remains current"),
+        );
+        assert_eq!(adapter.tracks().len(), 1);
+        let track_id = adapter.tracks()[0]
+            .native_track_id
+            .clone()
+            .expect("accepted identity");
+        (adapter, track_id)
+    }
+
+    /// A committed retained write replaced the file content at the same
+    /// relative path; the refresh must republish the row and the
+    /// attribution profile from the fresh parse.
+    fn assert_republished_attribution(adapter: &RemovableMediaAdapter, track_id: &TrackId) {
+        let published = adapter.tracks();
+        assert_eq!(published.len(), 1);
+        assert_eq!(published[0].title, "After Refresh");
+        assert_eq!(
+            published[0].native_track_id.as_ref(),
+            Some(track_id),
+            "the row keeps its accepted identity"
+        );
+        let profile = adapter
+            .playback_attribution_profile(track_id)
+            .expect("fresh real tags keep attribution authorized");
+        assert_eq!(profile.title(), "After Refresh");
+        assert_eq!(profile.track_number(), Some(2));
+    }
+
     #[tokio::test]
     async fn refresh_republishes_written_identities_and_attribution() {
         let mount = tempfile::tempdir().expect("temporary removable mount");
@@ -876,26 +936,9 @@ mod tests {
 
         let source_id = SourceId::removable("test:refresh-republish").expect("source identity");
         let (_registry, owner, cancellation) = live_cancellation(source_id);
-        let adapter = Arc::new(
-            RemovableMediaAdapter::scan(
-                source_id,
-                mount.path().to_path_buf(),
-                &cancellation,
-                Handle::current(),
-            )
-            .expect("scan removable media")
-            .expect("scan remains current"),
-        );
-        assert_eq!(adapter.tracks().len(), 1);
-        let track_id = adapter.tracks()[0]
-            .native_track_id
-            .clone()
-            .expect("accepted identity");
+        let (adapter, track_id) = scanned_single_track(source_id, mount.path(), &cancellation);
         assert_eq!(adapter.tracks()[0].title, "Before Refresh");
 
-        // A committed retained write replaced the file content at the same
-        // relative path; the refresh re-derives the row and the attribution
-        // profile from the fresh parse.
         write_tagged_flac(
             &song_path,
             Some("After Refresh"),
@@ -914,19 +957,7 @@ mod tests {
         assert_eq!(refreshed.len(), 1);
         assert_eq!(refreshed[0].title, "After Refresh");
 
-        let published = adapter.tracks();
-        assert_eq!(published.len(), 1);
-        assert_eq!(published[0].title, "After Refresh");
-        assert_eq!(
-            published[0].native_track_id.as_ref(),
-            Some(&track_id),
-            "the row keeps its accepted identity"
-        );
-        let profile = adapter
-            .playback_attribution_profile(&track_id)
-            .expect("fresh real tags keep attribution authorized");
-        assert_eq!(profile.title(), "After Refresh");
-        assert_eq!(profile.track_number(), Some(2));
+        assert_republished_attribution(&adapter, &track_id);
         drop(owner);
     }
 

--- a/src/source_lifecycle.rs
+++ b/src/source_lifecycle.rs
@@ -2707,8 +2707,10 @@ impl<A: LifecycleAdapter + ?Sized, S> SourceLifecycleRegistry<A, S> {
     /// Resolve an adapter-owned capability through one exact session and
     /// return the lease captured by that same atomic adapter/epoch snapshot.
     /// Typed boundary helpers attach the lease only after the post-resolution
-    /// current-session recheck succeeds.
-    async fn resolve_exact_session<R, F, Fut>(
+    /// current-session recheck succeeds. Crate-visible so the source registry
+    /// can retain the lease itself as an independent revocation handle over
+    /// retained mutation authority.
+    pub(crate) async fn resolve_exact_session<R, F, Fut>(
         &self,
         source_id: SourceId,
         expected_session_epoch: u64,

--- a/src/source_lifecycle.rs
+++ b/src/source_lifecycle.rs
@@ -3247,6 +3247,7 @@ impl<A: LifecycleAdapter + ?Sized, S> SourceLifecycleRegistry<A, S> {
             session,
             cancellation: observer,
             completed: false,
+            on_accepted: None,
         })
     }
 
@@ -4199,6 +4200,13 @@ pub struct RefreshOwner<A: LifecycleAdapter + ?Sized, S> {
     session: SessionHandle<A>,
     cancellation: CancellationObserver,
     completed: bool,
+    /// Runs exactly when this generation's publication is ACCEPTED by the
+    /// lifecycle — never on a superseded rejection, failure, cancellation,
+    /// or drop. Callers use it for bookkeeping that must be bound to
+    /// settlement (e.g. consuming a pending-work batch only once this
+    /// generation's payload has actually published), so a generation whose
+    /// payload is rejected consumes nothing.
+    on_accepted: Option<Box<dyn FnOnce() + Send>>,
 }
 
 impl<A: LifecycleAdapter + ?Sized, S> RefreshOwner<A, S> {
@@ -4222,6 +4230,18 @@ impl<A: LifecycleAdapter + ?Sized, S> RefreshOwner<A, S> {
         self.cancellation.clone()
     }
 
+    /// Bind a hook to this generation's settlement acceptance.
+    ///
+    /// The hook runs exactly when [`Self::spawn`]'s submission of this
+    /// generation's payload is accepted by the lifecycle (the generation was
+    /// still current and the publication landed) — and never when the
+    /// submission is rejected as superseded, fails, is cancelled, or the
+    /// owner drops unfinished.
+    pub fn on_acceptance(mut self, hook: Box<dyn FnOnce() + Send>) -> Self {
+        self.on_accepted = Some(hook);
+        self
+    }
+
     /// Exact operational adapter/lease/epoch captured atomically when this
     /// refresh generation began.
     fn session(&self) -> SessionHandle<A> {
@@ -4238,6 +4258,14 @@ impl<A: LifecycleAdapter + ?Sized, S> RefreshOwner<A, S> {
             snapshot,
         );
         self.completed = true;
+        if accepted {
+            // Settlement-confirmed: this exact generation's publication was
+            // accepted, so bookkeeping bound to acceptance may run now. A
+            // rejected submission consumed nothing.
+            if let Some(on_accepted) = self.on_accepted.take() {
+                on_accepted();
+            }
+        }
         accepted
     }
 

--- a/src/source_registry.rs
+++ b/src/source_registry.rs
@@ -21,7 +21,7 @@ use crate::architecture::backend::{
 };
 use crate::architecture::error::BackendError;
 use crate::architecture::media::{
-    MediaRequest, PublicHttpAuthority, PublicHttpEndpoint, RemoteMediaResolver,
+    MediaLease, MediaRequest, PublicHttpAuthority, PublicHttpEndpoint, RemoteMediaResolver,
     ResolvedHttpRequest, ResolvedPublicHttpRequest,
 };
 use crate::architecture::models::{RatingCapability, Track};
@@ -30,7 +30,7 @@ use crate::architecture::{
     ViewOrigin,
 };
 use crate::external_file::{ExternalFileCandidate, ExternalFileHint};
-use crate::local::resolver::ResolvedFileMedia;
+use crate::local::resolver::{MountedMutationTarget, ResolvedFileMedia};
 use crate::source_lifecycle::{
     AdapterCloseFuture, AdapterStream, AdapterTaskResult, CatalogueCommitAuthority,
     CatalogueCommitRequest, CloseAuthority, ConstructionCancellationPolicy, FailureCategory,
@@ -47,6 +47,9 @@ pub type StreamFuture =
     Pin<Box<dyn Future<Output = BackendResult<AdapterStream>> + Send + 'static>>;
 type ArtworkFuture =
     Pin<Box<dyn Future<Output = BackendResult<Option<ResolvedHttpRequest>>> + Send + 'static>>;
+/// One retained mutation target resolved through a live managed adapter.
+pub type MutationTargetFuture =
+    Pin<Box<dyn Future<Output = BackendResult<MountedMutationTarget>> + Send + 'static>>;
 // Record C intentionally stops at an internally tested authority foundation;
 // Record D is the first non-test caller of the server-playlist surface.
 #[cfg_attr(not(test), allow(dead_code))]
@@ -64,6 +67,93 @@ pub type ServerPlaylistSnapshotFuture =
 pub enum ResolvedSourceStream {
     Http(MediaRequest),
     File(ResolvedFileMedia),
+}
+
+/// Typed retained mutation authority over one exact accepted removable file.
+///
+/// The value carries the live mount authority, the exact retained file
+/// object, and the owning session's media lease. A tag write through
+/// [`Self::write_tags`] revalidates the mount, ancestry, exact file, write
+/// rights, and replacement target through commit, and is refused once the
+/// owning session is no longer active. The native mount location is
+/// deliberately absent from errors and debug output.
+#[derive(Clone)]
+pub struct RemovableMutationTarget {
+    inner: Arc<MountedMutationTarget>,
+    lease: MediaLease,
+    source_id: SourceId,
+    track_id: TrackId,
+}
+
+impl RemovableMutationTarget {
+    /// The mount-relative identity this target was admitted under.
+    pub fn relative_path(&self) -> &std::path::Path {
+        self.inner.relative_path()
+    }
+
+    /// The exact source session this target belongs to.
+    pub fn source_id(&self) -> SourceId {
+        self.source_id
+    }
+
+    /// The exact accepted track identity this target may replace.
+    pub fn track_id(&self) -> &TrackId {
+        &self.track_id
+    }
+
+    /// Whether the owning source session is still the live one.
+    ///
+    /// A retirement (device removal, pre-unmount, disconnect, or same-source
+    /// replacement) revokes this immediately; a revoked lease can never
+    /// authorize a commit.
+    pub fn is_active(&self) -> bool {
+        self.lease.is_active()
+    }
+
+    /// Point-in-time write-capability probe for the properties dialog.
+    ///
+    /// Revalidates the owning session, the retained authority, then
+    /// rehearses the complete atomic replacement shape beside the exact
+    /// target. Advisory only: the commit revalidates everything fail-closed.
+    /// Blocking — worker threads only.
+    pub fn preflight_write_capability(
+        &self,
+    ) -> Result<(), crate::local::tag_writer::TagWritePreflightError> {
+        use crate::local::tag_writer::TagWritePreflightError;
+
+        // A retirement (device removal, pre-unmount, disconnect, or
+        // same-source replacement) revokes this immediately; a revoked
+        // lease can never authorize a commit, so the probe reports it
+        // before any filesystem rehearsal runs.
+        if !self.is_active() {
+            return Err(TagWritePreflightError::Unavailable);
+        }
+        self.inner
+            .validate()
+            .map_err(|_| TagWritePreflightError::Unavailable)?;
+        crate::local::tag_writer::preflight_tag_write(self.inner.replacement_path())
+    }
+
+    /// Write tag edits through the retained authority.
+    ///
+    /// Fails closed when the owning session was retired, when the mount or
+    /// retained evidence changed, or when the exact pathname no longer names
+    /// the admitted file at commit time. Blocking — worker threads only.
+    pub fn write_tags(&self, edits: &crate::local::tag_writer::TagEdits) -> anyhow::Result<()> {
+        if !self.lease.is_active() {
+            anyhow::bail!("The removable media source is no longer active");
+        }
+        crate::local::tag_writer::write_tags_with_mutation_target(&self.inner, edits)
+    }
+}
+
+impl std::fmt::Debug for RemovableMutationTarget {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RemovableMutationTarget")
+            .field("source_id", &self.source_id)
+            .finish_non_exhaustive()
+    }
 }
 
 /// Whether one managed adapter permits Tributary-owned regular-playlist
@@ -1012,6 +1102,23 @@ pub trait ManagedSourceAdapter: LifecycleAdapter + Send + Sync {
 
     fn resolve_artwork(self: Arc<Self>, _track_id: TrackId) -> ArtworkFuture {
         Box::pin(async { Ok(None) })
+    }
+
+    /// Resolve a typed retained mutation authority for one exact accepted
+    /// file.
+    ///
+    /// The returned target must retain the adapter's own live filesystem
+    /// authority and the exact admitted file object; a commit section through
+    /// it revalidates the mount, ancestry, exact file, and replacement target
+    /// fail-closed. The default and every adapter without a reviewed
+    /// retained-mutation design return unsupported, so pathless rows of
+    /// unreviewed sources stay write-protected.
+    fn resolve_mutation_target(self: Arc<Self>, _track_id: TrackId) -> MutationTargetFuture {
+        Box::pin(async {
+            Err(BackendError::Unsupported {
+                operation: "retained mutation authority".to_string(),
+            })
+        })
     }
 }
 
@@ -2533,6 +2640,40 @@ impl SourceRegistry {
                 move |adapter| async move { adapter.resolve_artwork(track_id).await },
             )
             .await
+    }
+
+    /// Resolve a typed retained mutation authority for one exact accepted
+    /// track through the source's current live session.
+    ///
+    /// The caller's captured session epoch must still be current, the exact
+    /// track must be accepted by the live adapter, and the adapter must opt
+    /// in to retained mutation authority. The returned target keeps the
+    /// session's media lease, so a retirement revokes the ability to commit
+    /// even while the target object itself is still held.
+    pub async fn resolve_mutation_target(
+        &self,
+        source_id: SourceId,
+        expected_session_epoch: u64,
+        track_id: TrackId,
+    ) -> BackendResult<RemovableMutationTarget> {
+        let binding_track_id = track_id.clone();
+        let (inner, lease) =
+            self.inner
+                .lifecycle
+                .resolve_exact_session(
+                    source_id,
+                    expected_session_epoch,
+                    move |adapter| async move {
+                        adapter.resolve_mutation_target(binding_track_id).await
+                    },
+                )
+                .await?;
+        Ok(RemovableMutationTarget {
+            inner: Arc::new(inner),
+            lease,
+            source_id,
+            track_id,
+        })
     }
 }
 

--- a/src/source_registry.rs
+++ b/src/source_registry.rs
@@ -138,11 +138,21 @@ impl RemovableMutationTarget {
     ///
     /// Fails closed when the owning session was retired, when the mount or
     /// retained evidence changed, or when the exact pathname no longer names
-    /// the admitted file at commit time. Blocking — worker threads only.
+    /// the admitted file at commit time. A pass through the active check
+    /// atomically acquires one in-flight lease permit and holds it until the
+    /// write commits or rolls back, so a retirement that begins mid-write is
+    /// serialized behind this section instead of revoking the authority
+    /// underneath an observed-but-unadmitted check. Blocking — worker threads
+    /// only.
     pub fn write_tags(&self, edits: &crate::local::tag_writer::TagEdits) -> anyhow::Result<()> {
-        if !self.lease.is_active() {
-            anyhow::bail!("The removable media source is no longer active");
-        }
+        // Acquire — never merely observe — the lease. `is_active()` followed
+        // by a write leaves a revocation window between the two steps; a
+        // permit makes admission and revocation mutually exclusive, and the
+        // revoker waits until this section ends.
+        let _write_section = self
+            .lease
+            .try_acquire()
+            .ok_or_else(|| anyhow::anyhow!("The removable media source is no longer active"))?;
         crate::local::tag_writer::write_tags_with_mutation_target(&self.inner, edits)
     }
 }
@@ -7469,6 +7479,149 @@ mod tests {
         assert!(registry.release_provenance(source_id, claim));
         wait_until_pruned(&registry, source_id).await;
         assert!(!resolved.is_active());
+        registry.shutdown().wait().await;
+    }
+
+    /// A resolved removable mutation target authorizes writes only while its
+    /// owning session is live: a full retirement must refuse the next commit
+    /// even though every retained filesystem object is still untouched, and
+    /// the refused write must leave the admitted file byte-identical.
+    #[tokio::test]
+    async fn retired_removable_session_refuses_its_retained_mutation_target() {
+        let registry = registry();
+        let mount = tempfile::tempdir().expect("temporary removable mount");
+        let path = mount.path().join("tagged.flac");
+        write_tagged_removable_fixture(&path, "Before Retirement", "Fixture Artist", None);
+        let source_id = SourceId::removable("registry:test:mutation-retire")
+            .expect("removable source identity");
+        let claim = registry
+            .claim_provenance(source_id, SourceProvenance::Removable)
+            .expect("claim removable source");
+        registry
+            .connect_removable(source_id, mount.path().to_path_buf(), |_| {})
+            .expect("removable connection admitted");
+        let (_, session_epoch) = wait_for_catalogue(&registry, source_id).await;
+        let track_id = registry
+            .snapshot(source_id)
+            .and_then(|snapshot| snapshot.catalogue)
+            .and_then(|catalogue| catalogue.value.tracks().first().cloned())
+            .and_then(|track| track.native_track_id)
+            .expect("accepted track identity");
+
+        let target = registry
+            .resolve_mutation_target(source_id, session_epoch, track_id)
+            .await
+            .expect("resolve retained mutation target");
+        assert!(target.is_active());
+
+        // The live session admits a write through the retained authority.
+        target
+            .write_tags(&crate::local::tag_writer::TagEdits {
+                title: Some("Retirement Pending".to_string()),
+                ..Default::default()
+            })
+            .expect("a live session authorizes its mutation target");
+
+        // Retirement revokes the lease the target carries: the write
+        // authority must die with the session even though the mount, the
+        // retained ancestry, and the exact file are all still valid.
+        assert!(registry.release_provenance(source_id, claim));
+        wait_until_pruned(&registry, source_id).await;
+        assert!(!target.is_active());
+
+        target
+            .write_tags(&crate::local::tag_writer::TagEdits {
+                title: Some("After Retirement".to_string()),
+                ..Default::default()
+            })
+            .expect_err("a retired session must never authorize a commit");
+
+        let tagged = lofty::read_from_path(&path).expect("reopen untouched fixture");
+        use lofty::file::TaggedFileExt;
+        use lofty::tag::Accessor;
+        assert_eq!(
+            tagged
+                .primary_tag()
+                .expect("primary tag")
+                .title()
+                .as_deref(),
+            Some("Retirement Pending"),
+            "the refused write must leave the admitted file untouched"
+        );
+        registry.shutdown().wait().await;
+    }
+
+    /// Revocation racing a tag write can serialize in either order, and both
+    /// must be consistent: either the write was admitted first — revocation
+    /// waits behind its in-flight permit and the tags land — or retirement
+    /// landed first and the write is refused at admission with the file
+    /// untouched. No order may tear the file or lose the retirement.
+    #[tokio::test]
+    async fn revocation_during_a_removable_tag_write_never_tears_the_outcome() {
+        let registry = registry();
+        let mount = tempfile::tempdir().expect("temporary removable mount");
+        let path = mount.path().join("tagged.flac");
+        write_tagged_removable_fixture(&path, "Before Retirement", "Fixture Artist", None);
+        let source_id =
+            SourceId::removable("registry:test:mutation-race").expect("removable source identity");
+        let claim = registry
+            .claim_provenance(source_id, SourceProvenance::Removable)
+            .expect("claim removable source");
+        registry
+            .connect_removable(source_id, mount.path().to_path_buf(), |_| {})
+            .expect("removable connection admitted");
+        let (_, session_epoch) = wait_for_catalogue(&registry, source_id).await;
+        let track_id = registry
+            .snapshot(source_id)
+            .and_then(|snapshot| snapshot.catalogue)
+            .and_then(|catalogue| catalogue.value.tracks().first().cloned())
+            .and_then(|track| track.native_track_id)
+            .expect("accepted track identity");
+
+        let target = registry
+            .resolve_mutation_target(source_id, session_epoch, track_id)
+            .await
+            .expect("resolve retained mutation target");
+        let writer_target = target.clone();
+        let writer = std::thread::spawn(move || {
+            writer_target
+                .write_tags(&crate::local::tag_writer::TagEdits {
+                    title: Some("Mid-Flight Title".to_string()),
+                    ..Default::default()
+                })
+                .is_ok()
+        });
+
+        // Retire while the write may be mid-flight. An admitted section
+        // holds its lease permit until commit or rollback, so a revocation
+        // that began after admission cannot invalidate authority underneath
+        // the write; it must wait for the section to end.
+        assert!(registry.release_provenance(source_id, claim));
+        let admitted = writer.join().expect("writer thread finishes");
+        wait_until_pruned(&registry, source_id).await;
+        assert!(!target.is_active());
+
+        let tagged = lofty::read_from_path(&path).expect("reopen fixture");
+        use lofty::file::TaggedFileExt;
+        use lofty::tag::Accessor;
+        let title = tagged
+            .primary_tag()
+            .expect("primary tag")
+            .title()
+            .as_deref()
+            .expect("fixture keeps a title")
+            .to_string();
+        if admitted {
+            assert_eq!(
+                title, "Mid-Flight Title",
+                "an admitted write must complete even when revocation began mid-flight"
+            );
+        } else {
+            assert_eq!(
+                title, "Before Retirement",
+                "a write refused at admission must leave the admitted file untouched"
+            );
+        }
         registry.shutdown().wait().await;
     }
 

--- a/src/source_registry.rs
+++ b/src/source_registry.rs
@@ -2773,6 +2773,13 @@ impl SourceRegistry {
     /// republished row set. A cancelled or failed refresh consumes nothing:
     /// its batch stays pending for the next refresh to re-read.
     ///
+    /// Consumption is settlement-confirmed: a task's carried batch leaves the
+    /// pending map only when that exact generation's publication is ACCEPTED
+    /// by the lifecycle. A superseded generation consumes nothing, so no
+    /// window between its adapter result and its settlement can strand a
+    /// written identity outside both the successor's carried set and the
+    /// pending map — the successor re-reads everything not yet published.
+    ///
     /// Returns the minted refresh generations, one per source that still had
     /// an exact live session. Fire-and-forget — publication happens on the
     /// lifecycle runtime and the visible row, subsequent Properties values,
@@ -2809,7 +2816,23 @@ impl SourceRegistry {
                 continue;
             };
             let generation = owner.generation();
+            let consumed_ids = track_ids.clone();
             let pending_written = Arc::clone(&self.inner);
+            let owner = owner.on_acceptance(Box::new(move || {
+                // Settlement-confirmed consumption: this exact generation's
+                // publication was accepted by the lifecycle, so the carried
+                // batch is published and may leave the pending map. A
+                // superseded generation consumes nothing — its payload was
+                // rejected — and the successor cloned the pending map
+                // including this batch, so every committed identity is either
+                // republished by the successor or stays pending for the next
+                // refresh.
+                if let Some(entry) =
+                    lock(&pending_written.mutation_refresh_pending).get_mut(&source_id)
+                {
+                    entry.retain(|track_id| !consumed_ids.contains(track_id));
+                }
+            }));
             owner.spawn(move |session, cancellation| async move {
                 let adapter = session.adapter();
                 let regular_playlist_capability = adapter.regular_playlist_capability();
@@ -2818,18 +2841,12 @@ impl SourceRegistry {
                     .await
                 {
                     Ok(tracks) => {
-                        // Consume the carried batch only while this
-                        // publication is uncontested: a cancelled token means
-                        // a newer refresh displaced this lane, and the
-                        // identities stay pending for the successor, whose
-                        // carried set already includes their union.
-                        if !cancellation.is_cancelled() {
-                            if let Some(entry) =
-                                lock(&pending_written.mutation_refresh_pending).get_mut(&source_id)
-                            {
-                                entry.retain(|track_id| !track_ids.contains(track_id));
-                            }
-                        }
+                        // Test-only seam between the adapter's Ok and the
+                        // payload's submission for settlement: the window a
+                        // supersede races the settlement-confirmed batch
+                        // consumption across.
+                        #[cfg(test)]
+                        run_post_mutation_refresh_ok_interpose();
                         RefreshTaskResult::Refreshed(AcceptedSourcePayload::catalogue(
                             tracks,
                             regular_playlist_capability,
@@ -2853,6 +2870,42 @@ impl SourceRegistry {
         }
         generations
     }
+}
+
+/// Test-only hook fired inside a post-mutation refresh task after its adapter
+/// call returned `Ok` and before its payload is submitted for settlement: the
+/// Ok→settlement window whose supersede races the pending batch's
+/// consumption.
+#[cfg(test)]
+type PostMutationRefreshOkInterpose = dyn Fn() + Send + Sync;
+
+#[cfg(test)]
+static POST_MUTATION_REFRESH_OK_INTERPOSE: std::sync::Mutex<
+    Option<Box<PostMutationRefreshOkInterpose>>,
+> = std::sync::Mutex::new(None);
+
+/// Serializes tests that use the post-mutation Ok interposition seam.
+#[cfg(test)]
+static POST_MUTATION_REFRESH_OK_INTERPOSE_SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(test)]
+fn run_post_mutation_refresh_ok_interpose() {
+    if let Some(interpose) = lock(&POST_MUTATION_REFRESH_OK_INTERPOSE).as_ref() {
+        interpose();
+    }
+}
+
+/// Install the post-mutation Ok interposition seam for the duration of `run`,
+/// serializing against other tests that use the seam.
+#[cfg(test)]
+fn with_post_mutation_refresh_ok_interpose(
+    interpose: Box<PostMutationRefreshOkInterpose>,
+    run: impl FnOnce(),
+) {
+    let _serial = lock(&POST_MUTATION_REFRESH_OK_INTERPOSE_SERIAL);
+    *lock(&POST_MUTATION_REFRESH_OK_INTERPOSE) = Some(interpose);
+    run();
+    *lock(&POST_MUTATION_REFRESH_OK_INTERPOSE) = None;
 }
 
 /// Closed source-kind/provenance policy for structured playback attribution.
@@ -4472,6 +4525,127 @@ mod tests {
             snapshot.catalogue.is_none(),
             "the retired mount's catalogue is gone: the cancelled coalesced refresh published nothing"
         );
+        drop(registry);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_supersede_between_ok_and_settlement_loses_no_committed_identity() {
+        let registry = registry();
+        let source_id = SourceId::random();
+        let first_track = TrackId::remote("settle-first-track").expect("track ID");
+        let second_track = TrackId::remote("settle-second-track").expect("track ID");
+        let third_track = TrackId::remote("settle-third-track").expect("track ID");
+        let probe = FakeProbe::new(true);
+        probe.hold_post_mutation_refresh();
+
+        let adapter = probe
+            .playlist_adapter(
+                "settlement-supersede",
+                vec![fixture_track(first_track.clone())],
+            )
+            .with_post_mutation_refresh(vec![fixture_track(first_track.clone())]);
+        connect_playlist_fixture(&registry, source_id, adapter).await;
+        let (initial_generation, _epoch) = wait_for_catalogue(&registry, source_id).await;
+
+        // The first save's refresh blocks inside the adapter call, holding
+        // its generation and its carried batch.
+        let first_generation =
+            registry.refresh_catalogue_after_mutation(&[(source_id, first_track.clone())])[0];
+        probe.wait_for_post_mutation_calls(1).await;
+
+        // Drive the exact race the settlement-confirmed consumption guards:
+        // the moment the blocked refresh's adapter call returns Ok — after
+        // the Ok, before its payload is submitted for settlement — an
+        // overlapping save supersedes the lane. The superseding generation
+        // must clone a pending map the superseded generation has not consumed
+        // from: a superseded generation consumes nothing, so the successor
+        // re-reads every identity the rejected payload can no longer publish.
+        let (supersede_landed_signal, supersede_landed) = mpsc::channel::<()>();
+        let interpose_registry = registry.clone();
+        let interpose_source = source_id;
+        let interpose_second = second_track.clone();
+        let successor_generation: Arc<Mutex<Option<u64>>> = Arc::new(Mutex::new(None));
+        let successor_slot = Arc::clone(&successor_generation);
+        let fired = AtomicBool::new(false);
+        with_post_mutation_refresh_ok_interpose(
+            Box::new(move || {
+                if fired.swap(true, Ordering::SeqCst) {
+                    return; // only the superseded generation's Ok drives the race
+                }
+                let written = [(interpose_source, interpose_second.clone())];
+                let generations = interpose_registry.refresh_catalogue_after_mutation(&written);
+                *successor_slot.lock().unwrap() = generations.first().copied();
+                let _ = supersede_landed_signal.send(());
+            }),
+            || {
+                probe.release_post_mutation_refresh();
+                supersede_landed
+                    .recv_timeout(Duration::from_secs(2))
+                    .expect("the supersede landed between Ok and settlement");
+            },
+        );
+        probe.wait_for_post_mutation_calls(2).await;
+        wait_for_post_mutation_refresh_settled(&registry, source_id).await;
+
+        // The successor re-read both identities: the superseded refresh's
+        // payload was rejected without consuming, so neither identity was
+        // stranded outside the successor's carried set.
+        let requests = probe.post_mutation_requests();
+        assert_eq!(
+            requests.len(),
+            2,
+            "exactly one refresh per save: {requests:?}"
+        );
+        assert_eq!(
+            requests[0],
+            HashSet::from([first_track.clone()]),
+            "the superseded refresh was dispatched with its own identity"
+        );
+        assert_eq!(
+            requests[1],
+            HashSet::from([first_track.clone(), second_track.clone()]),
+            "the successor re-reads the identity the superseded generation never consumed"
+        );
+        let successor = successor_generation
+            .lock()
+            .unwrap()
+            .expect("the superseding save minted a refresh generation");
+        assert_ne!(
+            successor, first_generation,
+            "the Ok→settlement supersede minted a newer generation"
+        );
+        let catalogue = registry
+            .snapshot(source_id)
+            .expect("the source stays live")
+            .catalogue
+            .expect("the accepted catalogue survives");
+        assert_ne!(
+            catalogue.generation, initial_generation,
+            "a refresh republished the catalogue"
+        );
+        assert_eq!(
+            catalogue.generation, successor,
+            "the successor's payload published; the superseded payload did not"
+        );
+
+        // Consumption is settlement-confirmed: the successor's acceptance
+        // emptied the batch, so a later save re-reads only its own identity.
+        let third_generation =
+            registry.refresh_catalogue_after_mutation(&[(source_id, third_track.clone())])[0];
+        probe.wait_for_post_mutation_calls(3).await;
+        wait_for_post_mutation_refresh_settled(&registry, source_id).await;
+        let requests = probe.post_mutation_requests();
+        assert_eq!(
+            requests[2],
+            HashSet::from([third_track]),
+            "the successor's settlement consumed the batch; nothing lingers pending"
+        );
+        let catalogue = registry
+            .snapshot(source_id)
+            .expect("the source stays live")
+            .catalogue
+            .expect("the accepted catalogue survives");
+        assert_eq!(catalogue.generation, third_generation);
         drop(registry);
     }
 

--- a/src/source_registry.rs
+++ b/src/source_registry.rs
@@ -2836,6 +2836,10 @@ impl SourceRegistry {
             let track_ids: HashSet<TrackId> = carried.keys().cloned().collect();
             let carried_versions = carried;
             let pending_written = Arc::clone(&self.inner);
+            // The spawned refresh task's test-only Ok seam names its source,
+            // so an armed closure can act only on its own test's generation.
+            #[cfg(test)]
+            let seam_source = source_id;
             let owner = owner.on_acceptance(Box::new(move || {
                 // Settlement-confirmed, version-matched consumption: this
                 // exact generation's publication was accepted by the
@@ -2851,7 +2855,7 @@ impl SourceRegistry {
                 // either republished by the successor or stays pending for
                 // the next refresh.
                 #[cfg(test)]
-                run_pending_consumption_interpose();
+                run_pending_consumption_interpose(&source_id);
                 if let Some(entry) =
                     lock(&pending_written.mutation_refresh_pending).get_mut(&source_id)
                 {
@@ -2875,7 +2879,7 @@ impl SourceRegistry {
                         // supersede races the settlement-confirmed batch
                         // consumption across.
                         #[cfg(test)]
-                        run_post_mutation_refresh_ok_interpose();
+                        run_post_mutation_refresh_ok_interpose(&seam_source);
                         RefreshTaskResult::Refreshed(AcceptedSourcePayload::catalogue(
                             tracks,
                             regular_playlist_capability,
@@ -2904,9 +2908,11 @@ impl SourceRegistry {
 /// Test-only hook fired inside a post-mutation refresh task after its adapter
 /// call returned `Ok` and before its payload is submitted for settlement: the
 /// Ok→settlement window whose supersede races the pending batch's
-/// consumption.
+/// consumption. The armed closure receives the refreshing source's id and
+/// acts only on its own — a foreign test's generation fires this seam on
+/// its own schedule under the parallel harness.
 #[cfg(test)]
-type PostMutationRefreshOkInterpose = dyn Fn() + Send + Sync;
+type PostMutationRefreshOkInterpose = dyn Fn(&SourceId) + Send + Sync;
 
 #[cfg(test)]
 static POST_MUTATION_REFRESH_OK_INTERPOSE: std::sync::Mutex<
@@ -2918,9 +2924,9 @@ static POST_MUTATION_REFRESH_OK_INTERPOSE: std::sync::Mutex<
 static POST_MUTATION_REFRESH_OK_INTERPOSE_SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[cfg(test)]
-fn run_post_mutation_refresh_ok_interpose() {
+fn run_post_mutation_refresh_ok_interpose(source_id: &SourceId) {
     if let Some(interpose) = lock(&POST_MUTATION_REFRESH_OK_INTERPOSE).as_ref() {
-        interpose();
+        interpose(source_id);
     }
 }
 
@@ -2940,9 +2946,13 @@ fn with_post_mutation_refresh_ok_interpose(
 /// Test-only hook fired inside a refresh generation's acceptance hook before
 /// it consumes the pending map: the acceptance→consumption window a
 /// same-track save races across, since the acceptance and the pending map
-/// take different locks.
+/// take different locks. The armed closure receives the refreshing source's
+/// id and acts only on its own: under the parallel test harness a foreign
+/// test's refresh generation fires this seam on its own schedule, and an
+/// identity-blind process-wide closure would run its race inside a
+/// stranger's window and desynchronize an innocent test.
 #[cfg(test)]
-type PendingConsumptionInterpose = dyn Fn() + Send + Sync;
+type PendingConsumptionInterpose = dyn Fn(&SourceId) + Send + Sync;
 
 #[cfg(test)]
 static PENDING_CONSUMPTION_INTERPOSE: std::sync::Mutex<Option<Box<PendingConsumptionInterpose>>> =
@@ -2953,9 +2963,9 @@ static PENDING_CONSUMPTION_INTERPOSE: std::sync::Mutex<Option<Box<PendingConsump
 static PENDING_CONSUMPTION_INTERPOSE_SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[cfg(test)]
-fn run_pending_consumption_interpose() {
+fn run_pending_consumption_interpose(source_id: &SourceId) {
     if let Some(interpose) = lock(&PENDING_CONSUMPTION_INTERPOSE).as_ref() {
-        interpose();
+        interpose(source_id);
     }
 }
 
@@ -4640,7 +4650,13 @@ mod tests {
         let successor_slot = Arc::clone(&successor_generation);
         let fired = AtomicBool::new(false);
         with_post_mutation_refresh_ok_interpose(
-            Box::new(move || {
+            Box::new(move |fired_source: &SourceId| {
+                // Identity scoping: a foreign test's refresh generation also
+                // fires this seam under the parallel harness; only this
+                // test's own source may spend the one-shot latch.
+                if fired_source != &interpose_source {
+                    return;
+                }
                 if fired.swap(true, Ordering::SeqCst) {
                     return; // only the superseded generation's Ok drives the race
                 }
@@ -4769,7 +4785,13 @@ mod tests {
         let successor_generation: Arc<Mutex<Option<u64>>> = Arc::new(Mutex::new(None));
         let successor_slot = Arc::clone(&successor_generation);
         with_pending_consumption_interpose(
-            Box::new(move || {
+            Box::new(move |fired_source: &SourceId| {
+                // Identity scoping: a foreign test's refresh generation also
+                // fires this seam under the parallel harness; only this
+                // test's own source may drive the race.
+                if fired_source != &race_source {
+                    return;
+                }
                 race_probe.set_post_mutation_failure(true);
                 let written = [(race_source, race_track.clone())];
                 let generations = race_registry.refresh_catalogue_after_mutation(&written);

--- a/src/source_registry.rs
+++ b/src/source_registry.rs
@@ -1437,10 +1437,15 @@ struct SourceRegistryInner {
     built_ins: Mutex<HashMap<SourceId, BuiltInInstallation>>,
     external_sessions: Mutex<HashMap<SourceId, ProvenanceClaimId>>,
     /// Written identities per source that no post-mutation refresh has
-    /// published yet. Every spawned Catalogue-lane refresh task carries the
-    /// accumulated union, so a superseding refresh re-reads an earlier
-    /// overlapping save's batch instead of dropping it.
-    mutation_refresh_pending: Mutex<HashMap<SourceId, HashSet<TrackId>>>,
+    /// published yet, versioned per track: each save bumps every track it
+    /// writes to a version past every earlier save's, so a refresh
+    /// generation's acceptance hook can tell the batch it carried from a
+    /// track a newer save re-wrote between the hook's acceptance and its
+    /// consumption. Every spawned Catalogue-lane refresh task carries the
+    /// accumulated union (with the versions present at carry time), so a
+    /// superseding refresh re-reads an earlier overlapping save's batch
+    /// instead of dropping it.
+    mutation_refresh_pending: Mutex<HashMap<SourceId, HashMap<TrackId, u64>>>,
 }
 
 impl PublicHttpAuthority for SourceRegistryInner {
@@ -2773,12 +2778,19 @@ impl SourceRegistry {
     /// republished row set. A cancelled or failed refresh consumes nothing:
     /// its batch stays pending for the next refresh to re-read.
     ///
-    /// Consumption is settlement-confirmed: a task's carried batch leaves the
-    /// pending map only when that exact generation's publication is ACCEPTED
-    /// by the lifecycle. A superseded generation consumes nothing, so no
-    /// window between its adapter result and its settlement can strand a
-    /// written identity outside both the successor's carried set and the
-    /// pending map — the successor re-reads everything not yet published.
+    /// Consumption is settlement-confirmed and version-matched: a task's
+    /// carried batch leaves the pending map only when that exact
+    /// generation's publication is ACCEPTED by the lifecycle, and a carried
+    /// track is consumed only when its CURRENT pending version still equals
+    /// the version the generation carried. A same-track save that lands
+    /// between the acceptance and the hook's consumption — the two take
+    /// different locks — bumps the track's version, so the older hook
+    /// leaves it pending for the successor or retry lane instead of
+    /// consuming a mutation the successor's own failure could then lose. A
+    /// superseded generation consumes nothing, so no window between its
+    /// adapter result and its settlement can strand a written identity
+    /// outside both the successor's carried set and the pending map — the
+    /// successor re-reads everything not yet published.
     ///
     /// Returns the minted refresh generations, one per source that still had
     /// an exact live session. Fire-and-forget — publication happens on the
@@ -2796,13 +2808,18 @@ impl SourceRegistry {
 
         let mut generations = Vec::with_capacity(by_source.len());
         for (source_id, batch) in by_source {
-            // Accumulate this save into the source's pending identities and
-            // carry the accumulated union: any earlier save whose refresh has
-            // not published yet is re-read by this task too.
-            let track_ids = {
+            // Accumulate this save into the source's pending identities —
+            // bumping every written track's version past every earlier
+            // save's — and carry the accumulated union with the versions
+            // present at carry time: any earlier save whose refresh has not
+            // published yet is re-read by this task too.
+            let carried: HashMap<TrackId, u64> = {
                 let mut pending = lock(&self.inner.mutation_refresh_pending);
                 let entry = pending.entry(source_id).or_default();
-                entry.extend(batch);
+                let version = entry.values().copied().max().unwrap_or(0) + 1;
+                for track_id in &batch {
+                    entry.insert(track_id.clone(), version);
+                }
                 entry.clone()
             };
             // No exact live session: a retired or replaced mount is never
@@ -2816,21 +2833,33 @@ impl SourceRegistry {
                 continue;
             };
             let generation = owner.generation();
-            let consumed_ids = track_ids.clone();
+            let track_ids: HashSet<TrackId> = carried.keys().cloned().collect();
+            let carried_versions = carried;
             let pending_written = Arc::clone(&self.inner);
             let owner = owner.on_acceptance(Box::new(move || {
-                // Settlement-confirmed consumption: this exact generation's
-                // publication was accepted by the lifecycle, so the carried
-                // batch is published and may leave the pending map. A
-                // superseded generation consumes nothing — its payload was
+                // Settlement-confirmed, version-matched consumption: this
+                // exact generation's publication was accepted by the
+                // lifecycle, so a carried track whose pending version still
+                // equals the version this generation carried was published
+                // and may leave the pending map. A track a newer save
+                // re-wrote between the acceptance and this hook — the two
+                // take different locks — carries a bumped version and stays
+                // pending for the successor or retry lane. A superseded
+                // generation never runs this hook — its payload was
                 // rejected — and the successor cloned the pending map
-                // including this batch, so every committed identity is either
-                // republished by the successor or stays pending for the next
-                // refresh.
+                // including this batch, so every committed identity is
+                // either republished by the successor or stays pending for
+                // the next refresh.
+                #[cfg(test)]
+                run_pending_consumption_interpose();
                 if let Some(entry) =
                     lock(&pending_written.mutation_refresh_pending).get_mut(&source_id)
                 {
-                    entry.retain(|track_id| !consumed_ids.contains(track_id));
+                    entry.retain(|track_id, current| {
+                        carried_versions
+                            .get(track_id)
+                            .is_none_or(|carried| current != carried)
+                    });
                 }
             }));
             owner.spawn(move |session, cancellation| async move {
@@ -2906,6 +2935,49 @@ fn with_post_mutation_refresh_ok_interpose(
     *lock(&POST_MUTATION_REFRESH_OK_INTERPOSE) = Some(interpose);
     run();
     *lock(&POST_MUTATION_REFRESH_OK_INTERPOSE) = None;
+}
+
+/// Test-only hook fired inside a refresh generation's acceptance hook before
+/// it consumes the pending map: the acceptance→consumption window a
+/// same-track save races across, since the acceptance and the pending map
+/// take different locks.
+#[cfg(test)]
+type PendingConsumptionInterpose = dyn Fn() + Send + Sync;
+
+#[cfg(test)]
+static PENDING_CONSUMPTION_INTERPOSE: std::sync::Mutex<Option<Box<PendingConsumptionInterpose>>> =
+    std::sync::Mutex::new(None);
+
+/// Serializes tests that use the pending-consumption interposition seam.
+#[cfg(test)]
+static PENDING_CONSUMPTION_INTERPOSE_SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(test)]
+fn run_pending_consumption_interpose() {
+    if let Some(interpose) = lock(&PENDING_CONSUMPTION_INTERPOSE).as_ref() {
+        interpose();
+    }
+}
+
+/// Install the pending-consumption interposition seam for the duration of
+/// `run`, serializing against other tests that use the seam. A drop guard
+/// uninstalls the closure, so a panicking observation cannot leave a stale
+/// seam armed for a later test's acceptance hooks.
+#[cfg(test)]
+fn with_pending_consumption_interpose(
+    interpose: Box<PendingConsumptionInterpose>,
+    run: impl FnOnce(),
+) {
+    struct UninstallPendingConsumptionInterpose;
+    impl Drop for UninstallPendingConsumptionInterpose {
+        fn drop(&mut self) {
+            *lock(&PENDING_CONSUMPTION_INTERPOSE) = None;
+        }
+    }
+    let _serial = lock(&PENDING_CONSUMPTION_INTERPOSE_SERIAL);
+    *lock(&PENDING_CONSUMPTION_INTERPOSE) = Some(interpose);
+    let _uninstall = UninstallPendingConsumptionInterpose;
+    run();
 }
 
 /// Closed source-kind/provenance policy for structured playback attribution.
@@ -4646,6 +4718,139 @@ mod tests {
             .catalogue
             .expect("the accepted catalogue survives");
         assert_eq!(catalogue.generation, third_generation);
+        drop(registry);
+    }
+
+    /// A save of the SAME track landing between an older generation's
+    /// acceptance and its hook's consumption — the two take different
+    /// locks — must not be consumed by the older hook. The track's pending
+    /// version was bumped by the newer save, so the older hook leaves it
+    /// pending; when the successor then fails, the track is still pending
+    /// and a later refresh re-reads it, so the newer mutation is republished
+    /// instead of being lost. A clean save after a successful settlement
+    /// still empties the batch: its acceptance re-reads only its own
+    /// identity.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_same_track_save_between_acceptance_and_its_hook_stays_pending() {
+        let registry = registry();
+        let source_id = SourceId::random();
+        let first_track = TrackId::remote("hook-race-first-track").expect("track ID");
+        let third_track = TrackId::remote("hook-race-third-track").expect("track ID");
+        let fourth_track = TrackId::remote("hook-race-fourth-track").expect("track ID");
+        let probe = FakeProbe::new(true);
+        probe.hold_post_mutation_refresh();
+
+        let adapter = probe
+            .playlist_adapter("hook-race", vec![fixture_track(first_track.clone())])
+            .with_post_mutation_refresh(vec![fixture_track(first_track.clone())]);
+        connect_playlist_fixture(&registry, source_id, adapter).await;
+        let (initial_generation, _epoch) = wait_for_catalogue(&registry, source_id).await;
+
+        // The first save's refresh blocks inside the adapter call, holding
+        // its generation and its carried batch.
+        let first_generation =
+            registry.refresh_catalogue_after_mutation(&[(source_id, first_track.clone())])[0];
+        probe.wait_for_post_mutation_calls(1).await;
+
+        // Release the adapter: the blocked generation's payload is accepted
+        // and its acceptance hook fires — but before the hook consumes the
+        // pending map, a save of the SAME track lands, bumping the track's
+        // pending version and minting a successor generation. The failure
+        // fixture arms inside the seam: the blocked generation's adapter
+        // call has already returned Ok by the time the hook runs, so the
+        // flag can only arm the successor's call — which must FAIL: nothing
+        // it carries may be consumed, and the older hook must have left the
+        // re-written track pending for it.
+        let (hook_raced_signal, hook_raced) = mpsc::channel::<()>();
+        let race_probe = Arc::clone(&probe);
+        let race_registry = registry.clone();
+        let race_source = source_id;
+        let race_track = first_track.clone();
+        let successor_generation: Arc<Mutex<Option<u64>>> = Arc::new(Mutex::new(None));
+        let successor_slot = Arc::clone(&successor_generation);
+        with_pending_consumption_interpose(
+            Box::new(move || {
+                race_probe.set_post_mutation_failure(true);
+                let written = [(race_source, race_track.clone())];
+                let generations = race_registry.refresh_catalogue_after_mutation(&written);
+                *successor_slot.lock().unwrap() = generations.first().copied();
+                let _ = hook_raced_signal.send(());
+            }),
+            || {
+                probe.release_post_mutation_refresh();
+                hook_raced
+                    .recv_timeout(Duration::from_secs(2))
+                    .expect("the same-track save landed between acceptance and consumption");
+            },
+        );
+        probe.wait_for_post_mutation_calls(2).await;
+        wait_for_post_mutation_refresh_settled(&registry, source_id).await;
+        let snapshot = registry.snapshot(source_id).expect("the source stays live");
+        assert!(
+            snapshot
+                .refresh_failures
+                .contains_key(&RefreshLane::Catalogue),
+            "the successor generation failed: {:?}",
+            snapshot.refresh_failures
+        );
+        assert_ne!(
+            successor_generation
+                .lock()
+                .unwrap()
+                .expect("the race save minted a successor"),
+            first_generation,
+            "the acceptance→hook save minted a newer generation"
+        );
+
+        // The older hook consumed nothing: a later save's refresh still
+        // re-reads the twice-written track, so the catalogue eventually
+        // reflects the newer metadata.
+        probe.set_post_mutation_failure(false);
+        let third_generation =
+            registry.refresh_catalogue_after_mutation(&[(source_id, third_track.clone())])[0];
+        probe.wait_for_post_mutation_calls(3).await;
+        wait_for_post_mutation_refresh_settled(&registry, source_id).await;
+        let requests = probe.post_mutation_requests();
+        assert_eq!(
+            requests[2],
+            HashSet::from([first_track.clone(), third_track.clone()]),
+            "the track re-written between acceptance and consumption stays pending \
+             and is re-read by the next refresh"
+        );
+        let catalogue = registry
+            .snapshot(source_id)
+            .expect("the source stays live")
+            .catalogue
+            .expect("the accepted catalogue survives");
+        assert_ne!(
+            catalogue.generation, initial_generation,
+            "a refresh republished the catalogue"
+        );
+        assert_eq!(
+            catalogue.generation, third_generation,
+            "the re-read published under the newest generation"
+        );
+
+        // The clean single-save path still empties the batch on acceptance:
+        // the third save's settlement consumed its batch, so a later clean
+        // save re-reads only its own identity.
+        let fourth_generation =
+            registry.refresh_catalogue_after_mutation(&[(source_id, fourth_track.clone())])[0];
+        probe.wait_for_post_mutation_calls(4).await;
+        wait_for_post_mutation_refresh_settled(&registry, source_id).await;
+        let requests = probe.post_mutation_requests();
+        assert_eq!(
+            requests[3],
+            HashSet::from([fourth_track]),
+            "the settled batch is consumed; only the clean save's own identity \
+             lingers for its own refresh"
+        );
+        let catalogue = registry
+            .snapshot(source_id)
+            .expect("the source stays live")
+            .catalogue
+            .expect("the accepted catalogue survives");
+        assert_eq!(catalogue.generation, fourth_generation);
         drop(registry);
     }
 

--- a/src/source_registry.rs
+++ b/src/source_registry.rs
@@ -131,6 +131,16 @@ impl RemovableMutationTarget {
         self.inner
             .validate()
             .map_err(|_| TagWritePreflightError::Unavailable)?;
+        // A leaf renamed or replaced while its retained inode stays open
+        // keeps validate() passing — the swap is proven only inside the
+        // commit section — yet the next write is guaranteed to refuse in
+        // the commit's replacement confirmation. The preflight runs the
+        // same leaf-identity proof so a permanently stale target reports
+        // unavailable before the user edits and saves into a doomed
+        // dialog.
+        self.inner
+            .confirm_leaf_names_admitted_object()
+            .map_err(|_| TagWritePreflightError::Unavailable)?;
         // The format check reads only the file extension — exactly like the
         // writer itself; the retained file's liveness and regularity are
         // already proven by the validate() above.
@@ -7649,6 +7659,67 @@ mod tests {
                 "a write refused at admission must leave the admitted file untouched"
             );
         }
+        registry.shutdown().wait().await;
+    }
+
+    /// A leaf renamed or replaced while its retained inode stays open keeps
+    /// `validate()` passing — the swap is proven only inside the commit
+    /// section — so the advisory preflight must run the same leaf-identity
+    /// proof the commit does. A target whose accepted leaf was swapped after
+    /// admission reports unavailable before the user edits and saves into a
+    /// dialog whose every future commit is guaranteed to refuse, and the
+    /// preflight's refusal must predict the commit's refusal exactly.
+    #[tokio::test]
+    async fn removable_preflight_refuses_a_leaf_replaced_after_admission() {
+        let registry = registry();
+        let mount = tempfile::tempdir().expect("temporary removable mount");
+        let path = mount.path().join("tagged.flac");
+        write_tagged_removable_fixture(&path, "Admitted Title", "Admitted Artist", None);
+        let source_id = SourceId::removable("registry:test:preflight-leaf-swap")
+            .expect("removable source identity");
+        let claim = registry
+            .claim_provenance(source_id, SourceProvenance::Removable)
+            .expect("claim removable source");
+        registry
+            .connect_removable(source_id, mount.path().to_path_buf(), |_| {})
+            .expect("removable connection admitted");
+        let (_, session_epoch) = wait_for_catalogue(&registry, source_id).await;
+        let track_id = registry
+            .snapshot(source_id)
+            .and_then(|snapshot| snapshot.catalogue)
+            .and_then(|catalogue| catalogue.value.tracks().first().cloned())
+            .and_then(|track| track.native_track_id)
+            .expect("accepted track identity");
+
+        let target = registry
+            .resolve_mutation_target(source_id, session_epoch, track_id)
+            .await
+            .expect("resolve retained mutation target");
+        assert!(
+            target.preflight_write_capability().is_ok(),
+            "the untouched admitted target is write-capable"
+        );
+
+        // Swap the accepted leaf for a different object while the retained
+        // inode stays open, exactly like an external writer would.
+        let impostor = mount.path().join("impostor.flac");
+        write_tagged_removable_fixture(&impostor, "Impostor Title", "Impostor Artist", None);
+        std::fs::rename(&impostor, &path).expect("swap the accepted leaf");
+
+        assert!(matches!(
+            target.preflight_write_capability(),
+            Err(crate::local::tag_writer::TagWritePreflightError::Unavailable)
+        ));
+
+        target
+            .write_tags(&crate::local::tag_writer::TagEdits {
+                title: Some("Post Swap".to_string()),
+                ..Default::default()
+            })
+            .expect_err("a swapped leaf must refuse the commit");
+
+        assert!(registry.release_provenance(source_id, claim));
+        wait_until_pruned(&registry, source_id).await;
         registry.shutdown().wait().await;
     }
 

--- a/src/source_registry.rs
+++ b/src/source_registry.rs
@@ -1167,6 +1167,28 @@ pub trait ManagedSourceAdapter: LifecycleAdapter + Send + Sync {
             })
         })
     }
+
+    /// Re-derive accepted catalogue content for exact identities whose
+    /// retained mutations committed.
+    ///
+    /// Called through the catalogue refresh lane after a successful write,
+    /// so republication carries a fresh generation and inherits every exact
+    /// session/catalogue validation the lane performs. The default refuses:
+    /// adapters without reviewed post-mutation refresh semantics never
+    /// republish catalogue content from outside their accepted scan, and
+    /// the registry treats that refusal as a cancelled (never failed)
+    /// refresh lane.
+    fn refresh_catalogue_after_mutation(
+        self: Arc<Self>,
+        _written_track_ids: HashSet<TrackId>,
+        _cancellation: crate::source_lifecycle::CancellationObserver,
+    ) -> CatalogueFuture {
+        Box::pin(async {
+            Err(BackendError::Unsupported {
+                operation: "post-mutation catalogue refresh".to_string(),
+            })
+        })
+    }
 }
 
 mod source_scoped_playlist_sealed {
@@ -2722,6 +2744,73 @@ impl SourceRegistry {
             track_id,
         })
     }
+
+    /// Refresh exact sources' accepted catalogues after retained removable
+    /// writes committed.
+    ///
+    /// Each affected source refreshes through its existing catalogue lane:
+    /// the refresh mints a fresh generation, captures the exact live session,
+    /// and settlement revalidates that session before replacing the accepted
+    /// catalogue — a late completion after disconnect, replacement, or a
+    /// superseding refresh can never repopulate a retired mount or overwrite
+    /// a newer generation. Only identities whose writes committed are
+    /// re-derived; the adapter republishes every other accepted row
+    /// untouched, and no other source is ever rescanned.
+    ///
+    /// Returns the minted refresh generations, one per source that still had
+    /// an exact live session. Fire-and-forget — publication happens on the
+    /// lifecycle runtime and the visible row, subsequent Properties values,
+    /// and playback attribution follow the ordinary catalogue-change
+    /// invalidations.
+    pub fn refresh_catalogue_after_mutation(&self, written: &[(SourceId, TrackId)]) -> Vec<u64> {
+        let mut by_source: HashMap<SourceId, HashSet<TrackId>> = HashMap::new();
+        for (source_id, track_id) in written {
+            by_source
+                .entry(*source_id)
+                .or_default()
+                .insert(track_id.clone());
+        }
+
+        let mut generations = Vec::with_capacity(by_source.len());
+        for (source_id, track_ids) in by_source {
+            // No exact live session: a retired or replaced mount is never
+            // repopulated.
+            let Some(owner) = self
+                .inner
+                .lifecycle
+                .begin_refresh(source_id, RefreshLane::Catalogue)
+            else {
+                continue;
+            };
+            let generation = owner.generation();
+            owner.spawn(move |session, cancellation| async move {
+                let adapter = session.adapter();
+                let regular_playlist_capability = adapter.regular_playlist_capability();
+                match adapter
+                    .refresh_catalogue_after_mutation(track_ids, cancellation.clone())
+                    .await
+                {
+                    Ok(tracks) => RefreshTaskResult::Refreshed(AcceptedSourcePayload::catalogue(
+                        tracks,
+                        regular_playlist_capability,
+                    )),
+                    // A cancelled lane publishes nothing, and the default
+                    // adapter refusal (an adapter never reviewed for
+                    // post-mutation refresh semantics) is a no-op, never a
+                    // source failure: neither may degrade a live session.
+                    Err(error)
+                        if cancellation.is_cancelled()
+                            || matches!(error, BackendError::Unsupported { .. }) =>
+                    {
+                        RefreshTaskResult::Cancelled
+                    }
+                    Err(error) => RefreshTaskResult::Failed(failure_category(&error)),
+                }
+            });
+            generations.push(generation);
+        }
+        generations
+    }
 }
 
 /// Closed source-kind/provenance policy for structured playback attribution.
@@ -3059,6 +3148,7 @@ mod tests {
                 server_playlist_snapshot_failure: None,
                 stream_failure: None,
                 artwork_available: false,
+                post_mutation_refresh: None,
             }
         }
 
@@ -3083,6 +3173,7 @@ mod tests {
                 server_playlist_snapshot_failure: None,
                 stream_failure: None,
                 artwork_available: true,
+                post_mutation_refresh: None,
             }
         }
 
@@ -3120,6 +3211,7 @@ mod tests {
                 server_playlist_snapshot_failure: None,
                 stream_failure: None,
                 artwork_available: true,
+                post_mutation_refresh: None,
             }
         }
 
@@ -3184,6 +3276,7 @@ mod tests {
         server_playlist_snapshot_failure: Option<String>,
         stream_failure: Option<String>,
         artwork_available: bool,
+        post_mutation_refresh: Option<Vec<Track>>,
     }
 
     impl FakeAdapter {
@@ -3204,6 +3297,13 @@ mod tests {
                     Some(181),
                 ),
             );
+            self
+        }
+
+        /// Authorize one post-mutation catalogue refresh payload. `None`
+        /// keeps the fixture on the default refusal contract.
+        fn with_post_mutation_refresh(mut self, tracks: Vec<Track>) -> Self {
+            self.post_mutation_refresh = Some(tracks);
             self
         }
     }
@@ -3412,6 +3512,22 @@ mod tests {
 
         fn load_initial_catalogue(self: Arc<Self>) -> CatalogueFuture {
             Box::pin(async move { Ok(self.catalogue.clone()) })
+        }
+
+        fn refresh_catalogue_after_mutation(
+            self: Arc<Self>,
+            _written_track_ids: HashSet<TrackId>,
+            _cancellation: crate::source_lifecycle::CancellationObserver,
+        ) -> CatalogueFuture {
+            let refreshed = self.post_mutation_refresh.clone();
+            Box::pin(async move {
+                match refreshed {
+                    Some(tracks) => Ok(tracks),
+                    None => Err(BackendError::Unsupported {
+                        operation: "post-mutation catalogue refresh".to_string(),
+                    }),
+                }
+            })
         }
 
         fn resolve_stream(self: Arc<Self>, track_id: TrackId) -> StreamFuture {
@@ -3900,6 +4016,155 @@ mod tests {
         .await
         .expect("catalogue refresh accepted");
         generation
+    }
+
+    async fn wait_for_post_mutation_refresh_settled(
+        registry: &SourceRegistry,
+        source_id: SourceId,
+    ) {
+        timeout(Duration::from_secs(2), async {
+            loop {
+                let Some(snapshot) = registry.snapshot(source_id) else {
+                    tokio::task::yield_now().await;
+                    continue;
+                };
+                if !snapshot
+                    .pending_refreshes
+                    .contains_key(&RefreshLane::Catalogue)
+                {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("post-mutation catalogue refresh settles");
+    }
+
+    #[tokio::test]
+    async fn post_mutation_refresh_refusal_is_never_a_lane_failure() {
+        let registry = registry();
+        let source_id = SourceId::random();
+        let track_id = TrackId::remote("refused-refresh-track").expect("track ID");
+        let probe = FakeProbe::new(true);
+        connect_playlist_fixture(
+            &registry,
+            source_id,
+            probe.playlist_adapter("refused-refresh", vec![fixture_track(track_id.clone())]),
+        )
+        .await;
+        let (generation, _epoch) = wait_for_catalogue(&registry, source_id).await;
+
+        let minted = registry.refresh_catalogue_after_mutation(&[(source_id, track_id)]);
+        assert_eq!(
+            minted.len(),
+            1,
+            "one source with an exact live session mints one refresh generation"
+        );
+        wait_for_post_mutation_refresh_settled(&registry, source_id).await;
+
+        // The unreviewed adapter's refusal settles as a cancellation: no
+        // refresh failure is recorded and the accepted catalogue is left
+        // exactly as the scan accepted it.
+        let snapshot = registry
+            .snapshot(source_id)
+            .expect("a refused refresh never retires the source");
+        assert!(
+            !snapshot
+                .refresh_failures
+                .contains_key(&RefreshLane::Catalogue),
+            "the post-mutation refusal is a cancellation, never a lane failure: {:?}",
+            snapshot.refresh_failures
+        );
+        let catalogue = snapshot
+            .catalogue
+            .expect("the accepted catalogue survives the refusal");
+        assert_eq!(catalogue.generation, generation, "nothing is republished");
+        drop(registry);
+    }
+
+    #[tokio::test]
+    async fn authorized_post_mutation_refresh_republishes_only_the_written_source() {
+        let registry = registry();
+        let written_source = SourceId::random();
+        let untouched_source = SourceId::random();
+        let written_track = TrackId::remote("written-track").expect("track ID");
+        let untouched_track = TrackId::remote("untouched-track").expect("track ID");
+        let probe = FakeProbe::new(true);
+
+        let initial = fixture_track(written_track.clone());
+        let mut replacement = fixture_track(written_track.clone());
+        replacement.title = "Republished After Retained Write".to_string();
+        let adapter = probe
+            .playlist_adapter("written", vec![initial])
+            .with_post_mutation_refresh(vec![replacement]);
+        connect_playlist_fixture(&registry, written_source, adapter).await;
+        connect_playlist_fixture(
+            &registry,
+            untouched_source,
+            probe.playlist_adapter("untouched", vec![fixture_track(untouched_track)]),
+        )
+        .await;
+        let (written_generation, _epoch) = wait_for_catalogue(&registry, written_source).await;
+        let (untouched_generation, _epoch) = wait_for_catalogue(&registry, untouched_source).await;
+
+        let minted = registry.refresh_catalogue_after_mutation(&[(written_source, written_track)]);
+        assert_eq!(minted.len(), 1);
+        timeout(Duration::from_secs(2), async {
+            loop {
+                if registry
+                    .snapshot(written_source)
+                    .and_then(|snapshot| snapshot.catalogue)
+                    .is_some_and(|catalogue| catalogue.generation == minted[0])
+                {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the minted refresh generation publishes");
+
+        let written = registry
+            .snapshot(written_source)
+            .expect("the written source stays live");
+        let catalogue = written.catalogue.expect("republished catalogue accepted");
+        assert_eq!(
+            catalogue.generation, minted[0],
+            "the publication carries the minted refresh generation"
+        );
+        assert_ne!(catalogue.generation, written_generation);
+        assert!(catalogue
+            .value
+            .tracks
+            .iter()
+            .any(|track| track.title == "Republished After Retained Write"));
+        assert!(
+            written.refresh_failures.is_empty(),
+            "an authorized refresh never records a failure: {:?}",
+            written.refresh_failures
+        );
+
+        let untouched = registry
+            .snapshot(untouched_source)
+            .expect("the untouched source stays live");
+        assert_eq!(
+            untouched.catalogue.expect("untouched catalogue").generation,
+            untouched_generation,
+            "a source outside the written set is never rescanned"
+        );
+        drop(registry);
+    }
+
+    #[tokio::test]
+    async fn post_mutation_refresh_without_a_live_session_mints_nothing() {
+        let registry = registry();
+        let ghost = SourceId::random();
+        let track_id = TrackId::remote("ghost-track").expect("track ID");
+        assert!(registry
+            .refresh_catalogue_after_mutation(&[(ghost, track_id)])
+            .is_empty());
+        drop(registry);
     }
 
     #[tokio::test]

--- a/src/source_registry.rs
+++ b/src/source_registry.rs
@@ -2953,17 +2953,25 @@ fn run_post_mutation_refresh_ok_interpose(source_id: &SourceId) {
     }
 }
 
-/// Install the post-mutation Ok interposition seam for the duration of `run`,
-/// serializing against other tests that use the seam.
+/// Install the post-mutation Ok interposition seam for the duration of
+/// `run`, serializing against other tests that use the seam. A drop guard
+/// uninstalls the closure, so a panicking observation cannot leave a stale
+/// seam armed for a later test's post-mutation hooks.
 #[cfg(test)]
 fn with_post_mutation_refresh_ok_interpose(
     interpose: Box<PostMutationRefreshOkInterpose>,
     run: impl FnOnce(),
 ) {
+    struct UninstallPostMutationRefreshOkInterpose;
+    impl Drop for UninstallPostMutationRefreshOkInterpose {
+        fn drop(&mut self) {
+            *lock(&POST_MUTATION_REFRESH_OK_INTERPOSE) = None;
+        }
+    }
     let _serial = lock(&POST_MUTATION_REFRESH_OK_INTERPOSE_SERIAL);
     *lock(&POST_MUTATION_REFRESH_OK_INTERPOSE) = Some(interpose);
+    let _uninstall = UninstallPostMutationRefreshOkInterpose;
     run();
-    *lock(&POST_MUTATION_REFRESH_OK_INTERPOSE) = None;
 }
 
 /// Test-only hook fired inside a refresh generation's acceptance hook before

--- a/src/source_registry.rs
+++ b/src/source_registry.rs
@@ -1436,6 +1436,11 @@ struct SourceRegistryInner {
     playback_reference_binding: PlaybackReferenceBinding,
     built_ins: Mutex<HashMap<SourceId, BuiltInInstallation>>,
     external_sessions: Mutex<HashMap<SourceId, ProvenanceClaimId>>,
+    /// Written identities per source that no post-mutation refresh has
+    /// published yet. Every spawned Catalogue-lane refresh task carries the
+    /// accumulated union, so a superseding refresh re-reads an earlier
+    /// overlapping save's batch instead of dropping it.
+    mutation_refresh_pending: Mutex<HashMap<SourceId, HashSet<TrackId>>>,
 }
 
 impl PublicHttpAuthority for SourceRegistryInner {
@@ -1588,6 +1593,7 @@ impl SourceRegistry {
                 playback_reference_binding: PlaybackReferenceBinding(Arc::new(())),
                 built_ins: Mutex::new(built_ins),
                 external_sessions: Mutex::new(HashMap::new()),
+                mutation_refresh_pending: Mutex::new(HashMap::new()),
             }),
         }
     }
@@ -2757,6 +2763,16 @@ impl SourceRegistry {
     /// re-derived; the adapter republishes every other accepted row
     /// untouched, and no other source is ever rescanned.
     ///
+    /// Overlapping saves for one source coalesce rather than supersede with
+    /// disjoint sets: written identities stay pending per source until a
+    /// refresh publishes them, and every spawned task carries the accumulated
+    /// union. `begin_refresh` supersedes — cancels — the pending Catalogue
+    /// lane task, so a second save's refresh would otherwise cancel the
+    /// first save's refresh before it publishes and never re-read its
+    /// identities; carrying the union keeps every committed identity in the
+    /// republished row set. A cancelled or failed refresh consumes nothing:
+    /// its batch stays pending for the next refresh to re-read.
+    ///
     /// Returns the minted refresh generations, one per source that still had
     /// an exact live session. Fire-and-forget — publication happens on the
     /// lifecycle runtime and the visible row, subsequent Properties values,
@@ -2772,32 +2788,58 @@ impl SourceRegistry {
         }
 
         let mut generations = Vec::with_capacity(by_source.len());
-        for (source_id, track_ids) in by_source {
+        for (source_id, batch) in by_source {
+            // Accumulate this save into the source's pending identities and
+            // carry the accumulated union: any earlier save whose refresh has
+            // not published yet is re-read by this task too.
+            let track_ids = {
+                let mut pending = lock(&self.inner.mutation_refresh_pending);
+                let entry = pending.entry(source_id).or_default();
+                entry.extend(batch);
+                entry.clone()
+            };
             // No exact live session: a retired or replaced mount is never
-            // repopulated.
+            // repopulated, and its pending identities can never publish.
             let Some(owner) = self
                 .inner
                 .lifecycle
                 .begin_refresh(source_id, RefreshLane::Catalogue)
             else {
+                lock(&self.inner.mutation_refresh_pending).remove(&source_id);
                 continue;
             };
             let generation = owner.generation();
+            let pending_written = Arc::clone(&self.inner);
             owner.spawn(move |session, cancellation| async move {
                 let adapter = session.adapter();
                 let regular_playlist_capability = adapter.regular_playlist_capability();
                 match adapter
-                    .refresh_catalogue_after_mutation(track_ids, cancellation.clone())
+                    .refresh_catalogue_after_mutation(track_ids.clone(), cancellation.clone())
                     .await
                 {
-                    Ok(tracks) => RefreshTaskResult::Refreshed(AcceptedSourcePayload::catalogue(
-                        tracks,
-                        regular_playlist_capability,
-                    )),
-                    // A cancelled lane publishes nothing, and the default
-                    // adapter refusal (an adapter never reviewed for
-                    // post-mutation refresh semantics) is a no-op, never a
-                    // source failure: neither may degrade a live session.
+                    Ok(tracks) => {
+                        // Consume the carried batch only while this
+                        // publication is uncontested: a cancelled token means
+                        // a newer refresh displaced this lane, and the
+                        // identities stay pending for the successor, whose
+                        // carried set already includes their union.
+                        if !cancellation.is_cancelled() {
+                            if let Some(entry) =
+                                lock(&pending_written.mutation_refresh_pending).get_mut(&source_id)
+                            {
+                                entry.retain(|track_id| !track_ids.contains(track_id));
+                            }
+                        }
+                        RefreshTaskResult::Refreshed(AcceptedSourcePayload::catalogue(
+                            tracks,
+                            regular_playlist_capability,
+                        ))
+                    }
+                    // A cancelled lane publishes nothing and keeps its batch
+                    // pending, and the default adapter refusal (an adapter
+                    // never reviewed for post-mutation refresh semantics) is
+                    // a no-op, never a source failure: neither may degrade a
+                    // live session.
                     Err(error)
                         if cancellation.is_cancelled()
                             || matches!(error, BackendError::Unsupported { .. }) =>
@@ -3092,6 +3134,10 @@ mod tests {
         stream_release: watch::Sender<bool>,
         server_playlist_release: watch::Sender<bool>,
         server_playlist_snapshot_release: watch::Sender<bool>,
+        post_mutation_release: watch::Sender<bool>,
+        post_mutation_calls: AtomicUsize,
+        post_mutation_requests: Mutex<Vec<HashSet<TrackId>>>,
+        post_mutation_failure: AtomicBool,
         view_specs: Mutex<HashMap<ViewOrigin, VecDeque<ViewSpec>>>,
     }
 
@@ -3106,6 +3152,7 @@ mod tests {
             let (stream_release, _receiver) = watch::channel(true);
             let (server_playlist_release, _receiver) = watch::channel(true);
             let (server_playlist_snapshot_release, _receiver) = watch::channel(true);
+            let (post_mutation_release, _receiver) = watch::channel(true);
             Arc::new(Self {
                 close_calls: AtomicUsize::new(0),
                 stream_calls: AtomicUsize::new(0),
@@ -3117,8 +3164,42 @@ mod tests {
                 stream_release,
                 server_playlist_release,
                 server_playlist_snapshot_release,
+                post_mutation_release,
+                post_mutation_calls: AtomicUsize::new(0),
+                post_mutation_requests: Mutex::new(Vec::new()),
+                post_mutation_failure: AtomicBool::new(false),
                 view_specs: Mutex::new(HashMap::new()),
             })
+        }
+
+        /// Hold every subsequent post-mutation refresh inside the adapter
+        /// call until [`FakeProbe::release_post_mutation_refresh`].
+        fn hold_post_mutation_refresh(&self) {
+            self.post_mutation_release.send_replace(false);
+        }
+
+        fn release_post_mutation_refresh(&self) {
+            self.post_mutation_release.send_replace(true);
+        }
+
+        /// Make every unblocked post-mutation refresh call fail with a
+        /// backend error until switched off.
+        fn set_post_mutation_failure(&self, failing: bool) {
+            self.post_mutation_failure.store(failing, Ordering::Release);
+        }
+
+        async fn wait_for_post_mutation_calls(&self, expected: usize) {
+            timeout(Duration::from_secs(2), async {
+                while self.post_mutation_calls.load(Ordering::Acquire) < expected {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("post-mutation refresh call started");
+        }
+
+        fn post_mutation_requests(&self) -> Vec<HashSet<TrackId>> {
+            lock(&self.post_mutation_requests).clone()
         }
 
         fn queue_public_view(&self, view: ViewOrigin, endpoint: &str, delay: Duration) {
@@ -3516,11 +3597,40 @@ mod tests {
 
         fn refresh_catalogue_after_mutation(
             self: Arc<Self>,
-            _written_track_ids: HashSet<TrackId>,
-            _cancellation: crate::source_lifecycle::CancellationObserver,
+            written_track_ids: HashSet<TrackId>,
+            mut cancellation: crate::source_lifecycle::CancellationObserver,
         ) -> CatalogueFuture {
             let refreshed = self.post_mutation_refresh.clone();
+            let mut release = self.probe.post_mutation_release.subscribe();
+            let probe = Arc::clone(&self.probe);
             Box::pin(async move {
+                // Record exactly which identities each refresh call is
+                // handed, so a test can require the coalesced union.
+                lock(&probe.post_mutation_requests).push(written_track_ids);
+                probe.post_mutation_calls.fetch_add(1, Ordering::AcqRel);
+                // A held gate keeps the call open so a test can overlap
+                // saves; a real device observes cancellation the same way.
+                while !*release.borrow_and_update() {
+                    tokio::select! {
+                        () = cancellation.cancelled() => {
+                            return Err(BackendError::ConnectionFailed {
+                                message: "fixture post-mutation refresh cancelled".to_string(),
+                                source: None,
+                            });
+                        }
+                        changed = release.changed() => {
+                            if changed.is_err() {
+                                break;
+                            }
+                        }
+                    }
+                }
+                if probe.post_mutation_failure.load(Ordering::Acquire) {
+                    return Err(BackendError::ConnectionFailed {
+                        message: "fixture device error".to_string(),
+                        source: None,
+                    });
+                }
                 match refreshed {
                     Some(tracks) => Ok(tracks),
                     None => Err(BackendError::Unsupported {
@@ -4164,6 +4274,204 @@ mod tests {
         assert!(registry
             .refresh_catalogue_after_mutation(&[(ghost, track_id)])
             .is_empty());
+        drop(registry);
+    }
+
+    #[tokio::test]
+    async fn overlapping_saves_coalesce_into_one_superseding_refresh() {
+        let registry = registry();
+        let source_id = SourceId::random();
+        let first_track = TrackId::remote("first-written-track").expect("track ID");
+        let second_track = TrackId::remote("second-written-track").expect("track ID");
+        let probe = FakeProbe::new(true);
+        probe.hold_post_mutation_refresh();
+
+        let republished = fixture_track(first_track.clone());
+        let adapter = probe
+            .playlist_adapter("coalescing", vec![fixture_track(first_track.clone())])
+            .with_post_mutation_refresh(vec![republished]);
+        connect_playlist_fixture(&registry, source_id, adapter).await;
+        let (initial_generation, _epoch) = wait_for_catalogue(&registry, source_id).await;
+
+        // The first save's refresh blocks inside the adapter call.
+        let first_generation =
+            registry.refresh_catalogue_after_mutation(&[(source_id, first_track.clone())])[0];
+        probe.wait_for_post_mutation_calls(1).await;
+
+        // A second overlapping save supersedes the blocked lane. Its refresh
+        // must carry the union of both saves' written identities — not only
+        // its own — because the superseded first refresh publishes nothing.
+        let second_generation =
+            registry.refresh_catalogue_after_mutation(&[(source_id, second_track.clone())])[0];
+        assert_ne!(
+            second_generation, first_generation,
+            "the second save supersedes the first save's refresh lane"
+        );
+        probe.wait_for_post_mutation_calls(2).await;
+
+        probe.release_post_mutation_refresh();
+        wait_for_post_mutation_refresh_settled(&registry, source_id).await;
+
+        let requests = probe.post_mutation_requests();
+        assert_eq!(
+            requests.len(),
+            2,
+            "exactly one refresh per save: {requests:?}"
+        );
+        assert_eq!(
+            requests[0],
+            HashSet::from([first_track.clone()]),
+            "the first save's refresh carries its own identity"
+        );
+        assert_eq!(
+            requests[1],
+            HashSet::from([first_track.clone(), second_track.clone()]),
+            "the superseding refresh coalesces the first save's written identity with its own"
+        );
+
+        let catalogue = registry
+            .snapshot(source_id)
+            .expect("the source stays live")
+            .catalogue
+            .expect("the accepted catalogue survives");
+        assert_ne!(
+            catalogue.generation, initial_generation,
+            "the coalesced refresh republished the catalogue"
+        );
+        assert_eq!(
+            catalogue.generation, second_generation,
+            "the publication carries the superseding generation"
+        );
+        drop(registry);
+    }
+
+    #[tokio::test]
+    async fn a_failed_coalesced_refresh_keeps_earlier_identities_pending() {
+        let registry = registry();
+        let source_id = SourceId::random();
+        let first_track = TrackId::remote("pending-first-track").expect("track ID");
+        let second_track = TrackId::remote("pending-second-track").expect("track ID");
+        let third_track = TrackId::remote("pending-third-track").expect("track ID");
+        let probe = FakeProbe::new(true);
+        probe.hold_post_mutation_refresh();
+        probe.set_post_mutation_failure(true);
+
+        let adapter = probe
+            .playlist_adapter("failing-coalesce", vec![fixture_track(first_track.clone())])
+            .with_post_mutation_refresh(vec![fixture_track(first_track.clone())]);
+        connect_playlist_fixture(&registry, source_id, adapter).await;
+        let (_initial_generation, _epoch) = wait_for_catalogue(&registry, source_id).await;
+
+        // Two overlapping saves: the coalesced refresh (carrying both
+        // identities) is the one that fails.
+        registry.refresh_catalogue_after_mutation(&[(source_id, first_track.clone())]);
+        probe.wait_for_post_mutation_calls(1).await;
+        registry.refresh_catalogue_after_mutation(&[(source_id, second_track.clone())]);
+        probe.wait_for_post_mutation_calls(2).await;
+        probe.release_post_mutation_refresh();
+        wait_for_post_mutation_refresh_settled(&registry, source_id).await;
+
+        let requests = probe.post_mutation_requests();
+        assert_eq!(
+            requests[1],
+            HashSet::from([first_track.clone(), second_track.clone()]),
+            "the coalesced refresh carried both saves' identities"
+        );
+        let snapshot = registry.snapshot(source_id).expect("the source stays live");
+        assert!(
+            snapshot
+                .refresh_failures
+                .contains_key(&RefreshLane::Catalogue),
+            "the coalesced refresh's failure is recorded: {:?}",
+            snapshot.refresh_failures
+        );
+
+        // A later save's refresh must still re-read the earlier identities:
+        // the failed coalesced batch stayed pending, never vanished.
+        probe.set_post_mutation_failure(false);
+        let third_generation =
+            registry.refresh_catalogue_after_mutation(&[(source_id, third_track.clone())])[0];
+        probe.wait_for_post_mutation_calls(3).await;
+        wait_for_post_mutation_refresh_settled(&registry, source_id).await;
+
+        let requests = probe.post_mutation_requests();
+        assert_eq!(
+            requests[2],
+            HashSet::from([
+                first_track.clone(),
+                second_track.clone(),
+                third_track.clone()
+            ]),
+            "the later refresh republishes the failed batch's identities together with its own"
+        );
+        let catalogue = registry
+            .snapshot(source_id)
+            .expect("the source stays live")
+            .catalogue
+            .expect("the accepted catalogue survives");
+        assert_eq!(catalogue.generation, third_generation);
+        drop(registry);
+    }
+
+    #[tokio::test]
+    async fn a_disconnect_during_a_coalesced_refresh_publishes_nothing() {
+        let registry = registry();
+        let source_id = SourceId::random();
+        let first_track = TrackId::remote("disconnect-first-track").expect("track ID");
+        let second_track = TrackId::remote("disconnect-second-track").expect("track ID");
+        let probe = FakeProbe::new(true);
+        probe.hold_post_mutation_refresh();
+
+        let adapter = probe
+            .playlist_adapter(
+                "disconnect-coalesce",
+                vec![fixture_track(first_track.clone())],
+            )
+            .with_post_mutation_refresh(vec![fixture_track(first_track.clone())]);
+        connect_playlist_fixture(&registry, source_id, adapter).await;
+        let (initial_generation, _epoch) = wait_for_catalogue(&registry, source_id).await;
+
+        // Two overlapping saves coalesce into the second refresh while the
+        // first blocks inside the adapter call.
+        registry.refresh_catalogue_after_mutation(&[(source_id, first_track.clone())]);
+        probe.wait_for_post_mutation_calls(1).await;
+        registry.refresh_catalogue_after_mutation(&[(source_id, second_track.clone())]);
+        probe.wait_for_post_mutation_calls(2).await;
+        assert_eq!(
+            registry
+                .snapshot(source_id)
+                .expect("the source stays live while the refresh is held")
+                .catalogue
+                .expect("the accepted catalogue survives")
+                .generation,
+            initial_generation,
+            "a held refresh publishes nothing"
+        );
+
+        // Disconnecting mid-refresh cancels the coalesced task; releasing
+        // the gate must not let either call publish.
+        let disconnect = registry.disconnect(source_id).expect("disconnect source");
+        probe.release_post_mutation_refresh();
+        disconnect.wait().await;
+
+        let requests = probe.post_mutation_requests();
+        assert_eq!(
+            requests[1],
+            HashSet::from([first_track.clone(), second_track.clone()]),
+            "the coalesced refresh was dispatched before the disconnect"
+        );
+        let snapshot = registry
+            .snapshot(source_id)
+            .expect("the retired source keeps its entry");
+        assert_eq!(
+            snapshot.state,
+            crate::source_lifecycle::SourceState::Dormant,
+            "the disconnected source retired to its dormant resting state"
+        );
+        assert!(
+            snapshot.catalogue.is_none(),
+            "the retired mount's catalogue is gone: the cancelled coalesced refresh published nothing"
+        );
         drop(registry);
     }
 

--- a/src/source_registry.rs
+++ b/src/source_registry.rs
@@ -131,7 +131,34 @@ impl RemovableMutationTarget {
         self.inner
             .validate()
             .map_err(|_| TagWritePreflightError::Unavailable)?;
-        crate::local::tag_writer::preflight_tag_write(self.inner.replacement_path())
+        // The format check reads only the file extension — exactly like the
+        // writer itself; the retained file's liveness and regularity are
+        // already proven by the validate() above.
+        if !crate::local::tag_writer::supports_tag_writes(self.inner.replacement_path()) {
+            return Err(TagWritePreflightError::UnsupportedFormat);
+        }
+        // The directory rehearsal runs through the retained parent handle —
+        // the same directory object the anchored commit resolves — so an
+        // ancestor displaced after admission can neither take the probe
+        // siblings outside the admitted mount directory nor reject a target
+        // the anchored writer could safely update. Platforms without
+        // retained parent handles keep the documented path-based rehearsal.
+        #[cfg(unix)]
+        {
+            let (parent, leaf) = self
+                .inner
+                .retained_directory_handle()
+                .map_err(|_| TagWritePreflightError::Unavailable)?;
+            crate::local::tag_writer::preflight_tag_write_directory_retained(
+                &parent,
+                &leaf,
+                "the removable mutation target",
+            )
+        }
+        #[cfg(not(unix))]
+        {
+            crate::local::tag_writer::preflight_tag_write(self.inner.replacement_path())
+        }
     }
 
     /// Write tag edits through the retained authority.

--- a/src/source_registry.rs
+++ b/src/source_registry.rs
@@ -1446,6 +1446,14 @@ struct SourceRegistryInner {
     /// superseding refresh re-reads an earlier overlapping save's batch
     /// instead of dropping it.
     mutation_refresh_pending: Mutex<HashMap<SourceId, HashMap<TrackId, u64>>>,
+    /// Last version minted per source by [`Self::refresh_catalogue_after_mutation`],
+    /// consulted for the next version. This is the monotonicity anchor: it
+    /// never resets when a pending batch drains or its pending entry is
+    /// removed, so a version number is never re-minted for a source — an
+    /// older descheduled generation carrying a consumed version can never
+    /// collide with the current pending version and consume a newer save's
+    /// unpublished mutation.
+    mutation_refresh_versions: Mutex<HashMap<SourceId, u64>>,
 }
 
 impl PublicHttpAuthority for SourceRegistryInner {
@@ -1599,6 +1607,7 @@ impl SourceRegistry {
                 built_ins: Mutex::new(built_ins),
                 external_sessions: Mutex::new(HashMap::new()),
                 mutation_refresh_pending: Mutex::new(HashMap::new()),
+                mutation_refresh_versions: Mutex::new(HashMap::new()),
             }),
         }
     }
@@ -2782,7 +2791,13 @@ impl SourceRegistry {
     /// carried batch leaves the pending map only when that exact
     /// generation's publication is ACCEPTED by the lifecycle, and a carried
     /// track is consumed only when its CURRENT pending version still equals
-    /// the version the generation carried. A same-track save that lands
+    /// the version the generation carried. Versions are minted from a
+    /// per-source monotonic counter that survives drained batches, so a
+    /// version number is never re-minted after the batch that first used it
+    /// is consumed — an older descheduled generation's carried version can
+    /// never equal a newer save's pending version, and its hook can never
+    /// consume a mutation the newer generation has not published. A
+    /// same-track save that lands
     /// between the acceptance and the hook's consumption — the two take
     /// different locks — bumps the track's version, so the older hook
     /// leaves it pending for the successor or retry lane instead of
@@ -2812,11 +2827,19 @@ impl SourceRegistry {
             // bumping every written track's version past every earlier
             // save's — and carry the accumulated union with the versions
             // present at carry time: any earlier save whose refresh has not
-            // published yet is re-read by this task too.
+            // published yet is re-read by this task too. The next version
+            // comes from the per-source monotonic counter, never from the
+            // pending map's current maximum: a drained or emptied batch must
+            // not reset the sequence, or the next save would re-mint a
+            // version an older descheduled generation also carried and its
+            // hook could consume this save's unpublished mutation.
             let carried: HashMap<TrackId, u64> = {
                 let mut pending = lock(&self.inner.mutation_refresh_pending);
+                let mut versions = lock(&self.inner.mutation_refresh_versions);
+                let version = versions.entry(source_id).or_insert(0);
+                *version += 1;
+                let version = *version;
                 let entry = pending.entry(source_id).or_default();
-                let version = entry.values().copied().max().unwrap_or(0) + 1;
                 for track_id in &batch {
                     entry.insert(track_id.clone(), version);
                 }
@@ -4873,6 +4896,120 @@ mod tests {
             .catalogue
             .expect("the accepted catalogue survives");
         assert_eq!(catalogue.generation, fourth_generation);
+        drop(registry);
+    }
+
+    /// Arm the pending-consumption seam for the drained-batch race: while
+    /// the older accepted generation's hook is descheduled just before its
+    /// consumption, remove the source's pending entry the way the
+    /// session-loss path removes it, then re-save the same track with the
+    /// successor forced to fail. The re-save must mint the monotonic
+    /// counter's next version — never a version the descheduled generation
+    /// also carried — or the older hook would consume the newer save's
+    /// unpublished marker.
+    #[cfg(test)]
+    fn arm_descheduled_hook_drain_race(
+        probe: &Arc<FakeProbe>,
+        registry: &SourceRegistry,
+        source_id: SourceId,
+        track: &TrackId,
+        raced_signal: mpsc::Sender<()>,
+        raced: mpsc::Receiver<()>,
+    ) {
+        let race_probe = Arc::clone(probe);
+        let race_registry = registry.clone();
+        let race_source = source_id;
+        let race_track = track.clone();
+        with_pending_consumption_interpose(
+            Box::new(move |fired_source: &SourceId| {
+                if fired_source != &race_source {
+                    return;
+                }
+                // Session-loss drain: the pending entry is removed while
+                // the older accepted generation's hook is descheduled.
+                lock(&race_registry.inner.mutation_refresh_pending).remove(&race_source);
+                race_probe.set_post_mutation_failure(true);
+                let _ = race_registry
+                    .refresh_catalogue_after_mutation(&[(race_source, race_track.clone())]);
+                // The re-save must mint the counter's next version, never
+                // a version the descheduled generation already carried.
+                let version = lock(&race_registry.inner.mutation_refresh_pending)
+                    .get(&race_source)
+                    .and_then(|entry| entry.get(&race_track))
+                    .copied();
+                assert_eq!(
+                    version,
+                    Some(2),
+                    "a save after a drained batch mints the counter's next \
+                     version, never a version an older descheduled \
+                     generation also carried"
+                );
+                let _ = raced_signal.send(());
+            }),
+            || {
+                probe.release_post_mutation_refresh();
+                raced
+                    .recv_timeout(Duration::from_secs(2))
+                    .expect("the re-save landed while the older hook was descheduled");
+            },
+        );
+    }
+
+    /// The version-matching consumption must stay correct across a drained
+    /// batch: while an older accepted generation's hook is descheduled, the
+    /// source's pending entry is removed (the session-loss drain), and the
+    /// same track is re-saved. The re-save must mint a version the older
+    /// generation never carried — deriving it from the pending map's
+    /// maximum would re-mint the drained version and let the older hook
+    /// consume the newer save's unpublished marker, losing it behind the
+    /// forced successor failure. With the monotonic counter, the marker
+    /// survives and a later clean refresh republishes the mutation.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_descheduled_hook_after_a_drained_batch_never_consumes_a_re_minted_version() {
+        let registry = registry();
+        let source_id = SourceId::random();
+        let track = TrackId::remote("rearm-track").expect("track ID");
+        let later_track = TrackId::remote("rearm-later-track").expect("track ID");
+        let probe = FakeProbe::new(true);
+        probe.hold_post_mutation_refresh();
+
+        let adapter = probe
+            .playlist_adapter("pending-rearm", vec![fixture_track(track.clone())])
+            .with_post_mutation_refresh(vec![fixture_track(track.clone())]);
+        connect_playlist_fixture(&registry, source_id, adapter).await;
+        let _ = wait_for_catalogue(&registry, source_id).await;
+
+        // The first save's generation blocks inside the adapter call.
+        registry.refresh_catalogue_after_mutation(&[(source_id, track.clone())]);
+        probe.wait_for_post_mutation_calls(1).await;
+
+        let (raced_signal, raced) = mpsc::channel::<()>();
+        arm_descheduled_hook_drain_race(&probe, &registry, source_id, &track, raced_signal, raced);
+        probe.wait_for_post_mutation_calls(2).await;
+        wait_for_post_mutation_refresh_settled(&registry, source_id).await;
+        let snapshot = registry.snapshot(source_id).expect("the source stays live");
+        assert!(
+            snapshot
+                .refresh_failures
+                .contains_key(&RefreshLane::Catalogue),
+            "the forced-failure successor failed: {:?}",
+            snapshot.refresh_failures
+        );
+
+        // The failed successor published nothing and the descheduled older
+        // hook consumed nothing: a later clean save re-reads BOTH
+        // identities, republishing the mutation the failure would lose.
+        probe.set_post_mutation_failure(false);
+        let _later = registry.refresh_catalogue_after_mutation(&[(source_id, later_track.clone())]);
+        probe.wait_for_post_mutation_calls(3).await;
+        wait_for_post_mutation_refresh_settled(&registry, source_id).await;
+        let requests = probe.post_mutation_requests();
+        assert_eq!(
+            requests[2],
+            HashSet::from([track, later_track]),
+            "the re-saved track's marker survived the descheduled older hook \
+             and is republished after the forced successor failure"
+        );
         drop(registry);
     }
 

--- a/src/ui/context_menu.rs
+++ b/src/ui/context_menu.rs
@@ -1204,6 +1204,7 @@ fn build_properties_action(
     );
     let registry_for_props = mutation_context.source_registry.clone();
     let rt_handle_for_props = mutation_context.rt_handle.clone();
+    let failure_context_for_props = mutation_context.clone();
 
     props_action.connect_activate(move |_, _| {
         let Some(ref win) = win_for_props else {
@@ -1228,6 +1229,7 @@ fn build_properties_action(
         let rt_handle = rt_handle_for_props.clone();
         let win = win.clone();
         let track_infos_for_resolve = track_infos.clone();
+        let failure_context = failure_context_for_props.clone();
         let (tx, rx) = async_channel::bounded::<
             Option<
                 std::collections::HashMap<String, crate::source_registry::RemovableMutationTarget>,
@@ -1252,7 +1254,7 @@ fn build_properties_action(
                             %error,
                             source = %mutation.source_id,
                             track = mutation.track_id.as_str(),
-                            "removable properties resolution failed; skipping dialog"
+                            "removable properties resolution failed; surfacing the cancelled action"
                         );
                         let _ = tx.send_blocking(None);
                         return;
@@ -1262,7 +1264,13 @@ fn build_properties_action(
             let _ = tx.send_blocking(Some(resolved));
         });
         glib::MainContext::default().spawn_local(async move {
+            // Every other failure path in this file presents an alert; a
+            // resolution refused between menu build and activation (device
+            // removed, session retired, epoch changed) must be visible too —
+            // the user activated Properties and must not watch the popover
+            // silently close.
             let Ok(Some(resolved)) = rx.recv().await else {
+                failure_context.show_mutation_failed();
                 return;
             };
             let mut infos = track_infos_for_resolve;

--- a/src/ui/context_menu.rs
+++ b/src/ui/context_menu.rs
@@ -1234,11 +1234,17 @@ fn build_properties_action(
         let failure_context = failure_context_for_props.clone();
         let (tx, rx) = async_channel::bounded::<
             Option<
-                std::collections::HashMap<String, crate::source_registry::RemovableMutationTarget>,
+                std::collections::HashMap<
+                    (SourceId, String),
+                    crate::source_registry::RemovableMutationTarget,
+                >,
             >,
         >(1);
         rt_handle.spawn(async move {
-            let mut resolved = std::collections::HashMap::new();
+            let mut resolved: std::collections::HashMap<
+                (SourceId, String),
+                crate::source_registry::RemovableMutationTarget,
+            > = std::collections::HashMap::new();
             for mutation in &pending {
                 match registry
                     .resolve_mutation_target(
@@ -1249,7 +1255,10 @@ fn build_properties_action(
                     .await
                 {
                     Ok(target) => {
-                        resolved.insert(mutation.track_id.as_str().to_owned(), target);
+                        resolved.insert(
+                            (mutation.source_id, mutation.track_id.as_str().to_owned()),
+                            target,
+                        );
                     }
                     Err(error) => {
                         tracing::warn!(
@@ -1278,7 +1287,9 @@ fn build_properties_action(
             let mut infos = track_infos_for_resolve;
             for info in &mut infos {
                 if let SaveTarget::PendingRemovable(pending) = &info.target {
-                    if let Some(target) = resolved.get(pending.track_id.as_str()) {
+                    if let Some(target) =
+                        resolved.get(&(pending.source_id, pending.track_id.as_str().to_owned()))
+                    {
                         info.target = SaveTarget::Removable(target.clone());
                     }
                 }
@@ -1380,6 +1391,12 @@ fn properties_save_target(
 ///
 /// Repeated playlist rows may refer to the same removable file; resolving
 /// the identity twice would retain two authorities over one exact object.
+///
+/// The identity is the complete `(source, track)` pair, not the track alone:
+/// `TrackId::removable_relative` is scoped to one source's mount root, so two
+/// devices exposing the same relative path produce equal track IDs. Keying on
+/// the track string alone would drop one device's pending resolution and
+/// rebind its rows to the surviving device's authority.
 fn distinct_pending_mutations(
     track_infos: &[super::properties_dialog::TrackInfo],
 ) -> Vec<super::properties_dialog::PendingRemovableMutation> {
@@ -1387,7 +1404,7 @@ fn distinct_pending_mutations(
     let mut pending = Vec::new();
     for info in track_infos {
         if let SaveTarget::PendingRemovable(mutation) = &info.target {
-            if seen.insert(mutation.track_id.as_str().to_owned()) {
+            if seen.insert((mutation.source_id, mutation.track_id.as_str().to_owned())) {
                 pending.push(mutation.clone());
             }
         }
@@ -1508,6 +1525,9 @@ pub mod tests {
     use std::path::PathBuf;
 
     use super::*;
+    // `super` inside this test module is `context_menu`, so the sibling
+    // dialog module must be named from the `ui` parent directly.
+    use crate::ui::properties_dialog;
 
     fn remote_catalogue_track(
         track_id: TrackId,
@@ -1602,6 +1622,75 @@ pub mod tests {
         assert!(candidates
             .iter()
             .all(|candidate| matches!(candidate, PlaylistAddCandidate::Local(_))));
+    }
+
+    /// A pending removable mutation is identified by the complete
+    /// `(source, track)` pair. `TrackId::removable_relative` is scoped to one
+    /// source's mount root, so two devices exposing the same relative path
+    /// produce equal track IDs; keying on the track string alone would drop
+    /// one device's pending resolution and rebind its rows to the surviving
+    /// device's authority.
+    #[test]
+    fn distinct_pending_mutations_key_on_source_and_track_not_track_alone() {
+        fn info_with_target(target: SaveTarget) -> properties_dialog::TrackInfo {
+            properties_dialog::TrackInfo {
+                target,
+                title: "Title".to_string(),
+                artist: "Artist".to_string(),
+                album: "Album".to_string(),
+                genre: String::new(),
+                composer: String::new(),
+                year: String::new(),
+                track_number: String::new(),
+                disc_number: String::new(),
+                format: "FLAC".to_string(),
+                bitrate: String::new(),
+                sample_rate: String::new(),
+                duration: String::new(),
+            }
+        }
+
+        let pending_on = |source_id: SourceId| properties_dialog::PendingRemovableMutation {
+            source_id,
+            session_epoch: 1,
+            track_id: TrackId::new("unix:616c62756d2f736f6e67").expect("track id"),
+        };
+        let device_one = SourceId::random();
+        let device_two = SourceId::random();
+        let shared_track_on_device_one = pending_on(device_one);
+
+        // Two devices exposing the same relative path, plus a repeat of the
+        // first device's row: two distinct identities, not one.
+        let infos = vec![
+            info_with_target(SaveTarget::PendingRemovable(
+                shared_track_on_device_one.clone(),
+            )),
+            info_with_target(SaveTarget::PendingRemovable(pending_on(device_two))),
+            info_with_target(SaveTarget::PendingRemovable(
+                shared_track_on_device_one.clone(),
+            )),
+        ];
+        let pending = distinct_pending_mutations(&infos);
+        assert_eq!(
+            pending.len(),
+            2,
+            "the same relative path on two devices must stay distinct"
+        );
+        assert_eq!(pending[0].source_id, device_one);
+        assert_eq!(pending[1].source_id, device_two);
+
+        // The same source and track repeated still collapses to one.
+        let repeated = vec![
+            info_with_target(SaveTarget::PendingRemovable(
+                shared_track_on_device_one.clone(),
+            )),
+            info_with_target(SaveTarget::PendingRemovable(shared_track_on_device_one)),
+        ];
+        assert_eq!(
+            distinct_pending_mutations(&repeated).len(),
+            1,
+            "repeated rows over one identity must still deduplicate"
+        );
     }
 
     #[test]

--- a/src/ui/context_menu.rs
+++ b/src/ui/context_menu.rs
@@ -1217,7 +1217,14 @@ fn build_properties_action(
             .iter()
             .all(|info| matches!(info.target, SaveTarget::LocalPath(_)))
         {
-            super::properties_dialog::show_properties_dialog(win, &track_infos, automatic_device);
+            // A local-path-only selection can never write through a removable
+            // authority, so no post-mutation catalogue refresh can apply.
+            super::properties_dialog::show_properties_dialog(
+                win,
+                &track_infos,
+                automatic_device,
+                None,
+            );
             return;
         }
 
@@ -1228,6 +1235,7 @@ fn build_properties_action(
         // and a native mount location is never surfaced.
         let pending = distinct_pending_mutations(&track_infos);
         let registry = registry_for_props.clone();
+        let registry_for_catalogue = registry.clone();
         let rt_handle = rt_handle_for_props.clone();
         let win = win.clone();
         let track_infos_for_resolve = track_infos.clone();
@@ -1304,7 +1312,15 @@ fn build_properties_action(
                 tracing::warn!("removable properties resolution left an identity unresolved");
                 return;
             }
-            super::properties_dialog::show_properties_dialog(&win, &infos, automatic_device);
+            // Successful removable writes republish refreshed metadata for
+            // exactly the written identities; the dialog triggers the
+            // registry's catalogue refresh lane itself.
+            super::properties_dialog::show_properties_dialog(
+                &win,
+                &infos,
+                automatic_device,
+                Some(registry_for_catalogue),
+            );
         });
     });
 

--- a/src/ui/context_menu.rs
+++ b/src/ui/context_menu.rs
@@ -11,6 +11,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use super::objects::{SourceObject, TrackObject};
+use super::properties_dialog::SaveTarget;
 use super::window_state::WindowState;
 use crate::architecture::{MediaKey, SourceId, TrackId};
 use crate::local::playlist_manager::{PlaylistEntryAddOutcome, PlaylistEntryInput};
@@ -516,10 +517,10 @@ fn append_context_menu_actions(
     build_properties_action(
         menu,
         action_group,
-        session.column_view,
         session.sm,
         &popup_plan.selection,
         automatic_device,
+        session.mutation_context,
     );
 }
 
@@ -1131,16 +1132,26 @@ fn exact_playlist_entry_ids(
 fn build_properties_action(
     menu: &gtk::gio::Menu,
     action_group: &gtk::gio::SimpleActionGroup,
-    column_view: &gtk::ColumnView,
     sm: &gtk::SortListModel,
     selection: &SelectionSnapshot,
     automatic_device: bool,
+    mutation_context: &PlaylistMutationContext,
 ) {
+    // The one removable source that can own rows of this view, if the active
+    // view is a removable device. Opaque logical GIO keys and mount-path
+    // spellings are not navigation identities, so the sidebar's exact
+    // SourceId decides — the same match `active_source_is_automatic_device`
+    // uses.
+    let active_source_key = mutation_context.active_source_key.borrow().clone();
+    let removable_source =
+        active_removable_source(&mutation_context.sidebar_store, &active_source_key);
+
     // Snapshot the exact selection while building the menu. Properties is an
-    // all-or-none path-authorized local-file operation: silently dropping a
-    // malformed, remote, or pathless lifecycle row would let a batch edit
-    // only an unexpected subset. Removable rows deliberately remain absent
-    // until a typed mutation target can revalidate their exact live epoch.
+    // all-or-none operation: silently dropping a malformed, remote, or
+    // pathless lifecycle row would let a batch edit only an unexpected
+    // subset. Local rows snapshot their validated native path; rows of the
+    // active removable device snapshot their exact source-scoped identity
+    // for resolution through the live session when the action fires.
     let mut track_infos = Vec::new();
     for &position in &selection.positions {
         let Some(item) = sm.item(position) else {
@@ -1149,11 +1160,11 @@ fn build_properties_action(
         let Some(track) = item.downcast_ref::<TrackObject>() else {
             return;
         };
-        let Some(path) = local_file_path(&track.uri()) else {
+        let Some(target) = properties_save_target(track, removable_source) else {
             return;
         };
         track_infos.push(super::properties_dialog::TrackInfo {
-            path,
+            target,
             title: track.title(),
             artist: track.artist(),
             album: track.album(),
@@ -1181,21 +1192,99 @@ fn build_properties_action(
     }
 
     let props_action = gtk::gio::SimpleAction::new("properties", None);
-    let win_for_props: Option<adw::ApplicationWindow> = column_view
+    let win_for_props: Option<adw::ApplicationWindow> = mutation_context
+        .column_view
         .root()
         .and_then(|root| root.downcast::<adw::ApplicationWindow>().ok());
     tracing::debug!(
         has_win = win_for_props.is_some(),
         track_count = track_infos.len(),
+        removable = removable_source.is_some(),
         "build_properties_action"
     );
+    let registry_for_props = mutation_context.source_registry.clone();
+    let rt_handle_for_props = mutation_context.rt_handle.clone();
 
     props_action.connect_activate(move |_, _| {
         let Some(ref win) = win_for_props else {
             tracing::warn!("properties action: win_for_props is None, cannot show dialog");
             return;
         };
-        super::properties_dialog::show_properties_dialog(win, &track_infos, automatic_device);
+        if track_infos
+            .iter()
+            .all(|info| matches!(info.target, SaveTarget::LocalPath(_)))
+        {
+            super::properties_dialog::show_properties_dialog(win, &track_infos, automatic_device);
+            return;
+        }
+
+        // Exchange every distinct pending removable identity for a retained
+        // mutation authority through its exact live session. The action is
+        // all-or-none: one unavailable device, retired session, or changed
+        // epoch cancels the dialog entirely rather than editing a subset,
+        // and a native mount location is never surfaced.
+        let pending = distinct_pending_mutations(&track_infos);
+        let registry = registry_for_props.clone();
+        let rt_handle = rt_handle_for_props.clone();
+        let win = win.clone();
+        let track_infos_for_resolve = track_infos.clone();
+        let (tx, rx) = async_channel::bounded::<
+            Option<
+                std::collections::HashMap<String, crate::source_registry::RemovableMutationTarget>,
+            >,
+        >(1);
+        rt_handle.spawn(async move {
+            let mut resolved = std::collections::HashMap::new();
+            for mutation in &pending {
+                match registry
+                    .resolve_mutation_target(
+                        mutation.source_id,
+                        mutation.session_epoch,
+                        mutation.track_id.clone(),
+                    )
+                    .await
+                {
+                    Ok(target) => {
+                        resolved.insert(mutation.track_id.as_str().to_owned(), target);
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            %error,
+                            source = %mutation.source_id,
+                            track = mutation.track_id.as_str(),
+                            "removable properties resolution failed; skipping dialog"
+                        );
+                        let _ = tx.send_blocking(None);
+                        return;
+                    }
+                }
+            }
+            let _ = tx.send_blocking(Some(resolved));
+        });
+        glib::MainContext::default().spawn_local(async move {
+            let Ok(Some(resolved)) = rx.recv().await else {
+                return;
+            };
+            let mut infos = track_infos_for_resolve;
+            for info in &mut infos {
+                if let SaveTarget::PendingRemovable(pending) = &info.target {
+                    if let Some(target) = resolved.get(pending.track_id.as_str()) {
+                        info.target = SaveTarget::Removable(target.clone());
+                    }
+                }
+            }
+            if infos
+                .iter()
+                .any(|info| matches!(info.target, SaveTarget::PendingRemovable(_)))
+            {
+                // Unreachable: every pending identity in `infos` came from
+                // the same resolved set. A retry-resolution must be exact,
+                // never partial.
+                tracing::warn!("removable properties resolution left an identity unresolved");
+                return;
+            }
+            super::properties_dialog::show_properties_dialog(&win, &infos, automatic_device);
+        });
     });
 
     action_group.add_action(&props_action);
@@ -1225,6 +1314,77 @@ fn local_file_path(uri: &str) -> Option<std::path::PathBuf> {
     (url.scheme() == "file")
         .then(|| url.to_file_path().ok())
         .flatten()
+}
+
+/// The removable source that owns the active view, if any.
+///
+/// Mirrors `active_source_is_automatic_device`: an opaque logical GIO key or
+/// mount-path spelling is not a navigation identity, so the sidebar's exact
+/// SourceId for the active key decides.
+fn active_removable_source(
+    sidebar_store: &gtk::gio::ListStore,
+    active_source_key: &str,
+) -> Option<SourceId> {
+    (0..sidebar_store.n_items())
+        .filter_map(|position| sidebar_store.item(position).and_downcast::<SourceObject>())
+        .find(|source| {
+            source.backend_type() == "usb-device"
+                && source
+                    .source_id()
+                    .is_some_and(|source_id| source_id.to_string() == active_source_key)
+        })
+        .and_then(|source| source.source_id())
+}
+
+/// The exact save target one selected row will be written through.
+///
+/// `None` means the row cannot be authorized for a Properties edit at all;
+/// the whole action is dropped rather than editing an unexpected subset.
+fn properties_save_target(
+    track: &TrackObject,
+    removable_source: Option<SourceId>,
+) -> Option<super::properties_dialog::SaveTarget> {
+    match removable_source {
+        Some(source_id) if track.source_id() == Some(source_id) => {
+            // A removable row is pathless by design: its edit authorization
+            // is the exact source-scoped identity, exchanged for a retained
+            // mutation authority through the live session when the action
+            // fires. A row without a session epoch is a wiring fault and
+            // aborts the whole selection.
+            let track_id = TrackId::new(track.track_id()).ok()?;
+            Some(SaveTarget::PendingRemovable(
+                super::properties_dialog::PendingRemovableMutation {
+                    source_id,
+                    session_epoch: track.source_session_epoch()?,
+                    track_id,
+                },
+            ))
+        }
+        _ => {
+            // Every other view remains a path-authorized local-file edit.
+            let path = local_file_path(&track.uri())?;
+            Some(SaveTarget::LocalPath(path))
+        }
+    }
+}
+
+/// One pending mutation per distinct removable identity, in selection order.
+///
+/// Repeated playlist rows may refer to the same removable file; resolving
+/// the identity twice would retain two authorities over one exact object.
+fn distinct_pending_mutations(
+    track_infos: &[super::properties_dialog::TrackInfo],
+) -> Vec<super::properties_dialog::PendingRemovableMutation> {
+    let mut seen = std::collections::HashSet::new();
+    let mut pending = Vec::new();
+    for info in track_infos {
+        if let SaveTarget::PendingRemovable(mutation) = &info.target {
+            if seen.insert(mutation.track_id.as_str().to_owned()) {
+                pending.push(mutation.clone());
+            }
+        }
+    }
+    pending
 }
 
 /// Match the active lifecycle source against exact sidebar metadata. Opaque

--- a/src/ui/context_menu.rs
+++ b/src/ui/context_menu.rs
@@ -1137,20 +1137,17 @@ fn build_properties_action(
     automatic_device: bool,
     mutation_context: &PlaylistMutationContext,
 ) {
-    // The one removable source that can own rows of this view, if the active
-    // view is a removable device. Opaque logical GIO keys and mount-path
-    // spellings are not navigation identities, so the sidebar's exact
-    // SourceId decides — the same match `active_source_is_automatic_device`
-    // uses.
-    let active_source_key = mutation_context.active_source_key.borrow().clone();
-    let removable_source =
-        active_removable_source(&mutation_context.sidebar_store, &active_source_key);
+    // A removable device can own rows of any view: a playlist can contain
+    // removable entries while the active view is the playlist, not the
+    // device, so removable ownership is decided per row from the sidebar's
+    // exact SourceId metadata — never from which view happens to be active.
+    let sidebar_store = &mutation_context.sidebar_store;
 
     // Snapshot the exact selection while building the menu. Properties is an
     // all-or-none operation: silently dropping a malformed, remote, or
     // pathless lifecycle row would let a batch edit only an unexpected
-    // subset. Local rows snapshot their validated native path; rows of the
-    // active removable device snapshot their exact source-scoped identity
+    // subset. Local rows snapshot their validated native path; rows owned by
+    // a known removable device snapshot their exact source-scoped identity
     // for resolution through the live session when the action fires.
     let mut track_infos = Vec::new();
     for &position in &selection.positions {
@@ -1160,7 +1157,7 @@ fn build_properties_action(
         let Some(track) = item.downcast_ref::<TrackObject>() else {
             return;
         };
-        let Some(target) = properties_save_target(track, removable_source) else {
+        let Some(target) = properties_save_target(track, sidebar_store) else {
             return;
         };
         track_infos.push(super::properties_dialog::TrackInfo {
@@ -1199,7 +1196,12 @@ fn build_properties_action(
     tracing::debug!(
         has_win = win_for_props.is_some(),
         track_count = track_infos.len(),
-        removable = removable_source.is_some(),
+        removable = track_infos.iter().any(|info| {
+            matches!(
+                info.target,
+                SaveTarget::PendingRemovable(_) | SaveTarget::Removable(_)
+            )
+        }),
         "build_properties_action"
     );
     let registry_for_props = mutation_context.source_registry.clone();
@@ -1324,22 +1326,24 @@ fn local_file_path(uri: &str) -> Option<std::path::PathBuf> {
         .flatten()
 }
 
-/// The removable source that owns the active view, if any.
+/// The removable device that owns one row, matched against exact sidebar
+/// metadata.
 ///
-/// Mirrors `active_source_is_automatic_device`: an opaque logical GIO key or
-/// mount-path spelling is not a navigation identity, so the sidebar's exact
-/// SourceId for the active key decides.
-fn active_removable_source(
+/// The match mirrors `active_source_is_automatic_device`: an opaque logical
+/// GIO key or mount-path spelling is not a navigation identity, so the
+/// sidebar's exact SourceId decides. Ownership is read from the row's own
+/// source identity — never from the active view — because a playlist can
+/// display removable rows while the active navigation key is the playlist,
+/// not the device.
+fn removable_row_source(
+    track: &TrackObject,
     sidebar_store: &gtk::gio::ListStore,
-    active_source_key: &str,
 ) -> Option<SourceId> {
+    let row_source = track.source_id()?;
     (0..sidebar_store.n_items())
         .filter_map(|position| sidebar_store.item(position).and_downcast::<SourceObject>())
         .find(|source| {
-            source.backend_type() == "usb-device"
-                && source
-                    .source_id()
-                    .is_some_and(|source_id| source_id.to_string() == active_source_key)
+            source.backend_type() == "usb-device" && source.source_id() == Some(row_source)
         })
         .and_then(|source| source.source_id())
 }
@@ -1350,30 +1354,26 @@ fn active_removable_source(
 /// the whole action is dropped rather than editing an unexpected subset.
 fn properties_save_target(
     track: &TrackObject,
-    removable_source: Option<SourceId>,
+    sidebar_store: &gtk::gio::ListStore,
 ) -> Option<super::properties_dialog::SaveTarget> {
-    match removable_source {
-        Some(source_id) if track.source_id() == Some(source_id) => {
-            // A removable row is pathless by design: its edit authorization
-            // is the exact source-scoped identity, exchanged for a retained
-            // mutation authority through the live session when the action
-            // fires. A row without a session epoch is a wiring fault and
-            // aborts the whole selection.
-            let track_id = TrackId::new(track.track_id()).ok()?;
-            Some(SaveTarget::PendingRemovable(
-                super::properties_dialog::PendingRemovableMutation {
-                    source_id,
-                    session_epoch: track.source_session_epoch()?,
-                    track_id,
-                },
-            ))
-        }
-        _ => {
-            // Every other view remains a path-authorized local-file edit.
-            let path = local_file_path(&track.uri())?;
-            Some(SaveTarget::LocalPath(path))
-        }
+    // A row owned by a known removable device is pathless by design, in this
+    // or any other view: its edit authorization is the exact source-scoped
+    // identity, exchanged for a retained mutation authority through the live
+    // session when the action fires. A row without a session epoch is a
+    // wiring fault and aborts the whole selection.
+    if let Some(source_id) = removable_row_source(track, sidebar_store) {
+        let track_id = TrackId::new(track.track_id()).ok()?;
+        return Some(SaveTarget::PendingRemovable(
+            super::properties_dialog::PendingRemovableMutation {
+                source_id,
+                session_epoch: track.source_session_epoch()?,
+                track_id,
+            },
+        ));
     }
+    // Every other row remains a path-authorized local-file edit.
+    let path = local_file_path(&track.uri())?;
+    Some(SaveTarget::LocalPath(path))
 }
 
 /// One pending mutation per distinct removable identity, in selection order.

--- a/src/ui/properties_dialog.rs
+++ b/src/ui/properties_dialog.rs
@@ -27,12 +27,91 @@ use crate::local::tag_writer::preflight_tag_write_target_access;
 use crate::local::tag_writer::{
     preflight_tag_write_directory, validate_tag_write_target, TagEdits, TagWritePreflightError,
 };
+use crate::source_registry::RemovableMutationTarget;
+
+/// Exactly what one selected row is saved through.
+#[derive(Clone, Debug)]
+pub enum SaveTarget {
+    /// Validated native path for a local-library track.
+    LocalPath(PathBuf),
+    /// A removable row's identity awaiting resolution through its exact live
+    /// source session. The context menu replaces this with
+    /// [`SaveTarget::Removable`] before the dialog can open; an unresolved
+    /// value never reaches a preflight or a write.
+    PendingRemovable(PendingRemovableMutation),
+    /// Retained mutation authority over one exact removable file.
+    Removable(RemovableMutationTarget),
+}
+
+impl PartialEq for SaveTarget {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::LocalPath(left), Self::LocalPath(right)) => left == right,
+            (Self::PendingRemovable(left), Self::PendingRemovable(right)) => left == right,
+            // Retained authorities are equal when they name the same exact
+            // source-scoped file, never when they merely hold equal evidence.
+            (Self::Removable(left), Self::Removable(right)) => {
+                left.source_id() == right.source_id() && left.track_id() == right.track_id()
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Eq for SaveTarget {}
+
+/// The removable identity a dialog save must resolve before it may commit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingRemovableMutation {
+    pub source_id: crate::architecture::SourceId,
+    pub session_epoch: u64,
+    pub track_id: crate::architecture::TrackId,
+}
+
+/// Deduplication identity for one save target. Repeated playlist rows may
+/// refer to the same file or the same removable identity; each exact target
+/// is probed and written once.
+#[derive(PartialEq, Eq, Hash)]
+enum SaveTargetKey {
+    LocalPath(PathBuf),
+    Removable(crate::architecture::SourceId, String),
+}
+
+fn save_target_key(target: &SaveTarget) -> Option<SaveTargetKey> {
+    match target {
+        SaveTarget::LocalPath(path) => Some(SaveTargetKey::LocalPath(path.clone())),
+        SaveTarget::Removable(authority) => Some(SaveTargetKey::Removable(
+            authority.source_id(),
+            authority.track_id().as_str().to_owned(),
+        )),
+        // An unresolved pending value has no identity to deduplicate and must
+        // never reach the probe or write phase.
+        SaveTarget::PendingRemovable(_) => None,
+    }
+}
+
+/// One exactly-deduplicated save target per distinct file or removable
+/// identity, in selection order.
+fn unique_save_targets(tracks: &[TrackInfo]) -> Vec<SaveTarget> {
+    let mut seen = HashSet::new();
+    let mut targets = Vec::new();
+    for track in tracks {
+        let Some(key) = save_target_key(&track.target) else {
+            continue;
+        };
+        if seen.insert(key) {
+            targets.push(track.target.clone());
+        }
+    }
+    targets
+}
 
 /// Information about a track passed into the dialog.
 #[derive(Debug, Clone)]
 pub struct TrackInfo {
-    /// Validated native path for this local track.
-    pub path: PathBuf,
+    /// Exact save target for this row: a validated local path or a retained
+    /// removable mutation authority.
+    pub target: SaveTarget,
     /// Current metadata values (for pre-populating the form).
     pub title: String,
     pub artist: String,
@@ -99,15 +178,6 @@ enum SaveOutcome {
     },
 }
 
-fn unique_track_paths(tracks: &[TrackInfo]) -> Vec<PathBuf> {
-    let mut seen = HashSet::new();
-    tracks
-        .iter()
-        .filter(|track| seen.insert(track.path.clone()))
-        .map(|track| track.path.clone())
-        .collect()
-}
-
 fn merge_preflight_failure(
     current: TagEditingAvailability,
     failure: TagWritePreflightError,
@@ -172,18 +242,37 @@ fn preflight_each_target(
 }
 
 /// Probe a complete, exact-deduplicated selection on a worker thread.
-fn preflight_paths(paths: &[PathBuf]) -> TagEditingAvailability {
-    if paths.is_empty() {
+///
+/// Local paths are probed per file and per distinct parent directory.
+/// Removable targets revalidate their retained authority and rehearse the
+/// complete atomic replacement beside the exact file in one check, so no
+/// path-based directory rehearsal runs for them.
+fn preflight_save_targets(targets: &[SaveTarget]) -> TagEditingAvailability {
+    if targets.is_empty() {
         return TagEditingAvailability::InvalidFile;
     }
-
-    let validation = paths
+    if targets
         .iter()
-        .fold(
+        .any(|target| matches!(target, SaveTarget::PendingRemovable(_)))
+    {
+        // Unresolved removable identities are a wiring fault: the context
+        // menu must resolve them through their live session first.
+        return TagEditingAvailability::Unavailable;
+    }
+
+    let validation =
+        targets.iter().fold(
             TagEditingAvailability::Ready,
-            |result, path| match validate_tag_write_target(path) {
-                Ok(()) => result,
-                Err(failure) => merge_preflight_failure(result, failure),
+            |result, target| match target {
+                SaveTarget::LocalPath(path) => match validate_tag_write_target(path) {
+                    Ok(()) => result,
+                    Err(failure) => merge_preflight_failure(result, failure),
+                },
+                SaveTarget::Removable(authority) => match authority.preflight_write_capability() {
+                    Ok(()) => result,
+                    Err(failure) => merge_preflight_failure(result, failure),
+                },
+                SaveTarget::PendingRemovable(_) => TagEditingAvailability::Unavailable,
             },
         );
     if validation != TagEditingAvailability::Ready {
@@ -193,18 +282,33 @@ fn preflight_paths(paths: &[PathBuf]) -> TagEditingAvailability {
     #[cfg(target_os = "windows")]
     {
         // Windows DACLs are file-specific even inside one directory. Rehearse
-        // the post-DACL read/write/delete reopen for every exact target before
-        // any Save can begin.
-        let target_access = preflight_each_target(paths, preflight_tag_write_target_access);
+        // the post-DACL read/write/delete reopen for every exact local target
+        // before any Save can begin. Removable targets rehearsed their
+        // complete replacement shape in `preflight_write_capability` above.
+        let local_paths: Vec<PathBuf> = targets
+            .iter()
+            .filter_map(|target| match target {
+                SaveTarget::LocalPath(path) => Some(path.clone()),
+                _ => None,
+            })
+            .collect();
+        let target_access = preflight_each_target(&local_paths, preflight_tag_write_target_access);
         if target_access != TagEditingAvailability::Ready {
             return target_access;
         }
     }
 
     // Directory mechanics are parent-scoped. Rehearse the flushed atomic
-    // replacement once per exact parent while retaining the per-file checks
-    // above (including Windows read-only attributes).
-    preflight_distinct_parents(paths, preflight_tag_write_directory)
+    // replacement once per exact local parent while retaining the per-file
+    // checks above (including Windows read-only attributes).
+    let local_paths: Vec<PathBuf> = targets
+        .iter()
+        .filter_map(|target| match target {
+            SaveTarget::LocalPath(path) => Some(path.clone()),
+            _ => None,
+        })
+        .collect();
+    preflight_distinct_parents(&local_paths, preflight_tag_write_directory)
 }
 
 fn apply_tag_editing_availability(
@@ -304,10 +408,16 @@ pub fn show_properties_dialog(
         .margin_bottom(12)
         .build();
 
-    // Repeated playlist entries may refer to the same file. Probe and write
-    // each exact path once while retaining every selected row for batch-field
-    // presentation.
-    let file_paths = unique_track_paths(tracks);
+    // Repeated playlist rows may refer to the same file or the same
+    // removable identity. Probe and write each exact save target once while
+    // retaining every selected row for batch-field presentation.
+    let save_targets = unique_save_targets(tracks);
+    debug_assert!(
+        !tracks
+            .iter()
+            .any(|track| matches!(track.target, SaveTarget::PendingRemovable(_))),
+        "the caller must resolve removable identities before showing the dialog"
+    );
 
     // ── Helper to compute initial value for a field ──────────────────
     let field_value = |getter: fn(&TrackInfo) -> &str| -> String {
@@ -417,9 +527,22 @@ pub fn show_properties_dialog(
         add_info_row(&info_group, "Sample Rate", &t.sample_rate);
         add_info_row(&info_group, "Duration", &t.duration);
 
-        // Show file path
-        if let Some(path) = file_paths.first() {
-            add_info_row(&info_group, "File", &path.to_string_lossy());
+        // Show the native file path only for a local-library target. A
+        // removable row shows its mount-relative identity — the one pathname
+        // that may cross the source boundary; its native mount location
+        // never enters the UI.
+        match save_targets.first() {
+            Some(SaveTarget::LocalPath(path)) => {
+                add_info_row(&info_group, "File", &path.to_string_lossy());
+            }
+            Some(SaveTarget::Removable(authority)) => {
+                add_info_row(
+                    &info_group,
+                    "File",
+                    &authority.relative_path().to_string_lossy(),
+                );
+            }
+            _ => {}
         }
 
         form.append(&info_group);
@@ -581,7 +704,7 @@ pub fn show_properties_dialog(
         .map(|(name, entry)| ((*name).to_string(), entry.clone()))
         .collect();
 
-    let file_paths_for_save = file_paths.clone();
+    let save_targets_for_save = save_targets.clone();
     let entries_for_save_state = entries_for_save.clone();
     let musicbrainz_for_save = musicbrainz_button.clone();
     let capability_for_save = capability_label.clone();
@@ -656,7 +779,7 @@ pub fn show_properties_dialog(
             automatic_device,
         );
 
-        let paths = file_paths_for_save.clone();
+        let targets = save_targets_for_save.clone();
 
         // Re-probe the entire selection before the first write, then track
         // both the files that were written and the ones that failed.
@@ -664,7 +787,7 @@ pub fn show_properties_dialog(
         let edits = edits.clone();
 
         std::thread::spawn(move || {
-            let availability = preflight_paths(&paths);
+            let availability = preflight_save_targets(&targets);
             if availability != TagEditingAvailability::Ready {
                 let _ = tx.send_blocking(SaveOutcome::Blocked(availability));
                 return;
@@ -672,17 +795,40 @@ pub fn show_properties_dialog(
 
             let mut modified = 0usize;
             let mut failed = 0usize;
-            for path in &paths {
-                match crate::local::tag_writer::write_tags(path, &edits) {
+            for target in &targets {
+                // An unresolved pending identity cannot reach the write loop:
+                // the preflight above refuses the whole selection first.
+                let outcome = match target {
+                    SaveTarget::LocalPath(path) => {
+                        crate::local::tag_writer::write_tags(path, &edits)
+                    }
+                    SaveTarget::Removable(authority) => authority.write_tags(&edits),
+                    SaveTarget::PendingRemovable(_) => {
+                        failed += 1;
+                        continue;
+                    }
+                };
+                match outcome {
                     Ok(()) => {
                         modified += 1;
                     }
                     Err(e) => {
-                        warn!(
-                            path = %path.display(),
-                            error = %e,
-                            "Failed to write tags"
-                        );
+                        // Removable failures must never log their native mount
+                        // location; identity is the source-scoped pair.
+                        match target {
+                            SaveTarget::LocalPath(path) => {
+                                warn!(path = %path.display(), error = %e, "Failed to write tags");
+                            }
+                            SaveTarget::Removable(authority) => {
+                                warn!(
+                                    source = %authority.source_id(),
+                                    track = authority.track_id().as_str(),
+                                    error = %e,
+                                    "Failed to write tags to removable target"
+                                );
+                            }
+                            SaveTarget::PendingRemovable(_) => {}
+                        }
                         failed += 1;
                     }
                 }
@@ -690,7 +836,7 @@ pub fn show_properties_dialog(
             let current_availability = if failed == 0 {
                 TagEditingAvailability::Ready
             } else {
-                preflight_paths(&paths)
+                preflight_save_targets(&targets)
             };
             let _ = tx.send_blocking(SaveOutcome::Finished {
                 modified,
@@ -790,9 +936,9 @@ pub fn show_properties_dialog(
     // dialog starts fail-closed and the complete selection is checked on a
     // worker. The result is advisory and is rechecked in the Save worker.
     let (preflight_tx, preflight_rx) = async_channel::bounded(1);
-    let paths_for_preflight = file_paths;
+    let targets_for_preflight = save_targets;
     std::thread::spawn(move || {
-        let _ = preflight_tx.send_blocking(preflight_paths(&paths_for_preflight));
+        let _ = preflight_tx.send_blocking(preflight_save_targets(&targets_for_preflight));
     });
 
     let entries_for_preflight = entries_for_save;
@@ -999,9 +1145,9 @@ fn musicbrainz_lookup(title: &str, artist: &str) -> Option<MusicBrainzResult> {
 mod tests {
     use super::*;
 
-    fn track(path: PathBuf) -> TrackInfo {
+    fn track(target: SaveTarget) -> TrackInfo {
         TrackInfo {
-            path,
+            target,
             title: "Title".to_string(),
             artist: "Artist".to_string(),
             album: "Album".to_string(),
@@ -1017,17 +1163,57 @@ mod tests {
         }
     }
 
+    fn local_track(path: PathBuf) -> TrackInfo {
+        track(SaveTarget::LocalPath(path))
+    }
+
     #[test]
-    fn repeated_playlist_rows_probe_and_write_one_exact_path() {
+    fn repeated_playlist_rows_probe_and_write_one_exact_target() {
         let first = PathBuf::from("/music/album/song.flac");
         let second = PathBuf::from("/music/other.flac");
         let tracks = vec![
-            track(first.clone()),
-            track(first.clone()),
-            track(second.clone()),
+            local_track(first.clone()),
+            local_track(first.clone()),
+            local_track(second.clone()),
         ];
 
-        assert_eq!(unique_track_paths(&tracks), vec![first, second]);
+        assert_eq!(
+            unique_save_targets(&tracks),
+            vec![SaveTarget::LocalPath(first), SaveTarget::LocalPath(second),]
+        );
+    }
+
+    #[test]
+    fn unresolved_removable_identities_never_reach_the_probe_or_write_set() {
+        let pending = PendingRemovableMutation {
+            source_id: crate::architecture::SourceId::local(),
+            session_epoch: 3,
+            track_id: crate::architecture::TrackId::new("unix:616c62756d").expect("track id"),
+        };
+        let local = PathBuf::from("/music/album/song.flac");
+        let tracks = vec![
+            track(SaveTarget::PendingRemovable(pending.clone())),
+            track(SaveTarget::PendingRemovable(pending)),
+            local_track(local.clone()),
+        ];
+
+        // A pending identity has no deduplication identity: it is skipped
+        // entirely rather than silently folded into another row's target.
+        assert_eq!(
+            unique_save_targets(&tracks),
+            vec![SaveTarget::LocalPath(local)]
+        );
+
+        // Defense in depth: the preflight refuses any unresolved identity
+        // that reaches it, so a wiring fault can never authorize a write.
+        assert_eq!(
+            preflight_save_targets(&[SaveTarget::PendingRemovable(PendingRemovableMutation {
+                source_id: crate::architecture::SourceId::local(),
+                session_epoch: 1,
+                track_id: crate::architecture::TrackId::new("unix:01").expect("track id"),
+            })]),
+            TagEditingAvailability::Unavailable
+        );
     }
 
     #[test]
@@ -1128,7 +1314,10 @@ mod tests {
 
     #[test]
     fn empty_and_mixed_preflight_selections_fail_closed() {
-        assert_eq!(preflight_paths(&[]), TagEditingAvailability::InvalidFile);
+        assert_eq!(
+            preflight_save_targets(&[]),
+            TagEditingAvailability::InvalidFile
+        );
 
         let directory = tempfile::tempdir().expect("create preflight fixture");
         let supported = directory.path().join("song.flac");
@@ -1137,7 +1326,10 @@ mod tests {
         std::fs::write(&unsupported, b"audio").expect("write unsupported fixture");
 
         assert_eq!(
-            preflight_paths(&[supported, unsupported]),
+            preflight_save_targets(&[
+                SaveTarget::LocalPath(supported),
+                SaveTarget::LocalPath(unsupported),
+            ]),
             TagEditingAvailability::UnsupportedFormat
         );
         assert!(

--- a/src/ui/properties_dialog.rs
+++ b/src/ui/properties_dialog.rs
@@ -241,6 +241,19 @@ fn preflight_each_target(
     TagEditingAvailability::Ready
 }
 
+/// The exact local paths in `targets`, preserving selection order, for
+/// path-scoped rehearsal. Removable targets carry no path-scoped mechanics:
+/// their rehearsal is authority-based and already complete at this point.
+fn local_paths_of(targets: &[SaveTarget]) -> Vec<PathBuf> {
+    targets
+        .iter()
+        .filter_map(|target| match target {
+            SaveTarget::LocalPath(path) => Some(path.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
 /// Probe a complete, exact-deduplicated selection on a worker thread.
 ///
 /// Local paths are probed per file and per distinct parent directory.
@@ -285,14 +298,8 @@ fn preflight_save_targets(targets: &[SaveTarget]) -> TagEditingAvailability {
         // the post-DACL read/write/delete reopen for every exact local target
         // before any Save can begin. Removable targets rehearsed their
         // complete replacement shape in `preflight_write_capability` above.
-        let local_paths: Vec<PathBuf> = targets
-            .iter()
-            .filter_map(|target| match target {
-                SaveTarget::LocalPath(path) => Some(path.clone()),
-                _ => None,
-            })
-            .collect();
-        let target_access = preflight_each_target(&local_paths, preflight_tag_write_target_access);
+        let target_access =
+            preflight_each_target(&local_paths_of(targets), preflight_tag_write_target_access);
         if target_access != TagEditingAvailability::Ready {
             return target_access;
         }
@@ -301,14 +308,7 @@ fn preflight_save_targets(targets: &[SaveTarget]) -> TagEditingAvailability {
     // Directory mechanics are parent-scoped. Rehearse the flushed atomic
     // replacement once per exact local parent while retaining the per-file
     // checks above (including Windows read-only attributes).
-    let local_paths: Vec<PathBuf> = targets
-        .iter()
-        .filter_map(|target| match target {
-            SaveTarget::LocalPath(path) => Some(path.clone()),
-            _ => None,
-        })
-        .collect();
-    preflight_distinct_parents(&local_paths, preflight_tag_write_directory)
+    preflight_distinct_parents(&local_paths_of(targets), preflight_tag_write_directory)
 }
 
 fn apply_tag_editing_availability(

--- a/src/ui/properties_dialog.rs
+++ b/src/ui/properties_dialog.rs
@@ -22,12 +22,13 @@ use adw::prelude::*;
 use gtk::glib;
 use tracing::{info, warn};
 
+use crate::architecture::{SourceId, TrackId};
 #[cfg(target_os = "windows")]
 use crate::local::tag_writer::preflight_tag_write_target_access;
 use crate::local::tag_writer::{
     preflight_tag_write_directory, validate_tag_write_target, TagEdits, TagWritePreflightError,
 };
-use crate::source_registry::RemovableMutationTarget;
+use crate::source_registry::{RemovableMutationTarget, SourceRegistry};
 
 /// Exactly what one selected row is saved through.
 #[derive(Clone, Debug)]
@@ -358,6 +359,7 @@ pub fn show_properties_dialog(
     parent: &adw::ApplicationWindow,
     tracks: &[TrackInfo],
     automatic_device: bool,
+    catalogue_refresh: Option<SourceRegistry>,
 ) {
     if tracks.is_empty() {
         return;
@@ -710,6 +712,7 @@ pub fn show_properties_dialog(
     let capability_for_save = capability_label.clone();
     let cancel_for_save = cancel_button.clone();
     let generation_for_save = operation_generation.clone();
+    let catalogue_refresh_for_save = catalogue_refresh.clone();
 
     save_button.connect_clicked(move |button| {
         // Build TagEdits from the form, only including changed fields.
@@ -780,6 +783,7 @@ pub fn show_properties_dialog(
         );
 
         let targets = save_targets_for_save.clone();
+        let catalogue_refresh_for_save = catalogue_refresh_for_save.clone();
 
         // Re-probe the entire selection before the first write, then track
         // both the files that were written and the ones that failed.
@@ -795,6 +799,7 @@ pub fn show_properties_dialog(
 
             let mut modified = 0usize;
             let mut failed = 0usize;
+            let mut written: Vec<(SourceId, TrackId)> = Vec::new();
             for target in &targets {
                 // An unresolved pending identity cannot reach the write loop:
                 // the preflight above refuses the whole selection first.
@@ -811,6 +816,9 @@ pub fn show_properties_dialog(
                 match outcome {
                     Ok(()) => {
                         modified += 1;
+                        if let SaveTarget::Removable(authority) = target {
+                            written.push((authority.source_id(), authority.track_id().clone()));
+                        }
                     }
                     Err(e) => {
                         // Removable failures must never log their native mount
@@ -833,6 +841,20 @@ pub fn show_properties_dialog(
                     }
                 }
             }
+
+            // Publish refreshed metadata for exactly the identities whose
+            // writes committed, before any completion branch can forget
+            // them. The trigger is fire-and-forget: publication flows through
+            // the registry's catalogue refresh lane, whose settlement
+            // revalidates the exact live session, so a completion that lands
+            // after a disconnect or replacement can never repopulate a stale
+            // mount or overwrite a newer generation.
+            if let Some(registry) = &catalogue_refresh_for_save {
+                if !written.is_empty() {
+                    registry.refresh_catalogue_after_mutation(&written);
+                }
+            }
+
             let current_availability = if failed == 0 {
                 TagEditingAvailability::Ready
             } else {

--- a/src/ui/properties_dialog.rs
+++ b/src/ui/properties_dialog.rs
@@ -107,6 +107,20 @@ fn unique_save_targets(tracks: &[TrackInfo]) -> Vec<SaveTarget> {
     targets
 }
 
+/// Release-enforced gate on the ORIGINAL selection, before any
+/// deduplication: a row still carrying an unresolved removable identity is
+/// a caller wiring fault — the context menu resolves every pending identity
+/// through its exact live session before the dialog may open. A pending
+/// row has no deduplication identity, so dedup alone would silently drop
+/// that row's edit and report success over a partial write set; the check
+/// therefore runs on the original selection, where the whole dialog
+/// refuses instead.
+fn selection_has_unresolved_removable(tracks: &[TrackInfo]) -> bool {
+    tracks
+        .iter()
+        .any(|track| matches!(track.target, SaveTarget::PendingRemovable(_)))
+}
+
 /// Information about a track passed into the dialog.
 #[derive(Debug, Clone)]
 pub struct TrackInfo {
@@ -365,6 +379,27 @@ pub fn show_properties_dialog(
         return;
     }
 
+    // Fail closed on the original selection, before any deduplication: an
+    // unresolved removable identity is a caller wiring fault, and dedup
+    // cannot see such a row — the fault would silently shrink the write
+    // set. This gate is release-enforced (not a debug assertion): the
+    // dialog never opens and the refusal is surfaced, while
+    // `preflight_save_targets`' pending refusal stays as the layered
+    // defense behind it.
+    if selection_has_unresolved_removable(tracks) {
+        tracing::warn!(
+            selection = tracks.len(),
+            "properties dialog refused: selection still carries an unresolved removable identity (caller wiring fault)"
+        );
+        let refusal = adw::AlertDialog::builder()
+            .heading("Cannot Edit These Files")
+            .body(TagEditingAvailability::Unavailable.message(automatic_device))
+            .build();
+        refusal.add_response("ok", "OK");
+        refusal.present(Some(parent));
+        return;
+    }
+
     let is_batch = tracks.len() > 1;
     let heading = if is_batch {
         format!("Properties — {} tracks", tracks.len())
@@ -412,14 +447,10 @@ pub fn show_properties_dialog(
 
     // Repeated playlist rows may refer to the same file or the same
     // removable identity. Probe and write each exact save target once while
-    // retaining every selected row for batch-field presentation.
+    // retaining every selected row for batch-field presentation. Unresolved
+    // removable identities were refused above, on the original selection,
+    // before this deduplication could silently drop one.
     let save_targets = unique_save_targets(tracks);
-    debug_assert!(
-        !tracks
-            .iter()
-            .any(|track| matches!(track.target, SaveTarget::PendingRemovable(_))),
-        "the caller must resolve removable identities before showing the dialog"
-    );
 
     // ── Helper to compute initial value for a field ──────────────────
     let field_value = |getter: fn(&TrackInfo) -> &str| -> String {
@@ -1215,19 +1246,40 @@ mod tests {
         let local = PathBuf::from("/music/album/song.flac");
         let tracks = vec![
             track(SaveTarget::PendingRemovable(pending.clone())),
-            track(SaveTarget::PendingRemovable(pending)),
+            track(SaveTarget::PendingRemovable(pending.clone())),
             local_track(local.clone()),
         ];
 
-        // A pending identity has no deduplication identity: it is skipped
-        // entirely rather than silently folded into another row's target.
+        // Fail closed on the ORIGINAL selection, before any deduplication:
+        // an unresolved removable identity is a caller wiring fault, so the
+        // dialog refuses entirely instead of opening with a partial write
+        // set — in release builds too, not behind a debug assertion.
+        assert!(selection_has_unresolved_removable(&tracks));
+
+        // The reason the gate must precede dedup: a pending value has no
+        // deduplication identity, so dedup alone would silently drop the
+        // row rather than refuse it.
+        let keyed = save_target_key(&SaveTarget::PendingRemovable(pending));
+        assert!(keyed.is_none());
+
+        // A fully resolved selection passes the gate, and deduplication
+        // keeps its exact semantics for identities that carry one.
+        let resolved = vec![
+            local_track(local.clone()),
+            local_track(local.clone()),
+            local_track(local),
+        ];
+        assert!(!selection_has_unresolved_removable(&resolved));
         assert_eq!(
-            unique_save_targets(&tracks),
-            vec![SaveTarget::LocalPath(local)]
+            unique_save_targets(&resolved),
+            vec![SaveTarget::LocalPath(PathBuf::from(
+                "/music/album/song.flac"
+            ))]
         );
 
-        // Defense in depth: the preflight refuses any unresolved identity
-        // that reaches it, so a wiring fault can never authorize a write.
+        // Defense in depth: the preflight still refuses any unresolved
+        // identity that reaches it directly, so a wiring fault can never
+        // authorize a write even past the entry-point gate.
         assert_eq!(
             preflight_save_targets(&[SaveTarget::PendingRemovable(PendingRemovableMutation {
                 source_id: crate::architecture::SourceId::local(),
@@ -1236,6 +1288,28 @@ mod tests {
             })]),
             TagEditingAvailability::Unavailable
         );
+    }
+
+    #[test]
+    fn a_mixed_selection_with_one_pending_identity_is_refused_in_release() {
+        // The release shape of the wiring fault: one local row plus one
+        // unresolved removable identity. Dedup alone would cover only the
+        // local row and report success while losing the pending edit — so
+        // the release-enforced entry-point gate fires on the original
+        // selection first and the whole dialog refuses; no partial write
+        // set is ever built.
+        let pending = PendingRemovableMutation {
+            source_id: crate::architecture::SourceId::local(),
+            session_epoch: 7,
+            track_id: crate::architecture::TrackId::new("unix:6d69786564").expect("track id"),
+        };
+        let local = PathBuf::from("/music/album/song.flac");
+        let tracks = vec![
+            local_track(local),
+            track(SaveTarget::PendingRemovable(pending)),
+        ];
+
+        assert!(selection_has_unresolved_removable(&tracks));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Per docs/task.md:1166-1168 (P2/P3 backlog).
Add typed retained mutation authority before enabling Properties/tag writes for pathless removable rows; revalidate the mount, ancestry, exact file, write rights, and replacement target through commit.

Work from current origin/main, keep the change scoped to this item, add focused regression coverage, run the full rig gates, and hand off to the refinery.

## Implementation notes

Resubmit (verified this session): deadlock fix 867c4e1 present (drop(commit) before target.rebind() in write_tags_with_mutation_target — non-reentrant std Mutex self-deadlock). Branch polecat/tr-mms4s == origin tip, based on origin/main @ab1c3f2 (rebase no-op). Gates this session: fmt --check, clippy debug+release -D warnings, cargo check --all-targets --locked, cargo build --release — all clean. Test gate per operator directive (no plain debug suite): formerly-deadlocking regression test a_mutation_target_write_round_trips_and_reanchors_for_a_follow_up passes isolated --test-threads=1 timeout-wrapped; local::tag_writer 16/16 and local::root_authority 24/24 pass single-threaded; 0 failures.

## Refinery handoff

- Issue: `tr-mms4s` (task, P3)
- Source branch: `polecat/tr-mms4s`
- Target: `main`
- Rebased on `main` via Gastown Refinery.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tag editing for tracks stored on removable devices from any view.
  * Added automatic catalogue and attribution refreshes after successful removable-media edits.
  * Added support for retrying follow-up saves on removable media.

* **Bug Fixes**
  * Prevented tag changes when removable media is unavailable, renamed, replaced, or mismatched.
  * Improved protection against symlinks, path replacement, parent-directory displacement, and concurrent destination changes.
  * Improved failure handling for unresolved removable-device identities and incomplete or cancelled refreshes.
  * Preserved existing catalogue entries when refreshed removable files cannot be read.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->