### PR TITLE
perf(macos): dedupe macOS bundle inspection and batch rpath edits (tr-zhf4p)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
           build-aux/linux/test-package-compliance.sh
           scripts/test-macos-icon-bundle-policy.sh
           scripts/test-macos-package-policy.sh
+          scripts/test-macos-rpath-batching.sh
           python3 scripts/test_build_helpers.py
 
       - name: Test dependency update policy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   scrobbling activation, with transactional updates and validation. Scrobbling remains disabled.
 - **Dependency maintenance** — Refresh Rust dependencies and the release-upload action,
   and keep the fuzz lockfile synchronized with dependency updates.
+- **macOS packaging throughput** — Inspect each immutable Homebrew dylib source once per
+  bundle build instead of once per plugin that links it, and apply each binary's equivalent
+  `install_name_tool -change` edits in a single invocation. Forbidden-component policy is
+  unchanged: a rejected source still aborts before any copy or edit is applied.
 
 ### Fixed
 

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -412,6 +412,22 @@ FRAMEWORKS_DIR="${APP_BUNDLE}/Contents/Frameworks"
 # not the bash wrapper we just created.
 BIN="${APP_BUNDLE}/Contents/MacOS/${APP_NAME}-bin"
 
+# >>> macOS rpath helpers
+#
+# copy_dylib and fix_rpaths do the repetitive per-dependency work for the
+# bundle. They preserve every policy decision above, but stop inspecting the
+# same immutable Homebrew source once per consumer and stop spawning one
+# install_name_tool process per equivalent edit.
+#
+# Validation results are keyed by the exact absolute source path, never by the
+# destination basename, so a basename collision cannot let one artifact's
+# inspection authorize a different one. Homebrew prefixes are immutable for the
+# life of a build, so each distinct source is inspected once before its first
+# copy; the counters below surface the avoided work in the build log.
+MACOS_VALIDATED_SOURCE_CACHE=$'\n'
+MACOS_SOURCE_VALIDATIONS=0
+MACOS_SOURCE_CACHE_HITS=0
+
 # Copy a single dylib into Frameworks/ if not already there.
 copy_dylib() {
   local src="$1"
@@ -419,8 +435,14 @@ copy_dylib() {
   basename="$(basename "$src")"
   local dest="${FRAMEWORKS_DIR}/${basename}"
 
-  if ! macos_validate_macho_copy_control "$src"; then
-    error "Refusing recursive dylib dependency: ${MACOS_PACKAGE_POLICY_REASON}"
+  if [[ "$MACOS_VALIDATED_SOURCE_CACHE" == *$'\n'"${src}"$'\n'* ]]; then
+    MACOS_SOURCE_CACHE_HITS=$((MACOS_SOURCE_CACHE_HITS + 1))
+  else
+    if ! macos_validate_macho_copy_control "$src"; then
+      error "Refusing recursive dylib dependency: ${MACOS_PACKAGE_POLICY_REASON}"
+    fi
+    MACOS_VALIDATED_SOURCE_CACHE+="${src}"$'\n'
+    MACOS_SOURCE_VALIDATIONS=$((MACOS_SOURCE_VALIDATIONS + 1))
   fi
 
   [[ -f "$dest" ]] && return 1
@@ -434,6 +456,7 @@ copy_dylib() {
 fix_rpaths() {
   local bin="$1"
   local new_libs=()
+  local change_args=()
   while IFS= read -r libpath; do
     local basename
     basename="$(basename "$libpath")"
@@ -450,15 +473,22 @@ fix_rpaths() {
       fi
     fi
     
-    install_name_tool -change "$libpath" \
-      "@executable_path/../Frameworks/${basename}" "$bin" 2>/dev/null || true
+    # install_name_tool applies every -change in a single invocation. Collect
+    # the equivalent edits for this binary and apply them together instead of
+    # spawning one subprocess per dependency.
+    change_args+=(-change "$libpath" "@executable_path/../Frameworks/${basename}")
       
   # The updated regex catches /opt/homebrew, /usr/local, AND @rpath/@loader_path
   done < <(otool -L "$bin" 2>/dev/null \
     | awk '/\/opt\/homebrew|\/usr\/local|@rpath\/|@loader_path\// {print $1}')
-    
+
+  if [[ ${#change_args[@]} -gt 0 ]]; then
+    install_name_tool "${change_args[@]}" "$bin" 2>/dev/null || true
+  fi
+
   NEWLY_COPIED=("${new_libs[@]+"${new_libs[@]}"}")
 }
+# <<< macOS rpath helpers
 
 # Fix the main binary
 fix_rpaths "$BIN"
@@ -493,6 +523,7 @@ done
 
 TOTAL_DYLIBS=$(ls -1 "${FRAMEWORKS_DIR}"/*.dylib 2>/dev/null | wc -l | tr -d ' ')
 info "Bundled ${TOTAL_DYLIBS} dylibs into Frameworks/."
+info "Dylib source policy inspections: ${MACOS_SOURCE_VALIDATIONS}; repeated inspections avoided: ${MACOS_SOURCE_CACHE_HITS}."
 
 # Fix GStreamer plugins
 if [[ -d "$GST_PLUGIN_DEST" ]]; then

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -523,7 +523,6 @@ done
 
 TOTAL_DYLIBS=$(ls -1 "${FRAMEWORKS_DIR}"/*.dylib 2>/dev/null | wc -l | tr -d ' ')
 info "Bundled ${TOTAL_DYLIBS} dylibs into Frameworks/."
-info "Dylib source policy inspections: ${MACOS_SOURCE_VALIDATIONS}; repeated inspections avoided: ${MACOS_SOURCE_CACHE_HITS}."
 
 # Fix GStreamer plugins
 if [[ -d "$GST_PLUGIN_DEST" ]]; then
@@ -558,6 +557,12 @@ if [[ -d "$PIXBUF_LOADERS_DEST" ]]; then
     fix_rpaths "$loader"
   done
 fi
+
+# Emit the full optimization counters only after every fix_rpaths consumer
+# (main binary, dylib closure, GStreamer plugins, scanner, pixbuf generator and
+# loaders) has run, so the native CI metrics include the dominant source
+# validations and cache hits rather than a partial pre-plugin prefix.
+info "Dylib source policy inspections: ${MACOS_SOURCE_VALIDATIONS}; repeated inspections avoided: ${MACOS_SOURCE_CACHE_HITS}."
 
 # A copied Homebrew cache contains builder paths and is mutable runtime state.
 # Runtime setup generates a relocated cache below the user's cache directory.

--- a/scripts/test-macos-rpath-batching.sh
+++ b/scripts/test-macos-rpath-batching.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# Regression coverage for the macOS rpath-repair helpers in build-macos.sh.
+#
+# The helpers must keep exactly the same policy decisions while doing far less
+# repeated work: each distinct immutable source is inspected once per build,
+# and the equivalent install_name_tool edits for one binary are batched into a
+# single invocation. The last scenario proves the batching is still fail
+# closed: a rejected source aborts before any edit is applied.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_SCRIPT="${SCRIPT_DIR}/build-macos.sh"
+
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/tributary-macos-rpath.XXXXXX")"
+cleanup() {
+  rm -rf "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "not ok - $*" >&2
+  exit 1
+}
+
+pass_count=0
+ok() {
+  pass_count=$((pass_count + 1))
+  echo "ok - $*"
+}
+
+# Extract the rpath helpers from the build script without executing it.
+HELPERS="${TEST_ROOT}/helpers.sh"
+sed -n '/^# >>> macOS rpath helpers$/,/^# <<< macOS rpath helpers$/p' \
+  "$BUILD_SCRIPT" > "$HELPERS"
+[[ -s "$HELPERS" ]] || fail "could not extract the macOS rpath helpers"
+# shellcheck source=/dev/null
+source "$HELPERS"
+grep -q '^fix_rpaths()' "$HELPERS" || fail "extracted helpers are missing fix_rpaths"
+grep -q '^copy_dylib()' "$HELPERS" || fail "extracted helpers are missing copy_dylib"
+
+# ── Tool fixtures ────────────────────────────────────────────────────────────
+FAKE_BIN="${TEST_ROOT}/tools"
+mkdir -p "$FAKE_BIN"
+
+# `otool -L <artifact>` prints the dependency list recorded beside the fixture.
+cat > "${FAKE_BIN}/otool" <<'EOF'
+#!/usr/bin/env bash
+artifact="${!#}"
+printf '%s:\n' "$artifact"
+if [[ -f "${artifact}.deps" ]]; then
+  while IFS= read -r dependency || [[ -n "$dependency" ]]; do
+    printf '\t%s (compatibility version 1.0.0, current version 1.0.0)\n' "$dependency"
+  done < "${artifact}.deps"
+fi
+EOF
+
+# Record every install_name_tool invocation so the test can count processes.
+cat > "${FAKE_BIN}/install_name_tool" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${INSTALL_NAME_LOG}"
+EOF
+chmod +x "${FAKE_BIN}/otool" "${FAKE_BIN}/install_name_tool"
+export PATH="${FAKE_BIN}:${PATH}"
+
+FRAMEWORKS_DIR="${TEST_ROOT}/Frameworks"
+BREW_PREFIX="${TEST_ROOT}/opt/homebrew"
+mkdir -p "$FRAMEWORKS_DIR" "${BREW_PREFIX}/lib"
+
+VALIDATION_LOG="${TEST_ROOT}/validations.log"
+INSTALL_NAME_LOG="${TEST_ROOT}/install-name.log"
+export INSTALL_NAME_LOG
+VALIDATION_REJECT=""
+
+# Count each source inspection. The real helper wraps
+# macos_validate_macho_copy_control, so overriding it here observes exactly the
+# number of policy inspections the build performs.
+macos_validate_macho_copy_control() {
+  local artifact="$1"
+  printf '%s\n' "$artifact" >> "$VALIDATION_LOG"
+  if [[ -n "$VALIDATION_REJECT" && "$artifact" == "$VALIDATION_REJECT" ]]; then
+    MACOS_PACKAGE_POLICY_REASON="fixture rejection for ${artifact}"
+    return 1
+  fi
+  return 0
+}
+
+error() {
+  printf 'fixture error: %s\n' "$*" >&2
+  exit 1
+}
+
+reset_fixture_state() {
+  : > "$VALIDATION_LOG"
+  : > "$INSTALL_NAME_LOG"
+  VALIDATION_REJECT=""
+  MACOS_VALIDATED_SOURCE_CACHE=$'\n'
+  MACOS_SOURCE_VALIDATIONS=0
+  MACOS_SOURCE_CACHE_HITS=0
+}
+
+make_library() {
+  local source="$1"
+  mkdir -p "$(dirname "$source")"
+  touch "$source"
+}
+
+make_binary() {
+  local binary="$1"
+  shift
+  touch "$binary"
+  printf '%s\n' "$@" > "${binary}.deps"
+}
+
+# ── Scenario 1: a shared dependency is inspected once across consumers ───────
+reset_fixture_state
+make_library "${BREW_PREFIX}/lib/libshared.dylib"
+make_library "${BREW_PREFIX}/lib/libalpha.dylib"
+make_library "${BREW_PREFIX}/lib/libbeta.dylib"
+PLUGIN_A="${TEST_ROOT}/libgstalpha.dylib"
+PLUGIN_B="${TEST_ROOT}/libgstbeta.dylib"
+make_binary "$PLUGIN_A" '@rpath/libshared.dylib' '@rpath/libalpha.dylib'
+make_binary "$PLUGIN_B" '@rpath/libshared.dylib' '@rpath/libbeta.dylib'
+
+fix_rpaths "$PLUGIN_A"
+fix_rpaths "$PLUGIN_B"
+
+inspect_count="$(wc -l < "$VALIDATION_LOG" | tr -d ' ')"
+[[ "$inspect_count" -eq 3 ]] \
+  || fail "expected 3 distinct source inspections, saw ${inspect_count}"
+[[ "$MACOS_SOURCE_CACHE_HITS" -eq 1 ]] \
+  || fail "expected 1 cached reuse, saw ${MACOS_SOURCE_CACHE_HITS}"
+[[ "$(grep -Fc "${BREW_PREFIX}/lib/libshared.dylib" "$VALIDATION_LOG")" -eq 1 ]] \
+  || fail "shared source was inspected more than once"
+
+change_lines="$(grep -c -- '-change' "$INSTALL_NAME_LOG" || true)"
+change_tokens="$(grep -o -- '-change' "$INSTALL_NAME_LOG" | wc -l | tr -d ' ')"
+[[ "$change_lines" -eq 2 ]] \
+  || fail "expected one batched install_name_tool -change call per binary, saw ${change_lines}"
+[[ "$change_tokens" -eq 4 ]] \
+  || fail "expected 4 total -change edits, saw ${change_tokens}"
+ok "shared sources are inspected once and edits are batched per binary"
+
+# ── Scenario 2: the cache keys on the exact source, not the basename ─────────
+reset_fixture_state
+DUP_ONE="${TEST_ROOT}/opt/homebrew/lib/one/libdup.dylib"
+DUP_TWO="${TEST_ROOT}/opt/homebrew/lib/two/libdup.dylib"
+make_library "$DUP_ONE"
+make_library "$DUP_TWO"
+PLUGIN_C="${TEST_ROOT}/libgstdup.dylib"
+make_binary "$PLUGIN_C" "$DUP_ONE" "$DUP_TWO"
+
+fix_rpaths "$PLUGIN_C"
+
+[[ "$(grep -Fc "$DUP_ONE" "$VALIDATION_LOG")" -eq 1 ]] \
+  || fail "first exact source was not inspected exactly once"
+[[ "$(grep -Fc "$DUP_TWO" "$VALIDATION_LOG")" -eq 1 ]] \
+  || fail "a same-basename source was skipped by an inexact cache key"
+[[ "$MACOS_SOURCE_CACHE_HITS" -eq 0 ]] \
+  || fail "distinct sources must not register as cache hits"
+ok "validation cache keys on the exact source path, not the basename"
+
+# ── Scenario 3: a rejected source still aborts before any edit ───────────────
+reset_fixture_state
+make_library "${BREW_PREFIX}/lib/libok.dylib"
+make_library "${BREW_PREFIX}/lib/libbad.dylib"
+PLUGIN_D="${TEST_ROOT}/libgstmixed.dylib"
+make_binary "$PLUGIN_D" '@rpath/libok.dylib' '@rpath/libbad.dylib'
+
+set +e
+( VALIDATION_REJECT="${BREW_PREFIX}/lib/libbad.dylib"; fix_rpaths "$PLUGIN_D" ) >/dev/null 2>&1
+rejection_status=$?
+set -e
+
+[[ "$rejection_status" -ne 0 ]] \
+  || fail "a prohibited source must abort the build"
+[[ ! -f "${FRAMEWORKS_DIR}/libbad.dylib" ]] \
+  || fail "a prohibited source reached Frameworks/"
+change_edits="$(grep -c -- '-change' "$INSTALL_NAME_LOG" || true)"
+[[ "$change_edits" -eq 0 ]] \
+  || fail "no batched -change edit may run once a source is rejected"
+ok "a rejected source aborts before any batched edit is applied"
+
+echo "1..${pass_count}"

--- a/scripts/test-macos-rpath-batching.sh
+++ b/scripts/test-macos-rpath-batching.sh
@@ -79,6 +79,9 @@ macos_validate_macho_copy_control() {
   printf '%s\n' "$artifact" >> "$VALIDATION_LOG"
   if [[ -n "$VALIDATION_REJECT" && "$artifact" == "$VALIDATION_REJECT" ]]; then
     MACOS_PACKAGE_POLICY_REASON="fixture rejection for ${artifact}"
+    # Surface the recorded reason so the rejection scenario can assert that the
+    # failure names the exact rejected source (and not a same-basename one).
+    printf 'policy_reason=%s\n' "$MACOS_PACKAGE_POLICY_REASON"
     return 1
   fi
   return 0
@@ -127,10 +130,14 @@ fix_rpaths "$PLUGIN_B"
 inspect_count="$(wc -l < "$VALIDATION_LOG" | tr -d ' ')"
 [[ "$inspect_count" -eq 3 ]] \
   || fail "expected 3 distinct source inspections, saw ${inspect_count}"
+[[ "$MACOS_SOURCE_VALIDATIONS" -eq "$inspect_count" ]] \
+  || fail "validator counter recorded ${MACOS_SOURCE_VALIDATIONS} of ${inspect_count} distinct-source inspections"
 [[ "$MACOS_SOURCE_CACHE_HITS" -eq 1 ]] \
   || fail "expected 1 cached reuse, saw ${MACOS_SOURCE_CACHE_HITS}"
 [[ "$(grep -Fc "${BREW_PREFIX}/lib/libshared.dylib" "$VALIDATION_LOG")" -eq 1 ]] \
   || fail "shared source was inspected more than once"
+[[ "$MACOS_VALIDATED_SOURCE_CACHE" == *$'\n'"${BREW_PREFIX}/lib/libshared.dylib"$'\n'* ]] \
+  || fail "validation cache did not record the exact inspected source path"
 
 change_lines="$(grep -c -- '-change' "$INSTALL_NAME_LOG" || true)"
 change_tokens="$(grep -o -- '-change' "$INSTALL_NAME_LOG" | wc -l | tr -d ' ')"
@@ -155,6 +162,12 @@ fix_rpaths "$PLUGIN_C"
   || fail "first exact source was not inspected exactly once"
 [[ "$(grep -Fc "$DUP_TWO" "$VALIDATION_LOG")" -eq 1 ]] \
   || fail "a same-basename source was skipped by an inexact cache key"
+[[ "$MACOS_SOURCE_VALIDATIONS" -eq 2 ]] \
+  || fail "expected 2 distinct-source validations, saw ${MACOS_SOURCE_VALIDATIONS}"
+[[ "$MACOS_VALIDATED_SOURCE_CACHE" == *$'\n'"$DUP_ONE"$'\n'* ]] \
+  || fail "validation cache did not key on the first exact source path"
+[[ "$MACOS_VALIDATED_SOURCE_CACHE" == *$'\n'"$DUP_TWO"$'\n'* ]] \
+  || fail "validation cache did not key on the second exact source path"
 [[ "$MACOS_SOURCE_CACHE_HITS" -eq 0 ]] \
   || fail "distinct sources must not register as cache hits"
 ok "validation cache keys on the exact source path, not the basename"
@@ -167,7 +180,10 @@ PLUGIN_D="${TEST_ROOT}/libgstmixed.dylib"
 make_binary "$PLUGIN_D" '@rpath/libok.dylib' '@rpath/libbad.dylib'
 
 set +e
-( VALIDATION_REJECT="${BREW_PREFIX}/lib/libbad.dylib"; fix_rpaths "$PLUGIN_D" ) >/dev/null 2>&1
+rejection_output="$(
+  VALIDATION_REJECT="${BREW_PREFIX}/lib/libbad.dylib"
+  fix_rpaths "$PLUGIN_D" 2>&1
+)"
 rejection_status=$?
 set -e
 
@@ -178,6 +194,10 @@ set -e
 change_edits="$(grep -c -- '-change' "$INSTALL_NAME_LOG" || true)"
 [[ "$change_edits" -eq 0 ]] \
   || fail "no batched -change edit may run once a source is rejected"
+[[ "$rejection_output" == *"policy_reason=fixture rejection for ${BREW_PREFIX}/lib/libbad.dylib"* ]] \
+  || fail "rejection did not surface the policy reason for the exact rejected source"
+[[ "$rejection_output" == *"Refusing recursive dylib dependency"* ]] \
+  || fail "rejection did not use the production error path"
 ok "a rejected source aborts before any batched edit is applied"
 
 echo "1..${pass_count}"

--- a/scripts/test-macos-rpath-batching.sh
+++ b/scripts/test-macos-rpath-batching.sh
@@ -79,9 +79,11 @@ macos_validate_macho_copy_control() {
   printf '%s\n' "$artifact" >> "$VALIDATION_LOG"
   if [[ -n "$VALIDATION_REJECT" && "$artifact" == "$VALIDATION_REJECT" ]]; then
     MACOS_PACKAGE_POLICY_REASON="fixture rejection for ${artifact}"
-    # Surface the recorded reason so the rejection scenario can assert that the
-    # failure names the exact rejected source (and not a same-basename one).
-    printf 'policy_reason=%s\n' "$MACOS_PACKAGE_POLICY_REASON"
+    # Mirror the reason through the same variable the production helper sets,
+    # but deliberately do NOT print it here: scenario 3 asserts that copy_dylib's
+    # production error call propagates this exact reason, so the output must come
+    # only from that path (a fixture that printed it too would mask a weakened
+    # error call that dropped ${MACOS_PACKAGE_POLICY_REASON}).
     return 1
   fi
   return 0
@@ -194,10 +196,14 @@ set -e
 change_edits="$(grep -c -- '-change' "$INSTALL_NAME_LOG" || true)"
 [[ "$change_edits" -eq 0 ]] \
   || fail "no batched -change edit may run once a source is rejected"
-[[ "$rejection_output" == *"policy_reason=fixture rejection for ${BREW_PREFIX}/lib/libbad.dylib"* ]] \
-  || fail "rejection did not surface the policy reason for the exact rejected source"
-[[ "$rejection_output" == *"Refusing recursive dylib dependency"* ]] \
-  || fail "rejection did not use the production error path"
+# The fixture no longer prints the reason, so the only possible source of the
+# complete production message is copy_dylib's
+# `error "Refusing recursive dylib dependency: ${MACOS_PACKAGE_POLICY_REASON}"`
+# call. Assert the whole message, including the exact rejected source path, so a
+# weakened error call that drops the reason (or the source identity) fails.
+expected_rejection="Refusing recursive dylib dependency: fixture rejection for ${BREW_PREFIX}/lib/libbad.dylib"
+[[ "$rejection_output" == *"$expected_rejection"* ]] \
+  || fail "rejection did not propagate the complete production error message for the exact rejected source"
 ok "a rejected source aborts before any batched edit is applied"
 
 echo "1..${pass_count}"

--- a/scripts/test-macos-rpath-batching.sh
+++ b/scripts/test-macos-rpath-batching.sh
@@ -68,6 +68,7 @@ mkdir -p "$FRAMEWORKS_DIR" "${BREW_PREFIX}/lib"
 
 VALIDATION_LOG="${TEST_ROOT}/validations.log"
 INSTALL_NAME_LOG="${TEST_ROOT}/install-name.log"
+REASON_CAPTURE_FILE="${TEST_ROOT}/policy-reason.txt"
 export INSTALL_NAME_LOG
 VALIDATION_REJECT=""
 
@@ -80,10 +81,12 @@ macos_validate_macho_copy_control() {
   if [[ -n "$VALIDATION_REJECT" && "$artifact" == "$VALIDATION_REJECT" ]]; then
     MACOS_PACKAGE_POLICY_REASON="fixture rejection for ${artifact}"
     # Mirror the reason through the same variable the production helper sets,
-    # but deliberately do NOT print it here: scenario 3 asserts that copy_dylib's
-    # production error call propagates this exact reason, so the output must come
-    # only from that path (a fixture that printed it too would mask a weakened
-    # error call that dropped ${MACOS_PACKAGE_POLICY_REASON}).
+    # capturing it to a fixture-side file rather than stdout: scenario 3 asserts
+    # that copy_dylib's production error call propagates this exact reason, so the
+    # rejection output must come only from that path (a fixture that printed the
+    # reason too would mask a weakened error call that dropped it). Reading the
+    # variable for the capture also consumes the assignment for static analysis.
+    printf '%s' "$MACOS_PACKAGE_POLICY_REASON" > "$REASON_CAPTURE_FILE"
     return 1
   fi
   return 0
@@ -97,6 +100,7 @@ error() {
 reset_fixture_state() {
   : > "$VALIDATION_LOG"
   : > "$INSTALL_NAME_LOG"
+  : > "$REASON_CAPTURE_FILE"
   VALIDATION_REJECT=""
   MACOS_VALIDATED_SOURCE_CACHE=$'\n'
   MACOS_SOURCE_VALIDATIONS=0
@@ -204,6 +208,13 @@ change_edits="$(grep -c -- '-change' "$INSTALL_NAME_LOG" || true)"
 expected_rejection="Refusing recursive dylib dependency: fixture rejection for ${BREW_PREFIX}/lib/libbad.dylib"
 [[ "$rejection_output" == *"$expected_rejection"* ]] \
   || fail "rejection did not propagate the complete production error message for the exact rejected source"
+# The fixture mirrors the rejected source's reason through the production
+# variable and captures it beside the build. Assert that captured value so the
+# fixture genuinely consumes MACOS_PACKAGE_POLICY_REASON, while the output
+# assertion above remains the sole proof that copy_dylib's production error call
+# propagates the reason.
+[[ "$(cat "$REASON_CAPTURE_FILE")" == "fixture rejection for ${BREW_PREFIX}/lib/libbad.dylib" ]] \
+  || fail "fixture did not mirror the rejected source's policy reason through the production variable"
 ok "a rejected source aborts before any batched edit is applied"
 
 echo "1..${pass_count}"


### PR DESCRIPTION
## Summary

# Measured macOS packaging bottleneck and bounded improvement

Current main baseline: 38318d78a4942473cbf83f73c99afe262bc2a422; inspected scripts/build-macos.sh at PR #263 head 79aef4f2fb0dd58dcde53b54ef6e501125bba066 (only fuzz/Cargo.lock differs).

This is a slow successful gate, not an abandoned job. PR #175 job 103648704910 spent 29m06s creating its bundle/DMG; #171 job 103644341290 spent 36m20s. In #175's timestamped log, GStreamer plugin rpath rewriting took 782.8s, the pre-sign policy validation interval 328.2s, and the pre-DMG policy validation interval 332.3s. 272 plugins were bundled. Full extracted evidence: 175.macos-packaging.log beside this report. #263 passed compile/tests and is running the same packaging stage.

Potential repeated work visible in scripts/build-macos.sh: fix_rpaths loops over every dependency of every plugin; copy_dylib validates each source with macos_validate_macho_copy_control before checking whether the same library has already been bundled. install_name_tool is invoked separately for every change. These are hypotheses to measure, not proof that validation may be removed. The independent final policy checks intentionally validate different post-mutation states and must remain.

Implementation scope: profile the actual subprocess/inspection counts and timing, then reduce repeated immutable-source inspection and/or batch equivalent rpath edits where demonstrated safe. Preserve full forbidden-component/dependency checks, path and source identity handling, basename-collision behavior, platform runtime probes, before/after-sign validation and final signature verification. Never cache solely by basename or reuse evidence across modified binaries; bind any cache to the exact source and relevant content/metadata or a clearly immutable build phase. Do not enable auto-merge, skip/fake checks, remove plugins to make timing look better, or change shared city/Kisakcod configuration.

Use a dedicated per-bead branch/PR from current main. Run existing macOS packaging/policy regression fixtures (including forbidden transitive sources) and syntax/static checks. Demonstrate before/after native macOS CI packaging timing and equivalent policy decisions; Linux fixture success alone is not a native performance measurement. If no safe optimization is established, record the profiling result rather than weakening checks. Hand off for independent exact-head review and operator merge; source remains open until an actual reviewed merge, or an explicit report-only disposition if implementation cannot be justified.

## Implementation notes

Implemented: dedupe immutable Homebrew dylib source validation by exact absolute path and batch equivalent install_name_tool -change edits per binary in scripts/build-macos.sh; new scripts/test-macos-rpath-batching.sh regression (registered in CI). Finding-to-fix mapping for operator corrective report (macos-packaging-improvement.md): (1) repeated per-plugin source inspection -> cached by exact source path, never basename; failures still abort -> test scenario 1+2; (2) one install_name_tool process per edit -> single batched invocation per binary -> test scenario 1; (3) rejected source must still fail closed before any edit -> test scenario 3. Preserved: forbidden-component/dependency checks, path+source identity, basename-collision behavior, before/after-sign and final signature checks. Validation at pushed head e0f3e9a: new rpath-batching test 3/3; test-macos-package-policy.sh pass; test-macos-icon-bundle-policy.sh pass; test_build_helpers.py 6 OK; cargo fmt/check/clippy/all-targets+release/build --release pass; cargo test --all-targets 1869+30 passed 0 failed. No existing PR; native macOS before/after from this PR's build-macos job via new inspection/cache-hit counters.
## Operator scope

Report: `/home/jmulesa/tributary/.gc/operations/reviews/health-20260913T020848Z/macos-packaging-improvement.md`
Bounded improvement only: reduce repeated immutable-source inspection and/or batch equivalent rpath edits where demonstrated safe. Full forbidden-component/dependency checks, path/source identity, basename-collision behavior, platform probes, before/after-sign validation and final signature verification preserved. No auto-merge.

## Refinery verification (rebased onto current main 3c94080)

- Branch `polecat/tr-zhf4p` rebased cleanly onto current main (which contains merged #247 lofty 0.25.1); head `aa07674442ee9c150faca9be24e37fc80f238e66`.
- Diff: `scripts/build-macos.sh` (memoize `macos_validate_macho_copy_control` by exact absolute source path, never basename; batch equivalent `install_name_tool -change` edits per binary), new `scripts/test-macos-rpath-batching.sh`, `ci.yml` registration, CHANGELOG.
- Ran at this exact rebased head (true exit 0): `bash -n` on the changed scripts; `scripts/test-macos-rpath-batching.sh` 3/3; `scripts/test-macos-package-policy.sh`; `scripts/test-macos-icon-bundle-policy.sh`; `python3 scripts/test_build_helpers.py` 6 OK.
- Native macOS before/after timing is to be captured by this PR's macOS packaging job (the commit adds inspection/cache-hit counters to the build log).

## Refinery handoff

- Issue: `tr-zhf4p` (task)
- Source branch: `polecat/tr-zhf4p`
- Target: `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved macOS package build throughput by reducing repeated inspection of bundled Homebrew libraries.
  * Grouped macOS library path updates to make packaging more efficient.
  * Build output now reports validation activity and avoided duplicate inspections.
  * Existing security checks remain enforced, and rejected components still stop packaging before changes are applied.

* **Tests**
  * Added regression coverage for macOS library validation, path updates, caching, and fail-closed behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->