### PR TITLE
ci: cancel obsolete PR builds and reuse macOS release output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [main]
 
+# New revisions replace obsolete runs of the same PR. Main pushes use their
+# own run IDs so pending main validation is never evicted by another push.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 
@@ -323,6 +329,9 @@ jobs:
         # Production must pin the repository policy and platform inspectors,
         # ignoring the helper's deliberately injectable test hooks.
         env:
+          # Reuse the target-specific release build above when the packaging
+          # helper verifies it, instead of compiling a second host-layout tree.
+          CARGO_BUILD_TARGET: ${{ matrix.rust_target }}
           TRIBUTARY_FORBIDDEN_COMPONENTS_FILE: /dev/null
           MACOS_FIND_COMMAND: /usr/bin/true
           MACOS_OTOOL_COMMAND: /usr/bin/false

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -146,7 +146,7 @@ fi
 info "All system dependencies satisfied."
 
 BREW_PREFIX="$(brew --prefix)"
-export PKG_CONFIG_PATH="${BREW_PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+export PKG_CONFIG_PATH="${BREW_PREFIX}/lib/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}"
 
 # ── Quick-exit modes: --check, --clippy ─────────────────────────────────────
 if $CHECK; then


### PR DESCRIPTION
Repeated pushes leave obsolete CI runs competing with current revisions. This groups CI by PR and cancels superseded runs; each main push keeps its own group. It also makes macOS packaging reuse the target-specific release output and pkg-config environment used by the preceding build, avoiding a second host-layout compile.

In #183's completed macOS job, the runner wait was 106m40s and packaging included another 7m23s release compile. This removes avoidable work; hosted runner wait reductions still need measurement. All existing checks and packaging validation remain enabled.

Validation: six build-helper tests, macOS package and icon policy tests, shell syntax, YAML job/permission preservation, and absent/empty/custom pkg-config path checks passed. Native macOS behavior awaits CI.

References: [GitHub concurrency](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency), [Cargo environment variables](https://doc.rust-lang.org/cargo/reference/environment-variables.html).

Gas City bead: `tr-j7kdb`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI/CD Improvements**
  * Obsolete pull request workflow runs are now canceled automatically.
  * Main-branch builds use distinct workflow run identifiers.
  * macOS packaging reuses the build output for the selected target architecture.

* **Bug Fixes**
  * Improved macOS package configuration to avoid an unnecessary trailing path separator while preserving existing package search paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->