### PR TITLE
Pre-existing failure: markdownlint in docs/refinery-config.md lines 22-33 (MD040 no-language fence, MD060 compact delimiter row x6, MD013 x3 — all on origin/main) (tr-9kamg)

### DIFF
--- a/docs/refinery-config.md
+++ b/docs/refinery-config.md
@@ -19,18 +19,20 @@ the timer would have blamed the wrong check.
 Configured under `[rigs.formula_vars]` in the city config (the rig-side
 clone does not own this value — `city.toml` does):
 
-```
+```toml
 ci_timeout_seconds = "3600"   # 1 hour, comfortable margin over the tail
 ```
 
 Everything else stays at the upstream defaults:
 
-| var | value | meaning |
-|---|---|---|
-| `ci_gate` | `true` | "pending is never green" — fail-closed when checks are still running. **Preserved.** |
-| `ci_poll_seconds` | `60` | Poll GitHub for check-runs every minute. **Preserved.** |
-| `ci_zero_check_grace_seconds` | `300` | Allow the workflow runs to materialize before declaring zero-on-this-branch. **Preserved.** |
-| `ci_timeout_seconds` | `3600` | **Raised from 900**: covers the observed ~20-53 min tail with margin. |
+- `ci_gate` — `true` — "pending is never green" — fail-closed when checks are
+  still running. **Preserved.**
+- `ci_poll_seconds` — `60` — Poll GitHub for check-runs every minute.
+  **Preserved.**
+- `ci_zero_check_grace_seconds` — `300` — Allow the workflow runs to
+  materialize before declaring zero-on-this-branch. **Preserved.**
+- `ci_timeout_seconds` — `3600` — **Raised from 900**: covers the observed
+  ~20-53 min tail with margin.
 
 The change is the deadline alone; the fail-closed policy is intentionally
 left intact. A bead (tr-3h7) opened the issue and another polecat can land


### PR DESCRIPTION
## Summary

Refinery handoff for `tr-9kamg` (no bead description recorded).

## Implementation notes

Operator-authorized 2026-09-07 gap repair: fix the existing MD040/MD060/MD013 findings in docs/refinery-config.md on a per-bead branch. Keep changes limited to Markdown formatting; preserve all policy wording and existing open PR #225 semantics. Verify with the repository markdownlint configuration. Publish one PR and hand off for independent review. Do not merge.
Implemented (polecat/tr-9kamg, ce0b363): markdownlint fixes in docs/refinery-config.md — fence tagged toml (MD040); defaults table converted to a wrapped bullet list with policy wording preserved verbatim (MD060 x6 + MD013 x3). Repo markdownlint config passes; cargo check/fmt/clippy/build/test all green; no overlap with PR #225.

## Refinery handoff

- Issue: `tr-9kamg` (bug, P1)
- Source branch: `polecat/tr-9kamg`
- Target: `main`
- Rebased on `main` via Gastown Refinery.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the refinery configuration documentation to use a bullet-list format.
  - Clarified that the `ci_timeout_seconds` override is set to 3600 seconds, while other CI settings and fail-closed behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->