### PR TITLE
deps(fuzz): align fuzz lock baseline to root for #247 (tr-chbht)

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -121,7 +121,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -132,7 +132,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -500,7 +500,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1384,7 +1384,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1507,7 +1507,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1721,7 +1721,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1926,7 +1926,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3189,7 +3189,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3728,7 +3728,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4062,7 +4062,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4075,7 +4075,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4134,7 +4134,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4467,7 +4467,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4502,7 +4502,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4660,7 +4660,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4942,9 +4942,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5015,7 +5015,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5055,7 +5055,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5512,7 +5512,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5829,7 +5829,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Discovered 2026-09-12 during tr-7f7yo remediation (workflow tr-5ckf8), end-to-end verification of the compat-family unification fix (branch polecat/tr-7f7yo @ 88aa5d1, unit-proven 43/43). Environment: throwaway worktree of the #247 rebase ff0c0e5, fixed script overlaid, real base cff7bb8, rollback clean.

SYMPTOM

  python3 scripts/sync_fuzz_lock.py write --base-ref cff7bb8 (at ff0c0e5, fixed script)
  now passes the syn 3.0.2 -> 3.0.5 attribution (tr-0crqs defect fixed) but the
  bounded proof then rejects the NEXT real-lock difference:

    fuzz lock repair semantically rebound an edge outside the reviewed
    dependency surface: anstyle-query@1.1.5 windows-sys:
    (('windows-sys', '0.60.2'),) -> (('windows-sys', '0.61.2'),)

  Write exit 2; fuzz/Cargo.lock rolled back clean. So NO repaired lock passes
  the CI coherence check for #247 even with the compat-family helper:
  stale fuzz lock = exit 1; repaired = exit 2 at this rebind.

TOPOLOGY (evidence from the real locks)

  - Base fuzz lock @ cff7bb8 co-hosts windows-sys 0.52.0, 0.59.0, 0.60.2,
    0.61.2. anstyle-query@1.1.5 edges to 0.60.2 there.
  - Root lock @ ff0c0e5 resolves anstyle-query@1.1.5 to windows-sys 0.61.2
    (root already drifted from the base fuzz lock outside the lofty surface).
  - The repair's graph refresh (declaration change on lofty triggers
    refresh_tributary_dependency_graph) re-resolves the tributary-reachable
    graph, aligning anstyle-query onto 0.61.2.
  - anstyle-query is OUTSIDE the old/after exact closures of the requested
    lofty transition, and (windows-sys, 0.61.2) is neither newly introduced
    nor a unification survivor (0.60.2 remains in the lock for anstyle-wincon,
    dirs-sys, notify, nu-ansi-term, socket2, uds_windows). So no attribution
    applies and the rebind is correctly rejected as an arbitrary edge rebind.

WHY THIS IS A POLICY GAP, NOT A BUG IN THE REJECTION

  The refresh step is by-design (declaration change), but the bounded proof
  only authorizes rebinds inside the requested transitions' closures. Any
  tributary-reachable transitive that the root has re-resolved since the base
  fuzz lock was generated will hit this. windows-sys is likely the first of a
  serial set; the proof fails one rebind at a time.

  Note: the operator spec for the tr-0crqs helper explicitly requires
  arbitrary edge rebinds to fail closed, so the tr-7f7yo helper must NOT admit
  this shape; the helper as pushed is correct and necessary but NOT sufficient
  to unblock #247.

RESOLUTION OPTIONS (need operator decision)

  A. Third policy-helper: admit graph-refresh alignment rebinds only where
     (i) the consumer is tributary-reachable, (ii) the after target identity
     already exists in the authoritative root lock with byte-identical
     source/checksum metadata, and (iii) the edge surface is otherwise
     unchanged (same names, same count) — keep every other check intact;
     add real-shaped regressions (anstyle-query windows-sys happy path +
     adversarial: rebind to an identity absent from the root lock, surface
     rewrite, cross-source target).
  B. Operator-blessed alignment procedure outside sync_fuzz_lock (e.g. a
     reviewed regeneration whose diff is verified by an allowlisted
     root-mirror check) — policy untouched.
  C. Alternative disposition.

Validation evidence of the helper itself (unchanged by this finding):
policy suite 43/43 exit 0 at 88aa5d1; real write passes syn attribution;
check on main @ cff7bb8 exit 0 (main coherence undisturbed).

Discovered during mol-polecat-work implement step (workflow tr-5ckf8, work bead tr-7f7yo).
## Operator disposition

Approved 2026-09-13: exact separate fuzz-lock-only baseline alignment; no policy relaxation.
Report: `/home/jmulesa/tributary/.gc/operations/reviews/health-20260913T000122Z/247-alignment-disposition.md`
Investigation source: tr-djv7e. This PR changes ONLY `fuzz/Cargo.lock`.

## Refinery verification at 79aef4f2fb0dd58dcde53b54ef6e501125bba066

- Base: `38318d78a4942473cbf83f73c99afe262bc2a422` (current main, includes merged #262); branch is based exactly on current main (no rebase needed).
- Diff base..head is `fuzz/Cargo.lock` only (21 insertions / 21 deletions); its change lines are identical to the operator-reviewed candidate `tr-djv7e-247lock-20260912T230754Z/03-baseline-alignment.diff`.
- `python3 scripts/sync_fuzz_lock.py check --base-ref 38318d78...` -> exit 0: "root and fuzz lockfiles have coherent production dependencies".
- `cargo metadata --manifest-path fuzz/Cargo.toml --format-version 1 --locked --offline` -> exit 0, 612 packages, `fuzz/Cargo.lock` sha256 unchanged.
- `cargo check --manifest-path fuzz/Cargo.toml --locked` -> exit 0.
- `python3 scripts/test_dependency_update_policy.py` -> 59 tests OK (exit 0).

Auto-merge OFF; operator merge only. Hosted CI runs on this head.

## Refinery handoff

- Issue: `tr-chbht` (task, P1)
- Source branch: `polecat/tr-chbht`
- Target: `main`
