### PR TITLE
fix(build): admit exact shared-transitive unification in the fuzz lock proof (tr-zo5lg)

### DIFF
--- a/scripts/sync_fuzz_lock.py
+++ b/scripts/sync_fuzz_lock.py
@@ -349,6 +349,43 @@ def is_exact_unification_rebind(
     return remapped == after_targets and remapped != before_targets
 
 
+def observed_unification_rebinds(
+    before_records: dict[tuple[str, str], dict[str, Any]],
+    after_records: dict[tuple[str, str], dict[str, Any]],
+    replacements: dict[tuple[str, str], tuple[str, str]],
+) -> set[tuple[str, str]]:
+    """
+    Return the removed identities whose mapping an edge rebind consumes.
+
+    A unification mapping justifies its removal only when at least one
+    retained consumer exhibits the exact before-edge to after-edge rebind:
+    cargo deleted the old record because that consumer now resolves onto the
+    surviving record. A survivor that merely shares the removed record's
+    name and source — for example a newly reachable dependency of an
+    upgraded facade — never consumes the mapping, and neither does a
+    consumer whose last old edge was dropped without a rebind. Unused
+    mappings stay unauthorized.
+    """
+    observed: set[tuple[str, str]] = set()
+    for identity in sorted(before_records.keys() & after_records.keys()):
+        before_edges = resolved_dependency_edges(
+            before_records[identity], before_records
+        )
+        after_edges = resolved_dependency_edges(after_records[identity], after_records)
+        for dependency_name in before_edges.keys() & after_edges.keys():
+            before_targets = before_edges[dependency_name]
+            after_targets = after_edges[dependency_name]
+            if before_targets == after_targets:
+                continue
+            if is_exact_unification_rebind(
+                before_targets, after_targets, replacements
+            ):
+                observed.update(
+                    target for target in before_targets if target in replacements
+                )
+    return observed
+
+
 # The explicit fail-closed branches mirror distinct lockfile invariants; folding
 # them together would make the safety proof harder to audit.
 def validate_dependency_edges(
@@ -507,6 +544,21 @@ def validate_bounded_package_changes(
     replacements = unification_replacements(
         before_records, after_records, old_identities, after_identities
     )
+    # A unification mapping authorizes its removal only when the repaired
+    # lock actually exhibits the exact edge rebind consuming it. A survivor
+    # that merely shares the removed record's name and source — or a last
+    # edge dropped without any rebind — leaves the mapping unused, so the
+    # removal stays outside the reviewed dependency surface.
+    observed = observed_unification_rebinds(
+        before_records, after_records, replacements
+    )
+    unused_replacements = replacements.keys() - observed
+    if unused_replacements:
+        raise PolicyError(
+            "fuzz lock repair removed package identities outside the exact "
+            "old dependency closure with no observed exact edge rebind onto "
+            f"the unified survivor: {sorted(unused_replacements)}"
+        )
     unexpected_removed = (
         removed_identities - old_identities - replacements.keys()
     )

--- a/scripts/sync_fuzz_lock.py
+++ b/scripts/sync_fuzz_lock.py
@@ -279,6 +279,67 @@ def resolved_dependency_edges(
     }
 
 
+def unification_replacements(
+    before_records: dict[tuple[str, str], dict[str, Any]],
+    after_records: dict[tuple[str, str], dict[str, Any]],
+    old_identities: set[tuple[str, str]],
+    after_identities: set[tuple[str, str]],
+) -> dict[tuple[str, str], tuple[str, str]]:
+    """Attribute exact removals to a Cargo shared-transitive unification.
+
+    Cargo unifies same-requirement consumers onto a single lock entry, so
+    promoting a shared transitive can delete an exact identity that the old
+    transition closure never contained: the base lock holds (name, old) only
+    for crates outside the transitioned subtree, and the repaired lock
+    resolves every requirer onto one surviving (name, new) record. A removal
+    is attributed to that unification only when the removed identity has
+    exactly one surviving same-name record, that record lies inside the exact
+    after closure (so the selected production update necessitated it), and it
+    preserves the removed record's source identity. Unrelated removals,
+    ambiguous survivors, and cross-source substitutions stay rejected.
+    """
+    replacements: dict[tuple[str, str], tuple[str, str]] = {}
+    candidates = sorted(
+        before_records.keys() - after_records.keys() - old_identities
+    )
+    for identity in candidates:
+        survivors = sorted(
+            candidate for candidate in after_records if candidate[0] == identity[0]
+        )
+        if len(survivors) != 1:
+            continue
+        replacement = survivors[0]
+        if replacement not in after_identities:
+            continue
+        if (
+            before_records[identity].get("source")
+            != after_records[replacement].get("source")
+        ):
+            continue
+        replacements[identity] = replacement
+    return replacements
+
+
+def is_exact_unification_rebind(
+    before_targets: tuple[tuple[str, str], ...],
+    after_targets: tuple[tuple[str, str], ...],
+    unification_replacements: dict[tuple[str, str], tuple[str, str]],
+) -> bool:
+    """True when an edge change is exactly the admitted unification mapping.
+
+    A rebinding consumer keeps its dependency-name surface and edge count;
+    every changed target must map from an admitted removed identity onto its
+    unique surviving replacement. Arbitrary rebinds, added or dropped edges,
+    and unrelated changes mixed into the same consumer still fail closed.
+    """
+    if len(before_targets) != len(after_targets):
+        return False
+    remapped = tuple(
+        unification_replacements.get(target, target) for target in before_targets
+    )
+    return remapped == after_targets and remapped != before_targets
+
+
 # The explicit fail-closed branches mirror distinct lockfile invariants; folding
 # them together would make the safety proof harder to audit.
 def validate_dependency_edges(
@@ -288,6 +349,7 @@ def validate_dependency_edges(
     authorized_identities: set[tuple[str, str]],
     old_identities: set[tuple[str, str]],
     target_identities: set[tuple[str, str]],
+    unification_replacements: dict[tuple[str, str], tuple[str, str]],
 ) -> None:
     """Reject semantic edge changes outside the reviewed dependency surface."""
     #lizard forgives
@@ -386,6 +448,13 @@ def validate_dependency_edges(
             if (
                 identity in authorized_identities
                 or edge_surface <= authorized_identities
+                # A shared-transitive promotion can rebind an unchanged
+                # consumer onto the single unified record. Admit only an
+                # exact old->replacement mapping proven by
+                # unification_replacements; every other rebind fails.
+                or is_exact_unification_rebind(
+                    before_targets, after_targets, unification_replacements
+                )
             ):
                 continue
 
@@ -424,7 +493,14 @@ def validate_bounded_package_changes(
     root_records = package_records_by_identity(current_root_lock)
     removed_identities = before_records.keys() - after_records.keys()
     added_identities = after_records.keys() - before_records.keys()
-    unexpected_removed = removed_identities - old_identities
+    # Exact shared-transitive unification replacements necessitated by the
+    # selected production update. Every other removal stays unexpected.
+    replacements = unification_replacements(
+        before_records, after_records, old_identities, after_identities
+    )
+    unexpected_removed = (
+        removed_identities - old_identities - replacements.keys()
+    )
     unexpected_added = added_identities - after_identities
     if unexpected_removed:
         raise PolicyError(
@@ -467,6 +543,7 @@ def validate_bounded_package_changes(
         authorized_identities,
         old_identities,
         after_identities,
+        replacements,
     )
 
 

--- a/scripts/sync_fuzz_lock.py
+++ b/scripts/sync_fuzz_lock.py
@@ -285,7 +285,8 @@ def unification_replacements(
     old_identities: set[tuple[str, str]],
     after_identities: set[tuple[str, str]],
 ) -> dict[tuple[str, str], tuple[str, str]]:
-    """Attribute exact removals to a Cargo shared-transitive unification.
+    """
+    Attribute exact removals to a Cargo shared-transitive unification.
 
     Cargo unifies same-requirement consumers onto a single lock entry, so
     promoting a shared transitive can delete an exact identity that the old
@@ -294,9 +295,10 @@ def unification_replacements(
     resolves every requirer onto one surviving (name, new) record. A removal
     is attributed to that unification only when the removed identity has
     exactly one surviving same-name record, that record lies inside the exact
-    after closure (so the selected production update necessitated it), and it
-    preserves the removed record's source identity. Unrelated removals,
-    ambiguous survivors, and cross-source substitutions stay rejected.
+    after closure (so the selected production update necessitated it), it
+    preserves the removed record's source identity, and the repair itself
+    introduced it. Unrelated removals, ambiguous survivors, pre-existing
+    survivors, and cross-source substitutions stay rejected.
     """
     replacements: dict[tuple[str, str], tuple[str, str]] = {}
     candidates = sorted(
@@ -311,6 +313,12 @@ def unification_replacements(
         replacement = survivors[0]
         if replacement not in after_identities:
             continue
+        if replacement in before_records:
+            # A survivor that already existed in the before lock could
+            # silently downgrade or substitute a transitive by absorbing its
+            # consumers; only a record the repair itself introduced is
+            # provably the unification target.
+            continue
         if (
             before_records[identity].get("source")
             != after_records[replacement].get("source")
@@ -323,9 +331,10 @@ def unification_replacements(
 def is_exact_unification_rebind(
     before_targets: tuple[tuple[str, str], ...],
     after_targets: tuple[tuple[str, str], ...],
-    unification_replacements: dict[tuple[str, str], tuple[str, str]],
+    replacements: dict[tuple[str, str], tuple[str, str]],
 ) -> bool:
-    """True when an edge change is exactly the admitted unification mapping.
+    """
+    True when an edge change is exactly the admitted unification mapping.
 
     A rebinding consumer keeps its dependency-name surface and edge count;
     every changed target must map from an admitted removed identity onto its
@@ -335,7 +344,7 @@ def is_exact_unification_rebind(
     if len(before_targets) != len(after_targets):
         return False
     remapped = tuple(
-        unification_replacements.get(target, target) for target in before_targets
+        replacements.get(target, target) for target in before_targets
     )
     return remapped == after_targets and remapped != before_targets
 
@@ -349,7 +358,7 @@ def validate_dependency_edges(
     authorized_identities: set[tuple[str, str]],
     old_identities: set[tuple[str, str]],
     target_identities: set[tuple[str, str]],
-    unification_replacements: dict[tuple[str, str], tuple[str, str]],
+    replacements: dict[tuple[str, str], tuple[str, str]],
 ) -> None:
     """Reject semantic edge changes outside the reviewed dependency surface."""
     #lizard forgives
@@ -453,7 +462,7 @@ def validate_dependency_edges(
                 # exact old->replacement mapping proven by
                 # unification_replacements; every other rebind fails.
                 or is_exact_unification_rebind(
-                    before_targets, after_targets, unification_replacements
+                    before_targets, after_targets, replacements
                 )
             ):
                 continue

--- a/scripts/test_dependency_update_policy.py
+++ b/scripts/test_dependency_update_policy.py
@@ -548,6 +548,405 @@ class FuzzLockPolicyTests(unittest.TestCase):
                 [sync_fuzz_lock.Transition("facade", "1.0.0", "1.1.0")],
             )
 
+    def test_bounded_repair_allows_shared_transitive_unification_replacement(self):
+        # Regression for the lofty 0.24.0 -> 0.25.1 repair: lofty-attr 0.13.0
+        # requires syn ^3.0.3, so cargo unifies every syn requirer onto a
+        # single record and deletes syn 3.0.2, which the old lofty closure
+        # never contained. The repaired lock must pass its own bounded proof.
+        base = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "syn": ["3.0.2"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        # package order: lofty, lofty-attr, syn, quote, async-trait,
+        # serde-derive. The old lofty subtree never reaches syn.
+        base["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        base["package"][3]["dependencies"] = ["quote 1.0.0"]
+        base["package"][5]["dependencies"] = ["syn 3.0.2"]
+        base["package"][6]["dependencies"] = ["syn 3.0.2"]
+        stale_fuzz = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "syn": ["3.0.2"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        stale_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        stale_fuzz["package"][3]["dependencies"] = ["quote 1.0.0"]
+        stale_fuzz["package"][5]["dependencies"] = ["syn 3.0.2"]
+        stale_fuzz["package"][6]["dependencies"] = ["syn 3.0.2"]
+        current = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "syn": ["3.0.5"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        current["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        current["package"][2]["dependencies"] = ["syn 3.0.5"]
+        current["package"][3]["dependencies"] = ["quote 1.0.0"]
+        current["package"][5]["dependencies"] = ["syn 3.0.5"]
+        current["package"][6]["dependencies"] = ["syn 3.0.5"]
+        repaired_fuzz = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "syn": ["3.0.5"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        repaired_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        repaired_fuzz["package"][2]["dependencies"] = ["syn 3.0.5"]
+        repaired_fuzz["package"][3]["dependencies"] = ["quote 1.0.0"]
+        repaired_fuzz["package"][5]["dependencies"] = ["syn 3.0.5"]
+        repaired_fuzz["package"][6]["dependencies"] = ["syn 3.0.5"]
+
+        requested, remaining = sync_fuzz_lock.validate_submitted_fuzz_update(
+            base,
+            current,
+            stale_fuzz,
+            repaired_fuzz,
+            {"dependencies": {"lofty": "1"}},
+        )
+        self.assertEqual(
+            requested,
+            [sync_fuzz_lock.Transition("lofty", "0.24.0", "0.25.1")],
+        )
+        self.assertEqual(remaining, [])
+        sync_fuzz_lock.validate_bounded_package_changes(
+            base,
+            current,
+            stale_fuzz,
+            repaired_fuzz,
+            requested,
+        )
+
+    def test_bounded_repair_rejects_unification_with_ambiguous_survivors(self):
+        # Two same-name records survive the repair, so the removal cannot be
+        # attributed to one exact unification; the proof fails closed.
+        base = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "syn": ["3.0.2"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+            },
+        )
+        base["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        base["package"][3]["dependencies"] = ["quote 1.0.0"]
+        base["package"][5]["dependencies"] = ["syn 3.0.2"]
+        stale_fuzz = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "syn": ["3.0.2"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+            },
+        )
+        stale_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        stale_fuzz["package"][3]["dependencies"] = ["quote 1.0.0"]
+        stale_fuzz["package"][5]["dependencies"] = ["syn 3.0.2"]
+        current = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "syn": ["3.0.5", "3.0.9"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+            },
+        )
+        current["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        current["package"][2]["dependencies"] = ["syn 3.0.5"]
+        current["package"][3]["dependencies"] = ["quote 1.0.0"]
+        current["package"][6]["dependencies"] = ["syn 3.0.9"]
+        repaired_fuzz = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "syn": ["3.0.5", "3.0.9"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+            },
+        )
+        repaired_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        repaired_fuzz["package"][2]["dependencies"] = ["syn 3.0.5"]
+        repaired_fuzz["package"][3]["dependencies"] = ["quote 1.0.0"]
+        repaired_fuzz["package"][6]["dependencies"] = ["syn 3.0.9"]
+
+        with self.assertRaises(sync_fuzz_lock.PolicyError):
+            sync_fuzz_lock.validate_bounded_package_changes(
+                base,
+                current,
+                stale_fuzz,
+                repaired_fuzz,
+                [sync_fuzz_lock.Transition("lofty", "0.24.0", "0.25.1")],
+            )
+
+    def test_bounded_repair_rejects_unification_survivor_outside_exact_after_closure(
+        self,
+    ):
+        # The only surviving same-name record is not reachable from the
+        # requested transition, so the removal is not necessitated by the
+        # selected production update and must fail closed.
+        base = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "syn": ["3.0.2"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+            },
+        )
+        base["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        base["package"][3]["dependencies"] = ["quote 1.0.0"]
+        base["package"][5]["dependencies"] = ["syn 3.0.2"]
+        stale_fuzz = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "syn": ["3.0.2"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+            },
+        )
+        stale_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        stale_fuzz["package"][3]["dependencies"] = ["quote 1.0.0"]
+        stale_fuzz["package"][5]["dependencies"] = ["syn 3.0.2"]
+        current = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "syn": ["3.0.9"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+            },
+        )
+        current["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        current["package"][3]["dependencies"] = ["quote 1.0.0"]
+        current["package"][5]["dependencies"] = ["syn 3.0.9"]
+        repaired_fuzz = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "syn": ["3.0.9"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+            },
+        )
+        repaired_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        repaired_fuzz["package"][3]["dependencies"] = ["quote 1.0.0"]
+        repaired_fuzz["package"][5]["dependencies"] = ["syn 3.0.9"]
+
+        with self.assertRaises(sync_fuzz_lock.PolicyError):
+            sync_fuzz_lock.validate_bounded_package_changes(
+                base,
+                current,
+                stale_fuzz,
+                repaired_fuzz,
+                [sync_fuzz_lock.Transition("lofty", "0.24.0", "0.25.1")],
+            )
+
+    def test_bounded_repair_rejects_unification_cross_source_substitution(self):
+        # The survivor carries a different source than the removed record:
+        # that is a source substitution, not a version unification.
+        base = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "syn": ["3.0.2"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+            },
+        )
+        base["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        base["package"][3]["dependencies"] = ["quote 1.0.0"]
+        base["package"][5]["dependencies"] = ["syn 3.0.2"]
+        stale_fuzz = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "syn": ["3.0.2"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+            },
+        )
+        stale_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        stale_fuzz["package"][3]["dependencies"] = ["quote 1.0.0"]
+        stale_fuzz["package"][5]["dependencies"] = ["syn 3.0.2"]
+        current = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "quote": ["1.0.0"],
+            },
+        )
+        current["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        current["package"][2]["dependencies"] = ["syn 3.0.5"]
+        repaired_fuzz = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "syn": ["3.0.5"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+            },
+        )
+        repaired_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        repaired_fuzz["package"][2]["dependencies"] = ["syn 3.0.5"]
+        repaired_fuzz["package"][3]["dependencies"] = ["quote 1.0.0"]
+        repaired_fuzz["package"][5]["dependencies"] = ["syn 3.0.5"]
+        repaired_fuzz["package"][3]["source"] = "git+https://invalid.example/syn"
+
+        with self.assertRaises(sync_fuzz_lock.PolicyError):
+            sync_fuzz_lock.validate_bounded_package_changes(
+                base,
+                current,
+                stale_fuzz,
+                repaired_fuzz,
+                [sync_fuzz_lock.Transition("lofty", "0.24.0", "0.25.1")],
+            )
+
+    def test_bounded_repair_rejects_unification_mixed_with_arbitrary_rebind(self):
+        # A consumer may rebind onto the unified record, but mixing that
+        # admitted rebind with an unrelated edge rewrite on the same consumer
+        # must still fail closed.
+        base = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "syn": ["3.0.2"],
+                "quote": ["1.0.0", "1.1.0"],
+                "async-trait": ["0.1.92"],
+            },
+        )
+        base["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        base["package"][3]["dependencies"] = ["quote 1.1.0"]
+        base["package"][6]["dependencies"] = ["quote 1.0.0", "syn 3.0.2"]
+        stale_fuzz = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "syn": ["3.0.2"],
+                "quote": ["1.0.0", "1.1.0"],
+                "async-trait": ["0.1.92"],
+            },
+        )
+        stale_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        stale_fuzz["package"][3]["dependencies"] = ["quote 1.1.0"]
+        stale_fuzz["package"][6]["dependencies"] = ["quote 1.0.0", "syn 3.0.2"]
+        current = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "syn": ["3.0.5"],
+                "quote": ["1.0.0", "1.1.0"],
+                "async-trait": ["0.1.92"],
+            },
+        )
+        current["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        current["package"][2]["dependencies"] = ["syn 3.0.5"]
+        current["package"][3]["dependencies"] = ["quote 1.1.0"]
+        current["package"][6]["dependencies"] = ["quote 1.1.0", "syn 3.0.5"]
+        repaired_fuzz = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "syn": ["3.0.5"],
+                "quote": ["1.0.0", "1.1.0"],
+                "async-trait": ["0.1.92"],
+            },
+        )
+        repaired_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        repaired_fuzz["package"][2]["dependencies"] = ["syn 3.0.5"]
+        repaired_fuzz["package"][3]["dependencies"] = ["quote 1.1.0"]
+        repaired_fuzz["package"][6]["dependencies"] = ["quote 1.1.0", "syn 3.0.5"]
+
+        with self.assertRaises(sync_fuzz_lock.PolicyError):
+            sync_fuzz_lock.validate_bounded_package_changes(
+                base,
+                current,
+                stale_fuzz,
+                repaired_fuzz,
+                [sync_fuzz_lock.Transition("lofty", "0.24.0", "0.25.1")],
+            )
+
+    def test_bounded_repair_rejects_removal_without_surviving_same_name_record(self):
+        # A crate removed entirely from the repaired lock has no unification
+        # successor, so the removal stays outside the old transition closure
+        # and must fail closed.
+        base = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "orphan": ["1.0.0"],
+            },
+        )
+        base["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        stale_fuzz = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "orphan": ["1.0.0"],
+            },
+        )
+        stale_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        current = lock(
+            ["lofty 0.25.1"],
+            {"lofty": ["0.25.1"], "lofty-attr": ["0.13.0"]},
+        )
+        current["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        repaired_fuzz = lock(
+            ["lofty 0.25.1"],
+            {"lofty": ["0.25.1"], "lofty-attr": ["0.13.0"]},
+        )
+        repaired_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+
+        with self.assertRaises(sync_fuzz_lock.PolicyError):
+            sync_fuzz_lock.validate_bounded_package_changes(
+                base,
+                current,
+                stale_fuzz,
+                repaired_fuzz,
+                [sync_fuzz_lock.Transition("lofty", "0.24.0", "0.25.1")],
+            )
+
     def test_check_mode_rejects_raw_rebind_after_direct_transition_is_repaired(self):
         base = lock(
             ["facade 1.0.0"],

--- a/scripts/test_dependency_update_policy.py
+++ b/scripts/test_dependency_update_policy.py
@@ -549,6 +549,7 @@ class FuzzLockPolicyTests(unittest.TestCase):
             )
 
     def test_bounded_repair_allows_shared_transitive_unification_replacement(self):
+        #lizard forgives
         # Regression for the lofty 0.24.0 -> 0.25.1 repair: lofty-attr 0.13.0
         # requires syn ^3.0.3, so cargo unifies every syn requirer onto a
         # single record and deletes syn 3.0.2, which the old lofty closure
@@ -639,6 +640,7 @@ class FuzzLockPolicyTests(unittest.TestCase):
         )
 
     def test_bounded_repair_rejects_unification_with_ambiguous_survivors(self):
+        #lizard forgives
         # Two same-name records survive the repair, so the removal cannot be
         # attributed to one exact unification; the proof fails closed.
         base = lock(
@@ -696,7 +698,9 @@ class FuzzLockPolicyTests(unittest.TestCase):
         repaired_fuzz["package"][3]["dependencies"] = ["quote 1.0.0"]
         repaired_fuzz["package"][6]["dependencies"] = ["syn 3.0.9"]
 
-        with self.assertRaises(sync_fuzz_lock.PolicyError):
+        with self.assertRaisesRegex(
+            sync_fuzz_lock.PolicyError, "removed package identities"
+        ):
             sync_fuzz_lock.validate_bounded_package_changes(
                 base,
                 current,
@@ -708,6 +712,7 @@ class FuzzLockPolicyTests(unittest.TestCase):
     def test_bounded_repair_rejects_unification_survivor_outside_exact_after_closure(
         self,
     ):
+        #lizard forgives
         # The only surviving same-name record is not reachable from the
         # requested transition, so the removal is not necessitated by the
         # selected production update and must fail closed.
@@ -764,7 +769,9 @@ class FuzzLockPolicyTests(unittest.TestCase):
         repaired_fuzz["package"][3]["dependencies"] = ["quote 1.0.0"]
         repaired_fuzz["package"][5]["dependencies"] = ["syn 3.0.9"]
 
-        with self.assertRaises(sync_fuzz_lock.PolicyError):
+        with self.assertRaisesRegex(
+            sync_fuzz_lock.PolicyError, "removed package identities"
+        ):
             sync_fuzz_lock.validate_bounded_package_changes(
                 base,
                 current,
@@ -774,6 +781,7 @@ class FuzzLockPolicyTests(unittest.TestCase):
             )
 
     def test_bounded_repair_rejects_unification_cross_source_substitution(self):
+        #lizard forgives
         # The survivor carries a different source than the removed record:
         # that is a source substitution, not a version unification.
         base = lock(
@@ -838,6 +846,7 @@ class FuzzLockPolicyTests(unittest.TestCase):
             )
 
     def test_bounded_repair_rejects_unification_mixed_with_arbitrary_rebind(self):
+        #lizard forgives
         # A consumer may rebind onto the unified record, but mixing that
         # admitted rebind with an unrelated edge rewrite on the same consumer
         # must still fail closed.
@@ -939,6 +948,78 @@ class FuzzLockPolicyTests(unittest.TestCase):
         repaired_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
 
         with self.assertRaises(sync_fuzz_lock.PolicyError):
+            sync_fuzz_lock.validate_bounded_package_changes(
+                base,
+                current,
+                stale_fuzz,
+                repaired_fuzz,
+                [sync_fuzz_lock.Transition("lofty", "0.24.0", "0.25.1")],
+            )
+
+    def test_bounded_repair_rejects_unification_onto_preexisting_survivor(self):
+        #lizard forgives
+        # The surviving syn record already existed in the before lock, so the
+        # removal of syn 3.0.2 cannot be proven a necessitated unification:
+        # admitting it would let consumers silently rebind onto a pre-existing
+        # (possibly older) version. The proof must fail closed on the removal.
+        base = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "syn": ["3.0.2", "3.0.5"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+            },
+        )
+        base["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        base["package"][3]["dependencies"] = ["quote 1.0.0"]
+        base["package"][6]["dependencies"] = ["syn 3.0.2"]
+        stale_fuzz = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "syn": ["3.0.2", "3.0.5"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+            },
+        )
+        stale_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        stale_fuzz["package"][3]["dependencies"] = ["quote 1.0.0"]
+        stale_fuzz["package"][6]["dependencies"] = ["syn 3.0.2"]
+        current = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "syn": ["3.0.5"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+            },
+        )
+        current["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        current["package"][2]["dependencies"] = ["syn 3.0.5"]
+        current["package"][3]["dependencies"] = ["quote 1.0.0"]
+        current["package"][5]["dependencies"] = ["syn 3.0.5"]
+        repaired_fuzz = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "syn": ["3.0.5"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+            },
+        )
+        repaired_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        repaired_fuzz["package"][2]["dependencies"] = ["syn 3.0.5"]
+        repaired_fuzz["package"][3]["dependencies"] = ["quote 1.0.0"]
+        repaired_fuzz["package"][5]["dependencies"] = ["syn 3.0.5"]
+
+        with self.assertRaisesRegex(
+            sync_fuzz_lock.PolicyError, "removed package identities"
+        ):
             sync_fuzz_lock.validate_bounded_package_changes(
                 base,
                 current,

--- a/scripts/test_dependency_update_policy.py
+++ b/scripts/test_dependency_update_policy.py
@@ -1028,6 +1028,84 @@ class FuzzLockPolicyTests(unittest.TestCase):
                 [sync_fuzz_lock.Transition("lofty", "0.24.0", "0.25.1")],
             )
 
+    def test_bounded_repair_rejects_unused_unification_replacement(self):
+        #lizard forgives
+        # The removed shared 1.0.0 record is unused: no before edge targets
+        # it, and the upgraded facade merely gains a new shared 2.0.0
+        # dependency. A newly reachable survivor that only shares the removed
+        # record's name and source does not authorize the removal — no edge
+        # rebind consumes the mapping — so the proof must fail closed.
+        base = lock(
+            ["facade 1.0.0"],
+            {"facade": ["1.0.0"], "shared": ["1.0.0"]},
+        )
+        stale_fuzz = lock(
+            ["facade 1.0.0"],
+            {"facade": ["1.0.0"], "shared": ["1.0.0"]},
+        )
+        current = lock(
+            ["facade 2.0.0"],
+            {"facade": ["2.0.0"], "shared": ["2.0.0"]},
+        )
+        current["package"][1]["dependencies"] = ["shared 2.0.0"]
+        repaired_fuzz = lock(
+            ["facade 2.0.0"],
+            {"facade": ["2.0.0"], "shared": ["2.0.0"]},
+        )
+        repaired_fuzz["package"][1]["dependencies"] = ["shared 2.0.0"]
+
+        with self.assertRaisesRegex(
+            sync_fuzz_lock.PolicyError, "no observed exact edge rebind"
+        ):
+            sync_fuzz_lock.validate_bounded_package_changes(
+                base,
+                current,
+                stale_fuzz,
+                repaired_fuzz,
+                [sync_fuzz_lock.Transition("facade", "1.0.0", "2.0.0")],
+            )
+
+    def test_bounded_repair_rejects_independently_dropped_last_edge(self):
+        # The helper's last edge targeting shared 1.0.0 is dropped without a
+        # rebind, while the upgraded facade independently introduces
+        # shared 2.0.0. The edge drop itself is bounded, but no observed
+        # exact rebind consumes the unification mapping, so the removed
+        # record's deletion must still fail closed.
+        base = lock(
+            ["facade 1.0.0"],
+            {"facade": ["1.0.0"], "helper": ["1.0.0"], "shared": ["1.0.0"]},
+        )
+        base["package"][2]["dependencies"] = ["shared 1.0.0"]
+        stale_fuzz = lock(
+            ["facade 1.0.0"],
+            {"facade": ["1.0.0"], "helper": ["1.0.0"], "shared": ["1.0.0"]},
+        )
+        stale_fuzz["package"][2]["dependencies"] = ["shared 1.0.0"]
+        current = lock(
+            ["facade 2.0.0"],
+            {"facade": ["2.0.0"], "helper": ["1.0.0"], "shared": ["2.0.0"]},
+        )
+        current["package"][1]["dependencies"] = ["helper 1.0.0", "shared 2.0.0"]
+        repaired_fuzz = lock(
+            ["facade 2.0.0"],
+            {"facade": ["2.0.0"], "helper": ["1.0.0"], "shared": ["2.0.0"]},
+        )
+        repaired_fuzz["package"][1]["dependencies"] = [
+            "helper 1.0.0",
+            "shared 2.0.0",
+        ]
+
+        with self.assertRaisesRegex(
+            sync_fuzz_lock.PolicyError, "no observed exact edge rebind"
+        ):
+            sync_fuzz_lock.validate_bounded_package_changes(
+                base,
+                current,
+                stale_fuzz,
+                repaired_fuzz,
+                [sync_fuzz_lock.Transition("facade", "1.0.0", "2.0.0")],
+            )
+
     def test_check_mode_rejects_raw_rebind_after_direct_transition_is_repaired(self):
         base = lock(
             ["facade 1.0.0"],

--- a/scripts/test_dependency_update_policy.py
+++ b/scripts/test_dependency_update_policy.py
@@ -836,7 +836,7 @@ class FuzzLockPolicyTests(unittest.TestCase):
         repaired_fuzz["package"][5]["dependencies"] = ["syn 3.0.5"]
         repaired_fuzz["package"][3]["source"] = "git+https://invalid.example/syn"
 
-        with self.assertRaises(sync_fuzz_lock.PolicyError):
+        with self.assertRaisesRegex(sync_fuzz_lock.PolicyError, 'removed package identities'):
             sync_fuzz_lock.validate_bounded_package_changes(
                 base,
                 current,


### PR DESCRIPTION
## Summary

Found: sync_fuzz_lock.py bounded proof is unsatisfiable for shared-transitive unification (blocks PR #247 lofty repair). Verified on PR #247 (dependabot/cargo/lofty-0.25.1 @ 7ca7cbc): the fuzz-lock repair performs the cargo-resolvable update (lofty 0.24.0->0.25.1, lofty_attr 0.12.0->0.13.0, syn unified 3.0.2->3.0.5) but fails its own bounded proof because cargo's shared-transitive unification removes syn@3.0.2 - held only by consumers outside the old lofty closure - and rebinds those consumers onto the unified record. This change admits exactly that unification pattern in the bounded proof while staying fail-closed: a removal is attributed to unification only when it has exactly one surviving same-name record, that survivor lies inside the exact after closure of the requested transition (so the reviewed production update necessitates it), and the source identity is preserved. Arbitrary rebinds, ambiguous or out-of-closure survivors, cross-source substitutions, mixed rebinds, and full removals are all still rejected. Operator disposition OPTION A (separate policy-helper PR, 2026-09-10T17:05Z): exact bounded proof preserved, adversarial tests included, no gate self-approval, no blanket version allowlist.

## Implementation notes

Admit exact shared-transitive unification in the fuzz lock bounded proof (sync_fuzz_lock.py) so the lofty 0.24->0.25 repair can pass its own check; fail-closed on ambiguous survivors, out-of-closure survivors, cross-source substitutions, mixed rebinds, and full removals. 6 new regression tests (36 total OK); full cargo gates clean on polecat/tr-zo5lg; refinery rebase onto current main (post-#246) was content-identical.

## Refinery handoff

- Issue: `tr-zo5lg` (bug, P1)
- Source branch: `polecat/tr-zo5lg`
- Target: `main`
- Rebased on `main` via Gastown Refinery.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dependency lock updates now authorize only narrowly scoped transitive unification repairs with a single newly introduced survivor and an exact dependency-edge rebind.
  * Continued rejection of ambiguous, pre-existing, cross-source, unused, unrelated, or unauthorized identity replacements and dropped edges without an exact rebind.

* **Tests**
  * Added regression coverage for valid transitive unification repairs and invalid survivor, replacement, source-substitution, and dependency-edge scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->