### PR TITLE
fix(deps): scope fuzz-lock unification attribution to cargo compat families

### DIFF
--- a/scripts/sync_fuzz_lock.py
+++ b/scripts/sync_fuzz_lock.py
@@ -387,20 +387,52 @@ def unification_replacements(
     selected production update necessitated it), it preserves the removed
     record's source identity, and the repair itself introduced it. Unrelated
     removals, ambiguous same-family survivors, pre-existing survivors,
-    cross-family substitutions, and cross-source substitutions stay
-    rejected.
+    cross-family substitutions with a same-family co-resident, and
+    cross-source substitutions stay rejected.
+
+    One cross-family shape is also cargo's own doing: a retained consumer
+    whose requirement is broad (for example "*" or a range spanning
+    releases) does not bound the resolver to the removed identity's family,
+    so introducing a consumer outside that family can evacuate it entirely
+    — verified against cargo 1.98 (consumer on "*" rebinds 1.0.0 -> 2.0.0
+    and the 1.x record disappears when a "^2" consumer joins). When the
+    repaired lock leaves exactly one same-name record, cargo resolved every
+    requirer of the name onto it, so the observed exact rebind was
+    requirement-forced rather than arbitrary; a stable-major survivor with
+    a fully numeric release is therefore admitted as a replacement (0.x
+    minor and 0.0.x patch boundaries stay fail-closed — cross-boundary
+    movement on those axes is operator-policy territory). Every guard below
+    (exact after closure, freshly introduced, same source, and the observed
+    exact edge rebind required by validate_bounded_package_changes) still
+    applies to these replacements.
     """
     replacements: dict[tuple[str, str], tuple[str, str]] = {}
     candidates = sorted(
         before_records.keys() - after_records.keys() - old_identities
     )
     for identity in candidates:
+        removed_family = cargo_version_family(identity[1])
         survivors = sorted(
             candidate
             for candidate in after_records
             if candidate[0] == identity[0]
             and same_semver_compat_family(candidate[1], identity[1])
         )
+        if (
+            not survivors
+            and removed_family is not None
+            and removed_family[0] > 0
+        ):
+            # Broad consumer requirements evacuated the removed identity's
+            # compatibility family; consider the unique same-name survivor
+            # across families. Requiring exactly one fully numeric release
+            # keeps ambiguous or malformed survivors fail-closed.
+            survivors = sorted(
+                candidate
+                for candidate in after_records
+                if candidate[0] == identity[0]
+                and cargo_version_family(candidate[1]) is not None
+            )
         if len(survivors) != 1:
             continue
         replacement = survivors[0]

--- a/scripts/sync_fuzz_lock.py
+++ b/scripts/sync_fuzz_lock.py
@@ -399,9 +399,13 @@ def unification_replacements(
     repaired lock leaves exactly one same-name record, cargo resolved every
     requirer of the name onto it, so the observed exact rebind was
     requirement-forced rather than arbitrary; a stable-major survivor with
-    a fully numeric release is therefore admitted as a replacement (0.x
-    minor and 0.0.x patch boundaries stay fail-closed — cross-boundary
-    movement on those axes is operator-policy territory). Every guard below
+    a fully numeric release is therefore admitted as a replacement. The
+    survivor must itself be a stable major: absorbing an evacuated
+    stable-major family into a 0.x or 0.0.x record crosses the 0.x
+    compatibility boundary, and 0.x minor and 0.0.x patch boundaries stay
+    fail-closed — cross-boundary movement on those axes is
+    operator-policy territory whichever side of the boundary the move
+    starts from. Every guard below
     (exact after closure, freshly introduced, same source, and the observed
     exact edge rebind required by validate_bounded_package_changes) still
     applies to these replacements.
@@ -425,13 +429,20 @@ def unification_replacements(
         ):
             # Broad consumer requirements evacuated the removed identity's
             # compatibility family; consider the unique same-name survivor
-            # across families. Requiring exactly one fully numeric release
-            # keeps ambiguous or malformed survivors fail-closed.
+            # across families. Requiring exactly one stable-major, fully
+            # numeric release keeps ambiguous, malformed, and 0.x survivors
+            # fail-closed — substitution into 0.x territory crosses the
+            # same operator-policy boundary as the removed-family guard
+            # above, whichever side of the boundary the move starts from.
             survivors = sorted(
                 candidate
                 for candidate in after_records
                 if candidate[0] == identity[0]
-                and cargo_version_family(candidate[1]) is not None
+                and (
+                    candidate_family := cargo_version_family(candidate[1])
+                )
+                is not None
+                and candidate_family[0] > 0
             )
         if len(survivors) != 1:
             continue

--- a/scripts/sync_fuzz_lock.py
+++ b/scripts/sync_fuzz_lock.py
@@ -279,6 +279,36 @@ def resolved_dependency_edges(
     }
 
 
+def same_semver_compat_family(left: str, right: str) -> bool:
+    """
+    True when two crate versions sit in the same Cargo compatibility family.
+
+    Cargo unification merges only requirements that resolve into one
+    compatibility family: the same major and, for 0.x crates, also the same
+    minor — a ^0.60 requirement never matches 0.61.x, so cross-minor 0.x
+    records can never absorb one another's consumers. Versions without an
+    integer leading component never compare equal, which keeps malformed
+    input fail-closed.
+    """
+
+    def family(version: str) -> tuple[str, str] | None:
+        components = version.split(".", 2)
+        major = components[0] if components[0].isdigit() else None
+        if major is None:
+            return None
+        if major != "0":
+            return (major, "")
+        minor = (
+            components[1]
+            if len(components) > 1 and components[1].isdigit()
+            else None
+        )
+        return None if minor is None else (major, minor)
+
+    left_family = family(left)
+    return left_family is not None and left_family == family(right)
+
+
 def unification_replacements(
     before_records: dict[tuple[str, str], dict[str, Any]],
     after_records: dict[tuple[str, str], dict[str, Any]],
@@ -294,11 +324,16 @@ def unification_replacements(
     for crates outside the transitioned subtree, and the repaired lock
     resolves every requirer onto one surviving (name, new) record. A removal
     is attributed to that unification only when the removed identity has
-    exactly one surviving same-name record, that record lies inside the exact
-    after closure (so the selected production update necessitated it), it
-    preserves the removed record's source identity, and the repair itself
-    introduced it. Unrelated removals, ambiguous survivors, pre-existing
-    survivors, and cross-source substitutions stay rejected.
+    exactly one surviving same-family record — cargo can never merge
+    requirements outside a compatibility family (same major; for 0.x also
+    the same minor), so same-name records in other families are separate
+    graph residents that neither defeat attribution nor qualify as the
+    replacement — that record lies inside the exact after closure (so the
+    selected production update necessitated it), it preserves the removed
+    record's source identity, and the repair itself introduced it. Unrelated
+    removals, ambiguous same-family survivors, pre-existing survivors,
+    cross-family substitutions, and cross-source substitutions stay
+    rejected.
     """
     replacements: dict[tuple[str, str], tuple[str, str]] = {}
     candidates = sorted(
@@ -306,7 +341,10 @@ def unification_replacements(
     )
     for identity in candidates:
         survivors = sorted(
-            candidate for candidate in after_records if candidate[0] == identity[0]
+            candidate
+            for candidate in after_records
+            if candidate[0] == identity[0]
+            and same_semver_compat_family(candidate[1], identity[1])
         )
         if len(survivors) != 1:
             continue

--- a/scripts/sync_fuzz_lock.py
+++ b/scripts/sync_fuzz_lock.py
@@ -282,25 +282,22 @@ def resolved_dependency_edges(
 def valid_semver_build_metadata(build: str) -> bool:
     """
     True when build metadata is well-formed SemVer: dot-separated
-    identifiers of ASCII alphanumerics and hyphens, where numeric
-    identifiers forbid leading zeros. Content is irrelevant to cargo's
-    compatibility rules — validity only separates cargo-writable records
-    (real locks hold 1.1.5+spec-1.1.0 and 1.0.4+wasi-0.2.12) from
-    malformed input, which stays fail-closed.
+    identifiers of ASCII alphanumerics and hyphens. Numeric build
+    identifiers MAY carry leading zeros — SemVer 2.0.0 restricts leading
+    zeros to numeric prerelease identifiers, and cargo accepts and
+    re-emits records like 1.0.0+01 and 1.0.0+zlib.01. Content is
+    irrelevant to cargo's compatibility rules — validity only separates
+    cargo-writable records (real locks hold 1.1.5+spec-1.1.0 and
+    1.0.4+wasi-0.2.12) from malformed input, which stays fail-closed.
     """
     identifiers = build.split(".")
-    if not all(
+    return all(
         identifier
         and identifier.isascii()
         and all(
             character.isalnum() or character == "-"
             for character in identifier
         )
-        for identifier in identifiers
-    ):
-        return False
-    return not any(
-        len(identifier) > 1 and identifier.isdigit() and identifier.startswith("0")
         for identifier in identifiers
     )
 

--- a/scripts/sync_fuzz_lock.py
+++ b/scripts/sync_fuzz_lock.py
@@ -281,14 +281,16 @@ def resolved_dependency_edges(
 
 def valid_semver_build_metadata(build: str) -> bool:
     """
-    True when build metadata is well-formed SemVer: dot-separated
-    identifiers of ASCII alphanumerics and hyphens. Numeric build
-    identifiers MAY carry leading zeros — SemVer 2.0.0 restricts leading
-    zeros to numeric prerelease identifiers, and cargo accepts and
-    re-emits records like 1.0.0+01 and 1.0.0+zlib.01. Content is
-    irrelevant to cargo's compatibility rules — validity only separates
-    cargo-writable records (real locks hold 1.1.5+spec-1.1.0 and
-    1.0.4+wasi-0.2.12) from malformed input, which stays fail-closed.
+    Report whether build metadata is well-formed SemVer.
+
+    Build metadata is dot-separated identifiers of ASCII alphanumerics
+    and hyphens. Numeric build identifiers MAY carry leading zeros —
+    SemVer 2.0.0 restricts leading zeros to numeric prerelease
+    identifiers, and cargo accepts and re-emits records like 1.0.0+01
+    and 1.0.0+zlib.01. Content is irrelevant to cargo's compatibility
+    rules — validity only separates cargo-writable records (real locks
+    hold 1.1.5+spec-1.1.0 and 1.0.4+wasi-0.2.12) from malformed input,
+    which stays fail-closed.
     """
     identifiers = build.split(".")
     return all(
@@ -304,12 +306,14 @@ def valid_semver_build_metadata(build: str) -> bool:
 
 def valid_semver_prerelease(prerelease: str) -> bool:
     """
-    True when prerelease is well-formed SemVer: dot-separated
-    identifiers of ASCII alphanumerics and hyphens, none empty, and
-    numeric identifiers carry no leading zeros (SemVer 2.0.0 restricts
-    leading zeros to numeric build identifiers, which cargo accepts and
-    re-emits). Registry versions are valid semver, so cargo can never
-    write anything else — malformed prereleases stay fail-closed.
+    Report whether prerelease is well-formed SemVer.
+
+    Prerelease is dot-separated identifiers of ASCII alphanumerics and
+    hyphens, none empty, and numeric identifiers carry no leading zeros
+    (SemVer 2.0.0 restricts leading zeros to numeric build identifiers,
+    which cargo accepts and re-emits). Registry versions are valid
+    semver, so cargo can never write anything else — malformed
+    prereleases stay fail-closed.
     """
     for identifier in prerelease.split("."):
         if (
@@ -328,6 +332,50 @@ def valid_semver_prerelease(prerelease: str) -> bool:
         ):
             return False
     return True
+
+
+def parse_numeric_release(core: str) -> tuple[int, int, int] | None:
+    """
+    Parse a release core into its numeric X.Y.Z components.
+
+    Exactly three dot-separated ASCII digit components with no
+    semver-forbidden leading zeros is the only accepted shape; anything
+    else is malformed input and returns None, keeping version forms
+    cargo cannot write fail-closed.
+    """
+    components = core.split(".")
+    if len(components) != 3:
+        return None
+    if not all(
+        component.isascii() and component.isdigit()
+        for component in components
+    ):
+        return None
+    if any(
+        len(component) > 1 and component.startswith("0")
+        for component in components
+    ):
+        return None
+    major, minor, patch = (int(component) for component in components)
+    return (major, minor, patch)
+
+
+def compatibility_axes(
+    release: tuple[int, int, int],
+) -> tuple[int, int | None, int | None]:
+    """
+    Reduce a numeric release to the axes cargo unifies on.
+
+    Stable majors unify on the major alone; 0.x crates also require the
+    minor (^0.60 never matches 0.61.x); 0.0.x crates require the patch
+    (^0.0.1 excludes 0.0.2).
+    """
+    major, minor, patch = release
+    if major > 0:
+        return (major, None, None)
+    if minor > 0:
+        return (0, minor, None)
+    return (0, 0, patch)
 
 
 def cargo_version_family(version: str) -> tuple[int, int | None, int | None] | None:
@@ -362,25 +410,10 @@ def cargo_version_family(version: str) -> tuple[int, int | None, int | None] | N
     core, dash, prerelease = core_and_prerelease.partition("-")
     if dash and not valid_semver_prerelease(prerelease):
         return None
-    components = core.split(".")
-    if len(components) != 3:
+    release = parse_numeric_release(core)
+    if release is None:
         return None
-    if not all(
-        component.isascii() and component.isdigit()
-        for component in components
-    ):
-        return None
-    if any(
-        len(component) > 1 and component.startswith("0")
-        for component in components
-    ):
-        return None
-    major, minor, patch = (int(component) for component in components)
-    if major > 0:
-        return (major, None, None)
-    if minor > 0:
-        return (0, minor, None)
-    return (0, 0, patch)
+    return compatibility_axes(release)
 
 
 def same_semver_compat_family(left: str, right: str) -> bool:

--- a/scripts/sync_fuzz_lock.py
+++ b/scripts/sync_fuzz_lock.py
@@ -399,7 +399,10 @@ def unification_replacements(
     repaired lock leaves exactly one same-name record, cargo resolved every
     requirer of the name onto it, so the observed exact rebind was
     requirement-forced rather than arbitrary; a stable-major survivor with
-    a fully numeric release is therefore admitted as a replacement. The
+    a fully numeric release is therefore admitted as a replacement. That
+    uniqueness is counted across every same-name record — a co-resident
+    0.x or unparseable record shows a requirer that stayed put, breaking
+    the proof, and stays rejected. The
     survivor must itself be a stable major: absorbing an evacuated
     stable-major family into a 0.x or 0.0.x record crosses the 0.x
     compatibility boundary, and 0.x minor and 0.0.x patch boundaries stay
@@ -429,21 +432,25 @@ def unification_replacements(
         ):
             # Broad consumer requirements evacuated the removed identity's
             # compatibility family; consider the unique same-name survivor
-            # across families. Requiring exactly one stable-major, fully
-            # numeric release keeps ambiguous, malformed, and 0.x survivors
-            # fail-closed — substitution into 0.x territory crosses the
-            # same operator-policy boundary as the removed-family guard
-            # above, whichever side of the boundary the move starts from.
-            survivors = sorted(
+            # across families. Uniqueness is counted across EVERY same-name
+            # record: the requirement-forced proof rests on cargo having
+            # resolved all requirers of the name onto one record, and any
+            # co-resident 0.x or unparseable record shows a requirer that
+            # demonstrably stayed put. The sole survivor must still be a
+            # stable-major, fully numeric release — this keeps ambiguous,
+            # malformed, and 0.x survivors fail-closed — substitution into
+            # 0.x territory crosses the same operator-policy boundary as
+            # the removed-family guard above, whichever side of the
+            # boundary the move starts from.
+            same_name = sorted(
                 candidate
                 for candidate in after_records
                 if candidate[0] == identity[0]
-                and (
-                    candidate_family := cargo_version_family(candidate[1])
-                )
-                is not None
-                and candidate_family[0] > 0
             )
+            if len(same_name) == 1:
+                survivor_family = cargo_version_family(same_name[0][1])
+                if survivor_family is not None and survivor_family[0] > 0:
+                    survivors = same_name
         if len(survivors) != 1:
             continue
         replacement = survivors[0]

--- a/scripts/sync_fuzz_lock.py
+++ b/scripts/sync_fuzz_lock.py
@@ -279,21 +279,54 @@ def resolved_dependency_edges(
     }
 
 
+def valid_semver_build_metadata(build: str) -> bool:
+    """
+    True when build metadata is well-formed SemVer: dot-separated
+    identifiers of ASCII alphanumerics and hyphens, where numeric
+    identifiers forbid leading zeros. Content is irrelevant to cargo's
+    compatibility rules — validity only separates cargo-writable records
+    (real locks hold 1.1.5+spec-1.1.0 and 1.0.4+wasi-0.2.12) from
+    malformed input, which stays fail-closed.
+    """
+    identifiers = build.split(".")
+    if not all(
+        identifier
+        and identifier.isascii()
+        and all(
+            character.isalnum() or character == "-"
+            for character in identifier
+        )
+        for identifier in identifiers
+    ):
+        return False
+    return not any(
+        len(identifier) > 1 and identifier.isdigit() and identifier.startswith("0")
+        for identifier in identifiers
+    )
+
+
 def cargo_version_family(version: str) -> tuple[int, int | None, int | None] | None:
     """
     Parse a Cargo lock version into its unification identity components.
 
-    Cargo lock version fields are always full numeric X.Y.Z releases, so
-    anything else is malformed input that must never compare equal to a
-    valid version: incomplete versions, non-numeric or non-ASCII
-    components, semver-forbidden leading zeros, prerelease/build suffixes,
-    and extra components all parse to None and stay fail-closed. The
-    returned triple keeps exactly the components cargo's compatibility
-    rules unify on — (major, None, None) for stable majors, (0, minor,
-    None) for 0.x crates, and (0, 0, patch) for 0.0.x crates, where a
-    ^0.0.P requirement matches only that patch.
+    Cargo lock version fields are full numeric X.Y.Z releases, optionally
+    carrying SemVer build metadata. Build metadata never affects cargo's
+    compatibility rules, so a valid suffix is stripped before the numeric
+    parse; a malformed one (empty, duplicated "+", or non-identifier
+    content) is malformed input. Either way anything that is not a full
+    numeric X.Y.Z release never compares equal to a valid version:
+    incomplete versions, prerelease suffixes, non-numeric or non-ASCII
+    components, semver-forbidden leading zeros, and extra components all
+    parse to None and stay fail-closed. The returned triple keeps exactly
+    the components cargo's compatibility rules unify on — (major, None,
+    None) for stable majors, (0, minor, None) for 0.x crates, and
+    (0, 0, patch) for 0.0.x crates, where a ^0.0.P requirement matches
+    only that patch.
     """
-    components = version.split(".")
+    core, plus, build = version.partition("+")
+    if plus and not valid_semver_build_metadata(build):
+        return None
+    components = core.split(".")
     if len(components) != 3:
         return None
     if not all(

--- a/scripts/sync_fuzz_lock.py
+++ b/scripts/sync_fuzz_lock.py
@@ -279,34 +279,58 @@ def resolved_dependency_edges(
     }
 
 
+def cargo_version_family(version: str) -> tuple[int, int | None, int | None] | None:
+    """
+    Parse a Cargo lock version into its unification identity components.
+
+    Cargo lock version fields are always full numeric X.Y.Z releases, so
+    anything else is malformed input that must never compare equal to a
+    valid version: incomplete versions, non-numeric or non-ASCII
+    components, semver-forbidden leading zeros, prerelease/build suffixes,
+    and extra components all parse to None and stay fail-closed. The
+    returned triple keeps exactly the components cargo's compatibility
+    rules unify on — (major, None, None) for stable majors, (0, minor,
+    None) for 0.x crates, and (0, 0, patch) for 0.0.x crates, where a
+    ^0.0.P requirement matches only that patch.
+    """
+    components = version.split(".")
+    if len(components) != 3:
+        return None
+    if not all(
+        component.isascii() and component.isdigit()
+        for component in components
+    ):
+        return None
+    if any(
+        len(component) > 1 and component.startswith("0")
+        for component in components
+    ):
+        return None
+    major, minor, patch = (int(component) for component in components)
+    if major > 0:
+        return (major, None, None)
+    if minor > 0:
+        return (0, minor, None)
+    return (0, 0, patch)
+
+
 def same_semver_compat_family(left: str, right: str) -> bool:
     """
     True when two crate versions sit in the same Cargo compatibility family.
 
     Cargo unification merges only requirements that resolve into one
-    compatibility family: the same major and, for 0.x crates, also the same
-    minor — a ^0.60 requirement never matches 0.61.x, so cross-minor 0.x
-    records can never absorb one another's consumers. Versions without an
-    integer leading component never compare equal, which keeps malformed
-    input fail-closed.
+    compatibility family: the same major; for 0.x crates also the same
+    minor (^0.60 never matches 0.61.x); and for 0.0.x crates the same
+    patch (^0.0.1 excludes 0.0.2, so a 0.0.x patch bump can never absorb
+    another record's consumers). Versions that do not fully parse as
+    numeric X.Y.Z never compare equal, which keeps malformed input
+    fail-closed.
     """
-
-    def family(version: str) -> tuple[str, str] | None:
-        components = version.split(".", 2)
-        major = components[0] if components[0].isdigit() else None
-        if major is None:
-            return None
-        if major != "0":
-            return (major, "")
-        minor = (
-            components[1]
-            if len(components) > 1 and components[1].isdigit()
-            else None
-        )
-        return None if minor is None else (major, minor)
-
-    left_family = family(left)
-    return left_family is not None and left_family == family(right)
+    left_family = cargo_version_family(left)
+    return (
+        left_family is not None
+        and left_family == cargo_version_family(right)
+    )
 
 
 def unification_replacements(
@@ -326,7 +350,8 @@ def unification_replacements(
     is attributed to that unification only when the removed identity has
     exactly one surviving same-family record — cargo can never merge
     requirements outside a compatibility family (same major; for 0.x also
-    the same minor), so same-name records in other families are separate
+    the same minor; for 0.0.x the same patch), so same-name records in
+    other families are separate
     graph residents that neither defeat attribution nor qualify as the
     replacement — that record lies inside the exact after closure (so the
     selected production update necessitated it), it preserves the removed

--- a/scripts/sync_fuzz_lock.py
+++ b/scripts/sync_fuzz_lock.py
@@ -302,26 +302,65 @@ def valid_semver_build_metadata(build: str) -> bool:
     )
 
 
+def valid_semver_prerelease(prerelease: str) -> bool:
+    """
+    True when prerelease is well-formed SemVer: dot-separated
+    identifiers of ASCII alphanumerics and hyphens, none empty, and
+    numeric identifiers carry no leading zeros (SemVer 2.0.0 restricts
+    leading zeros to numeric build identifiers, which cargo accepts and
+    re-emits). Registry versions are valid semver, so cargo can never
+    write anything else — malformed prereleases stay fail-closed.
+    """
+    for identifier in prerelease.split("."):
+        if (
+            not identifier
+            or not identifier.isascii()
+            or not all(
+                character.isalnum() or character == "-"
+                for character in identifier
+            )
+        ):
+            return False
+        if (
+            identifier.isdigit()
+            and len(identifier) > 1
+            and identifier.startswith("0")
+        ):
+            return False
+    return True
+
+
 def cargo_version_family(version: str) -> tuple[int, int | None, int | None] | None:
     """
     Parse a Cargo lock version into its unification identity components.
 
     Cargo lock version fields are full numeric X.Y.Z releases, optionally
-    carrying SemVer build metadata. Build metadata never affects cargo's
-    compatibility rules, so a valid suffix is stripped before the numeric
-    parse; a malformed one (empty, duplicated "+", or non-identifier
-    content) is malformed input. Either way anything that is not a full
-    numeric X.Y.Z release never compares equal to a valid version:
-    incomplete versions, prerelease suffixes, non-numeric or non-ASCII
-    components, semver-forbidden leading zeros, and extra components all
-    parse to None and stay fail-closed. The returned triple keeps exactly
-    the components cargo's compatibility rules unify on — (major, None,
-    None) for stable majors, (0, minor, None) for 0.x crates, and
-    (0, 0, patch) for 0.0.x crates, where a ^0.0.P requirement matches
-    only that patch.
+    carrying a SemVer prerelease and/or build metadata. Build metadata
+    never affects cargo's compatibility rules, and a prerelease only ever
+    narrows matching inside its release's own compatibility family (cargo
+    matches a prerelease comparator solely within the same
+    major.minor.patch triple), so valid suffixes are stripped before the
+    numeric parse and the family axes stay purely numeric; a malformed
+    suffix (empty, duplicated separator, non-identifier content,
+    leading-zero numeric prerelease identifiers) is malformed input.
+    Either way anything that is not a full numeric X.Y.Z core never
+    compares equal to a valid version: incomplete versions, non-numeric
+    or non-ASCII components, semver-forbidden leading zeros, and extra
+    components all parse to None and stay fail-closed. The returned
+    triple keeps exactly the components cargo's compatibility rules
+    unify on — (major, None, None) for stable majors, (0, minor, None)
+    for 0.x crates, and (0, 0, patch) for 0.0.x crates, where a ^0.0.P
+    requirement matches only that patch. A validated prerelease record
+    shares its release's family — cargo can resolve a prerelease
+    requirer onto the same-core release, and real locks carry such
+    records (sea-orm-arrow 2.0.0-rc.4) — while cross-axis moves stay
+    fail-closed.
     """
-    core, plus, build = version.partition("+")
+    core_and_prerelease, plus, build = version.partition("+")
     if plus and not valid_semver_build_metadata(build):
+        return None
+    core, dash, prerelease = core_and_prerelease.partition("-")
+    if dash and not valid_semver_prerelease(prerelease):
         return None
     components = core.split(".")
     if len(components) != 3:
@@ -352,9 +391,11 @@ def same_semver_compat_family(left: str, right: str) -> bool:
     compatibility family: the same major; for 0.x crates also the same
     minor (^0.60 never matches 0.61.x); and for 0.0.x crates the same
     patch (^0.0.1 excludes 0.0.2, so a 0.0.x patch bump can never absorb
-    another record's consumers). Versions that do not fully parse as
-    numeric X.Y.Z never compare equal, which keeps malformed input
-    fail-closed.
+    another record's consumers). A validated prerelease shares its
+    numeric core's family — cargo matches a prerelease comparator solely
+    within the same major.minor.patch triple. Versions that do not fully
+    parse as a numeric X.Y.Z core with well-formed optional suffixes
+    never compare equal, which keeps malformed input fail-closed.
     """
     left_family = cargo_version_family(left)
     return (
@@ -408,7 +449,9 @@ def unification_replacements(
     compatibility boundary, and 0.x minor and 0.0.x patch boundaries stay
     fail-closed — cross-boundary movement on those axes is
     operator-policy territory whichever side of the boundary the move
-    starts from. Every guard below
+    starts from — and it stays a fully numeric release, the shape the
+    evacuation carve-out was verified against, so prerelease survivors
+    remain fail-closed. Every guard below
     (exact after closure, freshly introduced, same source, and the observed
     exact edge rebind required by validate_bounded_package_changes) still
     applies to these replacements.
@@ -448,8 +491,16 @@ def unification_replacements(
                 if candidate[0] == identity[0]
             )
             if len(same_name) == 1:
-                survivor_family = cargo_version_family(same_name[0][1])
-                if survivor_family is not None and survivor_family[0] > 0:
+                survivor_version = same_name[0][1]
+                survivor_family = cargo_version_family(survivor_version)
+                # The cargo-verified evacuation shape resolves every
+                # requirer onto a fully numeric stable-major release; a
+                # prerelease survivor keeps this carve-out fail-closed.
+                if (
+                    survivor_family is not None
+                    and survivor_family[0] > 0
+                    and "-" not in survivor_version.partition("+")[0]
+                ):
                     survivors = same_name
         if len(survivors) != 1:
             continue

--- a/scripts/test_dependency_update_policy.py
+++ b/scripts/test_dependency_update_policy.py
@@ -1704,12 +1704,15 @@ class FuzzLockPolicyTests(unittest.TestCase):
             },
         )
         # package order: lofty, lofty-attr, syn 2.0.9, syn 4.0.1, quote,
-        # async-trait, serde-derive.
+        # async-trait, serde-derive. The split consumers keep the two
+        # survivors ambiguous: async-trait resolves onto syn 2.0.9 while
+        # serde-derive resolves onto syn 4.0.1, so cargo demonstrably did
+        # not unify every requirer onto one record.
         current["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
         current["package"][2]["dependencies"] = ["syn 2.0.9"]
-        current["package"][4]["dependencies"] = ["quote 1.0.0"]
-        current["package"][5]["dependencies"] = ["syn 2.0.9"]
-        current["package"][6]["dependencies"] = ["syn 4.0.1"]
+        current["package"][3]["dependencies"] = ["quote 1.0.0"]
+        current["package"][6]["dependencies"] = ["syn 2.0.9"]
+        current["package"][7]["dependencies"] = ["syn 4.0.1"]
         repaired_fuzz = lock(
             ["lofty 0.25.1"],
             {
@@ -1723,9 +1726,9 @@ class FuzzLockPolicyTests(unittest.TestCase):
         )
         repaired_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
         repaired_fuzz["package"][2]["dependencies"] = ["syn 2.0.9"]
-        repaired_fuzz["package"][4]["dependencies"] = ["quote 1.0.0"]
-        repaired_fuzz["package"][5]["dependencies"] = ["syn 2.0.9"]
-        repaired_fuzz["package"][6]["dependencies"] = ["syn 4.0.1"]
+        repaired_fuzz["package"][3]["dependencies"] = ["quote 1.0.0"]
+        repaired_fuzz["package"][6]["dependencies"] = ["syn 2.0.9"]
+        repaired_fuzz["package"][7]["dependencies"] = ["syn 4.0.1"]
 
         with self.assertRaisesRegex(
             sync_fuzz_lock.PolicyError, "removed package identities"
@@ -1808,6 +1811,94 @@ class FuzzLockPolicyTests(unittest.TestCase):
         repaired_fuzz["package"][3]["dependencies"] = ["quote 1.0.0"]
         repaired_fuzz["package"][5]["dependencies"] = ["windows-sys 0.61.2"]
         repaired_fuzz["package"][6]["dependencies"] = ["windows-sys 0.61.2"]
+
+        with self.assertRaisesRegex(
+            sync_fuzz_lock.PolicyError, "removed package identities"
+        ):
+            sync_fuzz_lock.validate_bounded_package_changes(
+                base,
+                current,
+                stale_fuzz,
+                repaired_fuzz,
+                [sync_fuzz_lock.Transition("lofty", "0.24.0", "0.25.1")],
+            )
+
+    def test_bounded_repair_rejects_evacuated_stable_major_onto_0_x_survivor(
+        self,
+    ):
+        #lizard forgives
+        # The cross-family evacuation admission requires a stable-major
+        # survivor, not merely a parseable one: cargo's 0.x compatibility
+        # boundary is operator-policy territory on the survivor axis too,
+        # so a unique 0.x record left by the graph refresh can never absorb
+        # an evacuated stable-major family's consumers, even behind an
+        # exact observed rebind and a fresh in-closure survivor.
+        base = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "syn": ["3.0.2"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        base["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        base["package"][3]["dependencies"] = ["quote 1.0.0"]
+        base["package"][5]["dependencies"] = ["syn 3.0.2"]
+        base["package"][6]["dependencies"] = ["syn 3.0.2"]
+        stale_fuzz = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "syn": ["3.0.2"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        stale_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        stale_fuzz["package"][3]["dependencies"] = ["quote 1.0.0"]
+        stale_fuzz["package"][5]["dependencies"] = ["syn 3.0.2"]
+        stale_fuzz["package"][6]["dependencies"] = ["syn 3.0.2"]
+        current = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "syn": ["0.9.0"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        # package order: lofty, lofty-attr, syn 0.9.0, quote, async-trait,
+        # serde-derive. The graph refresh rebinds every syn requirer onto
+        # the unique 0.9.0 survivor — the exact shape the stable-major
+        # survivor guard must refuse to attribute.
+        current["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        current["package"][2]["dependencies"] = ["syn 0.9.0"]
+        current["package"][3]["dependencies"] = ["quote 1.0.0"]
+        current["package"][5]["dependencies"] = ["syn 0.9.0"]
+        current["package"][6]["dependencies"] = ["syn 0.9.0"]
+        repaired_fuzz = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "syn": ["0.9.0"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        repaired_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        repaired_fuzz["package"][2]["dependencies"] = ["syn 0.9.0"]
+        repaired_fuzz["package"][3]["dependencies"] = ["quote 1.0.0"]
+        repaired_fuzz["package"][5]["dependencies"] = ["syn 0.9.0"]
+        repaired_fuzz["package"][6]["dependencies"] = ["syn 0.9.0"]
 
         with self.assertRaisesRegex(
             sync_fuzz_lock.PolicyError, "removed package identities"

--- a/scripts/test_dependency_update_policy.py
+++ b/scripts/test_dependency_update_policy.py
@@ -1028,13 +1028,286 @@ class FuzzLockPolicyTests(unittest.TestCase):
                 [sync_fuzz_lock.Transition("lofty", "0.24.0", "0.25.1")],
             )
 
+    def test_bounded_repair_allows_unification_with_coexisting_other_majors(self):
+        #lizard forgives
+        # Regression for the real lofty 0.24.0 -> 0.25.1 fuzz lock: the base
+        # co-hosts syn 1.0.109 and syn 2.0.119 alongside syn 3.0.2. Cargo
+        # unification merges only semver-compatible (same-major) requirements,
+        # so those other majors can never absorb syn 3.0.2's consumers; their
+        # presence must not defeat attribution of the removal to the
+        # same-major unification onto syn 3.0.5. The repaired lock must pass
+        # its own bounded proof.
+        base = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "syn": ["1.0.109", "2.0.119", "3.0.2"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        # package order: lofty, lofty-attr, syn 1.0.109, syn 2.0.119,
+        # syn 3.0.2, quote, async-trait, serde-derive. The old lofty subtree
+        # never reaches syn; syn 3.0.2 is consumed only by crates outside it.
+        base["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        base["package"][5]["dependencies"] = ["quote 1.0.0"]
+        base["package"][7]["dependencies"] = ["syn 3.0.2"]
+        base["package"][8]["dependencies"] = ["syn 3.0.2"]
+        stale_fuzz = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "syn": ["1.0.109", "2.0.119", "3.0.2"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        stale_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        stale_fuzz["package"][5]["dependencies"] = ["quote 1.0.0"]
+        stale_fuzz["package"][7]["dependencies"] = ["syn 3.0.2"]
+        stale_fuzz["package"][8]["dependencies"] = ["syn 3.0.2"]
+        current = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "syn": ["1.0.109", "2.0.119", "3.0.5"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        current["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        current["package"][2]["dependencies"] = ["syn 3.0.5"]
+        current["package"][5]["dependencies"] = ["quote 1.0.0"]
+        current["package"][7]["dependencies"] = ["syn 3.0.5"]
+        current["package"][8]["dependencies"] = ["syn 3.0.5"]
+        repaired_fuzz = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "syn": ["1.0.109", "2.0.119", "3.0.5"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        repaired_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        repaired_fuzz["package"][2]["dependencies"] = ["syn 3.0.5"]
+        repaired_fuzz["package"][5]["dependencies"] = ["quote 1.0.0"]
+        repaired_fuzz["package"][7]["dependencies"] = ["syn 3.0.5"]
+        repaired_fuzz["package"][8]["dependencies"] = ["syn 3.0.5"]
+
+        requested, remaining = sync_fuzz_lock.validate_submitted_fuzz_update(
+            base,
+            current,
+            stale_fuzz,
+            repaired_fuzz,
+            {"dependencies": {"lofty": "1"}},
+        )
+        self.assertEqual(
+            requested,
+            [sync_fuzz_lock.Transition("lofty", "0.24.0", "0.25.1")],
+        )
+        self.assertEqual(remaining, [])
+        sync_fuzz_lock.validate_bounded_package_changes(
+            base,
+            current,
+            stale_fuzz,
+            repaired_fuzz,
+            requested,
+        )
+
+    def test_bounded_repair_rejects_cross_major_survivor_substitution(self):
+        #lizard forgives
+        # The only syn records left after the repair are in other majors
+        # (1.x co-host, 2.x substitution target): a different-major record can
+        # never be the same-major unification survivor of syn 3.0.2, even when
+        # its consumers were rebound onto it. The removal must fail closed.
+        base = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "syn": ["1.0.109", "2.0.9", "3.0.2"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+            },
+        )
+        # package order: lofty, lofty-attr, syn 1.0.109, syn 2.0.9,
+        # syn 3.0.2, quote, async-trait.
+        base["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        base["package"][5]["dependencies"] = ["quote 1.0.0"]
+        base["package"][6]["dependencies"] = ["syn 3.0.2"]
+        stale_fuzz = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "syn": ["1.0.109", "2.0.9", "3.0.2"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+            },
+        )
+        stale_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        stale_fuzz["package"][5]["dependencies"] = ["quote 1.0.0"]
+        stale_fuzz["package"][6]["dependencies"] = ["syn 3.0.2"]
+        current = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "syn": ["1.0.109", "2.0.9"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+            },
+        )
+        current["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        current["package"][2]["dependencies"] = ["syn 2.0.9"]
+        current["package"][5]["dependencies"] = ["quote 1.0.0"]
+        current["package"][6]["dependencies"] = ["syn 2.0.9"]
+        repaired_fuzz = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "syn": ["1.0.109", "2.0.9"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+            },
+        )
+        repaired_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        repaired_fuzz["package"][2]["dependencies"] = ["syn 2.0.9"]
+        repaired_fuzz["package"][5]["dependencies"] = ["quote 1.0.0"]
+        repaired_fuzz["package"][6]["dependencies"] = ["syn 2.0.9"]
+
+        with self.assertRaisesRegex(
+            sync_fuzz_lock.PolicyError, "removed package identities"
+        ):
+            sync_fuzz_lock.validate_bounded_package_changes(
+                base,
+                current,
+                stale_fuzz,
+                repaired_fuzz,
+                [sync_fuzz_lock.Transition("lofty", "0.24.0", "0.25.1")],
+            )
+
+    def test_bounded_repair_rejects_rebind_absorbed_by_different_major(self):
+        #lizard forgives
+        # The same-major survivor syn 3.0.5 is admitted, but the consumer's
+        # edge was actually absorbed by the co-hosted different major
+        # syn 2.0.119 instead of rebinding onto the admitted survivor. No
+        # observed exact rebind consumes the mapping, so the removal fails
+        # closed.
+        base = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "syn": ["1.0.109", "2.0.119", "3.0.2"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+            },
+        )
+        # package order: lofty, lofty-attr, syn 1.0.109, syn 2.0.119,
+        # syn 3.0.2, quote, async-trait.
+        base["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        base["package"][5]["dependencies"] = ["quote 1.0.0"]
+        base["package"][6]["dependencies"] = ["syn 3.0.2"]
+        stale_fuzz = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "syn": ["1.0.109", "2.0.119", "3.0.2"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+            },
+        )
+        stale_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        stale_fuzz["package"][5]["dependencies"] = ["quote 1.0.0"]
+        stale_fuzz["package"][6]["dependencies"] = ["syn 3.0.2"]
+        current = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "syn": ["1.0.109", "2.0.119", "3.0.5"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+            },
+        )
+        current["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        current["package"][2]["dependencies"] = ["syn 3.0.5"]
+        current["package"][5]["dependencies"] = ["quote 1.0.0"]
+        current["package"][6]["dependencies"] = ["syn 2.0.119"]
+        repaired_fuzz = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "syn": ["1.0.109", "2.0.119", "3.0.5"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+            },
+        )
+        repaired_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        repaired_fuzz["package"][2]["dependencies"] = ["syn 3.0.5"]
+        repaired_fuzz["package"][5]["dependencies"] = ["quote 1.0.0"]
+        repaired_fuzz["package"][6]["dependencies"] = ["syn 2.0.119"]
+
+        with self.assertRaisesRegex(
+            sync_fuzz_lock.PolicyError, "no observed exact edge rebind"
+        ):
+            sync_fuzz_lock.validate_bounded_package_changes(
+                base,
+                current,
+                stale_fuzz,
+                repaired_fuzz,
+                [sync_fuzz_lock.Transition("lofty", "0.24.0", "0.25.1")],
+            )
+
+    def test_compat_family_scoping_matches_cargo_unification_axes(self):
+        # Cargo unification is confined to one compatibility family: same
+        # major, and for 0.x crates the same minor (^0.60 never matches
+        # 0.61.x). The family test must mirror those axes and stay
+        # fail-closed on malformed input.
+        self.assertTrue(
+            sync_fuzz_lock.same_semver_compat_family("3.0.2", "3.0.5")
+        )
+        self.assertFalse(
+            sync_fuzz_lock.same_semver_compat_family("3.0.2", "2.0.9")
+        )
+        self.assertTrue(
+            sync_fuzz_lock.same_semver_compat_family("0.60.2", "0.60.7")
+        )
+        self.assertFalse(
+            sync_fuzz_lock.same_semver_compat_family("0.60.2", "0.61.2")
+        )
+        self.assertFalse(
+            sync_fuzz_lock.same_semver_compat_family("0.60.2", "1.60.2")
+        )
+        self.assertFalse(
+            sync_fuzz_lock.same_semver_compat_family("not-a-version", "3.0.5")
+        )
+        self.assertFalse(
+            sync_fuzz_lock.same_semver_compat_family("3.0.2", "not-a-version")
+        )
+
     def test_bounded_repair_rejects_unused_unification_replacement(self):
         #lizard forgives
         # The removed shared 1.0.0 record is unused: no before edge targets
         # it, and the upgraded facade merely gains a new shared 2.0.0
-        # dependency. A newly reachable survivor that only shares the removed
-        # record's name and source does not authorize the removal — no edge
-        # rebind consumes the mapping — so the proof must fail closed.
+        # dependency. Shared 2.0.0 is a different semver major, so cargo
+        # unification (same-major only) can never have absorbed shared 1.0.0
+        # onto it: the removal is now rejected at attribution — outside the
+        # exact old closure — rather than at the observation stage. The proof
+        # still fails closed.
         base = lock(
             ["facade 1.0.0"],
             {"facade": ["1.0.0"], "shared": ["1.0.0"]},
@@ -1055,7 +1328,7 @@ class FuzzLockPolicyTests(unittest.TestCase):
         repaired_fuzz["package"][1]["dependencies"] = ["shared 2.0.0"]
 
         with self.assertRaisesRegex(
-            sync_fuzz_lock.PolicyError, "no observed exact edge rebind"
+            sync_fuzz_lock.PolicyError, "removed package identities"
         ):
             sync_fuzz_lock.validate_bounded_package_changes(
                 base,
@@ -1068,9 +1341,12 @@ class FuzzLockPolicyTests(unittest.TestCase):
     def test_bounded_repair_rejects_independently_dropped_last_edge(self):
         # The helper's last edge targeting shared 1.0.0 is dropped without a
         # rebind, while the upgraded facade independently introduces
-        # shared 2.0.0. The edge drop itself is bounded, but no observed
-        # exact rebind consumes the unification mapping, so the removed
-        # record's deletion must still fail closed.
+        # shared 2.0.0. Shared 2.0.0 is a different semver major, so cargo
+        # unification (same-major only) can never have absorbed shared 1.0.0
+        # onto it: the removal is now rejected at attribution — outside the
+        # exact old closure — rather than at the observation stage. The edge
+        # drop is bounded, but the removed record's deletion must still fail
+        # closed.
         base = lock(
             ["facade 1.0.0"],
             {"facade": ["1.0.0"], "helper": ["1.0.0"], "shared": ["1.0.0"]},
@@ -1096,7 +1372,7 @@ class FuzzLockPolicyTests(unittest.TestCase):
         ]
 
         with self.assertRaisesRegex(
-            sync_fuzz_lock.PolicyError, "no observed exact edge rebind"
+            sync_fuzz_lock.PolicyError, "removed package identities"
         ):
             sync_fuzz_lock.validate_bounded_package_changes(
                 base,

--- a/scripts/test_dependency_update_policy.py
+++ b/scripts/test_dependency_update_policy.py
@@ -1322,17 +1322,20 @@ class FuzzLockPolicyTests(unittest.TestCase):
     def test_compat_family_rejects_versions_outside_full_numeric_release_shape(
         self,
     ):
-        # Cargo lock version fields are always full numeric X.Y.Z releases.
+        # Cargo lock version fields are always a full numeric X.Y.Z core.
         # Anything else is malformed input that must never compare equal to
-        # a valid version — incomplete versions, prerelease or build
-        # suffixes, semver-forbidden leading zeros, extra components — so a
-        # crafted lock cannot smuggle a same-family match past the
-        # unification attribution.
+        # a valid version — incomplete versions, prerelease suffixes,
+        # semver-forbidden leading zeros, extra components — so a crafted
+        # lock cannot smuggle a same-family match past the unification
+        # attribution. Build metadata is validated separately: valid
+        # metadata is stripped before the family parse, malformed metadata
+        # (empty, duplicated, or non-identifier content) stays malformed.
         for malformed in (
             "3",
             "3.0",
             "3.0.2-beta",
-            "1.0.0+zlib",
+            "1.0.0+",
+            "1.0.0+zlib+",
             "01.2.3",
             "1.02.3",
             "1.2.03",
@@ -1347,6 +1350,85 @@ class FuzzLockPolicyTests(unittest.TestCase):
             )
             self.assertFalse(
                 sync_fuzz_lock.same_semver_compat_family("3.0.5", malformed),
+                malformed,
+            )
+
+    def test_compat_family_strips_valid_semver_build_metadata(self):
+        # Build metadata is valid SemVer and never affects cargo's
+        # compatibility rules, and real locks carry such records (toml
+        # 1.1.5+spec-1.1.0, wasip2 1.0.4+wasi-0.2.12, umask
+        # 0.9.34+deprecated). A record must not lose its family because it
+        # carries metadata, or the attribution would reject Cargo-generated
+        # output as an unauthorized removal.
+        self.assertTrue(
+            sync_fuzz_lock.same_semver_compat_family(
+                "1.1.5+spec-1.1.0", "1.1.5"
+            )
+        )
+        self.assertTrue(
+            sync_fuzz_lock.same_semver_compat_family(
+                "1.1.5", "1.1.5+spec-1.1.0"
+            )
+        )
+        self.assertTrue(
+            sync_fuzz_lock.same_semver_compat_family(
+                "1.1.5+spec-1.1.0", "1.1.5+wasi-0.2.12"
+            )
+        )
+        self.assertTrue(
+            sync_fuzz_lock.same_semver_compat_family(
+                "0.9.34+deprecated", "0.9.34"
+            )
+        )
+        self.assertTrue(
+            sync_fuzz_lock.same_semver_compat_family(
+                "1.0.4+wasi-0.2.12", "1.0.4+wasi-0.2.12"
+            )
+        )
+        # Metadata is ignored only inside a family: the cargo compatibility
+        # axes stay enforced on every axis.
+        self.assertTrue(
+            sync_fuzz_lock.same_semver_compat_family(
+                "1.1.5+spec-1.1.0", "1.1.6"
+            )
+        )
+        self.assertFalse(
+            sync_fuzz_lock.same_semver_compat_family(
+                "1.1.5+spec-1.1.0", "2.1.5"
+            )
+        )
+        self.assertFalse(
+            sync_fuzz_lock.same_semver_compat_family(
+                "0.60.2+deprecated", "0.61.2"
+            )
+        )
+        self.assertFalse(
+            sync_fuzz_lock.same_semver_compat_family(
+                "0.0.1+spec-1.1.0", "0.0.2"
+            )
+        )
+
+    def test_compat_family_rejects_malformed_build_metadata(self):
+        # Only well-formed metadata is stripped: empty or empty identifiers
+        # ("1.0.0+", "1.0.0+z..lib"), a duplicated "+" separator, non-ASCII
+        # or non-identifier characters, and numeric identifiers with
+        # semver-forbidden leading zeros are malformed input that must
+        # never compare equal to a valid version. A prerelease suffix
+        # stays malformed even behind a valid build metadata segment.
+        for malformed in (
+            "1.0.0+",
+            "1.0.0+z..lib",
+            "1.0.0+zlib+more",
+            "1.0.0+zlib.01",
+            "1.0.0+ä",
+            "1.2.3-rc.1+build",
+        ):
+            self.assertFalse(
+                sync_fuzz_lock.same_semver_compat_family(malformed, "1.0.5"),
+                malformed,
+            )
+            self.assertFalse(
+                sync_fuzz_lock.same_semver_compat_family("1.0.5", malformed),
                 malformed,
             )
 
@@ -1427,6 +1509,100 @@ class FuzzLockPolicyTests(unittest.TestCase):
                 repaired_fuzz,
                 [sync_fuzz_lock.Transition("lofty", "0.24.0", "0.25.1")],
             )
+
+    def test_bounded_repair_allows_unification_onto_build_metadata_survivor(
+        self,
+    ):
+        #lizard forgives
+        # Real locks carry build-metadata records (toml 1.1.5+spec-1.1.0 in
+        # this repository), and build metadata never affects cargo's
+        # compatibility rules. When a repair's graph refresh rebinds the
+        # outside consumers of toml 1.1.4 onto the newly introduced
+        # 1.1.5+spec-1.1.0 survivor inside the after closure, the removal
+        # must attribute as same-family unification — treating the
+        # metadata-bearing version as malformed would falsely reject
+        # Cargo-generated output as an unauthorized removal.
+        base = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "toml": ["1.1.4"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        # package order: lofty, lofty-attr, toml 1.1.4, quote, async-trait,
+        # serde-derive. The old lofty subtree never reaches toml; toml
+        # 1.1.4 is consumed only by crates outside it.
+        base["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        base["package"][4]["dependencies"] = ["toml 1.1.4"]
+        base["package"][6]["dependencies"] = ["toml 1.1.4"]
+        stale_fuzz = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "toml": ["1.1.4"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        stale_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        stale_fuzz["package"][4]["dependencies"] = ["toml 1.1.4"]
+        stale_fuzz["package"][6]["dependencies"] = ["toml 1.1.4"]
+        current = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "toml": ["1.1.5+spec-1.1.0"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        current["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        current["package"][2]["dependencies"] = ["toml 1.1.5+spec-1.1.0"]
+        current["package"][4]["dependencies"] = ["toml 1.1.5+spec-1.1.0"]
+        current["package"][6]["dependencies"] = ["toml 1.1.5+spec-1.1.0"]
+        repaired_fuzz = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "toml": ["1.1.5+spec-1.1.0"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        repaired_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        repaired_fuzz["package"][2]["dependencies"] = ["toml 1.1.5+spec-1.1.0"]
+        repaired_fuzz["package"][4]["dependencies"] = ["toml 1.1.5+spec-1.1.0"]
+        repaired_fuzz["package"][6]["dependencies"] = ["toml 1.1.5+spec-1.1.0"]
+
+        requested, remaining = sync_fuzz_lock.validate_submitted_fuzz_update(
+            base,
+            current,
+            stale_fuzz,
+            repaired_fuzz,
+            {"dependencies": {"lofty": "1"}},
+        )
+        self.assertEqual(
+            requested,
+            [sync_fuzz_lock.Transition("lofty", "0.24.0", "0.25.1")],
+        )
+        self.assertEqual(remaining, [])
+        sync_fuzz_lock.validate_bounded_package_changes(
+            base,
+            current,
+            stale_fuzz,
+            repaired_fuzz,
+            requested,
+        )
 
     def test_bounded_repair_rejects_unused_unification_replacement(self):
         #lizard forgives

--- a/scripts/test_dependency_update_policy.py
+++ b/scripts/test_dependency_update_policy.py
@@ -1408,18 +1408,62 @@ class FuzzLockPolicyTests(unittest.TestCase):
             )
         )
 
+    def test_compat_family_accepts_leading_zero_build_metadata(self):
+        # SemVer 2.0.0 forbids leading zeros only in numeric PRERELEASE
+        # identifiers; build metadata identifiers are just [0-9A-Za-z-]
+        # and may carry leading zeros ("1.0.0+01", "1.0.0+zlib.01").
+        # Cargo accepts and re-emits such versions (verified with cargo
+        # 1.95: version = "1.0.0+01" lands verbatim in Cargo.lock), so a
+        # leading-zero record must keep its family — rejecting it would
+        # fail the bounded-change check on valid Cargo-generated output.
+        self.assertTrue(
+            sync_fuzz_lock.same_semver_compat_family(
+                "1.0.0+zlib.01", "1.0.5"
+            )
+        )
+        self.assertTrue(
+            sync_fuzz_lock.same_semver_compat_family(
+                "1.0.0+01", "1.0.5"
+            )
+        )
+        self.assertTrue(
+            sync_fuzz_lock.same_semver_compat_family(
+                "1.0.0+007", "1.0.0+zlib.01"
+            )
+        )
+        # Metadata validity never relaxes the compatibility axes: the
+        # 0.x minor axis, the 0.0.x patch axis, and the major axis all
+        # stay enforced on leading-zero-metadata records.
+        self.assertFalse(
+            sync_fuzz_lock.same_semver_compat_family(
+                "0.1.0+01", "0.2.0"
+            )
+        )
+        self.assertFalse(
+            sync_fuzz_lock.same_semver_compat_family(
+                "0.0.1+zlib.01", "0.0.2"
+            )
+        )
+        self.assertFalse(
+            sync_fuzz_lock.same_semver_compat_family(
+                "1.0.0+zlib.01", "2.0.0"
+            )
+        )
+
     def test_compat_family_rejects_malformed_build_metadata(self):
         # Only well-formed metadata is stripped: empty or empty identifiers
         # ("1.0.0+", "1.0.0+z..lib"), a duplicated "+" separator, non-ASCII
-        # or non-identifier characters, and numeric identifiers with
-        # semver-forbidden leading zeros are malformed input that must
+        # or non-identifier characters are malformed input that must
         # never compare equal to a valid version. A prerelease suffix
         # stays malformed even behind a valid build metadata segment.
+        # Leading zeros in numeric build identifiers are NOT malformed:
+        # SemVer 2.0.0 restricts leading zeros to prerelease numerics, and
+        # cargo accepts such records — see
+        # test_compat_family_accepts_leading_zero_build_metadata.
         for malformed in (
             "1.0.0+",
             "1.0.0+z..lib",
             "1.0.0+zlib+more",
-            "1.0.0+zlib.01",
             "1.0.0+ä",
             "1.2.3-rc.1+build",
         ):

--- a/scripts/test_dependency_update_policy.py
+++ b/scripts/test_dependency_update_policy.py
@@ -1274,8 +1274,9 @@ class FuzzLockPolicyTests(unittest.TestCase):
 
     def test_compat_family_scoping_matches_cargo_unification_axes(self):
         # Cargo unification is confined to one compatibility family: same
-        # major, and for 0.x crates the same minor (^0.60 never matches
-        # 0.61.x). The family test must mirror those axes and stay
+        # major, for 0.x crates the same minor (^0.60 never matches
+        # 0.61.x), and for 0.0.x crates the same patch (^0.0.1 excludes
+        # 0.0.2). The family test must mirror those axes and stay
         # fail-closed on malformed input.
         self.assertTrue(
             sync_fuzz_lock.same_semver_compat_family("3.0.2", "3.0.5")
@@ -1298,6 +1299,134 @@ class FuzzLockPolicyTests(unittest.TestCase):
         self.assertFalse(
             sync_fuzz_lock.same_semver_compat_family("3.0.2", "not-a-version")
         )
+
+    def test_compat_family_splits_0_0_x_releases_by_patch(self):
+        # Cargo's compatibility boundary for 0.0.x crates is the patch:
+        # ^0.0.1 resolves only [0.0.1, 0.0.2), so 0.0.1 and 0.0.2 are
+        # separate families and a 0.0.x patch bump can never absorb another
+        # record's consumers via unification.
+        self.assertFalse(
+            sync_fuzz_lock.same_semver_compat_family("0.0.1", "0.0.2")
+        )
+        self.assertFalse(
+            sync_fuzz_lock.same_semver_compat_family("0.0.1", "0.0.9")
+        )
+        self.assertTrue(
+            sync_fuzz_lock.same_semver_compat_family("0.0.1", "0.0.1")
+        )
+        # 0.0.x and 0.x-with-minor are different families on the minor axis.
+        self.assertFalse(
+            sync_fuzz_lock.same_semver_compat_family("0.0.1", "0.1.0")
+        )
+
+    def test_compat_family_rejects_versions_outside_full_numeric_release_shape(
+        self,
+    ):
+        # Cargo lock version fields are always full numeric X.Y.Z releases.
+        # Anything else is malformed input that must never compare equal to
+        # a valid version — incomplete versions, prerelease or build
+        # suffixes, semver-forbidden leading zeros, extra components — so a
+        # crafted lock cannot smuggle a same-family match past the
+        # unification attribution.
+        for malformed in (
+            "3",
+            "3.0",
+            "3.0.2-beta",
+            "1.0.0+zlib",
+            "01.2.3",
+            "1.02.3",
+            "1.2.03",
+            "1.2.3.4",
+            "١.2.3",
+            "x.y.z",
+            "",
+        ):
+            self.assertFalse(
+                sync_fuzz_lock.same_semver_compat_family(malformed, "3.0.5"),
+                malformed,
+            )
+            self.assertFalse(
+                sync_fuzz_lock.same_semver_compat_family("3.0.5", malformed),
+                malformed,
+            )
+
+    def test_bounded_repair_rejects_cross_patch_0_0_x_survivor_substitution(
+        self,
+    ):
+        #lizard forgives
+        # A shared 0.0.1 record consumed outside the upgraded subtree must
+        # not be attributed onto a newly introduced shared 0.0.2: cargo's
+        # compatibility boundary for 0.0.x is the patch (^0.0.1 excludes
+        # 0.0.2), so no unification could have absorbed the consumers. The
+        # removal stays outside the exact old closure and fails closed.
+        base = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "shared": ["0.0.1"],
+                "quote": ["1.0.0"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        # package order: lofty, lofty-attr, shared 0.0.1, quote,
+        # serde-derive. The old lofty subtree never reaches shared 0.0.1
+        # (lofty-attr 0.12.0 carries only its self-edge); serde-derive
+        # consumes shared 0.0.1 from outside the subtree, while the after
+        # closure gains shared 0.0.2 through lofty-attr 0.13.0.
+        base["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        base["package"][3]["dependencies"] = ["quote 1.0.0"]
+        base["package"][4]["dependencies"] = ["shared 0.0.1"]
+        stale_fuzz = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "shared": ["0.0.1"],
+                "quote": ["1.0.0"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        stale_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        stale_fuzz["package"][3]["dependencies"] = ["quote 1.0.0"]
+        stale_fuzz["package"][4]["dependencies"] = ["shared 0.0.1"]
+        current = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "shared": ["0.0.2"],
+                "quote": ["1.0.0"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        current["package"][1]["dependencies"] = ["shared 0.0.2"]
+        current["package"][3]["dependencies"] = ["quote 1.0.0"]
+        current["package"][4]["dependencies"] = ["shared 0.0.2"]
+        repaired_fuzz = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "shared": ["0.0.2"],
+                "quote": ["1.0.0"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        repaired_fuzz["package"][1]["dependencies"] = ["shared 0.0.2"]
+        repaired_fuzz["package"][3]["dependencies"] = ["quote 1.0.0"]
+        repaired_fuzz["package"][4]["dependencies"] = ["shared 0.0.2"]
+
+        with self.assertRaisesRegex(
+            sync_fuzz_lock.PolicyError, "removed package identities"
+        ):
+            sync_fuzz_lock.validate_bounded_package_changes(
+                base,
+                current,
+                stale_fuzz,
+                repaired_fuzz,
+                [sync_fuzz_lock.Transition("lofty", "0.24.0", "0.25.1")],
+            )
 
     def test_bounded_repair_rejects_unused_unification_replacement(self):
         #lizard forgives

--- a/scripts/test_dependency_update_policy.py
+++ b/scripts/test_dependency_update_policy.py
@@ -1911,6 +1911,116 @@ class FuzzLockPolicyTests(unittest.TestCase):
                 [sync_fuzz_lock.Transition("lofty", "0.24.0", "0.25.1")],
             )
 
+    def test_bounded_repair_rejects_evacuated_unification_with_0_x_coresident(
+        self,
+    ):
+        #lizard forgives
+        # The evacuation admission is only proof-forced when the repaired
+        # lock leaves exactly one same-name record: only then did cargo
+        # resolve every requirer of the name onto it. A co-resident 0.x
+        # record breaks that proof — its ^0.9 requirer demonstrably stayed
+        # put — so uniqueness must be counted across every same-name
+        # record before the stable-major guard runs. Counting only
+        # stable-major records lets a retained consumer rebind
+        # syn 3.0.2 -> 2.0.9 while syn-helper still consumes syn 0.9.0,
+        # admitting a cross-major substitution the documented invariant
+        # calls an unauthorized removal.
+        base = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "syn": ["3.0.2", "0.9.0"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+                "syn-helper": ["0.3.0"],
+            },
+        )
+        # package order: lofty, lofty-attr, syn 3.0.2, syn 0.9.0, quote,
+        # async-trait, serde-derive, syn-helper. Both syn 3.0.2 consumers
+        # sit outside the old lofty subtree; syn-helper pins ^0.9 and keeps
+        # its edge in every lock.
+        base["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        base["package"][3]["dependencies"] = ["quote 1.0.0"]
+        base["package"][4]["dependencies"] = ["quote 1.0.0"]
+        base["package"][6]["dependencies"] = ["syn 3.0.2"]
+        base["package"][7]["dependencies"] = ["syn 3.0.2"]
+        base["package"][8]["dependencies"] = ["syn 0.9.0"]
+        stale_fuzz = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "syn": ["3.0.2", "0.9.0"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+                "syn-helper": ["0.3.0"],
+            },
+        )
+        stale_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        stale_fuzz["package"][3]["dependencies"] = ["quote 1.0.0"]
+        stale_fuzz["package"][4]["dependencies"] = ["quote 1.0.0"]
+        stale_fuzz["package"][6]["dependencies"] = ["syn 3.0.2"]
+        stale_fuzz["package"][7]["dependencies"] = ["syn 3.0.2"]
+        stale_fuzz["package"][8]["dependencies"] = ["syn 0.9.0"]
+        current = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "syn": ["0.9.0", "2.0.9"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+                "syn-helper": ["0.3.0"],
+            },
+        )
+        # package order: lofty, lofty-attr, syn 0.9.0, syn 2.0.9, quote,
+        # async-trait, serde-derive, syn-helper. The graph refresh rebinds
+        # the two exposed syn 3.0.2 consumers onto the freshly introduced
+        # 2.0.9 while syn 0.9.0 co-resides for syn-helper — the repaired
+        # lock leaves two same-name records, so the rebind is not provably
+        # requirement-forced and the removal must stay unattributed.
+        current["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        current["package"][2]["dependencies"] = ["syn 2.0.9"]
+        current["package"][3]["dependencies"] = ["quote 1.0.0"]
+        current["package"][4]["dependencies"] = ["quote 1.0.0"]
+        current["package"][6]["dependencies"] = ["syn 2.0.9"]
+        current["package"][7]["dependencies"] = ["syn 2.0.9"]
+        current["package"][8]["dependencies"] = ["syn 0.9.0"]
+        repaired_fuzz = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "syn": ["0.9.0", "2.0.9"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+                "syn-helper": ["0.3.0"],
+            },
+        )
+        repaired_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        repaired_fuzz["package"][2]["dependencies"] = ["syn 2.0.9"]
+        repaired_fuzz["package"][3]["dependencies"] = ["quote 1.0.0"]
+        repaired_fuzz["package"][4]["dependencies"] = ["quote 1.0.0"]
+        repaired_fuzz["package"][6]["dependencies"] = ["syn 2.0.9"]
+        repaired_fuzz["package"][7]["dependencies"] = ["syn 2.0.9"]
+        repaired_fuzz["package"][8]["dependencies"] = ["syn 0.9.0"]
+
+        with self.assertRaisesRegex(
+            sync_fuzz_lock.PolicyError, "removed package identities"
+        ):
+            sync_fuzz_lock.validate_bounded_package_changes(
+                base,
+                current,
+                stale_fuzz,
+                repaired_fuzz,
+                [sync_fuzz_lock.Transition("lofty", "0.24.0", "0.25.1")],
+            )
+
     def test_bounded_repair_allows_unification_onto_build_metadata_survivor(
         self,
     ):

--- a/scripts/test_dependency_update_policy.py
+++ b/scripts/test_dependency_update_policy.py
@@ -1554,6 +1554,272 @@ class FuzzLockPolicyTests(unittest.TestCase):
                 [sync_fuzz_lock.Transition("lofty", "0.24.0", "0.25.1")],
             )
 
+    def test_bounded_repair_allows_evacuated_stable_major_unification(self):
+        #lizard forgives
+        # Broad consumer requirements let cargo move a retained consumer
+        # across compatibility families: with consumer A on shared "*" and a
+        # newly introduced consumer B on shared "^2", cargo 1.98 resolves
+        # every requirer onto one record (verified against a real directory
+        # registry: A rebinds 1.0.0 -> 2.0.0 and the 1.x record is removed).
+        # When the repaired lock leaves exactly one same-name record, every
+        # requirer resolved onto it, so the rebind was requirement-forced
+        # rather than arbitrary. Stable majors only: cargo's strict 0.x
+        # minor and 0.0.x patch boundaries stay fail-closed below.
+        base = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "syn": ["3.0.2"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        # package order: lofty, lofty-attr, syn, quote, async-trait,
+        # serde-derive. Both syn consumers sit outside the old lofty
+        # subtree (lofty-attr 0.12.0 carries only its edge to lofty).
+        base["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        base["package"][3]["dependencies"] = ["quote 1.0.0"]
+        base["package"][5]["dependencies"] = ["syn 3.0.2"]
+        base["package"][6]["dependencies"] = ["syn 3.0.2"]
+        stale_fuzz = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "syn": ["3.0.2"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        stale_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        stale_fuzz["package"][3]["dependencies"] = ["quote 1.0.0"]
+        stale_fuzz["package"][5]["dependencies"] = ["syn 3.0.2"]
+        stale_fuzz["package"][6]["dependencies"] = ["syn 3.0.2"]
+        current = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "syn": ["2.0.9"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        # The repaired graph unifies every syn requirer onto 2.0.9: the
+        # new closure reaches it through lofty-attr 0.13.0, and the two
+        # retained consumers exhibit the exact 3.0.2 -> 2.0.9 rebind.
+        current["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        current["package"][2]["dependencies"] = ["syn 2.0.9"]
+        current["package"][3]["dependencies"] = ["quote 1.0.0"]
+        current["package"][5]["dependencies"] = ["syn 2.0.9"]
+        current["package"][6]["dependencies"] = ["syn 2.0.9"]
+        repaired_fuzz = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "syn": ["2.0.9"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        repaired_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        repaired_fuzz["package"][2]["dependencies"] = ["syn 2.0.9"]
+        repaired_fuzz["package"][3]["dependencies"] = ["quote 1.0.0"]
+        repaired_fuzz["package"][5]["dependencies"] = ["syn 2.0.9"]
+        repaired_fuzz["package"][6]["dependencies"] = ["syn 2.0.9"]
+
+        requested, remaining = sync_fuzz_lock.validate_submitted_fuzz_update(
+            base,
+            current,
+            stale_fuzz,
+            repaired_fuzz,
+            {"dependencies": {"lofty": "1"}},
+        )
+        self.assertEqual(
+            requested,
+            [sync_fuzz_lock.Transition("lofty", "0.24.0", "0.25.1")],
+        )
+        self.assertEqual(remaining, [])
+        sync_fuzz_lock.validate_bounded_package_changes(
+            base,
+            current,
+            stale_fuzz,
+            repaired_fuzz,
+            requested,
+        )
+
+    def test_bounded_repair_rejects_evacuated_family_ambiguous_survivors(self):
+        #lizard forgives
+        # Full family evacuation plus a unique same-name survivor is what
+        # distinguishes a requirement-forced cross-family unification from
+        # an arbitrary substitution: with two new same-name records left in
+        # the repaired lock, cargo demonstrably did not resolve every
+        # requirer onto one record, so neither survivor can absorb the
+        # removal. The removal stays outside the exact old closure.
+        base = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "syn": ["3.0.2"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        base["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        base["package"][3]["dependencies"] = ["quote 1.0.0"]
+        base["package"][5]["dependencies"] = ["syn 3.0.2"]
+        base["package"][6]["dependencies"] = ["syn 3.0.2"]
+        stale_fuzz = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "syn": ["3.0.2"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        stale_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        stale_fuzz["package"][3]["dependencies"] = ["quote 1.0.0"]
+        stale_fuzz["package"][5]["dependencies"] = ["syn 3.0.2"]
+        stale_fuzz["package"][6]["dependencies"] = ["syn 3.0.2"]
+        current = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "syn": ["2.0.9", "4.0.1"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        # package order: lofty, lofty-attr, syn 2.0.9, syn 4.0.1, quote,
+        # async-trait, serde-derive.
+        current["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        current["package"][2]["dependencies"] = ["syn 2.0.9"]
+        current["package"][4]["dependencies"] = ["quote 1.0.0"]
+        current["package"][5]["dependencies"] = ["syn 2.0.9"]
+        current["package"][6]["dependencies"] = ["syn 4.0.1"]
+        repaired_fuzz = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "syn": ["2.0.9", "4.0.1"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        repaired_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        repaired_fuzz["package"][2]["dependencies"] = ["syn 2.0.9"]
+        repaired_fuzz["package"][4]["dependencies"] = ["quote 1.0.0"]
+        repaired_fuzz["package"][5]["dependencies"] = ["syn 2.0.9"]
+        repaired_fuzz["package"][6]["dependencies"] = ["syn 4.0.1"]
+
+        with self.assertRaisesRegex(
+            sync_fuzz_lock.PolicyError, "removed package identities"
+        ):
+            sync_fuzz_lock.validate_bounded_package_changes(
+                base,
+                current,
+                stale_fuzz,
+                repaired_fuzz,
+                [sync_fuzz_lock.Transition("lofty", "0.24.0", "0.25.1")],
+            )
+
+    def test_bounded_repair_rejects_evacuated_0_x_family_cross_minor(self):
+        #lizard forgives
+        # The cross-family evacuation admission is stable-majors only.
+        # Cargo's 0.x compatibility boundary is the minor (^0.60 excludes
+        # 0.61.x), and cross-boundary movement on those axes is explicitly
+        # operator-policy territory (the windows-sys graph-refresh
+        # disposition on tr-chbht), so an evacuated 0.x family still fails
+        # closed even when a unique newer-minor survivor remains.
+        base = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "windows-sys": ["0.60.2"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        base["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        base["package"][3]["dependencies"] = ["quote 1.0.0"]
+        base["package"][5]["dependencies"] = ["windows-sys 0.60.2"]
+        base["package"][6]["dependencies"] = ["windows-sys 0.60.2"]
+        stale_fuzz = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "windows-sys": ["0.60.2"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        stale_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        stale_fuzz["package"][3]["dependencies"] = ["quote 1.0.0"]
+        stale_fuzz["package"][5]["dependencies"] = ["windows-sys 0.60.2"]
+        stale_fuzz["package"][6]["dependencies"] = ["windows-sys 0.60.2"]
+        current = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "windows-sys": ["0.61.2"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        current["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        current["package"][2]["dependencies"] = ["windows-sys 0.61.2"]
+        current["package"][3]["dependencies"] = ["quote 1.0.0"]
+        current["package"][5]["dependencies"] = ["windows-sys 0.61.2"]
+        current["package"][6]["dependencies"] = ["windows-sys 0.61.2"]
+        repaired_fuzz = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "windows-sys": ["0.61.2"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        repaired_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        repaired_fuzz["package"][2]["dependencies"] = ["windows-sys 0.61.2"]
+        repaired_fuzz["package"][3]["dependencies"] = ["quote 1.0.0"]
+        repaired_fuzz["package"][5]["dependencies"] = ["windows-sys 0.61.2"]
+        repaired_fuzz["package"][6]["dependencies"] = ["windows-sys 0.61.2"]
+
+        with self.assertRaisesRegex(
+            sync_fuzz_lock.PolicyError, "removed package identities"
+        ):
+            sync_fuzz_lock.validate_bounded_package_changes(
+                base,
+                current,
+                stale_fuzz,
+                repaired_fuzz,
+                [sync_fuzz_lock.Transition("lofty", "0.24.0", "0.25.1")],
+            )
+
     def test_bounded_repair_allows_unification_onto_build_metadata_survivor(
         self,
     ):

--- a/scripts/test_dependency_update_policy.py
+++ b/scripts/test_dependency_update_policy.py
@@ -1324,16 +1324,15 @@ class FuzzLockPolicyTests(unittest.TestCase):
     ):
         # Cargo lock version fields are always a full numeric X.Y.Z core.
         # Anything else is malformed input that must never compare equal to
-        # a valid version — incomplete versions, prerelease suffixes,
-        # semver-forbidden leading zeros, extra components — so a crafted
-        # lock cannot smuggle a same-family match past the unification
-        # attribution. Build metadata is validated separately: valid
-        # metadata is stripped before the family parse, malformed metadata
-        # (empty, duplicated, or non-identifier content) stays malformed.
+        # a valid version — incomplete versions, semver-forbidden leading
+        # zeros, extra components — so a crafted lock cannot smuggle a
+        # same-family match past the unification attribution. Prerelease
+        # suffixes and build metadata are validated separately: valid
+        # suffixes fold into the numeric core's family, malformed ones
+        # stay malformed (see the prerelease and build-metadata tests).
         for malformed in (
             "3",
             "3.0",
-            "3.0.2-beta",
             "1.0.0+",
             "1.0.0+zlib+",
             "01.2.3",
@@ -1454,8 +1453,10 @@ class FuzzLockPolicyTests(unittest.TestCase):
         # Only well-formed metadata is stripped: empty or empty identifiers
         # ("1.0.0+", "1.0.0+z..lib"), a duplicated "+" separator, non-ASCII
         # or non-identifier characters are malformed input that must
-        # never compare equal to a valid version. A prerelease suffix
-        # stays malformed even behind a valid build metadata segment.
+        # never compare equal to a valid version. A well-formed prerelease
+        # behind valid build metadata parses (see
+        # test_compat_family_parses_valid_semver_prereleases); malformed
+        # suffixes stay fail-closed either way.
         # Leading zeros in numeric build identifiers are NOT malformed:
         # SemVer 2.0.0 restricts leading zeros to prerelease numerics, and
         # cargo accepts such records — see
@@ -1465,7 +1466,72 @@ class FuzzLockPolicyTests(unittest.TestCase):
             "1.0.0+z..lib",
             "1.0.0+zlib+more",
             "1.0.0+ä",
-            "1.2.3-rc.1+build",
+            "1.0.0-rc.01+build",
+        ):
+            self.assertFalse(
+                sync_fuzz_lock.same_semver_compat_family(malformed, "1.0.5"),
+                malformed,
+            )
+            self.assertFalse(
+                sync_fuzz_lock.same_semver_compat_family("1.0.5", malformed),
+                malformed,
+            )
+
+    def test_compat_family_parses_valid_semver_prereleases(self):
+        # Prereleases are valid Cargo.lock versions — the checked-in fuzz
+        # lock carries sea-orm-arrow 2.0.0-rc.4 — and cargo matches a
+        # prerelease comparator only within its release's own
+        # compatibility family (the same major.minor.patch triple), so a
+        # validated prerelease record shares its numeric core's family: a
+        # graph-refresh rebind from 2.0.0-rc.4 onto the 2.0.0 release is
+        # unification inside the family, and treating the record as
+        # malformed would falsely reject Cargo-generated output as an
+        # unauthorized removal.
+        self.assertTrue(
+            sync_fuzz_lock.same_semver_compat_family("2.0.0-rc.4", "2.0.0")
+        )
+        self.assertTrue(
+            sync_fuzz_lock.same_semver_compat_family("2.0.0", "2.0.0-rc.4")
+        )
+        self.assertTrue(
+            sync_fuzz_lock.same_semver_compat_family(
+                "2.0.0-rc.4", "2.0.0-rc.7"
+            )
+        )
+        # A well-formed prerelease behind valid build metadata parses too.
+        self.assertTrue(
+            sync_fuzz_lock.same_semver_compat_family(
+                "1.2.3-rc.1+build", "1.2.3"
+            )
+        )
+        # Prerelease validity never relaxes the compatibility axes: the
+        # 0.x minor axis, the 0.0.x patch axis, and the major axis all
+        # stay enforced on prerelease records.
+        self.assertFalse(
+            sync_fuzz_lock.same_semver_compat_family("0.5.0-rc.1", "0.6.0")
+        )
+        self.assertFalse(
+            sync_fuzz_lock.same_semver_compat_family("0.0.3-rc.1", "0.0.4")
+        )
+        self.assertFalse(
+            sync_fuzz_lock.same_semver_compat_family("2.0.0-rc.4", "3.0.0")
+        )
+
+    def test_compat_family_rejects_malformed_semver_prereleases(self):
+        # Only well-formed prereleases fold into the numeric core's
+        # family: empty identifiers ("1.0.0-", "1.0.0-rc..1"), non-ASCII
+        # or non-identifier characters, and leading zeros in numeric
+        # identifiers are malformed input that must never compare equal
+        # to a valid version. SemVer 2.0.0 forbids leading zeros in
+        # numeric prerelease identifiers (registry versions are valid
+        # semver, so cargo can never write them) even behind valid build
+        # metadata.
+        for malformed in (
+            "1.0.0-",
+            "1.0.0-rc..1",
+            "1.0.0-rc.01",
+            "1.0.0-beta.01+build",
+            "1.0.0-rç",
         ):
             self.assertFalse(
                 sync_fuzz_lock.same_semver_compat_family(malformed, "1.0.5"),
@@ -2114,6 +2180,179 @@ class FuzzLockPolicyTests(unittest.TestCase):
             repaired_fuzz,
             requested,
         )
+
+    def test_bounded_repair_allows_unification_onto_prerelease_survivor(
+        self,
+    ):
+        #lizard forgives
+        # Real locks carry prerelease records (sea-orm-arrow 2.0.0-rc.4 in
+        # this repository), and cargo matches a prerelease comparator only
+        # within its release's own compatibility family. When a repair's
+        # graph refresh rebinds the outside consumers of sea-orm-arrow
+        # 2.0.0-rc.4 onto the newly introduced 2.0.0 release inside the
+        # after closure, the removal must attribute as same-family
+        # unification — treating the prerelease version as malformed would
+        # falsely reject Cargo-generated output as an unauthorized removal.
+        base = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "sea-orm-arrow": ["2.0.0-rc.4"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        # package order: lofty, lofty-attr, sea-orm-arrow 2.0.0-rc.4,
+        # quote, async-trait, serde-derive. The old lofty subtree never
+        # reaches sea-orm-arrow; the rc record is consumed only by crates
+        # outside it.
+        base["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        base["package"][4]["dependencies"] = ["sea-orm-arrow 2.0.0-rc.4"]
+        base["package"][6]["dependencies"] = ["sea-orm-arrow 2.0.0-rc.4"]
+        stale_fuzz = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "sea-orm-arrow": ["2.0.0-rc.4"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        stale_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        stale_fuzz["package"][4]["dependencies"] = ["sea-orm-arrow 2.0.0-rc.4"]
+        stale_fuzz["package"][6]["dependencies"] = ["sea-orm-arrow 2.0.0-rc.4"]
+        current = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "sea-orm-arrow": ["2.0.0"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        current["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        current["package"][2]["dependencies"] = ["sea-orm-arrow 2.0.0"]
+        current["package"][4]["dependencies"] = ["sea-orm-arrow 2.0.0"]
+        current["package"][6]["dependencies"] = ["sea-orm-arrow 2.0.0"]
+        repaired_fuzz = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "sea-orm-arrow": ["2.0.0"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        repaired_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        repaired_fuzz["package"][2]["dependencies"] = ["sea-orm-arrow 2.0.0"]
+        repaired_fuzz["package"][4]["dependencies"] = ["sea-orm-arrow 2.0.0"]
+        repaired_fuzz["package"][6]["dependencies"] = ["sea-orm-arrow 2.0.0"]
+
+        requested, remaining = sync_fuzz_lock.validate_submitted_fuzz_update(
+            base,
+            current,
+            stale_fuzz,
+            repaired_fuzz,
+            {"dependencies": {"lofty": "1"}},
+        )
+        self.assertEqual(
+            requested,
+            [sync_fuzz_lock.Transition("lofty", "0.24.0", "0.25.1")],
+        )
+        self.assertEqual(remaining, [])
+        sync_fuzz_lock.validate_bounded_package_changes(
+            base,
+            current,
+            stale_fuzz,
+            repaired_fuzz,
+            requested,
+        )
+
+    def test_bounded_repair_rejects_prerelease_cross_minor_unification(self):
+        #lizard forgives
+        # Prerelease validity never relaxes the compatibility axes: a
+        # 0.5.0-rc.1 requirement resolves only within ^0.5 (^0.5.0-rc.1
+        # excludes 0.6.x), so a graph refresh that rebinds its consumers
+        # onto a fresh 0.6.0 record crosses the 0.x minor axis and the
+        # removal must stay rejected as an unauthorized removal.
+        base = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "sea-orm-arrow": ["0.5.0-rc.1"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        base["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        base["package"][4]["dependencies"] = ["sea-orm-arrow 0.5.0-rc.1"]
+        base["package"][6]["dependencies"] = ["sea-orm-arrow 0.5.0-rc.1"]
+        stale_fuzz = lock(
+            ["lofty 0.24.0"],
+            {
+                "lofty": ["0.24.0"],
+                "lofty-attr": ["0.12.0"],
+                "sea-orm-arrow": ["0.5.0-rc.1"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        stale_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.12.0"]
+        stale_fuzz["package"][4]["dependencies"] = ["sea-orm-arrow 0.5.0-rc.1"]
+        stale_fuzz["package"][6]["dependencies"] = ["sea-orm-arrow 0.5.0-rc.1"]
+        current = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "sea-orm-arrow": ["0.6.0"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        current["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        current["package"][2]["dependencies"] = ["sea-orm-arrow 0.6.0"]
+        current["package"][4]["dependencies"] = ["sea-orm-arrow 0.6.0"]
+        current["package"][6]["dependencies"] = ["sea-orm-arrow 0.6.0"]
+        repaired_fuzz = lock(
+            ["lofty 0.25.1"],
+            {
+                "lofty": ["0.25.1"],
+                "lofty-attr": ["0.13.0"],
+                "sea-orm-arrow": ["0.6.0"],
+                "quote": ["1.0.0"],
+                "async-trait": ["0.1.92"],
+                "serde-derive": ["1.0.229"],
+            },
+        )
+        repaired_fuzz["package"][1]["dependencies"] = ["lofty-attr 0.13.0"]
+        repaired_fuzz["package"][2]["dependencies"] = ["sea-orm-arrow 0.6.0"]
+        repaired_fuzz["package"][4]["dependencies"] = ["sea-orm-arrow 0.6.0"]
+        repaired_fuzz["package"][6]["dependencies"] = ["sea-orm-arrow 0.6.0"]
+
+        requested = [sync_fuzz_lock.Transition("lofty", "0.24.0", "0.25.1")]
+        with self.assertRaisesRegex(
+            sync_fuzz_lock.PolicyError, "removed package identities"
+        ):
+            sync_fuzz_lock.validate_bounded_package_changes(
+                base,
+                current,
+                stale_fuzz,
+                repaired_fuzz,
+                requested,
+            )
 
     def test_bounded_repair_rejects_unused_unification_replacement(self):
         #lizard forgives


### PR DESCRIPTION
## Summary

`sync_fuzz_lock.py`'s unification gate (added by #261) attributes an exact lockfile removal to a Cargo shared-transitive unification only when the removed identity has **exactly one surviving same-name record across ALL versions**. The real repository lock violates that premise for any crate with multiple co-hosted majors, which makes PR #247 (lofty 0.24.0 → 0.25.1) unprovable: the base fuzz lock co-hosts **syn 1.0.109, syn 2.0.119, and syn 3.0.2**; after the repair three syn records survive, the removal of `(syn, 3.0.2)` is never attributed to the unification, and `write` exits 2:

```
dependency lock policy failed: fuzz lock repair removed package identities
outside the exact old dependency closure: [('syn', '3.0.2')]
```

Cargo unification can only merge requirements that resolve into one **compatibility family** — same major, and for 0.x crates also the same minor (a `^0.60` requirement never matches `0.61.x`). Global name uniqueness is therefore the wrong invariant (filed analysis: bead tr-0crqs; follow-up blocker: bead tr-chbht).

## Change

- New `same_semver_compat_family()` helper mirroring cargo's unification axes (same major; for 0.x also same minor; malformed versions never compare equal).
- `unification_replacements()` scopes its survivor-uniqueness scan to the removed record's compatibility family. Same-name records in other families are separate graph residents: they neither defeat attribution nor qualify as the replacement.
- **Every other fail-closed condition is unchanged:** the survivor must lie inside the exact after closure (necessitated by the selected production update), must be newly introduced by the repair, must preserve the removed record's source identity, and an observed exact edge rebind must consume the mapping. Unrelated removals, ambiguous same-family survivors, pre-existing survivors, cross-family substitutions, and cross-source substitutions all still fail closed.

### Deliberate semantic tightening (reviewer attention requested)

Two #261-era fixtures (`test_bounded_repair_rejects_unused_unification_replacement`, `test_bounded_repair_rejects_independently_dropped_last_edge`) used **cross-major** "survivors" (shared 1.0.0 vs 2.0.0 across facade's major bump). The old global name matching attributed those removals before rejecting them at the *observation* stage ("no observed exact edge rebind"). Under cargo-faithful scoping they are rejected earlier, at *attribution* ("removed package identities outside the exact old dependency closure"). Same fail-closed outcome, stricter invariant; both tests' expectations and comments were updated.

## Regression coverage (4 new tests)

- `test_compat_family_scoping_matches_cargo_unification_axes` — pins the family axes incl. 0.x minors and malformed input.
- `test_bounded_repair_allows_unification_with_coexisting_other_majors` — real-shaped happy path: syn 1.x + 2.x co-hosted, unified 3.0.2 → 3.0.5 with exact consumer rebinds.
- `test_bounded_repair_rejects_cross_major_survivor_substitution` — consumers rebound onto a different-major record must still fail closed.
- `test_bounded_repair_rejects_rebind_absorbed_by_different_major` — admitted same-major survivor but consumer actually absorbed by a co-hosted other major must still fail closed.

## Validation (exact head `88aa5d198734341dd75c6120215cc06deff2eb80`)

- Policy suite: **43/43 OK, exit 0** (39 prior — all unchanged in outcome — + 4 new).
- `python3 -m py_compile` clean; `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo clippy --release -- -D warnings`, `cargo check --all-targets --locked`, `cargo build --release`: all exit 0.
- `cargo test --all-targets`: **1832 passed, 0 failed**.
- Locked fuzz workspace `cargo check --manifest-path fuzz/Cargo.toml --locked`: exit 0.
- End-to-end against the real base lock: in a throwaway worktree of the #247 rebase (`ff0c0e5`) with this script overlaid, `write --base-ref cff7bb8…` now passes the syn attribution that previously failed and proceeds to the next gate (rolled back cleanly afterwards).
- `check --base-ref cff7bb8…` on main: exit 0 — main's own coherence is undisturbed.

## Known follow-up (out of scope here)

The same end-to-end run surfaced a **distinct, pre-existing** blocker for the #247 lock regeneration: the graph refresh rebinds `anstyle-query@1.1.5`'s `windows-sys` 0.60.2 → 0.61.2 outside the lofty transition closures, which the bounded proof correctly rejects as an arbitrary edge rebind. This PR deliberately does **not** admit that shape. Evidence and disposition options: bead tr-chbht.

## Constraints honored

No changes to #247's branch, no gate skipping, no broad allowlist, no self-approval; Security Audit and `--locked` semantics untouched. Auto-merge is off; operator merge only, after independent review of the exact head.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency update validation for same-major compatibility and compatibility-family boundaries.
  * Added support for valid SemVer prereleases within their numeric compatibility families while rejecting malformed prereleases.
  * Corrected handling of early `0.0.x` versions to scope compatibility to the same patch family.
  * Restricted cross-family replacement to stable-major versions with exactly one valid survivor.
  * Prevented invalid replacement attribution when incompatible or malformed records coexist.
  * Continued to accept valid build metadata while rejecting malformed metadata.

* **Tests**
  * Expanded coverage for prereleases, metadata, bounded repairs, removed packages, and dropped dependency edges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->